### PR TITLE
[Battery] Correct IDL file name

### DIFF
--- a/battery-status/battery-interface-idlharness.https.window.js
+++ b/battery-status/battery-interface-idlharness.https.window.js
@@ -6,7 +6,7 @@
 'use strict';
 
 idl_test(
-  ['battery'],
+  ['battery-status'],
   ['dom', 'html'],
   async idl_array => {
     idl_array.add_objects({


### PR DESCRIPTION
The IDL file name is [`battery-status.idl`](https://github.com/web-platform-tests/wpt/blob/master/interfaces/battery-status.idl)