### PR TITLE
Sync Mozilla tests as of 2018-08-07

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-table-caption-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-table-caption-001-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
+  <style>
+  caption {
+    border: 1em solid green;
+  }
+  </style>
+</head>
+<body>
+  <table>
+    <caption></caption>
+  </table>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-table-caption-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-table-caption-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: 'contain: size' on table captions should cause them to be sized as if they had no contents.</title>
+  <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-size">
+  <link rel="match" href="contain-size-table-caption-001-ref.html">
+  <style>
+  .contain {
+    contain:size;
+  }
+  .innerContents {
+    height: 100px;
+    width: 100px;
+    color: transparent;
+  }
+  caption {
+    border: 1em solid green;
+  }
+  </style>
+</head>
+<body>
+  <table>
+    <caption class="contain">
+      <div class="innerContents">
+        inner
+      </div>
+    </caption>
+  </table>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
@@ -26,3 +26,4 @@
 == contain-size-fieldset-002.html contain-size-fieldset-002-ref.html
 == contain-size-multicol-002.html contain-size-multicol-002-ref.html
 == contain-size-multicol-003.html contain-size-multicol-003-ref.html
+== contain-size-table-caption-001.html contain-size-table-caption-001-ref.html


### PR DESCRIPTION
Sync Mozilla tests as of https://hg.mozilla.org/mozilla-central/rev/fe6020e5c9d901a40fa2e7ea2f1ab2a36bf6d856 .

This contains a single change, from [bug 1478550](https://bugzilla.mozilla.org/show_bug.cgi?id=1478550) by @MReschenberg, already reviewed by @dholbert.