### PR TITLE
Fix bug in Document-url.sub.html

### DIFF
--- a/dom/nodes/Document-URL.html
+++ b/dom/nodes/Document-URL.html
@@ -12,7 +12,7 @@ async_test(function() {
   this.add_cleanup(function() { document.body.removeChild(iframe); });
   iframe.onload = this.step_func_done(function() {
     assert_equals(iframe.contentDocument.URL,
-                  "http://{{host}}:{{ports[http][0]}}/common/blank.html");
+                  location.origin + "/common/blank.html");
   });
 })
 </script>


### PR DESCRIPTION
Test will fail if there's no port in url, so replace it with location.origin.
Fix #3475, @cdumez, PTAL.