### PR TITLE
[cookies] Correct utility function and tests

### DIFF
--- a/cookies/prefix/__host.header.html
+++ b/cookies/prefix/__host.header.html
@@ -8,6 +8,7 @@
     set_prefixed_cookie_via_http_test({
       prefix: "__Host-",
       params: "Path=/;" + extraParams,
+      origin: self.origin,
       shouldExistInDOM: false,
       shouldExistViaHTTP: false,
       title: "__Host: Non-secure origin: Does not set 'Path=/;" + extraParams + "'"
@@ -17,6 +18,7 @@
     set_prefixed_cookie_via_http_test({
       prefix: "__Host-",
       params: "Secure; Path=/;" + extraParams,
+      origin: self.origin,
       shouldExistInDOM: false,
       shouldExistViaHTTP: false,
       title: "__Host: Non-secure origin: Does not set 'Secure; Path=/;" + extraParams + "'"
@@ -26,6 +28,7 @@
     set_prefixed_cookie_via_http_test({
       prefix: "__Host-",
       params: "Secure; Path=/; Domain=" + document.location.hostname + "; " + extraParams,
+      origin: self.origin,
       shouldExistInDOM: false,
       shouldExistViaHTTP: false,
       title: "__Host: Secure origin: Does not set 'Secure; Path=/; Domain=" + document.location.hostname + "; " + extraParams + "'"
@@ -35,6 +38,7 @@
   set_prefixed_cookie_via_http_test({
     prefix: "__Host-",
     params: "Secure; Path=/cookies/resources/list.py",
+    origin: self.origin,
     shouldExistInDOM: false,
     shouldExistViaHTTP: false,
     title: "__Host: Non-secure origin: Does not set 'Secure; Path=/cookies/resources/list.py'"

--- a/cookies/prefix/__host.header.https.html
+++ b/cookies/prefix/__host.header.https.html
@@ -8,6 +8,7 @@
     set_prefixed_cookie_via_http_test({
       prefix: "__Host-",
       params: "Path=/;" + extraParams,
+      origin: self.origin,
       shouldExistInDOM: false,
       shouldExistViaHTTP: false,
       title: "__Host: Secure origin: Does not set 'Path=/;" + extraParams + "'"
@@ -17,6 +18,7 @@
     set_prefixed_cookie_via_http_test({
       prefix: "__Host-",
       params: "Secure; Path=/;" + extraParams,
+      origin: self.origin,
       shouldExistInDOM: true,
       shouldExistViaHTTP: true,
       title: "__Host: Secure origin: Does set 'Secure; Path=/;" + extraParams + "'"
@@ -26,6 +28,7 @@
     set_prefixed_cookie_via_http_test({
       prefix: "__Host-",
       params: "Secure; Path=/; Domain=" + document.location.hostname + "; " + extraParams,
+      origin: self.origin,
       shouldExistInDOM: false,
       shouldExistViaHTTP: false,
       title: "__Host: Secure origin: Does not set 'Secure; Path=/; Domain=" + document.location.hostname + "; " + extraParams + "'"
@@ -35,6 +38,7 @@
   set_prefixed_cookie_via_http_test({
     prefix: "__Host-",
     params: "Secure; Path=/cookies/resources/list.py",
+    origin: self.origin,
     shouldExistInDOM: false,
     shouldExistViaHTTP: false,
     title: "__Host: Secure origin: Does not set 'Secure; Path=/cookies/resources/list.py'"

--- a/cookies/prefix/__secure.header.html
+++ b/cookies/prefix/__secure.header.html
@@ -8,6 +8,7 @@
     set_prefixed_cookie_via_http_test({
       prefix: "__Secure-",
       params: "Path=/;" + extraParams,
+      origin: self.origin,
       shouldExistViaHTTP: false,
       title: "__Secure: Non-secure origin: Should not set 'Path=/;" + extraParams + "'"
     });
@@ -16,8 +17,9 @@
     set_prefixed_cookie_via_http_test({
       prefix: "__Secure-",
       params: "Secure; Path=/;" + extraParams,
-      shouldExistViaHTTP: true,
-      title: "__Secure: Non-secure origin: Should set 'Secure; Path=/;" + extraParams + "'"
+      origin: self.origin,
+      shouldExistViaHTTP: false,
+      title: "__Secure: Non-secure origin: Should not set 'Secure; Path=/;" + extraParams + "'"
     });
   });
 </script>

--- a/cookies/prefix/__secure.header.https.html
+++ b/cookies/prefix/__secure.header.https.html
@@ -3,11 +3,12 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/cookies/resources/cookie-helper.sub.js"></script>
 <script>
-  ["", "domain="+CROSS_SITE_HOST, "MaxAge=10", "HttpOnly"].forEach(extraParams => {
+  ["", "MaxAge=10", "HttpOnly"].forEach(extraParams => {
     // Without 'secure'
     set_prefixed_cookie_via_http_test({
       prefix: "__Secure-",
       params: "Path=/;" + extraParams,
+      origin: self.origin,
       shouldExistViaHTTP: false,
       title: "__Secure: secure origin: Should not set 'Path=/;" + extraParams + "'"
     });
@@ -16,8 +17,27 @@
     set_prefixed_cookie_via_http_test({
       prefix: "__Secure-",
       params: "Secure;Path=/;" + extraParams,
+      origin: self.origin,
       shouldExistViaHTTP: true,
       title: "__Secure: secure origin: Should set 'Secure;Path=/;" + extraParams + "'"
     });
+  });
+
+  // Without 'secure'
+  set_prefixed_cookie_via_http_test({
+    prefix: "__Secure-",
+    params: "Path=/;domain=" + CROSS_SITE_HOST,
+    origin: SECURE_CROSS_SITE_ORIGIN,
+    shouldExistViaHTTP: false,
+    title: "__Secure: secure origin: Should not set 'Path=/;domain=" + CROSS_SITE_HOST + "'"
+  });
+
+  // With 'secure'
+  set_prefixed_cookie_via_http_test({
+    prefix: "__Secure-",
+    params: "Secure;Path=/;domain=" + CROSS_SITE_HOST,
+    origin: SECURE_CROSS_SITE_ORIGIN,
+    shouldExistViaHTTP: true,
+    title: "__Secure: secure origin: Should set 'Secure;Path=/;domain=" + CROSS_SITE_HOST + "'"
   });
 </script>

--- a/cookies/resources/cookie-helper.sub.js
+++ b/cookies/resources/cookie-helper.sub.js
@@ -93,23 +93,20 @@ function set_prefixed_cookie_via_dom_test(options) {
 
 function set_prefixed_cookie_via_http_test(options) {
   promise_test(t => {
-    var postDelete = _ => {
-      var value = "" + Math.random();
-      return credFetch(options.origin + "/cookies/resources/set.py?" + name + "=" + value + ";" + options.params)
-        .then(_ => credFetch(options.origin + "/cookies/resources/list.py"))
-        .then(r => r.json())
-        .then(cookies => assert_equals(cookies[name], options.shouldExistViaHTTP ? value : undefined));
-    };
-
     var name = options.prefix + "prefixtestcookie";
-    if (!options.origin) {
-      options.origin = self.origin;
-      erase_cookie_from_js(name, options.params);
-      return postDelete;
-    } else {
-      return credFetch(options.origin + "/cookies/resources/drop.py?name=" + name)
-        .then(_ => postDelete());
-    }
+    var value = "" + Math.random();
+
+    t.add_cleanup(() => {
+      var cookie = name + "=0;expires=" + new Date(0).toUTCString() + ";" +
+        options.params;
+
+      return credFetch(options.origin + "/cookies/resources/set.py?" + cookie);
+    });
+
+    return credFetch(options.origin + "/cookies/resources/set.py?" + name + "=" + value + ";" + options.params)
+      .then(_ => credFetch(options.origin + "/cookies/resources/list.py"))
+      .then(r => r.json())
+      .then(cookies => assert_equals(cookies[name], options.shouldExistViaHTTP ? value : undefined));
   }, options.title);
 }
 

--- a/cookies/resources/cookie-helper.sub.js
+++ b/cookies/resources/cookie-helper.sub.js
@@ -28,7 +28,13 @@
 
 // A tiny helper which returns the result of fetching |url| with credentials.
 function credFetch(url) {
-  return fetch(url, {"credentials": "include"});
+  return fetch(url, {"credentials": "include"})
+    .then(response => {
+      if (response.status !== 200) {
+        throw new Error(response.statusText);
+      }
+      return response;
+    });
 }
 
 // Returns a URL on |origin| which redirects to a given absolute URL.

--- a/cookies/resources/set.py
+++ b/cookies/resources/set.py
@@ -1,7 +1,13 @@
 import helpers
+import urllib
 
 def main(request, response):
     """Respond to `/cookie/set?{cookie}` by echoing `{cookie}` as a `Set-Cookie` header."""
     headers = helpers.setNoCacheAndCORSHeaders(request, response)
-    headers.append(("Set-Cookie", request.url_parts.query))
+
+    # Cookies may require whitespace (e.g. in the `Expires` attribute), so the
+    # query string should be decoded.
+    cookie = urllib.unquote(request.url_parts.query)
+    headers.append(("Set-Cookie", cookie))
+
     return headers, '{"success": true}'


### PR DESCRIPTION
The `cookie-helper.sub.js` utility script includes
`set_prefixed_cookie_via_http_test`, a function that defines sub-tests
using the `promise_test` API. Previously, it included the following
code:

    promise_test(t => {
      var postDelete = _ => {
        // (elided)
      };

      if (!options.origin) {
        return postDelete;
      } else {
        // (elided)
      }
    });

The `promise_test` function does not recognize return values which are
functions, so returning the `postDelete` method had no effect, and as a
result, the generated tests performed zero assertions. Because none of
the consumers of `set_prefixed_cookie_via_http_test` specified a value
for the `origin` option, all invocations were effected by this bug.

Correcting the problem surfaced a number of errors in the tests. In the
interest of atomicity, this patch attempts to address them all:

- The logic intended to defensively remove cookies prior to testing was
  implemented using `document.cookie`. Because some tests create cookies
  which include the `HttpOnly` attribute, the DOM API cannot remove
  cookies in all cases. This patch refactors the solution to remove
  such cookies via an HTTP request. It also assumes the environment is
  initially clean and instead expresses the concern via an asynchronous
  "cleanup" function. (This change necessitated an extension to the
  `set.py` script so that it could be used to expire cookies.)
- The test name `__secure.header.html` incorrectly asserted that a
  cookie set with the `Secure` attribute could be observed in a
  non-secure context. This patch corrects the expectation.
- The test named `__secure.header.https.html` incorrectly asserted that
  a cookie set with a foreign `Origin` attribute could be observed from
  the current origin. This patch corrects the expectation.

---

This patch does not affect the test results in Firefox or Chrome. The commands:

    $ xvfb-run --auto-servernum ./wpt run firefox cookies/prefix
    $ xvfb-run --auto-servernum ./wpt run chrome cookies/prefix

...both continue to report the following:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 95 checks (9 tests, 86 subtests)
    Expected results: 95