### PR TITLE
[html] Verify synchronicity of beforeunload event

### DIFF
--- a/html/browsers/browsing-the-web/unloading-documents/beforeunload-synchronous.html
+++ b/html/browsers/browsing-the-web/unloading-documents/beforeunload-synchronous.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>beforeunload event is emitted synchronously</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#the-event-handler-processing-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+'use strict';
+// "navigate a browsing context" synchronously calls "prompt to unload", which
+// synchronously calls "dispatch an event".
+
+async_test(function(t) {
+  var iframe = document.createElement('iframe');
+
+  iframe.onload = t.step_func(function() {
+    var callCount = 0;
+
+    iframe.contentWindow.onbeforeunload = function() {
+      callCount += 1;
+    };
+
+    iframe.contentWindow.location.href = '/common/blank.html';
+
+    assert_equals(callCount, 1, 'invoked synchronously exactly once');
+
+    t.done();
+  });
+
+  document.body.appendChild(iframe);
+});
+</script>
+</body>


### PR DESCRIPTION
After reviewing all the files that reference "beforeunload" (as reported by `git grep -l beforeunload`), I can't find coverage for this behavior. There are a number of ways to observe this behavior. The choice of `location.href` is arbitrary, and I'm open to suggestion on using some other API either in place of `location.href` or in addition to it.

Browser     | Result
------------|-------
Chrome 68   | :x: 
Edge 17     | :x: 
Firefox 61  | :heavy_check_mark: 
IE 11       | :heavy_check_mark: 
Safari 11.1 | :x:

This came up in the context of gh-12290, where I authored a test to support asynchronous behavior. A number of tests in WPT are written in this way, but they generally concern other details of the specification, so I suppose it's acceptable for them to be loose in this regard.

