### PR TITLE
HTML: document.open()'s readiness step (lite)

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/readiness.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/readiness.window.js
@@ -1,0 +1,26 @@
+// This tests the behavior of dynamic markup insertion APIs with a document's
+// readiness.
+
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => { frame.remove(); });
+  frame.src = "/common/blank.html";
+  frame.onload = t.step_func_done(() => {
+    const states = [];
+    const onreadystatechange = t.step_func(() => {
+      states.push(frame.contentDocument.readyState);
+    });
+    frame.contentDocument.onreadystatechange = onreadystatechange;
+    assert_equals(frame.contentDocument.readyState, "complete");
+    assert_array_equals(states, []);
+
+    // When open() is called, it first removes the event listeners and handlers
+    // from all nodes in the DOM tree. Then, after a new parser is created and
+    // initialized, it changes the current document readiness to "loading".
+    // However, because all event listeners are removed, we cannot observe the
+    // readystatechange event filed for "loading" inside open().
+    frame.contentDocument.open();
+    assert_equals(frame.contentDocument.readyState, "loading");
+    assert_array_equals(states, []);
+  });
+}, "document.open() and readiness");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/readiness.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/readiness.window.js
@@ -7,10 +7,9 @@ async_test(t => {
   frame.src = "/common/blank.html";
   frame.onload = t.step_func_done(() => {
     const states = [];
-    const onreadystatechange = t.step_func(() => {
+    frame.contentDocument.onreadystatechange = t.step_func(() => {
       states.push(frame.contentDocument.readyState);
     });
-    frame.contentDocument.onreadystatechange = onreadystatechange;
     assert_equals(frame.contentDocument.readyState, "complete");
     assert_array_equals(states, []);
 
@@ -18,7 +17,7 @@ async_test(t => {
     // from all nodes in the DOM tree. Then, after a new parser is created and
     // initialized, it changes the current document readiness to "loading".
     // However, because all event listeners are removed, we cannot observe the
-    // readystatechange event filed for "loading" inside open().
+    // readystatechange event fired for "loading" inside open().
     frame.contentDocument.open();
     assert_equals(frame.contentDocument.readyState, "loading");
     assert_array_equals(states, []);


### PR DESCRIPTION
This is based on #10844 but only tests `document.open()` logic, rather than involving `document.close()` as well.