### PR TITLE
HTML: Add checks for the return value of document.open()

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/002.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/002.html
@@ -6,7 +6,7 @@
 <script>
 test(function() {
  var log = document.getElementById("log");
- document.open()
- assert_equals(document.getElementById("log"), log)
+ assert_equals(document.open(), document);
+ assert_equals(document.getElementById("log"), log);
 })
 </script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/004.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/004.html
@@ -11,7 +11,7 @@ onload = t.step_func(function() {
   var iframe = document.getElementsByTagName("iframe")[0];
   var handle = iframe.contentDocument;
   iframe.contentDocument.test_state = 1;
-  iframe.contentDocument.open();
+  assert_equals(iframe.contentDocument.open(), handle);
   assert_equals(iframe.contentDocument.test_state, 1);
   assert_equals(iframe.contentDocument, handle);
   t.done();

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/005.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/005.html
@@ -10,7 +10,7 @@ var iframe;
 onload = t.step_func(function() {
   var iframe = document.getElementsByTagName("iframe")[0];
   iframe.contentWindow.setTimeout(t.step_func(function() {assert_unreached()}), 100);
-  iframe.contentDocument.open()
+  assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
   setTimeout(function() {t.done();}, 200);
 });
 </script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/006.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/006.html
@@ -13,7 +13,7 @@ onload = t.step_func(function() {
   img.onerror = t.step_func(function() {assert_unreached()})
   img.src = "missing";
   iframe.contentDocument.body.appendChild(img);
-  iframe.contentDocument.open()
+  assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
   setTimeout(function() {t.done();}, 500);
 });
 </script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/008.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/008.html
@@ -11,7 +11,7 @@ onload = t.step_func(function() {
   var iframe = document.getElementsByTagName("iframe")[0];
   var handle = Object.getPrototypeOf(iframe.contentDocument);
   handle.test_state = 1;
-  iframe.contentDocument.open();
+  assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
   var new_handle = Object.getPrototypeOf(iframe.contentDocument);
   assert_equals(new_handle.test_state, undefined);
   assert_not_equals(new_handle, handle);

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/009.https.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/009.https.html
@@ -28,7 +28,7 @@ function(x) {
 );
 }
 onload = function() {
-  iframe.contentDocument.open();
+  assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
   steps.forEach(function(x) {x()});
 }
 </script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/010.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/010.html
@@ -9,7 +9,7 @@ var iframe;
 var t = async_test();
 onload = t.step_func(function() {
   iframe = document.getElementsByTagName("iframe")[0];
-  iframe.contentDocument.open();
+  assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
   iframe.contentDocument.close();
 
   iframe.contentWindow.setTimeout(t.step_func(function() {t.done();}), 500);

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/011-1.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/011-1.html
@@ -1,5 +1,5 @@
 <script>
-document.open()
+parent.t.step(() => { parent.assert_equals(document.open(), document); });
 setTimeout(parent.t.step_func(function() {parent.t.done()}), 0);
 document.close();
 </script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/012-1.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/012-1.html
@@ -1,6 +1,6 @@
 <script>
 onload = parent.t.step_func(function() {
-  document.open()
+  parent.assert_equals(document.open(), document);
   setTimeout(parent.t.step_func(function() {parent.t.done()}), 0);
   document.close();
 });

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/013-1.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/013-1.html
@@ -1,6 +1,6 @@
 <script>
 addEventListener("DOMContentLoaded", parent.t.step_func(function() {
-  document.open()
+  parent.assert_equals(document.open(), document);
   setTimeout(parent.t.step_func(function() {parent.t.done()}), 0);
   document.close();
 }), false);

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/014-1.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/014-1.html
@@ -1,7 +1,7 @@
 <script>
 onload = parent.t.step_func(function() {
   setTimeout(parent.t.step_func(function() {
-    document.open()
+    parent.assert_equals(document.open(), document);
     setTimeout(parent.t.step_func(function() {parent.t.done()}), 0);
     document.close();
   }), 100)

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/015-1.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/015-1.html
@@ -2,7 +2,7 @@
 onload = function() {
   window.test_prop = 1;
   parent.tests[0].step(function() {parent.assert_equals(test_prop, 1)});
-  document.open();
+  parent.tests[0].step(function() {parent.assert_equals(document.open(), document)});
   document.write("<script>test_prop = 2;<\/script>");
   document.close();
   parent.tests[0].step(function() {parent.assert_equals(test_prop, 1)});

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/016-1.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/016-1.html
@@ -3,7 +3,9 @@ window.test_prop = 1;
 </script>
 <script>
 onload = function() {
-  document.open();
+  parent.tests[0].step(function() {
+    parent.assert_equals(document.open(), document);
+  });
   document.write("<script>test_prop = 2; timeout_fired=false;<\/script>");
   document.close();
 

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-ignore-opens-during-unload.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-ignore-opens-during-unload.window.js
@@ -9,7 +9,7 @@ for (const ev of ["unload", "beforeunload", "pagehide"]) {
       iframe.contentWindow.addEventListener(ev, t.step_func_done(() => {
         const origURL = iframe.contentDocument.URL;
         assertDocumentIsReadyForSideEffectsTest(iframe.contentDocument, `ignore-opens-during-unload counter is greater than 0 during ${ev} event`);
-        iframe.contentDocument.open();
+        assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
         assertOpenHasNoSideEffects(iframe.contentDocument, origURL, `ignore-opens-during-unload counter is greater than 0 during ${ev} event`);
       }));
       iframe.src = "about:blank";

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-synchronous-script.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-synchronous-script.window.js
@@ -6,7 +6,7 @@ async_test(t => {
   self.testSynchronousScript = t.step_func_done(() => {
     const origURL = iframe.contentDocument.URL;
     assertDocumentIsReadyForSideEffectsTest(iframe.contentDocument, "active parser whose script nesting level is greater than 0");
-    iframe.contentDocument.open();
+    assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
     assertOpenHasNoSideEffects(iframe.contentDocument, origURL, "active parser whose script nesting level is greater than 0");
   });
   iframe.src = "resources/bailout-order-synchronous-script-frame.html";

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/custom-element.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/custom-element.window.js
@@ -16,7 +16,7 @@ class CustomElement extends HTMLElement {
   constructor() {
     super();
     try {
-      document.open();
+      assert_equals(document.open(), document);
     } catch (e) {
       err = e;
     }

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/encoding.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/encoding.window.js
@@ -4,7 +4,7 @@ async_test(t => {
   frame.onload = t.step_func_done(t => {
     // Using toLowerCase() to avoid an Edge bug
     assert_equals(frame.contentDocument.characterSet.toLowerCase(), "shift_jis", "precondition");
-    frame.contentDocument.open();
+    assert_equals(frame.contentDocument.open(), frame.contentDocument);
     assert_equals(frame.contentDocument.characterSet.toLowerCase(), "shift_jis", "actual test");
     frame.contentDocument.close();
     assert_equals(frame.contentDocument.characterSet.toLowerCase(), "shift_jis", "might as well");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/ignore-opens-during-unload.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/ignore-opens-during-unload.window.js
@@ -6,7 +6,7 @@ for (const ev of ["unload", "beforeunload", "pagehide"]) {
     iframe.onload = t.step_func(() => {
       iframe.contentWindow.addEventListener(ev, t.step_func_done(() => {
         assert_not_equals(iframe.contentDocument.childNodes.length, 0);
-        iframe.contentDocument.open();
+        assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
         assert_not_equals(iframe.contentDocument.childNodes.length, 0);
       }));
       iframe.src = "about:blank";

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/mutation-events.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/mutation-events.window.js
@@ -13,7 +13,7 @@ test(t => {
   frame.contentWindow.addEventListener("DOMSubtreeModified", t.unreached_func());
   frame.contentWindow.addEventListener("DOMSubtreeModified", t.unreached_func(), true);
   assert_equals(frame.contentDocument.documentElement.localName, "html");
-  frame.contentDocument.open();
+  assert_equals(frame.contentDocument.open(), frame.contentDocument);
   assert_equals(frame.contentDocument.documentElement, null);
   frame.contentDocument.write("<div>heya</div>");
   frame.contentDocument.close();

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/type-argument-plaintext.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/type-argument-plaintext.window.js
@@ -12,7 +12,7 @@
     document.body.appendChild(frame);
     t.add_cleanup(() => frame.remove());
     frame.onload = t.step_func_done(() => {
-      frame.contentDocument.open(type);
+      assert_equals(frame.contentDocument.open(type), frame.contentDocument);
       frame.contentDocument.write("<B>heya</b>");
       frame.contentDocument.close();
       assert_equals(frame.contentDocument.body.firstChild.localName, "b");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/type-argument.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/type-argument.window.js
@@ -9,7 +9,7 @@
   async_test(t => {
     const frame = document.body.appendChild(document.createElement("iframe"));
     t.add_cleanup(() => frame.remove());
-    frame.contentDocument.open(type);
+    assert_equals(frame.contentDocument.open(type), frame.contentDocument);
     frame.contentDocument.write("<B>heya</b>");
     frame.contentDocument.close();
     assert_equals(frame.contentDocument.body.firstChild.localName, "b");


### PR DESCRIPTION
Edge currently fails some of these as they return `null` instead of the document sometimes.