### PR TITLE
[HTTP/2.0] Minor tweaks and more tests

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -492,9 +492,10 @@ def start_servers(host, ports, paths, routes, bind_address, config, **kwargs):
     for scheme, ports in ports.items():
         assert len(ports) == {"http":2}.get(scheme, 1)
 
-        # TODO Not very ideal, look into removing it in the future
-        # Check that python 2.7.15 is being used for HTTP/2.0
+        # If trying to start HTTP/2.0 server, check compatibility
         if scheme == 'http2' and not http2_compatible():
+            logger.error('Cannot start HTTP/2.0 server as the environment is not compatible. ' +
+                         'Requires Python 2.7.10+ (< 3.0) and OpenSSL 1.0.2+')
             continue
 
         for port in ports:

--- a/tools/wptserve/tests/functional/test_server.py
+++ b/tools/wptserve/tests/functional/test_server.py
@@ -4,7 +4,7 @@ import pytest
 from six.moves.urllib.error import HTTPError
 
 wptserve = pytest.importorskip("wptserve")
-from .base import TestUsingServer
+from .base import TestUsingServer, TestUsingH2Server
 
 
 class TestFileHandler(TestUsingServer):
@@ -39,6 +39,52 @@ class TestRequestHandler(TestUsingServer):
             self.request("/test/raises")
 
         self.assertEqual(cm.exception.code, 500)
+
+class TestFileHandlerH2(TestUsingH2Server):
+    def test_not_handled(self):
+        self.conn.request("GET", "/not_existing")
+        resp = self.conn.get_response()
+
+        assert resp.status == 404
+
+class TestRewriterH2(TestUsingH2Server):
+    def test_rewrite(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            return request.request_path
+
+        route = ("GET", "/test/rewritten", handler)
+        self.server.rewriter.register("GET", "/test/original", route[1])
+        self.server.router.register(*route)
+        self.conn.request("GET", "/test/original")
+        resp = self.conn.get_response()
+        assert resp.status == 200
+        assert resp.read() == b"/test/rewritten"
+
+class TestRequestHandlerH2(TestUsingH2Server):
+    def test_exception(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            raise Exception
+
+        route = ("GET", "/test/raises", handler)
+        self.server.router.register(*route)
+        self.conn.request("GET", "/test/raises")
+        resp = self.conn.get_response()
+
+        assert resp.status == 500
+
+    def test_frame_handler_exception(self):
+        class handler_cls:
+            def frame_handler(self, request):
+                raise Exception
+
+        route = ("GET", "/test/raises", handler_cls())
+        self.server.router.register(*route)
+        self.conn.request("GET", "/test/raises")
+        resp = self.conn.get_response()
+
+        assert resp.status == 500
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -354,6 +354,10 @@ class Http2WebTestRequestHandler(BaseWebTestRequestHandler):
         try:
             while not self.close_connection:
                 data = self.request.recv(window_size)
+                if data == '':
+                    self.logger.debug('(%s) Socket Closed' % self.uid)
+                    self.close_connection = True
+                    continue
 
                 with self.conn as connection:
                     frames = connection.receive_data(data)


### PR DESCRIPTION
2 of these are very small, such as adding an Error log message if someone tries to start the h2 server but their environment doesn't match. The other minor one is when reading from the socket using `recv()` and you read a 0 length string, this indicates a closed socket. Just added something to handle this properly. 

I also added some tests to make sure H2 functionality in wptserve/server.py works correctly. 