### PR TITLE
Make reftests 800x600 everywhere

### DIFF
--- a/docs/_reviewing-tests/checklist.md
+++ b/docs/_reviewing-tests/checklist.md
@@ -110,7 +110,7 @@ the same way as the test.
 
 <label>
 <input type="checkbox">
-The test and reference render within a 600x600 viewport, only displaying
+The test and reference render within a 800x600 viewport, only displaying
 scrollbars if their presence is being tested.
 </label>
 
@@ -180,7 +180,7 @@ several minutes thinking or asking questions.
 
 <label>
 <input type="checkbox">
-The test renders within a 600x600 viewport, only displaying scrollbars if their
+The test renders within a 800x600 viewport, only displaying scrollbars if their
 presence is being tested.
 </label>
 

--- a/docs/_writing-tests/assumptions.md
+++ b/docs/_writing-tests/assumptions.md
@@ -8,7 +8,7 @@ The tests make a number of assumptions of the user agent, and new
 tests can freely rely on these assumptions being true:
 
  * The device is a full-color device.
- * The device has a viewport width of at least 600px.
+ * The device has a viewport width of at least 800px.
  * The UA imposes no minimum font size.
  * The `medium` `font-size` computes to 16px.
  * The canvas background is `white`.

--- a/docs/_writing-tests/general-guidelines.md
+++ b/docs/_writing-tests/general-guidelines.md
@@ -90,7 +90,7 @@ headers.
 ### Be Short
 
 Tests should be as short as possible. For reftests in particular
-scrollbars at 600&#xD7;600px window size must be avoided unless scrolling
+scrollbars at 800&#xD7;600px window size must be avoided unless scrolling
 behavior is specifically being tested. For all tests extraneous
 elements on the page should be avoided so it is clear what is part of
 the test (for a typical testharness test, the only content on the page

--- a/docs/_writing-tests/reftests.md
+++ b/docs/_writing-tests/reftests.md
@@ -27,7 +27,7 @@ tested. It also contains a `link` element with `rel="match"` or
 `rel="mismatch"` and `href` attribute pointing to the *reference*
 file, e.g. `<link rel=match href=references/green-box-ref.html>`. A
 `match` test only passes if the two files render pixel-for-pixel
-identically within a 600x600 window *including* scroll-bars if
+identically within a 800x600 window *including* scroll-bars if
 present; a `mismatch` test only passes if they *don't* render
 identically.
 

--- a/infrastructure/reftest/size-ref.html
+++ b/infrastructure/reftest/size-ref.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<p>innerWidth x innerHeight: <span>600x600</span></p>
+<p>innerWidth x innerHeight: <span>800x600</span></p>

--- a/tools/wptrunner/wptrunner/browsers/fennec.py
+++ b/tools/wptrunner/wptrunner/browsers/fennec.py
@@ -146,7 +146,7 @@ class FennecBrowser(FirefoxBrowser):
                                       "network.preload": True})
         if self.test_type == "reftest":
             self.logger.info("Setting android reftest preferences")
-            self.profile.set_preferences({"browser.viewport.desktopWidth": 600,
+            self.profile.set_preferences({"browser.viewport.desktopWidth": 800,
                                           # Disable high DPI
                                           "layout.css.devPixelsPerPx": "1.0",
                                           # Ensure that the full browser element

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -868,7 +868,9 @@ class InternalRefTestImplementation(object):
                                                              {"test": self.executor.test_url(test),
                                                               "references": references,
                                                               "expected": test.expected(),
-                                                              "timeout": timeout})["value"]
+                                                              "timeout": timeout,
+                                                              "width": 800,
+                                                              "height": 600})["value"]
         return rv
 
     def get_references(self, node):

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -372,7 +372,7 @@ class SeleniumRefTestExecutor(RefTestExecutor):
             """return [window.outerWidth - window.innerWidth,
                        window.outerHeight - window.innerHeight];"""
         )
-        self.protocol.webdriver.set_window_rect(0, 0, 600 + width_offset, 600 + height_offset)
+        self.protocol.webdriver.set_window_rect(0, 0, 800 + width_offset, 600 + height_offset)
 
         result = self.implementation.run_test(test)
 

--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -209,7 +209,7 @@ class ServoRefTestExecutor(ProcessTestExecutor):
             for pref, value in test.environment.get('prefs', {}).iteritems():
                 command += ["--pref", "%s=%s" % (pref, value)]
 
-            command += ["--resolution", viewport_size or "600x600"]
+            command += ["--resolution", viewport_size or "800x600"]
 
             if self.browser.ca_certificate_path:
                 command += ["--certificate-path", self.browser.ca_certificate_path]

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -406,7 +406,7 @@ class WebDriverRefTestExecutor(RefTestExecutor):
                        window.outerHeight - window.innerHeight];"""
         )
         self.protocol.webdriver.window.position = (0, 0)
-        self.protocol.webdriver.window.size = (600 + width_offset, 600 + height_offset)
+        self.protocol.webdriver.window.size = (800 + width_offset, 600 + height_offset)
 
         result = self.implementation.run_test(test)
 

--- a/tools/wptrunner/wptrunner/executors/reftest.js
+++ b/tools/wptrunner/wptrunner/executors/reftest.js
@@ -1,1 +1,1 @@
-var win = window.open("about:blank", "test", "left=0,top=0,width=600,height=600");
+var win = window.open("about:blank", "test", "left=0,top=0,width=800,height=600");


### PR DESCRIPTION
Fixes #7598 and fixes #12578.

This makes everything consistent with 800x600, instead of the current mix. Note the default executor mode (the internal reftest runner) in Firefox is broken as a result of this, but that's part of Marionette and not WPT.