### PR TITLE
Fix broken Battery Status API idlharness test (due to typo)

### DIFF
--- a/battery-status/idlharness.https.window.js
+++ b/battery-status/idlharness.https.window.js
@@ -6,7 +6,7 @@
 'use strict';
 
 idl_test(
-  ['battery'],
+  ['battery-status'],
   ['dom', 'html'],
   async idl_array => {
     idl_array.add_objects({


### PR DESCRIPTION
'battery' => 'battery-status' is the fix, but also rename to
idlharness.js for consistency with most other idlharness tests.