### PR TITLE
[wptrunner] Consistently hide tests

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -108,6 +108,14 @@ class TestExecutor(object):
     test_type = None
     convert_result = None
     supports_testdriver = False
+
+    # `supports_jsshell` determines whether a given test is enumerated in the
+    # various test-traversal commands exposed by the wptrunner CLI (see the
+    # `ignores` method). It is intended to be overridden by subclasses which
+    # are defined outside of WPT.
+    #
+    # Note that this interpretation of "supports" is distinct from that of the
+    # `supports_testdriver` attribute.
     supports_jsshell = False
 
     def __init__(self, browser, server_config, timeout_multiplier=1,
@@ -182,6 +190,16 @@ class TestExecutor(object):
 
     def test_url(self, test):
         return urlparse.urljoin(self.server_url(test.environment["protocol"]), test.url)
+
+    @classmethod
+    def ignores(cls, test):
+        """Determine if a given test should be omitted during test
+        traversal."""
+
+        if cls.supports_jsshell:
+            return False
+
+        return test.test_type == "testharness" and test.jsshell
 
     @abstractmethod
     def do_test(self, test):

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -467,7 +467,8 @@ class TestLoader(object):
                  total_chunks=1,
                  chunk_number=1,
                  include_https=True,
-                 skip_timeout=False):
+                 skip_timeout=False,
+                 executor_classes=None):
 
         self.test_types = test_types
         self.run_info = run_info
@@ -480,6 +481,7 @@ class TestLoader(object):
         self.disabled_tests = None
         self.include_https = include_https
         self.skip_timeout = skip_timeout
+        self.executor_classes = executor_classes
 
         self.chunk_type = chunk_type
         self.total_chunks = total_chunks
@@ -562,6 +564,11 @@ class TestLoader(object):
                  "disabled":defaultdict(list)}
 
         for test_path, test_type, test in self.iter_tests():
+            executor_class = (self.executor_classes and
+                              self.executor_classes.get(test_type))
+            if executor_class and executor_class.ignores(test):
+                continue
+
             enabled = not test.disabled()
             if not self.include_https and test.environment["protocol"] == "https":
                 enabled = False


### PR DESCRIPTION
Ensure the "jsshell" tests are not reported by any of the commands that
interface with the `TestLoader`.

---

@jgraham The `wpt_run` function optionally accepts a `TestLoader` instance as a keyword argument. I was only able to find one case where that is used: `reduce.py`. This patch breaks that usage, but I think it may be dead code, so I'm making a case for its removal in gh-12367.

This is intended to resolve gh-12366