### PR TITLE
Ensure the ls-tree/check-ignore pairing use the same separators.

### DIFF
--- a/tools/wptrunner/wptrunner/update/tree.py
+++ b/tools/wptrunner/wptrunner/update/tree.py
@@ -197,7 +197,7 @@ class GitTree(object):
                        add all files under that path.
         """
         with tempfile.TemporaryFile() as f:
-            sync_tree.git("ls-tree", "-r", "--name-only", "HEAD", stdout=f)
+            sync_tree.git("ls-tree", "-z", "-r", "--name-only", "HEAD", stdout=f)
             f.seek(0)
             ignored_files = sync_tree.git("check-ignore", "--no-index", "--stdin", "-z", stdin=f)
         args = []


### PR DESCRIPTION
I didn't test the `-z` change carefully after making it; the `check-ignore` man page points out that if `-z` and `--stdin` are both present then the input is expected to contain null byte separators as well.