### PR TITLE
[wptrunner] Report unstable tests with exit code

### DIFF
--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -314,7 +314,7 @@ def start(**kwargs):
     elif kwargs["list_tests"]:
         list_tests(**kwargs)
     elif kwargs["verify"] or kwargs["stability"]:
-        check_stability(**kwargs)
+        return check_stability(**kwargs)
     else:
         return not run_tests(**kwargs)
 


### PR DESCRIPTION
When `wpt run` is invoked with the `--verify` flag, any instability
reflects a failure state. Update the CLI to communicate this failure by
exiting with a non-zero exit code.