### PR TITLE
Do initEvent() before the test

### DIFF
--- a/dom/events/Event-defaultPrevented.html
+++ b/dom/events/Event-defaultPrevented.html
@@ -40,6 +40,7 @@ test(function() {
   assert_equals(ev.defaultPrevented, true, "defaultPrevented");
 }, "preventDefault() should change defaultPrevented if cancelable is true.");
 test(function() {
+  ev.initEvent("foo", true, true);
   assert_equals(ev.cancelable, true, "cancelable (before)");
   ev.returnValue = false;
   assert_equals(ev.cancelable, true, "cancelable (after)");


### PR DESCRIPTION
In the previous test(36-41), "ev.defaultPrevented" is true.
If we don't do the initEvent() in this test, the value is still true in the beginning.
Then we don't know whether "ev.returnValue = false;" is work or not.