### PR TITLE
Test length of `selectedOptions` after change

### DIFF
--- a/html/semantics/forms/the-select-element/select-selectedOptions.html
+++ b/html/semantics/forms/the-select-element/select-selectedOptions.html
@@ -114,12 +114,15 @@ test(() => {
 test(() => {
   const select = document.getElementById("select-same-object-change");
   const before = select.selectedOptions;
+  assert_equals(before.length, 3);
 
   select.selectedOptions[1].selected = false;
 
   const after = select.selectedOptions;
 
   assert_equals(before, after);
+  assert_equals(before.length, 2);
+  assert_equals(after.length, 2);
 
 }, ".selectedOptions should return the same object after selection changes - [SameObject]");
 </script>


### PR DESCRIPTION
This adds a test for the length of `select.selectedOptions` after an option element was changed through `option.selected`. jsdom would previously fail to update the value under these conditions.

The test passes consistently in Chrome and Safari. It passes in Firefox on the first run, but fails if the page is reloaded with cache as that retains the previous state of the `select` element.