### PR TITLE
Fix dependency order in subresource-integrity/idlharness.window.js

### DIFF
--- a/subresource-integrity/idlharness.window.js
+++ b/subresource-integrity/idlharness.window.js
@@ -7,7 +7,7 @@
 
 idl_test(
   ['SRI'],
-  ['html', 'dom', 'cssom'],
+  ['html', 'cssom', 'dom'],
   idl_array => {
     idl_array.add_objects({
       HTMLScriptElement: ['document.createElement("script")'],


### PR DESCRIPTION
With these 3 dependencies, there is only one order which doesn't
result in an error during setup, and this is it. The previous error
was "ProcessingInstruction includes LinkStyle, but
ProcessingInstruction is undefined.":
https://wpt.fyi/results/subresource-integrity/idlharness.window.html?sha=eea0b54014&labels=stable

Separate issue filed about the Edge failure:
https://github.com/web-platform-tests/wpt/issues/12428