### PR TITLE
[wptrunner] Make test skipping explicit

### DIFF
--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -246,7 +246,7 @@ def run_tests(config, test_paths, product, **kwargs):
                         run_tests = {"testharness": []}
                         for test in test_loader.tests["testharness"]:
                             if (test.testdriver and not executor_cls.supports_testdriver) or (
-                                test.jsshell and not executor_cls.supports_jsshell):
+                                    test.jsshell and not executor_cls.supports_jsshell):
                                 logger.test_start(test.id)
                                 logger.test_end(test.id, status="SKIP")
                             else:

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -245,15 +245,10 @@ def run_tests(config, test_paths, product, **kwargs):
                     if test_type == "testharness":
                         run_tests = {"testharness": []}
                         for test in test_loader.tests["testharness"]:
-                            if test.testdriver and not executor_cls.supports_testdriver:
+                            if (test.testdriver and not executor_cls.supports_testdriver) or (
+                                test.jsshell and not executor_cls.supports_jsshell):
                                 logger.test_start(test.id)
                                 logger.test_end(test.id, status="SKIP")
-                            elif test.jsshell and not executor_cls.supports_jsshell:
-                                # We expect that tests for JavaScript shells
-                                # will not be run along with tests that run in
-                                # a full web browser, so we silently skip them
-                                # here.
-                                pass
                             else:
                                 run_tests["testharness"].append(test)
                     else:


### PR DESCRIPTION
Explicitly report on skipped "jsshell" tests during execution. This
gives users an indication that the behavior is intentional and promotes
parity with the output generated by the `--list-tests` flag of the `wpt
run.  command.

---

@jgraham @Ms2ger This removes a comment that states "we silently skip them," so
I expect there is a good reason they aren't being documented as "SKIP". In
that case, I can look in to updating the `--list-tests` feature to correctly
support the new feature. But could we also extend this comment to explain why
this needs to be done "silently"?