### PR TITLE
[serve] Correct error detection and add more log messages

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -827,7 +827,7 @@ def run(**kwargs):
             servers = start(config, build_routes(config["aliases"]), **kwargs)
 
             try:
-                while any(item.is_alive() for item in iter_procs(servers)):
+                while all(item.is_alive() for item in iter_procs(servers)):
                     for item in iter_procs(servers):
                         item.join(1)
             except KeyboardInterrupt:

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -378,15 +378,17 @@ def build_routes(aliases):
 
 
 class ServerProc(object):
-    def __init__(self):
+    def __init__(self, scheme=None):
         self.proc = None
         self.daemon = None
         self.stop = Event()
+        self.scheme = scheme
 
     def start(self, init_func, host, port, paths, routes, bind_address, config, **kwargs):
         self.proc = Process(target=self.create_daemon,
                             args=(init_func, host, port, paths, routes, bind_address,
                                   config),
+                            name='%s on port %s' % (self.scheme, port),
                             kwargs=kwargs)
         self.proc.daemon = True
         self.proc.start()
@@ -506,7 +508,7 @@ def start_servers(host, ports, paths, routes, bind_address, config, **kwargs):
                          "ws":start_ws_server,
                          "wss":start_wss_server}[scheme]
 
-            server_proc = ServerProc()
+            server_proc = ServerProc(scheme=scheme)
             server_proc.start(init_func, host, port, paths, routes, bind_address,
                               config, **kwargs)
             servers[scheme].append((port, server_proc))
@@ -830,6 +832,13 @@ def run(**kwargs):
                 while all(item.is_alive() for item in iter_procs(servers)):
                     for item in iter_procs(servers):
                         item.join(1)
+                exited = [item for item in iter_procs(servers) if not item.is_alive()]
+                subject = "subprocess" if len(exited) == 1 else "subprocesses"
+
+                logger.info("%s %s exited:" % (len(exited), subject))
+
+                for item in iter_procs(servers):
+                    logger.info("Status of %s:\t%s" % (item.name, "running" if item.is_alive() else "not running"))
             except KeyboardInterrupt:
                 logger.info("Shutting down")
 

--- a/tools/serve/test_functional.py
+++ b/tools/serve/test_functional.py
@@ -1,0 +1,77 @@
+try:
+    from importlib import reload
+except ImportError:
+    pass
+import json
+import os
+try:
+    import Queue as queue
+except ImportError:
+    import queue
+import tempfile
+import threading
+
+import pytest
+
+from . import serve
+from wptserve import logger
+
+
+class ServerProcSpy(serve.ServerProc):
+    instances = None
+
+    def start(self, *args, **kwargs):
+        result = super(ServerProcSpy, self).start(*args, **kwargs)
+
+        if ServerProcSpy.instances is not None:
+            ServerProcSpy.instances.put(self)
+
+        return result
+
+serve.ServerProc = ServerProcSpy
+
+@pytest.fixture()
+def server_subprocesses():
+    ServerProcSpy.instances = queue.Queue()
+    yield ServerProcSpy.instances
+    ServerProcSpy.instances = None
+
+@pytest.fixture()
+def tempfile_name():
+    name = tempfile.mkstemp()[1]
+    yield name
+    os.remove(name)
+
+
+def test_subprocess_exit(server_subprocesses, tempfile_name):
+    timeout = 30
+
+    def target():
+        # By default, the server initially creates a child process to validate
+        # local system configuration. That process is unrelated to the behavior
+        # under test, but at the time of this writing, the parent uses the same
+        # constructor that is also used to create the long-running processes
+        # which are relevant to this functionality. Disable the check so that
+        # the constructor is only used to create relevant processes.
+        with open(tempfile_name, 'w') as handle:
+            json.dump({"check_subdomains": False}, handle)
+
+        # The `logger` module from the wptserver package uses a singleton
+        # pattern which resists testing. In order to avoid conflicting with
+        # other tests which rely on that module, pre-existing state is
+        # discarded through an explicit "reload" operation.
+        reload(logger)
+
+        serve.run(config_path=tempfile_name)
+
+    thread = threading.Thread(target=target)
+
+    thread.start()
+
+    server_subprocesses.get(True, timeout)
+    subprocess = server_subprocesses.get(True, timeout)
+    subprocess.kill()
+
+    thread.join(timeout)
+
+    assert not thread.is_alive()


### PR DESCRIPTION
A more advanced solution might involve attempting to re-start the failed
subprocess(es). I think we'd need to understand the failure conditions before
committing to something like that, though. Otherwise, we'll risk enabling a
"continual restart" state if the problem can't be resolved by creating a new
sub-process.

I wrote the new test to a dedicated file because as an integration-level test,
it's quite a bit slower than the existing tests. It's also a little messy
because it stubs out a module method. I'm open to suggestions about better ways
to test this!

