### PR TITLE
Install nightly geckodriver when testing Firefox nightly.

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -333,19 +333,23 @@ class Firefox(Browser):
             package_path = s.download()
         except mozdownload.errors.NotFoundError:
             return
-        exe_suffix = ".exe" if uname[0] == "Windows" else ""
-        with tarfile.open(package_path, "r") as f:
-            try:
-                member = f.getmember("bin%sgeckodriver%s" % (os.path.sep,
-                                                             exe_suffix))
-            except KeyError:
-                return
-            # Remove bin/ from the path.
-            member.name = os.path.basename(member.name)
-            f.extractall(members=[member], path=dest)
-            path = os.path.join(dest, member.name)
-        logger.info("Extracted geckodriver to %s" % path)
-        os.unlink(package_path)
+
+        try:
+            exe_suffix = ".exe" if uname[0] == "Windows" else ""
+            with tarfile.open(package_path, "r") as f:
+                try:
+                    member = f.getmember("bin%sgeckodriver%s" % (os.path.sep,
+                                                                 exe_suffix))
+                except KeyError:
+                    return
+                # Remove bin/ from the path.
+                member.name = os.path.basename(member.name)
+                f.extractall(members=[member], path=dest)
+                path = os.path.join(dest, member.name)
+            logger.info("Extracted geckodriver to %s" % path)
+        finally:
+            os.unlink(package_path)
+
         return path
 
     def version(self, binary=None, channel=None):

--- a/tools/wpt/install.py
+++ b/tools/wpt/install.py
@@ -35,7 +35,9 @@ def get_parser():
                         default="nightly", help='Name of browser release channel. '
                         '"stable" and "release" are synonyms for the latest browser stable release,'
                         '"nightly", "dev", "experimental", and "preview" are all synonyms for '
-                        'the latest available development release.')
+                        'the latest available development release. For WebDriver installs, '
+                        'we attempt to select an appropriate, compatible, version for the '
+                        'latest browser release on the selected channel.')
     parser.add_argument('-d', '--destination',
                         help='filesystem directory to place the component')
     return parser
@@ -78,9 +80,6 @@ def install(name, component, destination, channel="nightly"):
 
     subclass = getattr(browser, name.title())
     sys.stdout.write('Now installing %s %s...\n' % (name, component))
-    kwargs = {"dest": destination}
-    if component == "browser":
-        kwargs["channel"] = channel
-    path = getattr(subclass(), method)(**kwargs)
+    path = getattr(subclass(), method)(dest=destination, channel=channel)
     if path:
         sys.stdout.write('Binary installed as %s\n' % (path,))

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -53,7 +53,9 @@ def create_parser():
                         default=None, help='Name of browser release channel.'
                         '"stable" and "release" are synonyms for the latest browser stable release,'
                         '"nightly", "dev", "experimental", and "preview" are all synonyms for '
-                        'the latest available development release.')
+                        'the latest available development release. For WebDriver installs, '
+                        'we attempt to select an appropriate, compatible, version for the '
+                        'latest browser release on the selected channel.')
     parser._add_container_actions(wptcommandline.create_parser())
     return parser
 


### PR DESCRIPTION
This (ab)uses mozdownload to grab the common.tests.tar.gz package from the
latest nightly build and extracts geckodriver from that. The main disadvantage
is that it's rather slow since the package itself is rather large and we want
only a small part of it. The solution to this would be to package up
geckodriver by itself on taskcluster, but that will require changes in the
gecko buildsystem.