### PR TITLE
Test inheritance of CSS Inline Layout properties

### DIFF
--- a/css/css-inline/META.yml
+++ b/css/css-inline/META.yml
@@ -1,0 +1,4 @@
+spec: https://drafts.csswg.org/css-fonts/
+suggested_reviewers:
+  - dauwhe
+  - fantasai

--- a/css/css-inline/inheritance.html
+++ b/css/css-inline/inheritance.html
@@ -6,6 +6,7 @@
 <link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-inline-3/#property-index">
 <meta name="assert" content="Properties inherit or not according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/inheritance-testcommon.js"></script>
@@ -15,14 +16,14 @@
 <div id="target"></div>
 </div>
 <script>
-assert_not_inherited('alignment-baseline', 'central');
-assert_not_inherited('baseline-shift', '10px');
-assert_inherited('dominant-baseline', 'central');
-assert_not_inherited('initial-letters', '2 3');
-assert_inherited('initial-letters-align', 'hanging');
-assert_inherited('initial-letters-wrap', 'grid');
-assert_not_inherited('initial-sizing', 'stretch');
-assert_not_inherited('vertical-align', '10px');
+assert_not_inherited('alignment-baseline', 'baseline', 'central');
+assert_not_inherited('baseline-shift', '0px', '10px');
+assert_inherited('dominant-baseline', 'normal', 'central');
+assert_not_inherited('initial-letters', 'normal', '2 3');
+assert_inherited('initial-letters-align', 'alphabetic', 'hanging');
+assert_inherited('initial-letters-wrap', 'none', 'grid');
+assert_not_inherited('initial-sizing', 'normal', 'stretch');
+assert_not_inherited('vertical-align', 'baseline', '10px');
 </script>
 </body>
 </html>

--- a/css/css-inline/inheritance.html
+++ b/css/css-inline/inheritance.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Inline Layout properties</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#property-index">
+<meta name="assert" content="Properties inherit or not according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="container">
+<div id="target"></div>
+</div>
+<script>
+'use strict';
+
+function assert_inherited(property, value, expected) {
+  if (expected === undefined) {
+    expected = value;
+  }
+
+  test(() => {
+    if (!getComputedStyle(target)[property])
+      return;
+    assert_not_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = value;
+    assert_equals(getComputedStyle(container)[property], expected);
+    assert_equals(getComputedStyle(target)[property], expected);
+    target.style[property] = 'initial';
+    assert_not_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = '';
+    target.style[property] = '';
+  }, 'Property ' + property + ' inherits');
+}
+
+function assert_not_inherited(property, value, expected) {
+  if (expected === undefined) {
+    expected = value;
+  }
+
+  test(() => {
+    if (!getComputedStyle(target)[property])
+      return;
+    assert_not_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = value;
+    assert_equals(getComputedStyle(container)[property], expected);
+    assert_not_equals(getComputedStyle(target)[property], expected);
+    target.style[property] = 'inherit';
+    assert_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = '';
+    target.style[property] = '';
+  }, 'Property ' + property + ' does not inherit');
+}
+
+assert_not_inherited('alignment-baseline', 'central');
+assert_not_inherited('baseline-shift', '10px');
+assert_inherited('dominant-baseline', 'central');
+assert_not_inherited('initial-letters', '2 3');
+assert_inherited('initial-letters-align', 'hanging');
+assert_inherited('initial-letters-wrap', 'grid');
+assert_not_inherited('initial-sizing', 'stretch');
+assert_not_inherited('vertical-align', '10px');
+</script>
+</body>
+</html>

--- a/css/css-inline/inheritance.html
+++ b/css/css-inline/inheritance.html
@@ -8,52 +8,13 @@
 <meta name="assert" content="Properties inherit or not according to the spec.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
 </head>
 <body>
 <div id="container">
 <div id="target"></div>
 </div>
 <script>
-'use strict';
-
-function assert_inherited(property, value, expected) {
-  if (expected === undefined) {
-    expected = value;
-  }
-
-  test(() => {
-    if (!getComputedStyle(target)[property])
-      return;
-    assert_not_equals(getComputedStyle(target)[property], expected);
-    container.style[property] = value;
-    assert_equals(getComputedStyle(container)[property], expected);
-    assert_equals(getComputedStyle(target)[property], expected);
-    target.style[property] = 'initial';
-    assert_not_equals(getComputedStyle(target)[property], expected);
-    container.style[property] = '';
-    target.style[property] = '';
-  }, 'Property ' + property + ' inherits');
-}
-
-function assert_not_inherited(property, value, expected) {
-  if (expected === undefined) {
-    expected = value;
-  }
-
-  test(() => {
-    if (!getComputedStyle(target)[property])
-      return;
-    assert_not_equals(getComputedStyle(target)[property], expected);
-    container.style[property] = value;
-    assert_equals(getComputedStyle(container)[property], expected);
-    assert_not_equals(getComputedStyle(target)[property], expected);
-    target.style[property] = 'inherit';
-    assert_equals(getComputedStyle(target)[property], expected);
-    container.style[property] = '';
-    target.style[property] = '';
-  }, 'Property ' + property + ' does not inherit');
-}
-
 assert_not_inherited('alignment-baseline', 'central');
 assert_not_inherited('baseline-shift', '10px');
 assert_inherited('dominant-baseline', 'central');

--- a/css/support/inheritance-testcommon.js
+++ b/css/support/inheritance-testcommon.js
@@ -1,40 +1,53 @@
 'use strict';
 
-function assert_inherited(property, value, expected) {
-  if (expected === undefined) {
-    expected = value;
-  }
+function assert_initial(property, initial) {
+  test(() => {
+    if (!getComputedStyle(target)[property])
+      return;
+    target.style[property] = 'initial';
+    assert_equals(getComputedStyle(target)[property], initial);
+    target.style[property] = '';
+  }, 'Property ' + property + ' has initial value ' + initial);
+}
+
+function assert_inherited(property, initial, other) {
+  assert_initial(property, initial);
 
   test(() => {
     if (!getComputedStyle(target)[property])
       return;
-    assert_not_equals(getComputedStyle(container)[property], expected);
-    assert_not_equals(getComputedStyle(target)[property], expected);
-    container.style[property] = value;
-    assert_equals(getComputedStyle(container)[property], expected);
-    assert_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = 'initial';
+    target.style[property] = 'unset';
+    assert_not_equals(getComputedStyle(container)[property], other);
+    assert_not_equals(getComputedStyle(target)[property], other);
+    container.style[property] = other;
+    assert_equals(getComputedStyle(container)[property], other);
+    assert_equals(getComputedStyle(target)[property], other);
     target.style[property] = 'initial';
-    assert_not_equals(getComputedStyle(container)[property], expected);
-    assert_not_equals(getComputedStyle(target)[property], expected);
+    assert_not_equals(getComputedStyle(container)[property], other);
+    assert_not_equals(getComputedStyle(target)[property], other);
+    target.style[property] = 'inherit';
+    assert_equals(getComputedStyle(container)[property], other);
     container.style[property] = '';
     target.style[property] = '';
   }, 'Property ' + property + ' inherits');
 }
 
-function assert_not_inherited(property, value, expected) {
-  if (expected === undefined) {
-    expected = value;
-  }
+function assert_not_inherited(property, initial, other) {
+  assert_initial(property, initial);
 
   test(() => {
     if (!getComputedStyle(target)[property])
       return;
-    assert_not_equals(getComputedStyle(target)[property], expected);
-    container.style[property] = value;
-    assert_equals(getComputedStyle(container)[property], expected);
-    assert_not_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = 'initial';
+    target.style[property] = 'unset';
+    assert_not_equals(getComputedStyle(container)[property], other);
+    assert_not_equals(getComputedStyle(target)[property], other);
+    container.style[property] = other;
+    assert_equals(getComputedStyle(container)[property], other);
+    assert_not_equals(getComputedStyle(target)[property], other);
     target.style[property] = 'inherit';
-    assert_equals(getComputedStyle(target)[property], expected);
+    assert_equals(getComputedStyle(target)[property], other);
     container.style[property] = '';
     target.style[property] = '';
   }, 'Property ' + property + ' does not inherit');

--- a/css/support/inheritance-testcommon.js
+++ b/css/support/inheritance-testcommon.js
@@ -1,0 +1,41 @@
+'use strict';
+
+function assert_inherited(property, value, expected) {
+  if (expected === undefined) {
+    expected = value;
+  }
+
+  test(() => {
+    if (!getComputedStyle(target)[property])
+      return;
+    assert_not_equals(getComputedStyle(container)[property], expected);
+    assert_not_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = value;
+    assert_equals(getComputedStyle(container)[property], expected);
+    assert_equals(getComputedStyle(target)[property], expected);
+    target.style[property] = 'initial';
+    assert_not_equals(getComputedStyle(container)[property], expected);
+    assert_not_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = '';
+    target.style[property] = '';
+  }, 'Property ' + property + ' inherits');
+}
+
+function assert_not_inherited(property, value, expected) {
+  if (expected === undefined) {
+    expected = value;
+  }
+
+  test(() => {
+    if (!getComputedStyle(target)[property])
+      return;
+    assert_not_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = value;
+    assert_equals(getComputedStyle(container)[property], expected);
+    assert_not_equals(getComputedStyle(target)[property], expected);
+    target.style[property] = 'inherit';
+    assert_equals(getComputedStyle(target)[property], expected);
+    container.style[property] = '';
+    target.style[property] = '';
+  }, 'Property ' + property + ' does not inherit');
+}


### PR DESCRIPTION
Check that properties in
https://drafts.csswg.org/css-inline-3/#property-index
inherit or not, as per spec.

e.g. dominant-baseline inherits
https://github.com/w3c/csswg-drafts/issues/2926