### PR TITLE
[css-contain] use overflow:hidden on elements where it actually works

### DIFF
--- a/css/css-contain/contain-size-007.html
+++ b/css/css-contain/contain-size-007.html
@@ -3,15 +3,19 @@
 <title>CSS Containment Test: Size containment on table-row-group</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-contain-1/#containment-size">
-<link rel="match" href="../reference/pass_if_pass_below.html">
+<link rel="match" href="reference/pass_if_pass_below_clipped.html">
 <meta name=assert content="Size containment doesn't apply to table-row-group elements.">
 <style>
 div {
   display: table-row-group;
   contain: size;
+}
+section {
   overflow: hidden;
 }
 </style>
 
 <p>Test passes if there is the word "PASS" below.</p>
+<section>
 <div>PASS</div>
+<section>

--- a/css/css-contain/contain-size-008.html
+++ b/css/css-contain/contain-size-008.html
@@ -3,15 +3,19 @@
 <title>CSS Containment Test: Size containment on table-header-group</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-contain-1/#containment-size">
-<link rel="match" href="../reference/pass_if_pass_below.html">
+<link rel="match" href="reference/pass_if_pass_below_clipped.html">
 <meta name=assert content="Size containment doesn't apply to table-header-group elements.">
 <style>
 div {
   display: table-header-group;
   contain: size;
+}
+section {
   overflow: hidden;
 }
 </style>
 
 <p>Test passes if there is the word "PASS" below.</p>
+<section>
 <div>PASS</div>
+</section>

--- a/css/css-contain/contain-size-009.html
+++ b/css/css-contain/contain-size-009.html
@@ -3,15 +3,19 @@
 <title>CSS Containment Test: Size containment on table-footer-group</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-contain-1/#containment-size">
-<link rel="match" href="../reference/pass_if_pass_below.html">
+<link rel="match" href="reference/pass_if_pass_below_clipped.html">
 <meta name=assert content="Size containment doesn't apply to table-footer-group elements.">
 <style>
 div {
   display: table-footer-group;
   contain: size;
+}
+section {
   overflow: hidden;
 }
 </style>
 
 <p>Test passes if there is the word "PASS" below.</p>
+<section>
 <div>PASS</div>
+</section>

--- a/css/css-contain/contain-size-010.html
+++ b/css/css-contain/contain-size-010.html
@@ -3,15 +3,19 @@
 <title>CSS Containment Test: Size containment on table-row</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-contain-1/#containment-size">
-<link rel="match" href="../reference/pass_if_pass_below.html">
+<link rel="match" href="reference/pass_if_pass_below_clipped.html">
 <meta name=assert content="Size containment doesn't apply to table-row elements.">
 <style>
 div {
   display: table-row;
   contain: size;
+}
+section {
   overflow: hidden;
 }
 </style>
 
 <p>Test passes if there is the word "PASS" below.</p>
+<section>
 <div>PASS</div>
+</section>


### PR DESCRIPTION
Closes #12388

<del>This PR reuses the ref file introduced in #12485, so it is based on that branch. Should be merged (or rebased) after #12485 is landed.</del>

**edit: this is now rebased, and ready to review / merge**