### PR TITLE
HTML: more tests for document.open bailout order

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.js
@@ -1,0 +1,82 @@
+document.domain = "{{host}}";
+
+async_test(t => {
+  const iframe = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => { iframe.remove(); });
+  iframe.onload = t.step_func(() => {
+    // Here, the entry settings object is still the iframe's. Delay it in such
+    // a way that makes the entry settings object the top-level page's, but
+    // without delaying too much that the parser becomes inactive. A microtask
+    // is perfect as it's executed in "clean up after running script".
+    Promise.resolve().then(t.step_func_done(() => {
+      assert_throws("InvalidStateError", () => {
+        iframe.contentDocument.open();
+      }, "opening an XML document should throw an InvalidStateError");
+    }));
+  });
+  const frameURL = new URL("resources/bailout-order-xml-with-domain-frame.sub.xhtml", document.URL);
+  frameURL.port = "{{ports[http][1]}}";
+  iframe.src = frameURL.href;
+}, "document.open should throw an InvalidStateError with XML document even if it is cross-origin");
+
+async_test(t => {
+  const iframe = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => { iframe.remove(); });
+  window.onCustomElementReady = t.step_func(() => {
+    window.onCustomElementReady = t.unreached_func("onCustomElementReady called again");
+    // Here, the entry settings object is still the iframe's. Delay it in such
+    // a way that makes the entry settings object the top-level page's, but
+    // without delaying too much that the throw-on-dynamic-markup-insertion
+    // counter gets decremented. A microtask is perfect as it's executed in
+    // "clean up after running script".
+    Promise.resolve().then(t.step_func_done(() => {
+      assert_throws("InvalidStateError", () => {
+        iframe.contentDocument.open();
+      }, "opening a document from a custom element constructor should throw an InvalidStateError");
+    }));
+  });
+  const frameURL = new URL("resources/bailout-order-custom-element-with-domain-frame.sub.html", document.URL);
+  frameURL.port = "{{ports[http][1]}}";
+  iframe.src = frameURL.href;
+}, "document.open should throw an InvalidStateError during custom element constructor even if the document is cross-origin");
+
+async_test(t => {
+  const iframe = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => { iframe.remove(); });
+  self.testSynchronousScript = t.step_func(() => {
+    // Here, the entry settings object is still the iframe's. Delay it in such
+    // a way that makes the entry settings object the top-level page's, but
+    // without delaying too much that the parser becomes inactive. A microtask
+    // is perfect as it's executed in "clean up after running script".
+    Promise.resolve().then(t.step_func_done(() => {
+      assert_throws("SecurityError", () => {
+        iframe.contentDocument.open();
+      }, "opening a same origin-domain (but not same origin) document should throw a SecurityError");
+    }));
+  });
+  const frameURL = new URL("resources/bailout-order-synchronous-script-with-domain-frame.sub.html", document.URL);
+  frameURL.port = "{{ports[http][1]}}";
+  iframe.src = frameURL.href;
+}, "document.open should throw a SecurityError with cross-origin document even when there is an active parser executing script");
+
+for (const ev of ["beforeunload", "pagehide", "unload"]) {
+  async_test(t => {
+    const iframe = document.body.appendChild(document.createElement("iframe"));
+    t.add_cleanup(() => { iframe.remove(); });
+    iframe.addEventListener("load", t.step_func(() => {
+      iframe.contentWindow.addEventListener(ev, t.step_func(() => {
+        // Here, the entry settings object could still be the iframe's. Delay
+        // it in such a way that makes the entry settings object the top-level
+        // page's. A microtask is perfect as it's executed in "clean up after
+        // running script".
+        Promise.resolve().then(t.step_func_done(() => {
+          assert_throws("SecurityError", () => {
+            iframe.contentDocument.open();
+          }, "opening a same origin-domain (but not same origin) document should throw a SecurityError");
+        }));
+      }));
+      iframe.src = "about:blank";
+    }), { once: true });
+    iframe.src = "http://{{host}}:{{ports[http][1]}}/common/domain-setter.sub.html";
+  }, `document.open should throw a SecurityError with cross-origin document even when the ignore-opens-during-unload counter is greater than 0 (during ${ev} event)`);
+}

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.js
@@ -1,18 +1,22 @@
 document.domain = "{{host}}";
 
+// In many cases in this test, we want to delay execution of a piece of code so
+// that the entry settings object would be the top-level page. A microtask is
+// perfect for this purpose as it is executed in the "clean up after running
+// script" algorithm, which is generally called right after the callback.
+function setEntryToTopLevel(cb) {
+  Promise.resolve().then(cb);
+}
+
 async_test(t => {
   const iframe = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => { iframe.remove(); });
-  iframe.onload = t.step_func(() => {
-    // Here, the entry settings object is still the iframe's. Delay it in such
-    // a way that makes the entry settings object the top-level page's, but
-    // without delaying too much that the parser becomes inactive. A microtask
-    // is perfect as it's executed in "clean up after running script".
-    Promise.resolve().then(t.step_func_done(() => {
-      assert_throws("InvalidStateError", () => {
-        iframe.contentDocument.open();
-      }, "opening an XML document should throw an InvalidStateError");
-    }));
+  iframe.onload = t.step_func_done(() => {
+    // Since this is called as an event handler on an element of this window,
+    // the entry settings object is that of this browsing context.
+    assert_throws("InvalidStateError", () => {
+      iframe.contentDocument.open();
+    }, "opening an XML document should throw an InvalidStateError");
   });
   const frameURL = new URL("resources/bailout-order-xml-with-domain-frame.sub.xhtml", document.URL);
   frameURL.port = "{{ports[http][1]}}";
@@ -24,31 +28,38 @@ async_test(t => {
   t.add_cleanup(() => { iframe.remove(); });
   window.onCustomElementReady = t.step_func(() => {
     window.onCustomElementReady = t.unreached_func("onCustomElementReady called again");
-    // Here, the entry settings object is still the iframe's. Delay it in such
-    // a way that makes the entry settings object the top-level page's, but
-    // without delaying too much that the throw-on-dynamic-markup-insertion
-    // counter gets decremented. A microtask is perfect as it's executed in
-    // "clean up after running script".
-    Promise.resolve().then(t.step_func_done(() => {
+    // Here, the entry settings object is still the iframe's, as the function
+    // is called from a custom element constructor in the iframe document.
+    // Delay execution in such a way that makes the entry settings object the
+    // top-level page's, but without delaying too much that the
+    // throw-on-dynamic-markup-insertion counter gets decremented (which is
+    // what this test tries to pit against the cross-origin document check).
+    //
+    // "Clean up after running script" is executed through the "construct" Web
+    // IDL algorithm in "create an element", called by "create an element for a
+    // token" in the parser.
+    setEntryToTopLevel(t.step_func_done(() => {
       assert_throws("InvalidStateError", () => {
         iframe.contentDocument.open();
-      }, "opening a document from a custom element constructor should throw an InvalidStateError");
+      }, "opening a document when the throw-on-dynamic-markup-insertion counter is incremented should throw an InvalidStateError");
     }));
   });
   const frameURL = new URL("resources/bailout-order-custom-element-with-domain-frame.sub.html", document.URL);
   frameURL.port = "{{ports[http][1]}}";
   iframe.src = frameURL.href;
-}, "document.open should throw an InvalidStateError during custom element constructor even if the document is cross-origin");
+}, "document.open should throw an InvalidStateError when the throw-on-dynamic-markup-insertion counter is incremented even if the document is cross-origin");
 
 async_test(t => {
   const iframe = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => { iframe.remove(); });
   self.testSynchronousScript = t.step_func(() => {
-    // Here, the entry settings object is still the iframe's. Delay it in such
-    // a way that makes the entry settings object the top-level page's, but
-    // without delaying too much that the parser becomes inactive. A microtask
-    // is perfect as it's executed in "clean up after running script".
-    Promise.resolve().then(t.step_func_done(() => {
+    // Here, the entry settings object is still the iframe's, as the function
+    // is synchronously called from a <script> element in the iframe's
+    // document.
+    //
+    // "Clean up after running script" is executed when the </script> tag is
+    // seen by the HTML parser.
+    setEntryToTopLevel(t.step_func_done(() => {
       assert_throws("SecurityError", () => {
         iframe.contentDocument.open();
       }, "opening a same origin-domain (but not same origin) document should throw a SecurityError");
@@ -65,11 +76,15 @@ for (const ev of ["beforeunload", "pagehide", "unload"]) {
     t.add_cleanup(() => { iframe.remove(); });
     iframe.addEventListener("load", t.step_func(() => {
       iframe.contentWindow.addEventListener(ev, t.step_func(() => {
-        // Here, the entry settings object could still be the iframe's. Delay
-        // it in such a way that makes the entry settings object the top-level
-        // page's. A microtask is perfect as it's executed in "clean up after
-        // running script".
-        Promise.resolve().then(t.step_func_done(() => {
+        // Here, the entry settings object should be the top-level page's, as
+        // the callback context of this event listener is the incumbent
+        // settings object, which is the this page. However, due to a Chrome
+        // bug (https://crbug.com/606900), the entry settings object may be
+        // mis-set to the iframe's.
+        //
+        // "Clean up after running script" is called in the task that
+        // navigates.
+        setEntryToTopLevel(t.step_func_done(() => {
           assert_throws("SecurityError", () => {
             iframe.contentDocument.open();
           }, "opening a same origin-domain (but not same origin) document should throw a SecurityError");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-xml.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-xml.window.js
@@ -1,0 +1,32 @@
+async_test(t => {
+  const iframe = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => { iframe.remove(); });
+  self.testSynchronousScript = t.step_func(() => {
+    // Here, the entry settings object is still the iframe's. Delay it in such
+    // a way that makes the entry settings object the top-level page's, but
+    // without delaying too much that the parser becomes inactive. A microtask
+    // is perfect as it's executed in "clean up after running script".
+    Promise.resolve().then(t.step_func_done(() => {
+      assert_throws("InvalidStateError", () => {
+        iframe.contentDocument.open();
+      }, "opening an XML document should throw");
+    }));
+  });
+  iframe.src = "resources/bailout-order-xml-with-synchronous-script-frame.xhtml";
+}, "document.open should throw an InvalidStateError with XML document even when there is an active parser executing script");
+
+for (const ev of ["beforeunload", "pagehide", "unload"]) {
+  async_test(t => {
+    const iframe = document.body.appendChild(document.createElement("iframe"));
+    t.add_cleanup(() => { iframe.remove(); });
+    iframe.addEventListener("load", t.step_func(() => {
+      iframe.contentWindow.addEventListener(ev, t.step_func_done(() => {
+        assert_throws("InvalidStateError", () => {
+          iframe.contentDocument.open();
+        }, "opening an XML document should throw");
+      }));
+      iframe.src = "about:blank";
+    }), { once: true });
+    iframe.src = "/common/dummy.xhtml";
+  }, `document.open should throw an InvalidStateError with XML document even when the ignore-opens-during-unload counter is greater than 0 (during ${ev} event)`);
+}

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-xml.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-xml.window.js
@@ -1,16 +1,10 @@
 async_test(t => {
   const iframe = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => { iframe.remove(); });
-  self.testSynchronousScript = t.step_func(() => {
-    // Here, the entry settings object is still the iframe's. Delay it in such
-    // a way that makes the entry settings object the top-level page's, but
-    // without delaying too much that the parser becomes inactive. A microtask
-    // is perfect as it's executed in "clean up after running script".
-    Promise.resolve().then(t.step_func_done(() => {
-      assert_throws("InvalidStateError", () => {
-        iframe.contentDocument.open();
-      }, "opening an XML document should throw");
-    }));
+  self.testSynchronousScript = t.step_func_done(() => {
+    assert_throws("InvalidStateError", () => {
+      iframe.contentDocument.open();
+    }, "opening an XML document should throw");
   });
   iframe.src = "resources/bailout-order-xml-with-synchronous-script-frame.xhtml";
 }, "document.open should throw an InvalidStateError with XML document even when there is an active parser executing script");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-custom-element-with-domain-frame.sub.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-custom-element-with-domain-frame.sub.html
@@ -1,0 +1,13 @@
+<p>Text</p>
+<script>
+document.domain = "{{host}}";
+
+class CustomElement extends HTMLElement {
+  constructor() {
+    super();
+    parent.onCustomElementReady();
+  }
+}
+customElements.define("custom-element", CustomElement);
+</script>
+<custom-element></custom-element>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-synchronous-script-with-domain-frame.sub.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-synchronous-script-with-domain-frame.sub.html
@@ -1,0 +1,5 @@
+<p>Text</p>
+<script>
+document.domain = "{{host}}";
+parent.testSynchronousScript();
+</script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-xml-with-domain-frame.sub.xhtml
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-xml-with-domain-frame.sub.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <head><title>Dummy XHTML document</title></head>
+  <head><title>XHTML document with domain set</title></head>
   <body>
     <p>Text</p>
     <script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-xml-with-domain-frame.sub.xhtml
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-xml-with-domain-frame.sub.xhtml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Dummy XHTML document</title></head>
+  <body>
+    <p>Text</p>
+    <script>
+      document.domain = "{{host}}";
+    </script>
+  </body>
+</html>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-xml-with-synchronous-script-frame.xhtml
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-xml-with-synchronous-script-frame.xhtml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Dummy XHTML document</title></head>
+  <body>
+    <p>Text</p>
+    <script>
+      parent.testSynchronousScript();
+    </script>
+  </body>
+</html>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-xml-with-synchronous-script-frame.xhtml
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/bailout-order-xml-with-synchronous-script-frame.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <head><title>Dummy XHTML document</title></head>
+  <head><title>XHTML document with hook to run script from a script tag</title></head>
   <body>
     <p>Text</p>
     <script>


### PR DESCRIPTION
A continuation of https://github.com/web-platform-tests/wpt/pull/12240, but this treats cases when two bailout criteria compete against each other.

- Chrome passes all tests.
- Safari fails 5 out of 6 tests in bailout-exception-vs-return-origin.sub.window.js as they don't implement the same origin check yet, and because Safari Tech Preview hasn't gotten the [fix](https://bugs.webkit.org/show_bug.cgi?id=187319) for `document.open()` in custom element constructor yet. It passes all four tests in bailout-exception-vs-return-xml.window.js.
- Firefox passes 3 out of 6 tests in bailout-exception-vs-return-origin.sub.window.js due to internal bailout ordering differences and all four tests in bailout-exception-vs-return-xml.window.js.
- Edge only implements the active parser running script bailout so there isn't any meaningful ordering to test.

See https://github.com/whatwg/html/issues/3818.