### PR TITLE
Update webkit-pseudo-element test with correct spec link

### DIFF
--- a/css/selectors/webkit-pseudo-element.html
+++ b/css/selectors/webkit-pseudo-element.html
@@ -2,7 +2,7 @@
 <title>WebKit-prefixed pseudo-elements</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
-<link rel="help" href="https://compat.spec.whatwg.org/#css-webkit-pseudo-elements">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#compat">
 <meta name="assert" content="WebKit-prefixed pseudo-elements should always be valid">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
To reflect that this was added into selectors spec rather than compat spec, and update the link correspondingly.

Related to w3c/csswg-drafts#3051.