### PR TITLE
Added h2 dependency to wptserve/setup.py

### DIFF
--- a/tools/wptserve/setup.py
+++ b/tools/wptserve/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 PACKAGE_VERSION = '2.0'
-deps = ["six>=1.8"]
+deps = ["six>=1.8", "h2==3.0.1"]
 
 setup(name='wptserve',
       version=PACKAGE_VERSION,


### PR DESCRIPTION
As mentioned [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1473648#c18), wptserve needs the h2 dependency in its setup.py in order to be built and used via `python setup.py install`. 