### PR TITLE
HTML: fieldset's legend and position: relative

### DIFF
--- a/html/rendering/non-replaced-elements/the-fieldset-element-0/legend-position-relative-ref.html
+++ b/html/rendering/non-replaced-elements/the-fieldset-element-0/legend-position-relative-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>Reference for legend position: relative</title>
+<style>
+div { display: inline-block; width: 100px; background: lime; }
+.a { width: 100px; height: 200px; }
+.b { width: 100px; height: 100px; }
+.c { width: 200px; height: 200px; }
+</style>
+<p>There should be no red.</p>
+<div class=a></div><div class=b></div><div class=c></div>

--- a/html/rendering/non-replaced-elements/the-fieldset-element-0/legend-position-relative-ref.html
+++ b/html/rendering/non-replaced-elements/the-fieldset-element-0/legend-position-relative-ref.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Reference for legend position: relative</title>
 <style>
-div { display: inline-block; width: 100px; background: lime; }
+div { display: inline-block; background: lime; }
 .a { width: 100px; height: 200px; }
 .b { width: 100px; height: 100px; }
 .c { width: 200px; height: 200px; }

--- a/html/rendering/non-replaced-elements/the-fieldset-element-0/legend-position-relative.html
+++ b/html/rendering/non-replaced-elements/the-fieldset-element-0/legend-position-relative.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>legend position: relative</title>
+<link rel=match href=legend-position-relative-ref.html>
+<style>
+fieldset { border: 100px solid lime; width: 200px; padding: 0; margin: 0 }
+legend { position: relative; left: 100px; width: 100px; padding: 0 }
+.behind { position: absolute; left: 208px; width: 100px; height: 100px; background: red; z-index: -1 }
+</style>
+<p>There should be no red.</p>
+<div class=behind></div>
+<fieldset><legend></legend></fieldset>


### PR DESCRIPTION
The legend should mask the border at its static position, but
Edge moves the mask if it is relatively positioned.