### PR TITLE
document.open(): Test non-fully active documents

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/active.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/active.window.js
@@ -1,0 +1,94 @@
+test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => frame.remove());
+  assert_equals(frame.contentDocument.childNodes.length, 1);
+  assert_equals(frame.contentDocument.open(), frame.contentDocument);
+  assert_equals(frame.contentDocument.childNodes.length, 0);
+  frame.contentDocument.write("<!DOCTYPE html>");
+  assert_equals(frame.contentDocument.childNodes.length, 1);
+}, "document.open() removes the document's children (fully active document)");
+
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => frame.remove());
+  frame.onload = t.step_func(() => {
+    const childFrame = frame.contentDocument.querySelector("iframe");
+    const childDoc = childFrame.contentDocument;
+    const childWin = childFrame.contentWindow;
+
+    // Right now childDoc is still fully active.
+
+    frame.onload = t.step_func_done(() => {
+      // Now childDoc is still active but no longer fully active.
+      assert_equals(childDoc.childNodes.length, 1);
+      assert_equals(childDoc.open(), childDoc);
+      assert_equals(childDoc.childNodes.length, 0);
+      childDoc.write("<!DOCTYPE html>");
+      assert_equals(childDoc.childNodes.length, 1);
+    });
+    frame.src = "/common/blank.html";
+  });
+  frame.src = "resources/page-with-frame.html";
+}, "document.open() removes the document's children (active but not fully active document)");
+
+test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => frame.remove());
+  const doc = frame.contentDocument;
+
+  // Right now the frame is connected and it has an active document.
+  frame.remove();
+
+  // Now the frame is no longer connected. Its document is no longer active.
+  assert_equals(doc.childNodes.length, 1);
+  assert_equals(doc.open(), doc);
+  assert_equals(doc.childNodes.length, 0);
+  doc.write("<!DOCTYPE html>");
+  assert_equals(doc.childNodes.length, 1);
+}, "document.open() removes the document's children (non-active document with an associated Window object; frame is removed)");
+
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => frame.remove());
+  frame.src = "resources/dummy.html";
+
+  frame.onload = t.step_func(() => {
+    const doc = frame.contentDocument;
+    // Right now the frame is connected and it has an active document.
+
+    frame.onload = t.step_func_done(() => {
+      // Now even though the frame is still connected, its document is no
+      // longer active.
+      assert_not_equals(frame.contentDocument, doc);
+      assert_equals(doc.childNodes.length, 2);
+      assert_equals(doc.open(), doc);
+      assert_equals(doc.childNodes.length, 0);
+      doc.write("<!DOCTYPE html>");
+      assert_equals(doc.childNodes.length, 1);
+    });
+
+    frame.src = "/common/blank.html";
+  });
+}, "document.open() does not change document's URL (non-active document with an associated Window object; navigated away)");
+
+test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => frame.remove());
+  const doc = frame.contentDocument.implementation.createHTMLDocument();
+  assert_equals(doc.childNodes.length, 2);
+  assert_equals(doc.open(), doc);
+  assert_equals(doc.childNodes.length, 0);
+  doc.write("<!DOCTYPE html>");
+  assert_equals(doc.childNodes.length, 1);
+}, "document.open() does not change document's URL (non-active document without an associated Window object; createHTMLDocument)");
+
+test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => frame.remove());
+  const doc = new frame.contentWindow.DOMParser().parseFromString("", "text/html");
+  assert_equals(doc.childNodes.length, 1);
+  assert_equals(doc.open(), doc);
+  assert_equals(doc.childNodes.length, 0);
+  doc.write("<!DOCTYPE html>");
+  assert_equals(doc.childNodes.length, 1);
+}, "document.open() does not change document's URL (non-active document without an associated Window object; DOMParser)");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/active.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/active.window.js
@@ -74,17 +74,17 @@ async_test(t => {
 
     frame.src = "/common/blank.html";
   });
-}, "document.open() does not change document's URL (non-active document with an associated Window object; navigated away)");
+}, "document.open() removes the document's children (non-active document with an associated Window object; navigated away)");
 
 test(t => {
   const doc = document.implementation.createHTMLDocument();
   assertOpenIsEffective(doc, 2);
-}, "document.open() does not change document's URL (non-active document without an associated Window object; createHTMLDocument)");
+}, "document.open() removes the document's children (non-active document without an associated Window object; createHTMLDocument)");
 
 test(t => {
   const doc = new DOMParser().parseFromString("", "text/html");
   assertOpenIsEffective(doc, 1);
-}, "document.open() does not change document's URL (non-active document without an associated Window object; DOMParser)");
+}, "document.open() removes the document's children (non-active document without an associated Window object; DOMParser)");
 
 async_test(t => {
   const xhr = new XMLHttpRequest();
@@ -95,4 +95,4 @@ async_test(t => {
   xhr.responseType = "document";
   xhr.open("GET", "resources/dummy.html");
   xhr.send();
-}, "document.open() does not change document's URL (non-active document without an associated Window object; XMLHttpRequest)");
+}, "document.open() removes the document's children (non-active document without an associated Window object; XMLHttpRequest)");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/active.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/active.window.js
@@ -1,11 +1,27 @@
+function assertOpenIsEffective(doc, initialNodeCount) {
+  assert_equals(doc.childNodes.length, initialNodeCount);
+
+  // Test direct document.open() call.
+  assert_equals(doc.open(), doc);
+  assert_equals(doc.childNodes.length, 0);
+  doc.write("<!DOCTYPE html>");
+  assert_equals(doc.childNodes.length, 1);
+  doc.close();
+  assert_equals(doc.childNodes.length, 2);
+
+  // Test implicit document.open() call through write().
+  doc.write();
+  assert_equals(doc.childNodes.length, 0);
+  doc.write("<!DOCTYPE html>");
+  assert_equals(doc.childNodes.length, 1);
+  doc.close();
+  assert_equals(doc.childNodes.length, 2);
+}
+
 test(t => {
   const frame = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => frame.remove());
-  assert_equals(frame.contentDocument.childNodes.length, 1);
-  assert_equals(frame.contentDocument.open(), frame.contentDocument);
-  assert_equals(frame.contentDocument.childNodes.length, 0);
-  frame.contentDocument.write("<!DOCTYPE html>");
-  assert_equals(frame.contentDocument.childNodes.length, 1);
+  assertOpenIsEffective(frame.contentDocument, 1);
 }, "document.open() removes the document's children (fully active document)");
 
 async_test(t => {
@@ -20,11 +36,7 @@ async_test(t => {
 
     frame.onload = t.step_func_done(() => {
       // Now childDoc is still active but no longer fully active.
-      assert_equals(childDoc.childNodes.length, 1);
-      assert_equals(childDoc.open(), childDoc);
-      assert_equals(childDoc.childNodes.length, 0);
-      childDoc.write("<!DOCTYPE html>");
-      assert_equals(childDoc.childNodes.length, 1);
+      assertOpenIsEffective(childDoc, 1);
     });
     frame.src = "/common/blank.html";
   });
@@ -40,11 +52,7 @@ test(t => {
   frame.remove();
 
   // Now the frame is no longer connected. Its document is no longer active.
-  assert_equals(doc.childNodes.length, 1);
-  assert_equals(doc.open(), doc);
-  assert_equals(doc.childNodes.length, 0);
-  doc.write("<!DOCTYPE html>");
-  assert_equals(doc.childNodes.length, 1);
+  assertOpenIsEffective(doc, 1);
 }, "document.open() removes the document's children (non-active document with an associated Window object; frame is removed)");
 
 async_test(t => {
@@ -60,11 +68,7 @@ async_test(t => {
       // Now even though the frame is still connected, its document is no
       // longer active.
       assert_not_equals(frame.contentDocument, doc);
-      assert_equals(doc.childNodes.length, 2);
-      assert_equals(doc.open(), doc);
-      assert_equals(doc.childNodes.length, 0);
-      doc.write("<!DOCTYPE html>");
-      assert_equals(doc.childNodes.length, 1);
+      assertOpenIsEffective(doc, 2);
     });
 
     frame.src = "/common/blank.html";
@@ -75,20 +79,12 @@ test(t => {
   const frame = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => frame.remove());
   const doc = frame.contentDocument.implementation.createHTMLDocument();
-  assert_equals(doc.childNodes.length, 2);
-  assert_equals(doc.open(), doc);
-  assert_equals(doc.childNodes.length, 0);
-  doc.write("<!DOCTYPE html>");
-  assert_equals(doc.childNodes.length, 1);
+  assertOpenIsEffective(doc, 2);
 }, "document.open() does not change document's URL (non-active document without an associated Window object; createHTMLDocument)");
 
 test(t => {
   const frame = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => frame.remove());
   const doc = new frame.contentWindow.DOMParser().parseFromString("", "text/html");
-  assert_equals(doc.childNodes.length, 1);
-  assert_equals(doc.open(), doc);
-  assert_equals(doc.childNodes.length, 0);
-  doc.write("<!DOCTYPE html>");
-  assert_equals(doc.childNodes.length, 1);
+  assertOpenIsEffective(doc, 1);
 }, "document.open() does not change document's URL (non-active document without an associated Window object; DOMParser)");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/event-listeners.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/event-listeners.window.js
@@ -93,7 +93,7 @@ test(t => {
   focusEvent.initUIEvent("focus");
   win.dispatchEvent(focusEvent);
   doc.close();
-}, "Standard event listeners are to be removed from Window for a non-active document with a browsing context (frame is removed)");
+}, "Standard event listeners are to be removed from Window for a non-active document that is the associated Document of a Window (frame is removed)");
 
 test(t => {
   let winHappened = 0;
@@ -212,7 +212,7 @@ test(t => {
   doc.open();
   win.dispatchEvent(new Event("x"));
   doc.close();
-}, "Custom event listeners are to be removed from Window for a non-active document with a browsing context (frame is removed)");
+}, "Custom event listeners are to be removed from Window for a non-active document that is the associated Document of a Window (frame is removed)");
 
 test(t => {
   const doc = document.implementation.createHTMLDocument();

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/event-listeners.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/event-listeners.window.js
@@ -1,3 +1,7 @@
+// Many of the active-related test cases in this file came from
+// active.window.js. However, we cannot test the "navigated away" non-active
+// case right now due to https://github.com/whatwg/html/issues/3997.
+
 test(t => {
   const frame = document.body.appendChild(document.createElement("iframe")),
         body = frame.contentDocument.body;
@@ -36,6 +40,135 @@ test(t => {
   frame.contentDocument.close();
 }, "Standard event listeners are to be removed from Window");
 
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => frame.remove());
+  frame.onload = t.step_func(() => {
+    const childFrame = frame.contentDocument.querySelector("iframe");
+    const childWin = childFrame.contentWindow;
+    const childDoc = childFrame.contentDocument;
+    const childBody = childDoc.body;
+
+    // Right now childDoc is still fully active.
+
+    frame.onload = t.step_func_done(() => {
+      // Focus on the current window so that the frame's window is blurred.
+      window.focus();
+      // Now childDoc is still active but no longer fully active.
+      childWin.addEventListener("focus", t.unreached_func("window event listener not removed"));
+      childBody.onfocus = t.unreached_func("body event listener not removed");
+
+      childDoc.open();
+      assert_equals(childBody.onfocus, null);
+
+      // Now try to fire the focus event two different ways.
+      childWin.focus();
+      const focusEvent = new FocusEvent("focus");
+      focusEvent.initUIEvent("focus");
+      childWin.dispatchEvent(focusEvent);
+      childDoc.close();
+    });
+    frame.src = "/common/blank.html";
+  });
+  frame.src = "resources/page-with-frame.html";
+}, "Standard event listeners are to be removed from Window for an active but not fully active document");
+
+test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  const win = frame.contentWindow;
+  const doc = frame.contentDocument;
+  const body = doc.body;
+
+  // Right now the frame is connected and it has an active document.
+  frame.remove();
+
+  win.addEventListener("focus", t.unreached_func("window event listener not removed"));
+  body.onfocus = t.unreached_func("body event listener not removed");
+  doc.open();
+  assert_equals(body.onfocus, null);
+
+  // Now try to fire the focus event two different ways.
+  win.focus();
+  const focusEvent = new FocusEvent("focus");
+  focusEvent.initUIEvent("focus");
+  win.dispatchEvent(focusEvent);
+  doc.close();
+}, "Standard event listeners are to be removed from Window for a non-active document with a browsing context (frame is removed)");
+
+test(t => {
+  let winHappened = 0;
+  const winListener = t.step_func(() => { winHappened++; });
+  window.addEventListener("focus", winListener);
+  t.add_cleanup(() => { window.removeEventListener("focus", winListener); });
+
+  let bodyHappened = 0;
+  const bodyListener = t.step_func(() => { bodyHappened++; });
+  document.body.onfocus = bodyListener;
+  t.add_cleanup(() => { document.body.onfocus = null; });
+
+  const doc = document.implementation.createHTMLDocument();
+  doc.open();
+
+  const focusEvent = new FocusEvent("focus");
+  focusEvent.initUIEvent("focus");
+  window.dispatchEvent(focusEvent);
+
+  assert_equals(winHappened, 1);
+  assert_equals(bodyHappened, 1);
+}, "Standard event listeners are NOT to be removed from Window for a Window-less document (createHTMLDocument)");
+
+test(t => {
+  let winHappened = 0;
+  const winListener = t.step_func(() => { winHappened++; });
+  window.addEventListener("focus", winListener);
+  t.add_cleanup(() => { window.removeEventListener("focus", winListener); });
+
+  let bodyHappened = 0;
+  const bodyListener = t.step_func(() => { bodyHappened++; });
+  document.body.onfocus = bodyListener;
+  t.add_cleanup(() => { document.body.onfocus = null; });
+
+  const doc = new DOMParser().parseFromString("", "text/html");
+  doc.open();
+
+  const focusEvent = new FocusEvent("focus");
+  focusEvent.initUIEvent("focus");
+  window.dispatchEvent(focusEvent);
+
+  assert_equals(winHappened, 1);
+  assert_equals(bodyHappened, 1);
+}, "Standard event listeners are NOT to be removed from Window for a Window-less document (DOMParser)");
+
+async_test(t => {
+  const xhr = new XMLHttpRequest();
+  xhr.onload = t.step_func_done(() => {
+    assert_equals(xhr.status, 200);
+    const doc = xhr.responseXML;
+
+    let winHappened = 0;
+    const winListener = t.step_func(() => { winHappened++; });
+    window.addEventListener("focus", winListener);
+    t.add_cleanup(() => { window.removeEventListener("focus", winListener); });
+
+    let bodyHappened = 0;
+    const bodyListener = t.step_func(() => { bodyHappened++; });
+    document.body.onfocus = bodyListener;
+    t.add_cleanup(() => { document.body.onfocus = null; });
+
+    doc.open();
+
+    const focusEvent = new FocusEvent("focus");
+    focusEvent.initUIEvent("focus");
+    window.dispatchEvent(focusEvent);
+
+    assert_equals(winHappened, 1);
+    assert_equals(bodyHappened, 1);
+  });
+  xhr.responseType = "document";
+  xhr.open("GET", "resources/dummy.html");
+  xhr.send();
+}, "Standard event listeners are NOT to be removed from Window for a Window-less document (XMLHttpRequest)");
+
 test(t => {
   const frame = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => frame.remove());
@@ -44,6 +177,76 @@ test(t => {
   frame.contentWindow.dispatchEvent(new Event("x"));
   frame.contentDocument.close();
 }, "Custom event listeners are to be removed from Window");
+
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  t.add_cleanup(() => frame.remove());
+  frame.onload = t.step_func(() => {
+    const childFrame = frame.contentDocument.querySelector("iframe");
+    const childDoc = childFrame.contentDocument;
+    const childWin = childFrame.contentWindow;
+
+    // Right now childDoc is still fully active.
+
+    frame.onload = t.step_func_done(() => {
+      // Now childDoc is still active but no longer fully active.
+      childWin.addEventListener("x", t.unreached_func("window event listener not removed"));
+      childDoc.open();
+      childWin.dispatchEvent(new Event("x"));
+      childDoc.close();
+    });
+    frame.src = "/common/blank.html";
+  });
+  frame.src = "resources/page-with-frame.html";
+}, "Custom event listeners are to be removed from Window for an active but not fully active document");
+
+test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  const win = frame.contentWindow;
+  const doc = frame.contentDocument;
+
+  // Right now the frame is connected and it has an active document.
+  frame.remove();
+
+  win.addEventListener("x", t.unreached_func("window event listener not removed"));
+  doc.open();
+  win.dispatchEvent(new Event("x"));
+  doc.close();
+}, "Custom event listeners are to be removed from Window for a non-active document with a browsing context (frame is removed)");
+
+test(t => {
+  const doc = document.implementation.createHTMLDocument();
+  let happened = false;
+  window.addEventListener("createHTMLDocumentTest", t.step_func(() => { happened = true; }));
+  doc.open();
+  window.dispatchEvent(new Event("createHTMLDocumentTest"));
+  assert_true(happened);
+}, "Custom event listeners are NOT to be removed from Window for a Window-less document (createHTMLDocument)");
+
+test(t => {
+  const doc = new DOMParser().parseFromString("", "text/html");
+  let happened = false;
+  window.addEventListener("DOMParserTest", t.step_func(() => { happened = true; }));
+  doc.open();
+  window.dispatchEvent(new Event("DOMParserTest"));
+  assert_true(happened);
+}, "Custom event listeners are NOT to be removed from Window for a Window-less document (DOMParser)");
+
+async_test(t => {
+  const xhr = new XMLHttpRequest();
+  xhr.onload = t.step_func_done(() => {
+    assert_equals(xhr.status, 200);
+    const doc = xhr.responseXML;
+    let happened = false;
+    window.addEventListener("XHRTest", t.step_func(() => { happened = true; }));
+    doc.open();
+    window.dispatchEvent(new Event("XHRTest"));
+    assert_true(happened);
+  });
+  xhr.responseType = "document";
+  xhr.open("GET", "resources/dummy.html");
+  xhr.send();
+}, "Custom event listeners are NOT to be removed from Window for a Window-less document (XMLHttpRequest)");
 
 test(t => {
   const frame = document.body.appendChild(document.createElement("iframe")),

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/event-listeners.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/event-listeners.window.js
@@ -64,7 +64,6 @@ async_test(t => {
       // Now try to fire the focus event two different ways.
       childWin.focus();
       const focusEvent = new FocusEvent("focus");
-      focusEvent.initUIEvent("focus");
       childWin.dispatchEvent(focusEvent);
       childDoc.close();
     });
@@ -90,7 +89,6 @@ test(t => {
   // Now try to fire the focus event two different ways.
   win.focus();
   const focusEvent = new FocusEvent("focus");
-  focusEvent.initUIEvent("focus");
   win.dispatchEvent(focusEvent);
   doc.close();
 }, "Standard event listeners are to be removed from Window for a non-active document that is the associated Document of a Window (frame is removed)");
@@ -110,7 +108,6 @@ test(t => {
   doc.open();
 
   const focusEvent = new FocusEvent("focus");
-  focusEvent.initUIEvent("focus");
   window.dispatchEvent(focusEvent);
 
   assert_equals(winHappened, 1);
@@ -132,7 +129,6 @@ test(t => {
   doc.open();
 
   const focusEvent = new FocusEvent("focus");
-  focusEvent.initUIEvent("focus");
   window.dispatchEvent(focusEvent);
 
   assert_equals(winHappened, 1);
@@ -158,7 +154,6 @@ async_test(t => {
     doc.open();
 
     const focusEvent = new FocusEvent("focus");
-    focusEvent.initUIEvent("focus");
     window.dispatchEvent(focusEvent);
 
     assert_equals(winHappened, 1);

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/page-with-frame.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/page-with-frame.html
@@ -1,0 +1,1 @@
+<iframe src="/common/blank.html"></iframe>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window.js
@@ -13,16 +13,14 @@ async_test(t => {
   const frameURL = new URL("resources/page-with-frame.html", document.URL).href;
   const frame = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => frame.remove());
-
-  // We do not test for win.location.href in this test due to
-  // https://github.com/whatwg/html/issues/3959.
-
   frame.onload = t.step_func(() => {
     assert_equals(frame.contentDocument.URL, frameURL);
+    assert_equals(frame.contentWindow.location.href, frameURL);
     const childFrame = frame.contentDocument.querySelector("iframe");
     const childDoc = childFrame.contentDocument;
     const childWin = childFrame.contentWindow;
     assert_equals(childDoc.URL, blankURL);
+    assert_equals(childWin.location.href, blankURL);
 
     // Right now childDoc is still fully active.
 
@@ -30,6 +28,7 @@ async_test(t => {
       // Now childDoc is still active but no longer fully active.
       assert_equals(childDoc.open(), childDoc);
       assert_equals(childDoc.URL, blankURL);
+      assert_equals(childWin.location.href, blankURL);
     });
     frame.src = "/common/blank.html";
   });

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window.js
@@ -13,14 +13,16 @@ async_test(t => {
   const frameURL = new URL("resources/page-with-frame.html", document.URL).href;
   const frame = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => frame.remove());
+
+  // We do not test for win.location.href in this test due to
+  // https://github.com/whatwg/html/issues/3959.
+
   frame.onload = t.step_func(() => {
     assert_equals(frame.contentDocument.URL, frameURL);
-    assert_equals(frame.contentWindow.location.href, frameURL);
     const childFrame = frame.contentDocument.querySelector("iframe");
     const childDoc = childFrame.contentDocument;
     const childWin = childFrame.contentWindow;
     assert_equals(childDoc.URL, blankURL);
-    assert_equals(childWin.location.href, blankURL);
 
     // Right now childDoc is still fully active.
 
@@ -28,7 +30,6 @@ async_test(t => {
       // Now childDoc is still active but no longer fully active.
       assert_equals(childDoc.open(), childDoc);
       assert_equals(childDoc.URL, blankURL);
-      assert_equals(childWin.location.href, blankURL);
     });
     frame.src = "/common/blank.html";
   });


### PR DESCRIPTION
Also fix a missing file in the related `url.js` test.

For https://github.com/whatwg/html/pull/3977.

----

All six tests pass in Chrome and Safari.

The "active but not fully active" and "non-active with associated Window; navigated away" cases fail in Edge with a "Permission denied" error, but all others pass.

All but the first one fail in Firefox, which implements the active document bailout