### PR TITLE
Add historical tests for SSML in Speech API

### DIFF
--- a/speech-api/SpeechSynthesis-speak-SSML.html
+++ b/speech-api/SpeechSynthesis-speak-SSML.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+// This test ensures that SSML is *not* supported, see spec change at
+// https://github.com/w3c/speech-api/pull/38.
+
+// The shortest possible valid SSML document to speak "one":
+const ssmlText = `<speak version="1.1"
+       xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="en-US">
+  one
+</speak>`;
+
+// A precondition test to ensure the SSML can be parsed.
+// The resulting document isn't used in the actual test.
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(ssmlText, 'text/xml');
+  assert_equals(doc.documentElement.textContent.trim(), 'one');
+}, 'precondition: valid XML document');
+
+async_test(t => {
+  // The assumption of this test is that if SSML is *not* supported at all,
+  // then "less than speak version equals one point one ..." will be spoken,
+  // which will take at least twice as long as just "one".
+  const textUtterance = new SpeechSynthesisUtterance('one');
+  textUtterance.onerror = t.unreached_func('textUtterance.onerror');
+  textUtterance.lang = 'en-US';
+
+  const ssmlUtterance = new SpeechSynthesisUtterance(ssmlText);
+  ssmlUtterance.onerror = t.unreached_func('ssmlUtterance.onerror');
+
+  test_driver.bless('speechSynthesis.speak', t.step_func(() => {
+    // First measure the duration of a plain "one".
+    const textUtteranceStart = performance.now();
+    speechSynthesis.speak(textUtterance);
+    textUtterance.onend = t.step_func(() => {
+      const textUtteranceDuration = performance.now() - textUtteranceStart;
+
+      // Now speak the SSML "one" with a timeout.
+      speechSynthesis.speak(ssmlUtterance);
+      // Test passes if the end event isn't fired before the timeout.
+      ssmlUtterance.onend = t.unreached_func('SSML utterance took less than twice as long as plain utterance');
+      t.step_timeout(t.step_func_done(), 2 * textUtteranceDuration);
+    });
+  }));
+}, 'SpeechSynthesisUtterance with SSML text should not be supported');
+</script>

--- a/speech-api/historical.html
+++ b/speech-api/historical.html
@@ -16,4 +16,10 @@
     assert_false(name in window);
   }, name + " interface should not exist");
 });
+
+// https://github.com/w3c/speech-api/pull/38
+test(() => {
+  assert_false("onmark" in SpeechSynthesisUtterance.prototype, "on prototype");
+  assert_false("onmark" in new SpeechSynthesisUtterance, "on instance");
+}, "onmark event handler attribute (for SSML) should not exist");
 </script>


### PR DESCRIPTION
The onmark event handler attribute should be removed.

SpeechSynthesis-speak-SSML.html also checks for the non-support of
SSML based on the time it takes to speak an SSML document, making
reasonable assumptions about the time it would take if supported.

Follows https://github.com/w3c/speech-api/pull/38.