### PR TITLE
Ensure `x` is declared before use in test

### DIFF
--- a/html/dom/elements/global-attributes/dir_auto-contained-script-R-ref.html
+++ b/html/dom/elements/global-attributes/dir_auto-contained-script-R-ref.html
@@ -28,6 +28,7 @@
         display: none;
       }
     </style>
+    <script>var x;</script>
   </head>
   <body>
     <div class="instructions"><p>Test passes if the two boxes below look exactly the same.</p></div>

--- a/html/dom/elements/global-attributes/dir_auto-contained-script-R.html
+++ b/html/dom/elements/global-attributes/dir_auto-contained-script-R.html
@@ -29,6 +29,7 @@
         display: none;
       }
     </style>
+    <script>var x;</script>
   </head>
   <body>
     <div class="instructions"><p>Test passes if the two boxes below look exactly the same.</p></div>


### PR DESCRIPTION
This suppresses spurious warnings when running the platform tests in some test runners.