### PR TITLE
Sync Mozilla CSS tests as of 2018-08-21

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-overflow-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-overflow-001-ref.html
@@ -17,11 +17,6 @@
     width: 50px;
     background: lightblue;
   }
-  .inner-md {
-    height: 100px;
-    width: 100px;
-    background: lightblue;
-  }
   .inner-lg-1 {
     height: 95px;
     width: 95px;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-overflow-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-overflow-001.html
@@ -23,11 +23,6 @@
     width: 50px;
     background: lightblue;
   }
-  .inner-md {
-    height: 100px;
-    width: 100px;
-    background: lightblue;
-  }
   .inner-lg {
     height: 200px;
     width: 200px;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-overflow-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-overflow-002-ref.html
@@ -17,11 +17,6 @@
     width: 50px;
     background: lightblue;
   }
-  .inner-md {
-    height: 100px;
-    width: 100px;
-    background: lightblue;
-  }
   .inner-lg-1 {
     height: 95px;
     width: 95px;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-overflow-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-overflow-002.html
@@ -3,7 +3,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>CSS Test: 'contain: layout' should force all overflow to be ink overflow.</title>
+  <title>CSS Test: 'contain: layout' should force all overflow to be ink overflow (including when the overflow comes from floated descendants)</title>
   <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
   <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-layout">
   <link rel="match" href="contain-layout-overflow-002-ref.html">
@@ -11,6 +11,7 @@
   .contain {
     contain: layout;
   }
+  .float { float: left; }
   .outer {
     height: 100px;
     width: 100px;
@@ -23,16 +24,10 @@
     width: 50px;
     background: lightblue;
   }
-  .inner-md {
-    height: 100px;
-    width: 100px;
-    background: lightblue;
-  }
   .inner-lg {
     height: 200px;
     width: 200px;
     background: lightblue;
-    float: left;
   }
   .pass {
     background: green;
@@ -48,24 +43,23 @@
 <body>
   <!--CSS Test: Elements with contain:layout that do not produce scrollable overflow should paint as if containment were not applied. -->
   <div class="outer">
-    <div class="inner-sm contain" style="float:left;"></div>
+    <div class="inner-sm contain float"></div>
   </div>
   <br>
 
   <!--CSS Test: Layout-contained elements that overflow their container and have children who overflow should produce the same amount of scrollable overflow as if there were no children. -->
   <div class="outer auto">
-    <div class="outer contain">
-      <div class="inner-lg pass"></div>
-      <div class="inner-lg fail"></div>
+    <div class="inner-lg contain">
+      <div class="inner-lg pass float"></div>
+      <div class="inner-lg fail float"></div>
     </div>
   </div>
   <br>
 
-
   <!--CSS Test: Layout-contained elements that do not overflow their container, but have children who overflow, should not allow their children to affect the scrollable overflow regions of their parent. -->
   <div class="outer auto">
     <div class="inner-sm contain border">
-      <div class="inner-lg">
+      <div class="inner-lg float">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/a955df76e2b636889a1c37a7863739d6306520eb .

This contains only changes from [bug 1481951](https://bugzilla.mozilla.org/show_bug.cgi?id=1481951), by @dholbert, reviewed by me.