### PR TITLE
[wptserve] Limit number of additional subdomains 

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -702,8 +702,14 @@ def build_config(override_path=None, **kwargs):
 
     return rv
 
-def _make_subdomains_product(s, depth=3):
-    return set(u".".join(x) for x in chain(*(product(s, repeat=i) for i in range(1, depth+1))))
+def _make_subdomains_product(s):
+    # A "depth" of 2 satisfies the original feature request: the availability
+    # of "a subdomain of a subdomain (and another subdomain of the same
+    # subdomain)
+    # https://github.com/web-platform-tests/wpt/issues/8581
+    depth = 2
+
+    return set(u".".join(x) for x in chain(*(product(s, repeat=i) for i in range(1, depth + 1))))
 
 _subdomains = {u"www",
                u"www1",
@@ -712,10 +718,6 @@ _subdomains = {u"www",
                u"élève"}
 
 _not_subdomains = {u"nonexistent"}
-
-_subdomains = _make_subdomains_product(_subdomains)
-
-_not_subdomains = _make_subdomains_product(_not_subdomains)
 
 
 class ConfigBuilder(config.ConfigBuilder):
@@ -763,8 +765,12 @@ class ConfigBuilder(config.ConfigBuilder):
     def __init__(self, *args, **kwargs):
         if "subdomains" not in kwargs:
             kwargs["subdomains"] = _subdomains
+        kwargs["subdomains"] = _make_subdomains_product(kwargs["subdomains"])
+
         if "not_subdomains" not in kwargs:
             kwargs["not_subdomains"] = _not_subdomains
+        kwargs["not_subdomains"] = _make_subdomains_product(kwargs["not_subdomains"])
+
         super(ConfigBuilder, self).__init__(
             *args,
             **kwargs

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -35,7 +35,7 @@ def test_make_hosts_file_windows():
                        browser_host="foo.bar",
                        alternate_hosts={"alt": "foo2.bar"},
                        subdomains={"a", "b"},
-                       not_subdomains={"x, y"}) as c:
+                       not_subdomains={"x", "y"}) as c:
         hosts = serve.make_hosts_file(c, "192.168.42.42")
         lines = hosts.split("\n")
         assert set(lines) == {"",

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -23,9 +23,17 @@ def test_make_hosts_file_nix():
                               "192.168.42.42\tfoo.bar",
                               "192.168.42.42\tfoo2.bar",
                               "192.168.42.42\ta.foo.bar",
+                              "192.168.42.42\ta.a.foo.bar",
+                              "192.168.42.42\ta.b.foo.bar",
                               "192.168.42.42\ta.foo2.bar",
+                              "192.168.42.42\ta.a.foo2.bar",
+                              "192.168.42.42\ta.b.foo2.bar",
                               "192.168.42.42\tb.foo.bar",
-                              "192.168.42.42\tb.foo2.bar"}
+                              "192.168.42.42\tb.a.foo.bar",
+                              "192.168.42.42\tb.b.foo.bar",
+                              "192.168.42.42\tb.foo2.bar",
+                              "192.168.42.42\tb.a.foo2.bar",
+                              "192.168.42.42\tb.b.foo2.bar"}
         assert lines[-1] == ""
 
 @pytest.mark.skipif(platform.uname()[0] != "Windows",
@@ -40,15 +48,31 @@ def test_make_hosts_file_windows():
         lines = hosts.split("\n")
         assert set(lines) == {"",
                               "0.0.0.0\tx.foo.bar",
+                              "0.0.0.0\tx.x.foo.bar",
+                              "0.0.0.0\tx.y.foo.bar",
                               "0.0.0.0\tx.foo2.bar",
+                              "0.0.0.0\tx.x.foo2.bar",
+                              "0.0.0.0\tx.y.foo2.bar",
                               "0.0.0.0\ty.foo.bar",
+                              "0.0.0.0\ty.x.foo.bar",
+                              "0.0.0.0\ty.y.foo.bar",
                               "0.0.0.0\ty.foo2.bar",
+                              "0.0.0.0\ty.x.foo2.bar",
+                              "0.0.0.0\ty.y.foo2.bar",
                               "192.168.42.42\tfoo.bar",
                               "192.168.42.42\tfoo2.bar",
                               "192.168.42.42\ta.foo.bar",
+                              "192.168.42.42\ta.a.foo.bar",
+                              "192.168.42.42\ta.b.foo.bar",
                               "192.168.42.42\ta.foo2.bar",
+                              "192.168.42.42\ta.a.foo2.bar",
+                              "192.168.42.42\ta.b.foo2.bar",
                               "192.168.42.42\tb.foo.bar",
-                              "192.168.42.42\tb.foo2.bar"}
+                              "192.168.42.42\tb.a.foo.bar",
+                              "192.168.42.42\tb.b.foo.bar",
+                              "192.168.42.42\tb.foo2.bar",
+                              "192.168.42.42\tb.a.foo2.bar",
+                              "192.168.42.42\tb.b.foo2.bar"}
         assert lines[-1] == ""
 
 


### PR DESCRIPTION
[wptserve] Limit number of additional subdomains

Recently, the set of origins reserved by wptserve was increased to
include a combinatoric set of configuration values. This logic used a
"depth" of three, causing the server to reserve subdomains of subdomains
of subdomains (e.g. `www.www.www.web-platform.test`). For the default
configuration, this produced 312 distinct origins.

The motivating feature request describes a use case for a "depth" of 2
[1]. Re-implement to use that depth, limiting the generated set of
origins to 62. Update the implementation to make this functionality
testable, and update the corresponding tests to verify the intended
behavior.

[1] #8581