### PR TITLE
webrtc: fix no-media-call

### DIFF
--- a/webrtc/no-media-call.html
+++ b/webrtc/no-media-call.html
@@ -125,8 +125,8 @@ This test uses the legacy callback API with no media, and thus does not require 
 
     // The offerToReceiveVideo is necessary and sufficient to make
     // an actual connection.
-    gFirstConnection.createOffer().then(onOfferCreated, failed('createOffer'),
-        {offerToReceiveVideo: true});
+    gFirstConnection.createOffer({offerToReceiveVideo: true})
+      .then(onOfferCreated, failed('createOffer'));
   });
 </script>
 


### PR DESCRIPTION
the legacy offer options need to be passed to createOffer, not the then.
regression from #12715, caused chrome to fail on import

@youennf can you please take a look? Whether this test makes sense is another question...
@henbos: you can close https://bugs.chromium.org/p/chromium/issues/detail?id=879021 once this is resolved