### PR TITLE
[wptserver] Correct value in unit test

### DIFF
--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -35,7 +35,7 @@ def test_make_hosts_file_windows():
                        browser_host="foo.bar",
                        alternate_hosts={"alt": "foo2.bar"},
                        subdomains={"a", "b"},
-                       not_subdomains={"x, y"}) as c:
+                       not_subdomains={"x", "y"}) as c:
         hosts = serve.make_hosts_file(c, "192.168.42.42")
         lines = hosts.split("\n")
         assert set(lines) == {"",


### PR DESCRIPTION
This correction was previously submitted via gh-12459. Since the patch which that pull request intended to fix has since been reverted, it's unclear if/how the pull request can be accepted. I'm re-submitting the commit in a dedicated pull request because it corrects an unrelated mistake.

Since this concerns a Windows-specific codepath, TravisCI won't be able to validate the change. The following code may be manually inserted into the test module to verify expected behavior using a non-Windows system:

```python
def uname():
    return ('Windows',)
platform.uname = uname
```