### PR TITLE
Avoid using Promise.prototype.finally in idlharness.js

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -3221,7 +3221,7 @@ function idl_test(srcs, deps, idl_setup_func) {
                 }
             })
             .catch(function(e) { setup_error = e || 'IDL setup failed.'; })
-            .finally(function () {
+            .then(function () {
                 var error = setup_error;
                 try {
                     idl_array.test(); // Test what we can.


### PR DESCRIPTION
In this context, using .then() achieves the same thing because of the
preceding .catch().

Fixes https://github.com/web-platform-tests/wpt/issues/12428.