### PR TITLE
Don't try to re-encode already-encoded bytes when serializing.

### DIFF
--- a/tools/wptrunner/wptrunner/wptmanifest/serializer.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/serializer.py
@@ -6,6 +6,7 @@ atom_names = {v:"@%s" % k for (k,v) in atoms.iteritems()}
 named_escapes = set(["\a", "\b", "\f", "\n", "\r", "\t", "\v"])
 
 def escape(string, extras=""):
+    # Assumes input bytes are either UTF8 bytes or unicode.
     rv = ""
     for c in string:
         if c in named_escapes:
@@ -18,7 +19,10 @@ def escape(string, extras=""):
             rv += "\\" + c
         else:
             rv += c
-    return rv.encode("utf8")
+    if isinstance(rv, unicode):
+        return rv.encode("utf8")
+    else:
+        return rv
 
 
 class ManifestSerializer(NodeVisitor):


### PR DESCRIPTION
This unbreaks Servo's syncing process when strings like https://github.com/web-platform-tests/wpt/blob/5c219ef55a4b2099c0f4c53b9669df10d73e6f3a/url/urlsearchparams-sort.any.js#L31 are encountered during manifest serialization.