### PR TITLE
Make wpt run's hosts file check fail properly on Windows

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -105,7 +105,7 @@ def check_environ(product):
 
         missing_hosts = set(expected_hosts)
         if is_windows:
-            hosts_path = "C:\Windows\System32\drivers\etc\hosts"
+            hosts_path = "%s\System32\drivers\etc\hosts" % os.environ.get("SystemRoot", "C:\Windows")
         else:
             hosts_path = "/etc/hosts"
 
@@ -120,7 +120,7 @@ def check_environ(product):
                 if is_windows:
                     message = """Missing hosts file configuration. Run
 
-python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -Encoding ascii -Append
+python wpt make-hosts-file | Out-File %s -Encoding ascii -Append
 
 in PowerShell with Administrator privileges.""" % hosts_path
                 else:

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -1,0 +1,18 @@
+import mock
+
+import pytest
+
+from tools.wpt import run
+
+
+@pytest.mark.parametrize("platform", ["Windows", "Linux", "Darwin"])
+def test_check_environ_fail(platform):
+    m_open = mock.mock_open(read_data=b"")
+
+    with mock.patch.object(run, "open", m_open):
+        with mock.patch.object(run.platform, "uname",
+                               return_value=(platform, "", "", "", "", "")):
+            with pytest.raises(run.WptrunError) as excinfo:
+                run.check_environ("foo")
+
+    assert "wpt make-hosts-file" in excinfo.value.message

--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -7,6 +7,7 @@ deps =
   pytest
   pytest-cov
   hypothesis
+  mock
   -r{toxinidir}/../wptrunner/requirements.txt
   -r{toxinidir}/../wptrunner/requirements_chrome.txt
   -r{toxinidir}/../wptrunner/requirements_firefox.txt


### PR DESCRIPTION
Previously it threw ValueError due to the unescaped % in the error message.

This also makes sure we actually check the right file.