### PR TITLE
Fix worklet referrer tests to match spec

### DIFF
--- a/worklets/resources/referrer-checker.py
+++ b/worklets/resources/referrer-checker.py
@@ -2,14 +2,22 @@
 # |expected_referrer|.
 def main(request, response):
     referrer = request.headers.get("referer", "")
+    referrer_policy = request.GET.first("referrer_policy")
     expected_referrer = request.GET.first("expected_referrer", "")
-
     response_headers = [("Content-Type", "text/javascript"),
                         ("Access-Control-Allow-Origin", "*")]
 
-    # The expected referrer doesn't contain query params for simplification, so
-    # we check the referrer by startswith() here.
-    if (expected_referrer != "" and
-        referrer.startswith(expected_referrer + "?")):
-        return (200, response_headers, "")
+    if referrer_policy == "no-referrer" or referrer_policy == "origin":
+        if referrer == expected_referrer:
+            return (200, response_headers, "")
+        return (404, response_headers)
+    if referrer_policy == "same-origin":
+        if referrer == expected_referrer:
+            return (200, response_headers, "")
+        # The expected referrer doesn't contain query params for simplification,
+        # so we check the referrer by startswith() here.
+        if (expected_referrer != "" and
+            referrer.startswith(expected_referrer + "?")):
+            return (200, response_headers, "")
+        return (404, response_headers)
     return (404, response_headers)

--- a/worklets/resources/referrer-checker.py
+++ b/worklets/resources/referrer-checker.py
@@ -1,7 +1,12 @@
 # Returns a valid response when request's |referrer| matches
 # |expected_referrer|.
 def main(request, response):
-    referrer = request.headers.get("referer", "")
+    # We want |referrer| to be the referrer header with no query params,
+    # because |expected_referrer| will not contain any query params, and
+    # thus cannot be compared with the actual referrer header if it were to
+    # contain query params. This works fine if the actual referrer has no
+    # query params too.
+    referrer = request.headers.get("referer", "").split("?")[0]
     referrer_policy = request.GET.first("referrer_policy")
     expected_referrer = request.GET.first("expected_referrer", "")
     response_headers = [("Content-Type", "text/javascript"),
@@ -14,11 +19,6 @@ def main(request, response):
 
     if referrer_policy == "same-origin":
         if referrer == expected_referrer:
-            return (200, response_headers, "")
-        # The expected referrer doesn't contain query params for simplification,
-        # so we check the referrer by startswith() here.
-        if (expected_referrer != "" and
-            referrer.startswith(expected_referrer + "?")):
             return (200, response_headers, "")
         return (404, response_headers)
     return (404, response_headers)

--- a/worklets/resources/referrer-checker.py
+++ b/worklets/resources/referrer-checker.py
@@ -11,6 +11,7 @@ def main(request, response):
         if referrer == expected_referrer:
             return (200, response_headers, "")
         return (404, response_headers)
+
     if referrer_policy == "same-origin":
         if referrer == expected_referrer:
             return (200, response_headers, "")

--- a/worklets/resources/referrer-tests.js
+++ b/worklets/resources/referrer-tests.js
@@ -29,9 +29,7 @@ function runReferrerTest(settings) {
   }).then(msg_event => assert_equals(msg_event.data, 'RESOLVED'));
 }
 
-// Runs a series of tests related to the referrer policy on a worklet. Referrer
-// on worklet module loading should always be handled with the default referrer
-// policy.
+// Runs a series of tests related to the referrer policy on a worklet.
 //
 // Usage:
 // runReferrerTests("paint");
@@ -46,7 +44,7 @@ function runReferrerTests(workletType) {
                              referrerPolicy: 'no-referrer',
                              scriptOrigins: { topLevel: 'same' } });
   }, 'Importing a same-origin script from a page that has "no-referrer" ' +
-     'referrer policy.');
+     'referrer policy should not send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -54,7 +52,7 @@ function runReferrerTests(workletType) {
                              referrerPolicy: 'no-referrer',
                              scriptOrigins: { topLevel: 'remote' } });
   }, 'Importing a remote-origin script from a page that has "no-referrer" ' +
-     'referrer policy.');
+     'referrer policy should not send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -62,7 +60,7 @@ function runReferrerTests(workletType) {
                              referrerPolicy: 'origin',
                              scriptOrigins: { topLevel: 'same' } });
   }, 'Importing a same-origin script from a page that has "origin" ' +
-     'referrer policy.');
+     'referrer policy should send only an origin as referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -70,7 +68,7 @@ function runReferrerTests(workletType) {
                              referrerPolicy: 'origin',
                              scriptOrigins: { topLevel: 'remote' } });
   }, 'Importing a remote-origin script from a page that has "origin" ' +
-     'referrer policy.');
+     'referrer policy should send only an origin as referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -78,7 +76,7 @@ function runReferrerTests(workletType) {
                              referrerPolicy: 'same-origin',
                              scriptOrigins: { topLevel: 'same' } });
   }, 'Importing a same-origin script from a page that has "same-origin" ' +
-     'referrer policy.');
+     'referrer policy should send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -86,7 +84,7 @@ function runReferrerTests(workletType) {
                              referrerPolicy: 'same-origin',
                              scriptOrigins: { topLevel: 'remote' } });
   }, 'Importing a remote-origin script from a page that has "same-origin" ' +
-     'referrer policy.');
+     'referrer policy should not send referrer.');
 
   // Tests for descendant script fetch -----------------------------------------
 
@@ -97,7 +95,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'same',
                                               descendant: 'same' } });
   }, 'Importing a same-origin script from a same-origin worklet script that ' +
-     'has "no-referrer" referrer policy.');
+     'has "no-referrer" referrer policy should not send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -106,7 +104,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'same',
                                               descendant: 'remote' } });
   }, 'Importing a remote-origin script from a same-origin worklet script ' +
-     'that has "no-referrer" referrer policy.');
+     'that has "no-referrer" referrer policy should not send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -115,7 +113,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'remote',
                                               descendant: 'remote' } });
   }, 'Importing a remote-origin script from a remote-origin worklet script ' +
-     'that has "no-referrer" referrer policy.');
+     'that has "no-referrer" referrer policy should not send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -124,7 +122,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'same',
                                               descendant: 'same' } });
   }, 'Importing a same-origin script from a same-origin worklet script that ' +
-     'has "origin" referrer policy.');
+     'has "origin" referrer policy should send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -133,7 +131,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'same',
                                               descendant: 'remote' } });
   }, 'Importing a remote-origin script from a same-origin worklet script ' +
-     'that has "origin" referrer policy.');
+     'that has "origin" referrer policy should send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -142,7 +140,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'remote',
                                               descendant: 'remote' } });
   }, 'Importing a remote-origin script from a remote-origin worklet script ' +
-     'that has "origin" referrer policy.');
+     'that has "origin" referrer policy should send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -151,7 +149,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'same',
                                               descendant: 'same' } });
   }, 'Importing a same-origin script from a same-origin worklet script that ' +
-     'has "same-origin" referrer policy.');
+     'has "same-origin" referrer policy should send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -160,7 +158,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'same',
                                               descendant: 'remote' } });
   }, 'Importing a remote-origin script from a same-origin worklet script ' +
-     'that has "same-origin" referrer policy.');
+     'that has "same-origin" referrer policy should not send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -169,5 +167,5 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'remote',
                                               descendant: 'remote' } });
   }, 'Importing a remote-origin script from a remote-origin worklet script ' +
-     'that has "same-origin" referrer policy.');
+     'that has "same-origin" referrer policy should not send referrer.');
 }

--- a/worklets/resources/referrer-window.html
+++ b/worklets/resources/referrer-window.html
@@ -48,30 +48,47 @@ function isDestinationCrossOrigin(fetchType, scriptOrigins) {
   assert_unreached('fetchType has an invalid value.');
 }
 
+function createExpectedReferrer(
+    importerURL, fetchType, referrerPolicy, scriptOrigins) {
+  if (referrerPolicy === 'no-referrer')
+    return "";
+  if (referrerPolicy === 'same-origin') {
+    if (isDestinationCrossOrigin(fetchType, scriptOrigins))
+      return "";
+    // Delete query params to make it easier to match with an actual referrer in
+    // the referrer-checker.py.
+    const expectedReferrer = new URL(importerURL);
+    for (var key of expectedReferrer.searchParams.keys())
+      expectedReferrer.searchParams.delete(key);
+    return expectedReferrer;
+  }
+  if (referrerPolicy === 'origin')
+    return (new URL(importerURL)).origin + '/';
+  assert_unreached('referrerPolicy has an invalid value.');
+}
+
 window.onmessage = e => {
   const workletType = e.data.workletType;
   const fetchType = e.data.fetchType;
+  const referrerPolicy = e.data.referrerPolicy;
   const scriptOrigins = e.data.scriptOrigins;
 
   let scriptURL;
   let expectedReferrer;
   if (fetchType === 'top-level') {
     scriptURL = createScriptURLForTopLevel(scriptOrigins.topLevel);
-    // The referrer of the top-level script should be this file.
-    // Delete query params to make it easier to match with an actual referrer in
-    // the referrer-checker.py.
-    expectedReferrer = new URL(location.href);
-    for (var key of expectedReferrer.searchParams.keys())
-      expectedReferrer.searchParams.delete(key);
+    expectedReferrer = createExpectedReferrer(
+        location.href, fetchType, referrerPolicy, scriptOrigins);
   } else if (fetchType === 'descendant') {
     scriptURL = createScriptURLForDecendant(scriptOrigins);
-    // The referrer of the imported script should be the importer script.
-    expectedReferrer = scriptURL;
+    expectedReferrer = createExpectedReferrer(
+        scriptURL, fetchType, referrerPolicy, scriptOrigins);
   } else {
     assert_unreached('fetchType should be \'top-level\' or \'descendant\'');
   }
 
   const params = new URLSearchParams;
+  params.append('referrer_policy', referrerPolicy);
   params.append('expected_referrer', expectedReferrer);
 
   get_worklet(workletType).addModule(scriptURL + '?' + params)


### PR DESCRIPTION
This PR fixes worklet referrer tests to match the spec. Basically this reverts a good bit of https://github.com/web-platform-tests/wpt/commit/50b0943d82d36bb92977002bebd5a7990e0ed388#diff-f5dd3dfe0ce7dd53814287bc30b9a197 (the WPTs bit of https://chromium-review.googlesource.com/c/chromium/src/+/1111743) to ensure that we actually do test that the referrer policy of the ["outer settings object"](https://drafts.css-houdini.org/worklets/#dom-worklet-addmodule) is honored when fetching worklet scripts. Related PR for module worker referrer tests: https://github.com/web-platform-tests/wpt/pull/12321.

/cc @nhiroki @nyaxt @hiroshige-g (Note: when this is merged and auto-rolls into Blink, I'll submit my CL that allows Blink to conform to these tests).