### PR TITLE
[cookies] Remove cookies when tests complete

### DIFF
--- a/cookies/prefix/document-cookie.non-secure.html
+++ b/cookies/prefix/document-cookie.non-secure.html
@@ -6,7 +6,8 @@
   function create_test(prefix, params, shouldExistInDOM, shouldExistViaHTTP, title) {
     promise_test(t => {
       var name = prefix + "prefixtestcookie";
-      erase_cookie_from_js(name);
+      erase_cookie_from_js(name, params);
+      t.add_cleanup(() => erase_cookie_from_js(name, params));
       var value = "" + Math.random();
       document.cookie = name + "=" + value + ";" + params;
 

--- a/cookies/resources/cookie-helper.sub.js
+++ b/cookies/resources/cookie-helper.sub.js
@@ -72,7 +72,8 @@ function create_cookie(origin, name, value, extras) {
 function set_prefixed_cookie_via_dom_test(options) {
   promise_test(t => {
     var name = options.prefix + "prefixtestcookie";
-    erase_cookie_from_js(name);
+    erase_cookie_from_js(name, options.paras);
+    t.add_cleanup(() => erase_cookie_from_js(name, options.params));
     var value = "" + Math.random();
     document.cookie = name + "=" + value + ";" + options.params;
 
@@ -97,7 +98,7 @@ function set_prefixed_cookie_via_http_test(options) {
     var name = options.prefix + "prefixtestcookie";
     if (!options.origin) {
       options.origin = self.origin;
-      erase_cookie_from_js(name);
+      erase_cookie_from_js(name, options.params);
       return postDelete;
     } else {
       return credFetch(options.origin + "/cookies/resources/drop.py?name=" + name)
@@ -184,9 +185,8 @@ return credFetch(origin + "/cookies/resources/dropSecure.py")
 //
 
 // erase cookie value and set for expiration
-function erase_cookie_from_js(name) {
-  let secure = self.location.protocol == "https:" ? "Secure" : "";
-  document.cookie = `${name}=0; path=/; expires=${new Date(0).toUTCString()}; ${secure}`;
+function erase_cookie_from_js(name, params) {
+  document.cookie = `${name}=0; expires=${new Date(0).toUTCString()}; ${params};`;
   var re = new RegExp("(?:^|; )" + name);
   assert_equals(re.test(document.cookie), false, "Sanity check: " + name + " has been deleted.");
 }


### PR DESCRIPTION
Avoid test interactions by removing cookies at the completion of each
test. Use the `add_cleanup` feature of testharness.js to ensure that
this occurs regardless of the passing/failing status of each test.
Persist the existing "setup" logic which defensively removes cookies as
a precaution against still other tests which do not properly restore
global state.

This resolves a known instability caused by
`cookies/prefix/__secure.document-cookie.https.html`. That test sets a
cookie with a "Domain" attribute which
`cookies/prefix/__secure.header.https.html` is not written to remove.