### PR TITLE
Fix service worker tests generated from non-https .any.js

### DIFF
--- a/infrastructure/server/context.any.js
+++ b/infrastructure/server/context.any.js
@@ -1,0 +1,13 @@
+// META: global=window,dedicatedworker,sharedworker,serviceworker
+test(t => {
+  // Test for object that's only exposed in serviceworker
+  if (self.clients) {
+      assert_true(self.isSecureContext);
+      assert_equals(location.protocol, "https:");
+  } else {
+      assert_false(self.isSecureContext);
+      assert_equals(location.protocol, "http:");
+  }
+});
+
+done();

--- a/infrastructure/server/secure-context.https.any.js
+++ b/infrastructure/server/secure-context.https.any.js
@@ -1,3 +1,4 @@
+// META: global=window,dedicatedworker,sharedworker,serviceworker
 test(() => {
   assert_true(self.isSecureContext);
 }, "Use of .https file name flag implies secure context");

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin, urlparse
 from abc import ABCMeta, abstractproperty
 
 
@@ -47,13 +47,18 @@ class ManifestItem(object):
         pass
 
     @property
+    def meta_flags(self):
+        return set(self.source_file.meta_flags)
+
+    @property
     def path(self):
         """The test path relative to the test_root"""
         return self.source_file.rel_path
 
     @property
     def https(self):
-        return "https" in self.source_file.meta_flags
+        flags = self.meta_flags
+        return ("https" in flags or "serviceworker" in flags)
 
     def key(self):
         """A unique identifier for the test"""
@@ -94,6 +99,10 @@ class URLManifestItem(ManifestItem):
     @property
     def id(self):
         return self.url
+
+    @property
+    def meta_flags(self):
+        return set(urlparse(self.url).path.rsplit("/", 1)[1].split(".")[1:-1])
 
     @property
     def url(self):

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -113,8 +113,6 @@ def global_suffixes(value):
     for global_type in global_types:
         variant = _any_variants[global_type]
         suffix = variant.get("suffix", ".any.%s.html" % global_type.decode("utf-8"))
-        if variant.get("force_https", False):
-            suffix = ".https" + suffix
         rv.add((suffix, global_type == b"jsshell"))
 
     return rv
@@ -623,7 +621,8 @@ class SourceFile(object):
                     break
 
             tests = [
-                TestharnessTest(self, global_variant_url(self.url, suffix) + variant, timeout=self.timeout, jsshell=jsshell)
+                TestharnessTest(self, global_variant_url(self.url, suffix) + variant, timeout=self.timeout,
+                                jsshell=jsshell)
                 for (suffix, jsshell) in sorted(global_suffixes(globals))
                 for variant in self.test_variants
             ]

--- a/tools/manifest/tests/test_item.py
+++ b/tools/manifest/tests/test_item.py
@@ -1,0 +1,23 @@
+from ..item import SupportFile, URLManifestItem
+from ..sourcefile import SourceFile
+
+
+def test_base_meta_flags():
+    s = SourceFile("/", "a.b.c.d", "/", contents="")
+    m = SupportFile(s)
+
+    assert m.meta_flags == {"b", "c"}
+
+
+def test_url_meta_flags():
+    s = SourceFile("/", "a.b.c", "/", contents="")
+    m = URLManifestItem(s, "/foo.bar/a.b.d.e")
+
+    assert m.meta_flags == {"b", "d"}
+
+
+def test_url_empty_meta_flags():
+    s = SourceFile("/", "a.b.c", "/", contents="")
+    m = URLManifestItem(s, "/foo.bar/abcde")
+
+    assert m.meta_flags == set()

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -366,7 +366,7 @@ test()""" % input
 
     urls = {
         "dedicatedworker": "/html/test.any.worker.html",
-        "serviceworker": "/html/test.https.any.serviceworker.html",
+        "serviceworker": "/html/test.any.serviceworker.html",
         "sharedworker": "/html/test.any.sharedworker.html",
         "window": "/html/test.any.html",
     }
@@ -431,7 +431,7 @@ test()"""
 
     urls = {
         "dedicatedworker": "/html/test.any.worker.html",
-        "serviceworker": "/html/test.https.any.serviceworker.html",
+        "serviceworker": "/html/test.any.serviceworker.html",
         "sharedworker": "/html/test.any.sharedworker.html",
         "window": "/html/test.any.html",
     }

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -249,7 +249,7 @@ fetch_tests_from_worker(new SharedWorker("%(path)s%(query)s"));
 
 class ServiceWorkersHandler(HtmlWrapperHandler):
     global_type = b"serviceworker"
-    path_replace = [(".https.any.serviceworker.html", ".any.js", ".any.worker.js")]
+    path_replace = [(".any.serviceworker.html", ".any.js", ".any.worker.js")]
     wrapper = """<!doctype html>
 <meta charset=utf-8>
 %(meta)s
@@ -342,7 +342,7 @@ class RoutesBuilder(object):
             ("GET", "*.window.html", WindowHandler),
             ("GET", "*.any.html", AnyHtmlHandler),
             ("GET", "*.any.sharedworker.html", SharedWorkersHandler),
-            ("GET", "*.https.any.serviceworker.html", ServiceWorkersHandler),
+            ("GET", "*.any.serviceworker.html", ServiceWorkersHandler),
             ("GET", "*.any.worker.js", AnyWorkerHandler),
             ("GET", "*.asis", handlers.AsIsHandler),
             ("*", "*.py", handlers.PythonScriptHandler),


### PR DESCRIPTION
Note: this contains a change to the expected behaviour of test
runners.

Previously .any.js tests specifying a serviceworker variant generated
a url like foo.https.any.serviceworker.html. But that causes a problem
because that looks exctly like a url generated from a file named
foo.https.js. This ambiguity, together with the fact that wptrunner
wasn't actually looking at the https flag in the test id, but only in
the filename, meant that service worker tests weren't being run
properly.

This change stops adding .https. to serviceworker tests generated from
.any.js files and instead makes .serviceworker. in the test id
directly mean that the test should be loaded over https.