### PR TITLE
HTML: add test for history.state after document.open()

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/history-state.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/history-state.window.js
@@ -22,4 +22,4 @@ async_test(t => {
     iframe.contentDocument.open("", "replace");
     assert_equals(iframe.contentWindow.history.state, "state");
   });
-}, "history.state is kept by document.open() (with legacy replace parameter set)");
+}, "history.state is kept by document.open() (with historical replace parameter set)");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/history-state.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/history-state.window.js
@@ -1,0 +1,25 @@
+async_test(t => {
+  const iframe = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => iframe.remove());
+  iframe.src = "/common/blank.html";
+  iframe.onload = t.step_func_done(() => {
+    assert_equals(iframe.contentWindow.history.state, null);
+    iframe.contentWindow.history.replaceState("state", "");
+    assert_equals(iframe.contentWindow.history.state, "state");
+    iframe.contentDocument.open();
+    assert_equals(iframe.contentWindow.history.state, "state");
+  });
+}, "history.state is kept by document.open()");
+
+async_test(t => {
+  const iframe = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => iframe.remove());
+  iframe.src = "/common/blank.html";
+  iframe.onload = t.step_func_done(() => {
+    assert_equals(iframe.contentWindow.history.state, null);
+    iframe.contentWindow.history.replaceState("state", "");
+    assert_equals(iframe.contentWindow.history.state, "state");
+    iframe.contentDocument.open("", "replace");
+    assert_equals(iframe.contentWindow.history.state, "state");
+  });
+}, "history.state is kept by document.open() (with legacy replace parameter set)");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/history-state.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/history-state.window.js
@@ -3,11 +3,13 @@ async_test(t => {
   t.add_cleanup(() => iframe.remove());
   iframe.src = "/common/blank.html";
   iframe.onload = t.step_func_done(() => {
-    assert_equals(iframe.contentWindow.history.state, null);
-    iframe.contentWindow.history.replaceState("state", "");
-    assert_equals(iframe.contentWindow.history.state, "state");
-    iframe.contentDocument.open();
-    assert_equals(iframe.contentWindow.history.state, "state");
+    const win = iframe.contentWindow;
+    const doc = iframe.contentDocument;
+    assert_equals(win.history.state, null);
+    win.history.replaceState("state", "");
+    assert_equals(win.history.state, "state");
+    assert_equals(doc.open(), doc);
+    assert_equals(win.history.state, "state");
   });
 }, "history.state is kept by document.open()");
 
@@ -16,10 +18,12 @@ async_test(t => {
   t.add_cleanup(() => iframe.remove());
   iframe.src = "/common/blank.html";
   iframe.onload = t.step_func_done(() => {
-    assert_equals(iframe.contentWindow.history.state, null);
-    iframe.contentWindow.history.replaceState("state", "");
-    assert_equals(iframe.contentWindow.history.state, "state");
-    iframe.contentDocument.open("", "replace");
-    assert_equals(iframe.contentWindow.history.state, "state");
+    const win = iframe.contentWindow;
+    const doc = iframe.contentDocument;
+    assert_equals(win.history.state, null);
+    win.history.replaceState("state", "");
+    assert_equals(win.history.state, "state");
+    assert_equals(doc.open("", "replace"), doc);
+    assert_equals(win.history.state, "state");
   });
 }, "history.state is kept by document.open() (with historical replace parameter set)");


### PR DESCRIPTION
Chrome, Firefox, and Safari pass this.

For https://github.com/whatwg/html/pull/3946.