### PR TITLE
Capitalize WebdriverSpecTest => WebDriverSpecTest

### DIFF
--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -234,7 +234,7 @@ class Stub(URLManifestItem):
     item_type = "stub"
 
 
-class WebdriverSpecTest(URLManifestItem):
+class WebDriverSpecTest(URLManifestItem):
     item_type = "wdspec"
 
     def __init__(self, source_file, url, url_base="/", timeout=None, manifest=None):

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -4,7 +4,7 @@ import os
 from collections import defaultdict
 from six import iteritems, itervalues, viewkeys, string_types
 
-from .item import ManualTest, WebdriverSpecTest, Stub, RefTestNode, RefTest, TestharnessTest, SupportFile, ConformanceCheckerTest, VisualTest
+from .item import ManualTest, WebDriverSpecTest, Stub, RefTestNode, RefTest, TestharnessTest, SupportFile, ConformanceCheckerTest, VisualTest
 from .log import get_logger
 from .utils import from_os_path, to_os_path
 
@@ -193,7 +193,7 @@ class Manifest(object):
                         "reftest_node": RefTestNode,
                         "manual": ManualTest,
                         "stub": Stub,
-                        "wdspec": WebdriverSpecTest,
+                        "wdspec": WebDriverSpecTest,
                         "conformancechecker": ConformanceCheckerTest,
                         "visual": VisualTest,
                         "support": SupportFile}

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -12,7 +12,7 @@ except ImportError:
 import html5lib
 
 from . import XMLParser
-from .item import Stub, ManualTest, WebdriverSpecTest, RefTestNode, TestharnessTest, SupportFile, ConformanceCheckerTest, VisualTest
+from .item import Stub, ManualTest, WebDriverSpecTest, RefTestNode, TestharnessTest, SupportFile, ConformanceCheckerTest, VisualTest
 from .utils import rel_path_to_url, ContextManagerBytesIO, cached_property
 
 wd_pattern = "*.py"
@@ -645,7 +645,7 @@ class SourceFile(object):
             rv = TestharnessTest.item_type, tests
 
         elif self.name_is_webdriver:
-            rv = WebdriverSpecTest.item_type, [WebdriverSpecTest(self, self.url,
+            rv = WebDriverSpecTest.item_type, [WebDriverSpecTest(self, self.url,
                                                                  timeout=self.timeout)]
 
         elif self.content_is_css_manual and not self.name_is_reference:

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -43,7 +43,7 @@ def rel_dir_file_path(draw):
 @hs.composite
 def sourcefile_strategy(draw):
     item_classes = [item.TestharnessTest, item.RefTest, item.RefTestNode,
-                    item.ManualTest, item.Stub, item.WebdriverSpecTest,
+                    item.ManualTest, item.Stub, item.WebDriverSpecTest,
                     item.ConformanceCheckerTest, item.SupportFile]
     cls = draw(hs.sampled_from(item_classes))
 

--- a/tools/wptrunner/wptrunner/tests/test_update.py
+++ b/tools/wptrunner/wptrunner/tests/test_update.py
@@ -32,7 +32,7 @@ item_classes = {"testharness": manifest_item.TestharnessTest,
                 "reftest_node": manifest_item.RefTestNode,
                 "manual": manifest_item.ManualTest,
                 "stub": manifest_item.Stub,
-                "wdspec": manifest_item.WebdriverSpecTest,
+                "wdspec": manifest_item.WebDriverSpecTest,
                 "conformancechecker": manifest_item.ConformanceCheckerTest,
                 "visual": manifest_item.VisualTest,
                 "support": manifest_item.SupportFile}


### PR DESCRIPTION
This was the only class capitalized like this, and the only occurences
of "Webdriver" anywhere in the repo. For consistency with classes
WebDriverException, WebDriverProtocol and WebDriverServer.