### PR TITLE
[Fetch] Object.prototype shouldn't interfere with fetch streams

### DIFF
--- a/fetch/api/basic/stream-safe-creation.any.js
+++ b/fetch/api/basic/stream-safe-creation.any.js
@@ -1,3 +1,5 @@
+// META: global=worker
+
 // These tests verify that stream creation is not affected by changes to
 // Object.prototype.
 
@@ -19,7 +21,10 @@ for (creationCase of Object.keys(creationCases)) {
         get() { throw Error(`Object.prototype.${accessorName} was accessed`); },
         configurable: true
       });
-      t.add_cleanup(() => delete Object.prototype[accessorName]);
+      t.add_cleanup(() => {
+        delete Object.prototype[accessorName];
+        return Promise.resolve();
+      });
       await creationCases[creationCase]();
     }, `throwing Object.prototype.${accessorName} accessor should not affect ` +
        `stream creation by '${creationCase}'`);
@@ -28,7 +33,10 @@ for (creationCase of Object.keys(creationCases)) {
       // -1 is a convenient value which is invalid, and should cause the
       // constructor to throw, for all four fields.
       Object.prototype[accessorName] = -1;
-      t.add_cleanup(() => delete Object.prototype[accessorName]);
+      t.add_cleanup(() => {
+        delete Object.prototype[accessorName];
+        return Promise.resolve();
+      });
       await creationCases[creationCase]();
     }, `Object.prototype.${accessorName} accessor returning invalid value ` +
        `should not affect stream creation by '${creationCase}'`);
@@ -36,7 +44,10 @@ for (creationCase of Object.keys(creationCases)) {
 
   promise_test(async t => {
     Object.prototype.start = controller => controller.error(new Error('start'));
-      t.add_cleanup(() => delete Object.prototype.start);
+      t.add_cleanup(() => {
+        delete Object.prototype.start;
+        return Promise.resolve();
+      });
       await creationCases[creationCase]();
     }, `Object.prototype.start function which errors the stream should not ` +
        `affect stream creation by '${creationCase}'`);

--- a/fetch/api/basic/stream-safe-creation.any.js
+++ b/fetch/api/basic/stream-safe-creation.any.js
@@ -3,10 +3,13 @@
 
 const creationCases = {
   fetch: async () => fetch(location.href),
-  request: () => new Request(location.href),
-  response: () => new Response('hi'),
-  consumeEmpty: () => new Response().text(),
-  consumeNonEmpty: () => new Response(new Uint8Array([64])).text()
+  request: () => new Request(location.href, {method: 'POST', body: 'hi'}),
+  response: () => new Response('bye'),
+  consumeEmptyResponse: () => new Response().text(),
+  consumeNonEmptyResponse: () => new Response(new Uint8Array([64])).text(),
+  consumeEmptyRequest: () => new Request(location.href).text(),
+  consumeNonEmptyRequest: () => new Request(location.href,
+                                            {method: 'POST', body: 'yes'}).arrayBuffer(),
 };
 
 for (creationCase of Object.keys(creationCases)) {
@@ -15,7 +18,7 @@ for (creationCase of Object.keys(creationCases)) {
       throw Error('Object.prototype.start was called');
     };
     t.add_cleanup(() => delete Object.prototype.start);
-    await creationCases[creationCase];
+    await creationCases[creationCase]();
   }, `throwing Object.prototype.start() should not affect stream creation by ` +
      `'${creationCase}'`);
 
@@ -26,7 +29,7 @@ for (creationCase of Object.keys(creationCases)) {
         configurable: true
       });
       t.add_cleanup(() => delete Object.prototype[accessorName]);
-      await creationCases[creationCase];
+      await creationCases[creationCase]();
     }, `throwing Object.prototype.${accessorName} accessor should not affect ` +
        `stream creation by '${creationCase}'`);
   }

--- a/fetch/api/basic/stream-safe-creation.any.js
+++ b/fetch/api/basic/stream-safe-creation.any.js
@@ -1,0 +1,33 @@
+// These tests verify that stream creation is not affected by changes to
+// Object.prototype.
+
+const creationCases = {
+  fetch: async () => fetch(location.href),
+  request: () => new Request(location.href),
+  response: () => new Response('hi'),
+  consumeEmpty: () => new Response().text(),
+  consumeNonEmpty: () => new Response(new Uint8Array([64])).text()
+};
+
+for (creationCase of Object.keys(creationCases)) {
+  promise_test(async t => {
+    Object.prototype.start = () => {
+      throw Error('Object.prototype.start was called');
+    };
+    t.add_cleanup(() => delete Object.prototype.start);
+    await creationCases[creationCase];
+  }, `throwing Object.prototype.start() should not affect stream creation by ` +
+     `'${creationCase}'`);
+
+  for (accessorName of ['type', 'size', 'highWaterMark']) {
+    promise_test(async t => {
+      Object.defineProperty(Object.prototype, accessorName, {
+        get() { throw Error(`Object.prototype.${accessorName} was accessed`); },
+        configurable: true
+      });
+      t.add_cleanup(() => delete Object.prototype[accessorName]);
+      await creationCases[creationCase];
+    }, `throwing Object.prototype.${accessorName} accessor should not affect ` +
+       `stream creation by '${creationCase}'`);
+  }
+}


### PR DESCRIPTION
Test that setting Object.prototype.start to a function that throws
doesn't interfere with fetch operations that create a stream. Similarly,
verify that setting throwing accessors for 'type', 'size', and
'highWaterMark' doesn't cause problems.

See https://github.com/whatwg/fetch/pull/781 for background.