### PR TITLE
Avoid invoking the Notification constructor in service workers

### DIFF
--- a/notifications/idlharness.https.any.js
+++ b/notifications/idlharness.https.any.js
@@ -10,18 +10,22 @@ idl_test(
   ['notifications'],
   ['service-workers', 'html', 'dom'],
   idl_array => {
-    idl_array.add_objects({
-      Notification: ['notification'],
-    });
     if (self.ServiceWorkerGlobalScope) {
       idl_array.add_objects({
-        NotificationEvent: ['notificationEvent'],
         ServiceWorkerGlobalScope: ['self'],
       });
-    }
-    self.notification = new Notification("Running idlharness.");
-    if (self.ServiceWorkerGlobalScope) {
-      self.notificationEvent = new NotificationEvent("type", { notification: notification });
+      // NotificationEvent could be tested here, but the constructor requires
+      // a Notification instance which cannot be created in a service worker,
+      // see below.
+    } else {
+      // While the Notification interface is exposed in service workers, the
+      // constructor (https://notifications.spec.whatwg.org/#dom-notification-notification)
+      // is defined to throw a TypeError. Therefore, we only add the object in
+      // the other scopes.
+      idl_array.add_objects({
+        Notification: ['notification'],
+      });
+      self.notification = new Notification('title');
     }
   }
 );


### PR DESCRIPTION
The idlharness.https.any.serviceworker.html test had a lot of spurious
failures because of this:
https://wpt.fyi/results/notifications/idlharness.https.any.serviceworker.html?sha=86e157b387
https://wpt.fyi/results/notifications/idlharness.https.any.serviceworker.html?sha=3a498429bf

With these changes, there are fewer subtests, but no failures in
Chrome and 9 in Firefox, which appear to be legitimate failures.