### PR TITLE
Use --no-download when uploading manifest from Travis

### DIFF
--- a/tools/ci/ci_manifest.sh
+++ b/tools/ci/ci_manifest.sh
@@ -7,7 +7,7 @@ cd $WPT_ROOT
 mkdir -p ~/meta
 
 python tools/ci/tag_master.py
-./wpt manifest -p ~/meta/MANIFEST.json
+./wpt manifest --no-download -p ~/meta/MANIFEST.json
 cp ~/meta/MANIFEST.json $WPT_MANIFEST_FILE
 # Force overwrite of any existing file
 gzip -f $WPT_MANIFEST_FILE


### PR DESCRIPTION
This will be a lot slower than using the previous manifest, but it will mean
that issues like https://github.com/web-platform-tests/wpt/issues/12559 can't
persist over time.