### PR TITLE
HTML: fixup for legend position: relative test

### DIFF
--- a/html/rendering/non-replaced-elements/the-fieldset-element-0/legend-position-relative.html
+++ b/html/rendering/non-replaced-elements/the-fieldset-element-0/legend-position-relative.html
@@ -3,7 +3,7 @@
 <link rel=match href=legend-position-relative-ref.html>
 <style>
 fieldset { border: 100px solid lime; width: 200px; padding: 0; margin: 0 }
-legend { position: relative; left: 100px; width: 100px; padding: 0 }
+legend { position: relative; left: 100px; width: 100px; height: 100px; padding: 0 }
 .behind { position: absolute; left: 208px; width: 100px; height: 100px; background: red; z-index: -1 }
 </style>
 <p>There should be no red.</p>


### PR DESCRIPTION
This test fails in Firefox because it doesn't leave a gap for the
legend, but this test isn't intended to test that.