### PR TITLE
[Shadow DOM] Fix test using assert_array_equals

### DIFF
--- a/shadow-dom/Extensions-to-Event-Interface.html
+++ b/shadow-dom/Extensions-to-Event-Interface.html
@@ -54,7 +54,6 @@ function testComposedEvent(mode) {
 
         var expectedPath = ['A1a', 'A1-SR', 'A1', 'A-SR', 'A'];
         assert_array_equals(log.eventPath, expectedPath);
-        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], expectedPath);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
         assert_array_equals(log.pathAtTargets[2], mode == 'open' ? expectedPath : ['A1', 'A-SR', 'A'],
@@ -82,7 +81,6 @@ function testNonComposedEvent(mode) {
 
         var expectedPath = ['A1a', 'A1-SR'];
         assert_array_equals(log.eventPath, expectedPath);
-        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], expectedPath);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
     }, 'The event must not propagate out of ' + mode + ' mode shadow boundaries when the composed flag is unset');
@@ -108,7 +106,6 @@ function testNonComposedEventWithRelatedTarget(mode) {
 
         var expectedPath = ['A1a', 'A1-SR'];
         assert_array_equals(log.eventPath, expectedPath);
-        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], expectedPath);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
         assert_array_equals(log.relatedTargets, ['A2-S', 'A2-S']);
@@ -136,7 +133,6 @@ function testScopedEventWithUnscopedRelatedTargetThroughSlot(mode) {
         var expectedPath = ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR'];
         var pathExposedToB1a = ['B1a', 'B1', 'B-SR'];
         assert_array_equals(log.eventPath, expectedPath);
-        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], mode == 'open' ? expectedPath : pathExposedToB1a);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
         assert_array_equals(log.pathAtTargets[2], expectedPath);
@@ -167,7 +163,6 @@ function testComposedEventWithRelatedTarget(mode) {
         var expectedPath = ['A1a', 'A1-SR', 'A1', 'A-SR'];
         var pathExposedToA1 = ['A1', 'A-SR'];
         assert_array_equals(log.eventPath, expectedPath);
-        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], expectedPath);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
         assert_array_equals(log.pathAtTargets[2], mode == 'open' ? expectedPath : pathExposedToA1);
@@ -202,7 +197,6 @@ function testComposedEventThroughSlot(mode) {
         var pathExposedToA1 =       [                                       'B', 'A2-S', 'A-SR', 'A'];
 
         assert_array_equals(log.eventPath, expectedPath);
-        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], mode == 'open' ? expectedPath : pathExposedToB1a);
         assert_array_equals(log.pathAtTargets[1], mode == 'open' ? expectedPath : pathExposedToB1cS);
         assert_array_equals(log.pathAtTargets[2], mode == 'open' ? expectedPath : pathExposedToB1cS);

--- a/shadow-dom/Extensions-to-Event-Interface.html
+++ b/shadow-dom/Extensions-to-Event-Interface.html
@@ -54,6 +54,7 @@ function testComposedEvent(mode) {
 
         var expectedPath = ['A1a', 'A1-SR', 'A1', 'A-SR', 'A'];
         assert_array_equals(log.eventPath, expectedPath);
+        assert_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], expectedPath);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
         assert_array_equals(log.pathAtTargets[2], mode == 'open' ? expectedPath : ['A1', 'A-SR', 'A'],
@@ -81,6 +82,7 @@ function testNonComposedEvent(mode) {
 
         var expectedPath = ['A1a', 'A1-SR'];
         assert_array_equals(log.eventPath, expectedPath);
+        assert_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], expectedPath);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
     }, 'The event must not propagate out of ' + mode + ' mode shadow boundaries when the composed flag is unset');
@@ -106,6 +108,7 @@ function testNonComposedEventWithRelatedTarget(mode) {
 
         var expectedPath = ['A1a', 'A1-SR'];
         assert_array_equals(log.eventPath, expectedPath);
+        assert_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], expectedPath);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
         assert_array_equals(log.relatedTargets, ['A2-S', 'A2-S']);
@@ -133,6 +136,7 @@ function testScopedEventWithUnscopedRelatedTargetThroughSlot(mode) {
         var expectedPath = ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR'];
         var pathExposedToB1a = ['B1a', 'B1', 'B-SR'];
         assert_array_equals(log.eventPath, expectedPath);
+        assert_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], mode == 'open' ? expectedPath : pathExposedToB1a);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
         assert_array_equals(log.pathAtTargets[2], expectedPath);
@@ -163,6 +167,7 @@ function testComposedEventWithRelatedTarget(mode) {
         var expectedPath = ['A1a', 'A1-SR', 'A1', 'A-SR'];
         var pathExposedToA1 = ['A1', 'A-SR'];
         assert_array_equals(log.eventPath, expectedPath);
+        assert_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], expectedPath);
         assert_array_equals(log.pathAtTargets[1], expectedPath);
         assert_array_equals(log.pathAtTargets[2], mode == 'open' ? expectedPath : pathExposedToA1);
@@ -197,6 +202,7 @@ function testComposedEventThroughSlot(mode) {
         var pathExposedToA1 =       [                                       'B', 'A2-S', 'A-SR', 'A'];
 
         assert_array_equals(log.eventPath, expectedPath);
+        assert_equals(log.eventPath.length, log.pathAtTargets.length);
         assert_array_equals(log.pathAtTargets[0], mode == 'open' ? expectedPath : pathExposedToB1a);
         assert_array_equals(log.pathAtTargets[1], mode == 'open' ? expectedPath : pathExposedToB1cS);
         assert_array_equals(log.pathAtTargets[2], mode == 'open' ? expectedPath : pathExposedToB1cS);

--- a/shadow-dom/leaktests/get-elements.html
+++ b/shadow-dom/leaktests/get-elements.html
@@ -85,12 +85,12 @@ test(function() {
     assert_equals(doc.querySelectorAll('.bar').length, 1);
     assert_equals(doc.getElementsByClassName('bar')[0].getAttribute('label'), 'doc-div');
 
-    assert_array_equals(hostOpen.querySelectorAll('.bar').length, 0);
+    assert_equals(hostOpen.querySelectorAll('.bar').length, 0);
 
     assert_equals(shadowOpen.querySelectorAll('.bar').length, 1);
     assert_equals(shadowOpen.querySelectorAll('.bar')[0].getAttribute('label'), 'shadow-open-div');
 
-    assert_array_equals(hostClosed.querySelectorAll('.bar').length, 0);
+    assert_equals(hostClosed.querySelectorAll('.bar').length, 0);
 
     assert_equals(shadowClosed.querySelectorAll('.bar').length, 1);
     assert_equals(shadowClosed.querySelectorAll('.bar')[0].getAttribute('label'), 'shadow-closed-div');
@@ -106,11 +106,11 @@ test(function() {
 
     assert_equals(doc.querySelectorAll('[name=baz]').length, 1);
 
-    assert_array_equals(hostOpen.querySelectorAll('[name=baz]').length, 0);
+    assert_equals(hostOpen.querySelectorAll('[name=baz]').length, 0);
     assert_equals(shadowOpen.querySelectorAll('[name=baz]').length, 1);
     assert_equals(shadowOpen.querySelectorAll('[name=baz]')[0].getAttribute('label'), 'shadow-open-form');
 
-    assert_array_equals(hostClosed.querySelectorAll('[name=baz]').length, 0);
+    assert_equals(hostClosed.querySelectorAll('[name=baz]').length, 0);
     assert_equals(shadowClosed.querySelectorAll('[name=baz]').length, 1);
     assert_equals(shadowClosed.querySelectorAll('[name=baz]')[0].getAttribute('label'), 'shadow-closed-form');
 }, 'getElementsByName() should not leak nodes in shadow tree');
@@ -126,12 +126,12 @@ test(function() {
     assert_equals(doc.querySelectorAll('my-element').length, 1);
     assert_equals(doc.getElementsByTagName('my-element')[0].getAttribute('label'), 'doc-my-element');
 
-    assert_array_equals(hostOpen.querySelectorAll('my-element').length, 0);
+    assert_equals(hostOpen.querySelectorAll('my-element').length, 0);
     // ShadowRoot isn't an Element, does not have getElementsByTagName().
     assert_equals(shadowOpen.querySelectorAll('my-element').length, 1);
     assert_equals(shadowOpen.querySelectorAll('my-element')[0].getAttribute('label'), 'shadow-open-my-element');
 
-    assert_array_equals(hostClosed.querySelectorAll('my-element').length, 0);
+    assert_equals(hostClosed.querySelectorAll('my-element').length, 0);
     assert_equals(shadowClosed.querySelectorAll('my-element').length, 1);
     assert_equals(shadowClosed.querySelectorAll('my-element')[0].getAttribute('label'), 'shadow-closed-my-element');
 }, 'getElementsByTagName() should not leak nodes in shadow tree');


### PR DESCRIPTION
Fix occurences of assert_array_equals where it is used to compare the array length instead of the array itself.

https://staging.wpt.fyi/results/shadow-dom/leaktests/get-elements.html?sha=0398567bac
https://staging.wpt.fyi/results/shadow-dom/Extensions-to-Event-Interface.html?sha=0398567bac