### PR TITLE
Fix module worker referrer tests

### DIFF
--- a/workers/modules/dedicated-worker-import-referrer.html
+++ b/workers/modules/dedicated-worker-import-referrer.html
@@ -12,11 +12,6 @@ async function openWindow(url) {
   return win;
 }
 
-// Returns a URL string from the current path and the given relative path.
-function createURLString(relative_path) {
-  return (new URL(relative_path, location.href)).href;
-}
-
 // Removes URL parameters from the given URL string and returns it.
 function removeParams(url_string) {
   if (!url_string)
@@ -25,6 +20,21 @@ function removeParams(url_string) {
   for (var key of url.searchParams.keys())
     url.searchParams.delete(key);
   return url.href;
+}
+
+// Generates a referrer given a fetchType and a relevant referrer policy.
+function generateReferrer(referrerURL, referrerPolicy, requestURL) {
+  generatedReferrer = "";
+  if (referrerPolicy === 'no-referrer')
+    generatedReferrer = "";
+  else if (referrerPolicy === 'origin')
+    generatedReferrer = new URL('resources/' + referrerURL, location.href).origin + '/';
+  else if (referrerPolicy === 'same-origin')
+    generatedReferrer = requestURL.includes('remote') ? "" : new URL('resources/' + referrerURL, location.href).href;
+  else
+    generatedReferrer = new URL('resources/' + referrerURL, location.href).href;
+
+  return generatedReferrer;
 }
 
 // Runs a referrer policy test with the given settings. This opens a new window
@@ -36,16 +46,16 @@ function removeParams(url_string) {
 //     scriptURL: 'resources/referrer-checker.sub.js',
 //     windowReferrerPolicy: 'no-referrer',
 //     workerReferrerPolicy: 'same-origin',
-//     moduleGraphLevel: 'top-level' (or 'descendant')
+//     fetchType: 'top-level' or 'descendant-static' or 'descendant-dynamic'
 //   };
 //
 // - |scriptURL| is used for starting a new worker.
-// - |windowReferrerPolicy| is set to the ReferrerPolicy HTTP header of the
+// - |windowReferrerPolicy| is to set the ReferrerPolicy HTTP header of the
 //   window. This policy should be applied to top-level worker module script
 //   loading and static imports.
-// - |workerReferrerPolicy| is set to the ReferrerPolicy HTTP header of the
+// - |workerReferrerPolicy| is to set the ReferrerPolicy HTTP header of the
 //   worker. This policy should be applied to dynamic imports.
-// - |moduleGraphLevel| indicates a script whose referrer will be tested.
+// - |fetchType| indicates a script whose referrer will be tested.
 function import_referrer_test(settings, description) {
   promise_test(async () => {
     let windowURL = 'resources/new-worker-window.html';
@@ -68,11 +78,28 @@ function import_referrer_test(settings, description) {
     win.postMessage(scriptURL, '*');
     const msgEvent = await new Promise(resolve => window.onmessage = resolve);
 
+    // Generate the expected referrer given whether the test is a top-level or
+    // descendant test, the window's or worker's URL, and the window's or
+    // referrer policy, all respectively.
     let expectedReferrer;
-    if (settings.moduleGraphLevel == 'top-level')
-      expectedReferrer = createURLString('resources/new-worker-window.html');
-    else
-      expectedReferrer = createURLString('resources/' + settings.scriptURL);
+    if (settings.fetchType === 'top-level') {
+      // Top-level worker requests have their outgoing referrers set given their
+      // containing window's URL and referrer policy.
+      expectedReferrer = generateReferrer('new-worker-window.html', settings.windowReferrerPolicy, settings.scriptURL);
+    } else if (settings.fetchType === 'descendant-static') {
+      // Static descendant script requests from a worker have their outgoing
+      // referrer set given their containing script's URL and containing
+      // window's referrer policy.
+
+      // In the two below cases, the referrer URL and the request URLs are the
+      // same because the initial request (for the top-level worker script)
+      // should act as the referrer for future descendant requests.
+      expectedReferrer = generateReferrer(settings.scriptURL, settings.windowReferrerPolicy, settings.scriptURL);
+    } else if (settings.fetchType === 'descendant-dynamic') {
+      // Dynamic descendant script requests from a worker have their outgoing
+      // referrer set given their containing script's URL and referrer policy.
+      expectedReferrer = generateReferrer(settings.scriptURL, settings.workerReferrerPolicy, settings.scriptURL);
+    }
 
     // Delete query parameters from the actual referrer to make it easy to match
     // it with the expected referrer.
@@ -84,128 +111,128 @@ function import_referrer_test(settings, description) {
 
 // Tests for top-level worker module script loading.
 //
-// Top-level worker module script loading should obey the default referrer
-// policy (not the window's referrer policy), and send the window's URL as a
-// referrer.
+// Top-level worker module scripts should inherit the containing window's
+// referrer policy when using the containing window's URL as the referrer.
 //
 // [Current document]
 // --(open)--> [Window] whose referrer policy is |windowReferrerPolicy|.
-//   --(new Worker)--> [Worker] should be loaded with [Window]'s URL as a
-//                     referrer regardless of |windowReferrerPolicy|.
+//   --(new Worker)--> [Worker] should respect [windowReferrerPolicy| when
+//                     using [Window]'s URL as the referrer.
 
 import_referrer_test(
     { scriptURL: 'referrer-checker.py',
       windowReferrerPolicy: 'no-referrer',
-      moduleGraphLevel: 'top-level' },
+      fetchType: 'top-level' },
     'Same-origin top-level module script loading with "no-referrer" referrer ' +
         'policy');
 
 import_referrer_test(
     { scriptURL: 'referrer-checker.py',
       windowReferrerPolicy: 'origin',
-      moduleGraphLevel: 'top-level' },
+      fetchType: 'top-level' },
     'Same-origin top-level module script loading with "origin" referrer ' +
         'policy');
 
 import_referrer_test(
     { scriptURL: 'referrer-checker.py',
       windowReferrerPolicy: 'same-origin',
-      moduleGraphLevel: 'top-level' },
+      fetchType: 'top-level' },
     'Same-origin top-level module script loading with "same-origin" referrer ' +
         'policy');
 
 // Tests for static imports.
 //
-// Static imports should obey the default referrer policy, and send the worker's
-// URL as a referrer.
+// Static imports should inherit the containing window's referrer policy when
+// using the containing module script's URL as the referrer.
+// Note: This is subject to change in the future; see https://plz.put.me.here.
 //
 // [Current document]
 // --(open)--> [Window] whose referrer policy is |windowReferrerPolicy|.
 //   --(new Worker)--> [Worker]
-//     --(static import)--> [Script] should be loaded with [Worker]'s URL as a
-//                          referrer regardless of |windowReferrerPolicy|.
+//     --(static import)--> [Script] should respect |windowReferrerPolicy| when
+//                          using [Worker]'s URL as the referrer.
 
 import_referrer_test(
     { scriptURL: 'static-import-same-origin-referrer-checker-worker.js',
       windowReferrerPolicy: 'no-referrer',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-static' },
     'Same-origin static import with "no-referrer" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'static-import-same-origin-referrer-checker-worker.js',
       windowReferrerPolicy: 'origin',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-static' },
     'Same-origin static import with "origin" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'static-import-same-origin-referrer-checker-worker.js',
       windowReferrerPolicy: 'same-origin',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-static' },
     'Same-origin static import with "same-origin" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'static-import-remote-origin-referrer-checker-worker.sub.js',
       windowReferrerPolicy: 'no-referrer',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-static' },
     'Cross-origin static import with "no-referrer" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'static-import-remote-origin-referrer-checker-worker.sub.js',
       windowReferrerPolicy: 'origin',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-static' },
     'Cross-origin static import with "origin" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'static-import-remote-origin-referrer-checker-worker.sub.js',
       windowReferrerPolicy: 'same-origin',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-static' },
     'Cross-origin static import with "same-origin" referrer policy.');
 
 // Tests for dynamic imports.
 //
-// Dynamic imports should obey the default referrer policy (not the worker's
-// referrer policy), and send the worker's URL as a referrer.
+// Dynamic imports should inherit the containing script's referrer policy if
+// set, and use the default referrer policy otherwise, when using the
+// containing script's URL as the referrer.
 //
 // [Current document]
 // --(open)--> [Window]
 //   --(new Worker)--> [Worker] whose referrer policy is |workerReferrerPolicy|.
-//     --(dynamic import)--> [Script] should be loaded with [Worker]'s URL as a
-//                           referrer regardless of |workerReferrerPolicy|.
+//     --(dynamic import)--> [Script] should respect |workerReferrerPolicy| when
+//                           using [Worker]'s URL as the referrer.
 
 import_referrer_test(
     { scriptURL: 'dynamic-import-same-origin-referrer-checker-worker.js',
       workerReferrerPolicy: 'no-referrer',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-dynamic' },
     'Same-origin dynamic import with "no-referrer" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'dynamic-import-same-origin-referrer-checker-worker.js',
       workerReferrerPolicy: 'origin',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-dynamic' },
     'Same-origin dynamic import with "origin" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'dynamic-import-same-origin-referrer-checker-worker.js',
       workerReferrerPolicy: 'same-origin',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-dynamic' },
     'Same-origin dynamic import with "same-origin" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'dynamic-import-remote-origin-referrer-checker-worker.sub.js',
       workerReferrerPolicy: 'no-referrer',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-dynamic' },
     'Cross-origin dynamic import with "no-referrer" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'dynamic-import-remote-origin-referrer-checker-worker.sub.js',
       workerReferrerPolicy: 'origin',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-dynamic' },
     'Cross-origin dynamic import with "origin" referrer policy.');
 
 import_referrer_test(
     { scriptURL: 'dynamic-import-remote-origin-referrer-checker-worker.sub.js',
       workerReferrerPolicy: 'same-origin',
-      moduleGraphLevel: 'descendant' },
+      fetchType: 'descendant-dynamic' },
     'Cross-origin dynamic import with "same-origin" referrer policy.');
-
 </script>

--- a/workers/modules/dedicated-worker-import-referrer.html
+++ b/workers/modules/dedicated-worker-import-referrer.html
@@ -25,7 +25,7 @@ function removeParams(url_string) {
 // Generates a referrer given a fetchType, referrer policy, and a request URL
 // (used to determine whether request is remote-origin or not). This function
 // is used to generate expected referrers.
-function generateReferrer(referrerURL, referrerPolicy, requestURL) {
+function generateExpectedReferrer(referrerURL, referrerPolicy, requestURL) {
   let generatedReferrer = "";
   if (referrerPolicy === 'no-referrer')
     generatedReferrer = "";
@@ -89,7 +89,7 @@ function import_referrer_test(settings, description) {
     if (settings.fetchType === 'top-level') {
       // Top-level worker requests have their outgoing referrers set given their
       // containing window's URL and referrer policy.
-      expectedReferrer = generateReferrer('new-worker-window.html', settings.windowReferrerPolicy, settings.scriptURL);
+      expectedReferrer = generateExpectedReferrer('new-worker-window.html', settings.windowReferrerPolicy, settings.scriptURL);
     } else if (settings.fetchType === 'descendant-static') {
       // Static descendant script requests from a worker have their outgoing
       // referrer set given their containing script's URL and containing
@@ -98,11 +98,11 @@ function import_referrer_test(settings, description) {
       // In the below cases, the referrer URL and the request URLs are the same
       // because the initial request (for the top-level worker script) should
       // act as the referrer for future descendant requests.
-      expectedReferrer = generateReferrer(settings.scriptURL, settings.windowReferrerPolicy, settings.scriptURL);
+      expectedReferrer = generateExpectedReferrer(settings.scriptURL, settings.windowReferrerPolicy, settings.scriptURL);
     } else if (settings.fetchType === 'descendant-dynamic') {
       // Dynamic descendant script requests from a worker have their outgoing
       // referrer set given their containing script's URL and referrer policy.
-      expectedReferrer = generateReferrer(settings.scriptURL, settings.workerReferrerPolicy, settings.scriptURL);
+      expectedReferrer = generateExpectedReferrer(settings.scriptURL, settings.workerReferrerPolicy, settings.scriptURL);
     }
 
     // Delete query parameters from the actual referrer to make it easy to match

--- a/workers/modules/dedicated-worker-import-referrer.html
+++ b/workers/modules/dedicated-worker-import-referrer.html
@@ -22,9 +22,11 @@ function removeParams(url_string) {
   return url.href;
 }
 
-// Generates a referrer given a fetchType and a relevant referrer policy.
+// Generates a referrer given a fetchType, referrer policy, and a request URL
+// (used to determine whether request is remote-origin or not). This function
+// is used to generate expected referrers.
 function generateReferrer(referrerURL, referrerPolicy, requestURL) {
-  generatedReferrer = "";
+  let generatedReferrer = "";
   if (referrerPolicy === 'no-referrer')
     generatedReferrer = "";
   else if (referrerPolicy === 'origin')
@@ -78,9 +80,11 @@ function import_referrer_test(settings, description) {
     win.postMessage(scriptURL, '*');
     const msgEvent = await new Promise(resolve => window.onmessage = resolve);
 
-    // Generate the expected referrer given whether the test is a top-level or
-    // descendant test, the window's or worker's URL, and the window's or
-    // referrer policy, all respectively.
+    // Generate the expected referrer, given:
+    //   - The fetchType of the test
+    //   - Referrer URL to be used
+    //   - Relevant referrer policy
+    //   - Request URL
     let expectedReferrer;
     if (settings.fetchType === 'top-level') {
       // Top-level worker requests have their outgoing referrers set given their
@@ -91,9 +95,9 @@ function import_referrer_test(settings, description) {
       // referrer set given their containing script's URL and containing
       // window's referrer policy.
 
-      // In the two below cases, the referrer URL and the request URLs are the
-      // same because the initial request (for the top-level worker script)
-      // should act as the referrer for future descendant requests.
+      // In the below cases, the referrer URL and the request URLs are the same
+      // because the initial request (for the top-level worker script) should
+      // act as the referrer for future descendant requests.
       expectedReferrer = generateReferrer(settings.scriptURL, settings.windowReferrerPolicy, settings.scriptURL);
     } else if (settings.fetchType === 'descendant-dynamic') {
       // Dynamic descendant script requests from a worker have their outgoing
@@ -144,7 +148,8 @@ import_referrer_test(
 //
 // Static imports should inherit the containing window's referrer policy when
 // using the containing module script's URL as the referrer.
-// Note: This is subject to change in the future; see https://plz.put.me.here.
+// Note: This is subject to change in the future; see
+// https://github.com/w3c/webappsec-referrer-policy/issues/111.
 //
 // [Current document]
 // --(open)--> [Window] whose referrer policy is |windowReferrerPolicy|.


### PR DESCRIPTION
This PR fixes the module worker referrer tests to ensure that window and module worker referrer policies are respected in relevant contexts, and take into account for `Referer` generation. A follow-up to this PR is https://github.com/web-platform-tests/wpt/pull/12330, which fixes the worklet referrer tests.

/cc @nhiroki @nyaxt @hiroshige-g (once this is merged and auto-rolled into Chromium, I will submit my CL that makes module worker script loading in Blink conform to these tests).