### PR TITLE
CSS animations and transitions property parsing

### DIFF
--- a/css/css-animations/parsing/animation-delay-invalid.html
+++ b/css/css-animations/parsing/animation-delay-invalid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-delay with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-delay">
+<meta name="assert" content="animation-delay supports only the grammar '<single-animation-play-state> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-delay", "infinite");
+test_invalid_value("animation-delay", "0");
+test_invalid_value("animation-delay", "1s 2s");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-delay-invalid.html
+++ b/css/css-animations/parsing/animation-delay-invalid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-delay with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-delay with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-delay">
 <meta name="assert" content="animation-delay supports only the grammar '<single-animation-play-state> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-delay-valid.html
+++ b/css/css-animations/parsing/animation-delay-valid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-delay with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-delay with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-delay">
 <meta name="assert" content="animation-delay supports the full grammar '<single-animation-play-state> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-delay-valid.html
+++ b/css/css-animations/parsing/animation-delay-valid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-delay with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-delay">
+<meta name="assert" content="animation-delay supports the full grammar '<single-animation-play-state> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-delay", "-5ms");
+test_valid_value("animation-delay", "0s");
+test_valid_value("animation-delay", "10s");
+test_valid_value("animation-delay", "20s, 10s");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-direction-invalid.html
+++ b/css/css-animations/parsing/animation-direction-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-direction with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-direction">
+<meta name="assert" content="animation-direction supports only the grammar '<single-animation-direction> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-direction", "auto");
+test_invalid_value("animation-direction", "normal reverse");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-direction-invalid.html
+++ b/css/css-animations/parsing/animation-direction-invalid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-direction with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-direction with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-direction">
 <meta name="assert" content="animation-direction supports only the grammar '<single-animation-direction> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-direction-valid.html
+++ b/css/css-animations/parsing/animation-direction-valid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-direction with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-direction with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-direction">
 <meta name="assert" content="animation-direction supports the full grammar '<single-animation-direction> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-direction-valid.html
+++ b/css/css-animations/parsing/animation-direction-valid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-direction with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-direction">
+<meta name="assert" content="animation-direction supports the full grammar '<single-animation-direction> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-direction", "normal");
+test_valid_value("animation-direction", "reverse");
+test_valid_value("animation-direction", "alternate");
+test_valid_value("animation-direction", "alternate-reverse");
+test_valid_value("animation-direction", "normal, reverse, alternate, alternate-reverse");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-duration-invalid.html
+++ b/css/css-animations/parsing/animation-duration-invalid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-duration with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-duration with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-duration">
 <meta name="assert" content="animation-duration supports only the grammar '<time> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-duration-invalid.html
+++ b/css/css-animations/parsing/animation-duration-invalid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-duration with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-duration">
+<meta name="assert" content="animation-duration supports only the grammar '<time> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-duration", '-3s');
+test_invalid_value("animation-duration", '0');
+test_invalid_value("animation-duration", 'infinite');
+test_invalid_value("animation-duration", '1s 2s');
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-duration-valid.html
+++ b/css/css-animations/parsing/animation-duration-valid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-duration with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-duration">
+<meta name="assert" content="animation-duration supports the full grammar '<time> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-duration", '3s');
+test_valid_value("animation-duration", '500ms');
+test_valid_value("animation-duration", '1s, 2s, 3s');
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-duration-valid.html
+++ b/css/css-animations/parsing/animation-duration-valid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-duration with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-duration with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-duration">
 <meta name="assert" content="animation-duration supports the full grammar '<time> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-fill-mode-invalid.html
+++ b/css/css-animations/parsing/animation-fill-mode-invalid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-fill-mode with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-fill-mode with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-fill-mode">
 <meta name="assert" content="animation-fill-mode supports only the grammar '<single-animation-fill-mode> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-fill-mode-invalid.html
+++ b/css/css-animations/parsing/animation-fill-mode-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-fill-mode with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-fill-mode">
+<meta name="assert" content="animation-fill-mode supports only the grammar '<single-animation-fill-mode> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-fill-mode", "auto");
+test_invalid_value("animation-fill-mode", "forwards backwards");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-fill-mode-valid.html
+++ b/css/css-animations/parsing/animation-fill-mode-valid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-fill-mode with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-fill-mode with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-fill-mode">
 <meta name="assert" content="animation-fill-mode supports the full grammar '<single-animation-fill-mode> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-fill-mode-valid.html
+++ b/css/css-animations/parsing/animation-fill-mode-valid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-fill-mode with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-fill-mode">
+<meta name="assert" content="animation-fill-mode supports the full grammar '<single-animation-fill-mode> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-fill-mode", "none");
+test_valid_value("animation-fill-mode", "forwards");
+test_valid_value("animation-fill-mode", "backwards");
+test_valid_value("animation-fill-mode", "both");
+test_valid_value("animation-fill-mode", "none, forwards, backwards, both");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-iteration-count-invalid.html
+++ b/css/css-animations/parsing/animation-iteration-count-invalid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-iteration-count with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-iteration-count">
+<meta name="assert" content="animation-iteration-count supports only the grammar '<single-animation-iteration-count> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-iteration-count", "auto");
+test_invalid_value("animation-iteration-count", "-2");
+test_invalid_value("animation-iteration-count", "3 4");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-iteration-count-invalid.html
+++ b/css/css-animations/parsing/animation-iteration-count-invalid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-iteration-count with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-iteration-count with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-iteration-count">
 <meta name="assert" content="animation-iteration-count supports only the grammar '<single-animation-iteration-count> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-iteration-count-valid.html
+++ b/css/css-animations/parsing/animation-iteration-count-valid.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-iteration-count with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-iteration-count">
+<meta name="assert" content="animation-iteration-count supports the full grammar '<single-animation-iteration-count> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-iteration-count", "0");
+test_valid_value("animation-iteration-count", "3");
+test_valid_value("animation-iteration-count", "4.5");
+test_valid_value("animation-iteration-count", "infinite");
+
+test_valid_value("animation-iteration-count", "0, infinite, 3");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-iteration-count-valid.html
+++ b/css/css-animations/parsing/animation-iteration-count-valid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-iteration-count with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-iteration-count with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-iteration-count">
 <meta name="assert" content="animation-iteration-count supports the full grammar '<single-animation-iteration-count> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-name-invalid.html
+++ b/css/css-animations/parsing/animation-name-invalid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-name with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-name with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-name">
 <meta name="assert" content="animation-name supports only the grammar '[ none | <keyframes-name> ]#'.">
 <script src="/resources/testharness.js"></script>
@@ -14,6 +13,11 @@
 <script>
 test_invalid_value("animation-name", '12');
 test_invalid_value("animation-name", 'one two');
+
+test_invalid_value("animation-name", 'one, initial');
+test_invalid_value("animation-name", 'one, inherit');
+test_invalid_value("animation-name", 'one, unset');
+test_invalid_value("animation-name", 'default, two');
 </script>
 </body>
 </html>

--- a/css/css-animations/parsing/animation-name-invalid.html
+++ b/css/css-animations/parsing/animation-name-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-name with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-name">
+<meta name="assert" content="animation-name supports only the grammar '[ none | <keyframes-name> ]#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-name", '12');
+test_invalid_value("animation-name", 'one two');
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-name-valid.html
+++ b/css/css-animations/parsing/animation-name-valid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-name with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-name with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-name">
 <meta name="assert" content="animation-name supports the full grammar '[ none | <keyframes-name> ]#'.">
 <script src="/resources/testharness.js"></script>
@@ -12,13 +11,19 @@
 </head>
 <body>
 <script>
-test_valid_value("animation-name", 'none');
+test_valid_value("animation-name", 'NONE', 'none');
+
 test_valid_value("animation-name", 'foo');
-test_valid_value("animation-name", 'both');
+test_valid_value("animation-name", 'Both');
 test_valid_value("animation-name", 'ease-in');
 test_valid_value("animation-name", 'infinite');
 test_valid_value("animation-name", 'paused');
 test_valid_value("animation-name", 'first, second, third');
+
+test_valid_value("animation-name", '"string"');
+test_valid_value("animation-name", '"multi word string"');
+test_valid_value("animation-name", '"initial"');
+test_valid_value("animation-name", '"---\\22---"', '\"---\\\"---\"');
 </script>
 </body>
 </html>

--- a/css/css-animations/parsing/animation-name-valid.html
+++ b/css/css-animations/parsing/animation-name-valid.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-name with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-name">
+<meta name="assert" content="animation-name supports the full grammar '[ none | <keyframes-name> ]#'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-name", 'none');
+test_valid_value("animation-name", 'foo');
+test_valid_value("animation-name", 'both');
+test_valid_value("animation-name", 'ease-in');
+test_valid_value("animation-name", 'infinite');
+test_valid_value("animation-name", 'paused');
+test_valid_value("animation-name", 'first, second, third');
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-play-state-invalid.html
+++ b/css/css-animations/parsing/animation-play-state-invalid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-play-state with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-play-state with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-play-state">
 <meta name="assert" content="animation-play-state supports only the grammar '<single-animation-play-state> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-play-state-invalid.html
+++ b/css/css-animations/parsing/animation-play-state-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-play-state with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-play-state">
+<meta name="assert" content="animation-play-state supports only the grammar '<single-animation-play-state> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-play-state", "auto");
+test_invalid_value("animation-play-state", "paused running");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-play-state-valid.html
+++ b/css/css-animations/parsing/animation-play-state-valid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-play-state with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-play-state">
+<meta name="assert" content="animation-play-state supports the full grammar '<single-animation-play-state> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-play-state", "running");
+test_valid_value("animation-play-state", "paused");
+test_valid_value("animation-play-state", "running, paused");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-play-state-valid.html
+++ b/css/css-animations/parsing/animation-play-state-valid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-play-state with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-play-state with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-play-state">
 <meta name="assert" content="animation-play-state supports the full grammar '<single-animation-play-state> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-timing-function-invalid.html
+++ b/css/css-animations/parsing/animation-timing-function-invalid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-timing-function with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-timing-function with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-timing-function">
 <meta name="assert" content="animation-timing-function supports only the grammar '<timing-function> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-animations/parsing/animation-timing-function-invalid.html
+++ b/css/css-animations/parsing/animation-timing-function-invalid.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-timing-function with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-timing-function">
+<meta name="assert" content="animation-timing-function supports only the grammar '<timing-function> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-timing-function", "auto");
+test_invalid_value("animation-timing-function", "ease-in ease-out");
+test_invalid_value("animation-timing-function", "cubic-bezier(1, 2, 3)");
+test_invalid_value("animation-timing-function", "cubic-bezier(1, 2, 3, infinite)");
+test_invalid_value("animation-timing-function", "cubic-bezier(1, 2, 3, 4, 5)");
+test_invalid_value("animation-timing-function", "cubic-bezier(-0.1, 0.1, 0.5, 0.9)");
+test_invalid_value("animation-timing-function", "cubic-bezier(0.5, 0.1, 1.1, 0.9)");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-timing-function-valid.html
+++ b/css/css-animations/parsing/animation-timing-function-valid.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing animation-timing-function with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-timing-function">
+<meta name="assert" content="animation-timing-function supports the full grammar '<timing-function> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-timing-function", "linear");
+
+test_valid_value("animation-timing-function", "ease");
+test_valid_value("animation-timing-function", "ease-in");
+test_valid_value("animation-timing-function", "ease-out");
+test_valid_value("animation-timing-function", "ease-in-out");
+test_valid_value("animation-timing-function", "cubic-bezier(0.1, 0.2, 0.8, 0.9)");
+test_valid_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3)");
+test_valid_value("animation-timing-function", "cubic-bezier(0, 0.7, 1, 1.3)");
+
+
+test_valid_value("animation-timing-function", "steps(4, start)");
+test_valid_value("animation-timing-function", "steps(2, end)");
+
+test_valid_value("animation-timing-function", "linear, ease, linear");
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-timing-function-valid.html
+++ b/css/css-animations/parsing/animation-timing-function-valid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing animation-timing-function with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing animation-timing-function with valid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-timing-function">
 <meta name="assert" content="animation-timing-function supports the full grammar '<timing-function> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transitions/parsing/transition-delay-invalid.html
+++ b/css/css-transitions/parsing/transition-delay-invalid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: parsing transition-delay with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-delay">
+<meta name="assert" content="transition-delay supports only the grammar '<time> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("transition-delay", 'infinite');
+test_invalid_value("transition-delay", '0');
+test_invalid_value("transition-delay", '500ms 0.5s');
+</script>
+</body>
+</html>

--- a/css/css-transitions/parsing/transition-delay-invalid.html
+++ b/css/css-transitions/parsing/transition-delay-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transitions: parsing transition-delay with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-delay">
 <meta name="assert" content="transition-delay supports only the grammar '<time> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transitions/parsing/transition-delay-valid.html
+++ b/css/css-transitions/parsing/transition-delay-valid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: parsing transition-delay with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-delay">
+<meta name="assert" content="transition-delay supports the full grammar '<time> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("transition-delay", '0s');
+test_valid_value("transition-delay", '500ms');
+test_valid_value("transition-delay", '1s, 2s');
+test_valid_value("transition-delay", '-1s, -2s');
+</script>
+</body>
+</html>

--- a/css/css-transitions/parsing/transition-delay-valid.html
+++ b/css/css-transitions/parsing/transition-delay-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transitions: parsing transition-delay with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-delay">
 <meta name="assert" content="transition-delay supports the full grammar '<time> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transitions/parsing/transition-duration-invalid.html
+++ b/css/css-transitions/parsing/transition-duration-invalid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: parsing transition-duration with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-duration">
+<meta name="assert" content="transition-duration supports only the grammar '<time> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("transition-duration", 'infinite');
+test_invalid_value("transition-duration", '-500ms');
+test_invalid_value("transition-duration", '1s 2s');
+</script>
+</body>
+</html>

--- a/css/css-transitions/parsing/transition-duration-invalid.html
+++ b/css/css-transitions/parsing/transition-duration-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transitions: parsing transition-duration with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-duration">
 <meta name="assert" content="transition-duration supports only the grammar '<time> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transitions/parsing/transition-duration-valid.html
+++ b/css/css-transitions/parsing/transition-duration-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transitions: parsing transition-duration with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-duration">
 <meta name="assert" content="transition-duration supports the full grammar '<time> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transitions/parsing/transition-duration-valid.html
+++ b/css/css-transitions/parsing/transition-duration-valid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: parsing transition-duration with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-duration">
+<meta name="assert" content="transition-duration supports the full grammar '<time> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("transition-duration", '0s');
+test_valid_value("transition-duration", '500ms');
+test_valid_value("transition-duration", '1s, 2s');
+</script>
+</body>
+</html>

--- a/css/css-transitions/parsing/transition-property-invalid.html
+++ b/css/css-transitions/parsing/transition-property-invalid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: parsing transition-property with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-property">
+<meta name="assert" content="transition-property supports only the grammar 'none | <single-transition-property> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("transition-property", 'one two three');
+test_invalid_value("transition-property", '1, 2, 3');
+test_invalid_value("transition-property", 'none, one');
+</script>
+</body>
+</html>

--- a/css/css-transitions/parsing/transition-property-invalid.html
+++ b/css/css-transitions/parsing/transition-property-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transitions: parsing transition-property with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-property">
 <meta name="assert" content="transition-property supports only the grammar 'none | <single-transition-property> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transitions/parsing/transition-property-valid.html
+++ b/css/css-transitions/parsing/transition-property-valid.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: parsing transition-property with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-property">
+<meta name="assert" content="transition-property supports the full grammar 'none | <single-transition-property> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("transition-property", 'none');
+test_valid_value("transition-property", 'all');
+test_valid_value("transition-property", 'one');
+test_valid_value("transition-property", 'one-two-three');
+test_valid_value("transition-property", 'one, two, three');
+test_valid_value("transition-property", 'width, all');
+</script>
+</body>
+</html>

--- a/css/css-transitions/parsing/transition-property-valid.html
+++ b/css/css-transitions/parsing/transition-property-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transitions: parsing transition-property with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-property">
 <meta name="assert" content="transition-property supports the full grammar 'none | <single-transition-property> #'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transitions/parsing/transition-timing-function-invalid.html
+++ b/css/css-transitions/parsing/transition-timing-function-invalid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations Level 1: parsing transition-timing-function with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-timing-function">
+<link rel="help" href="https://drafts.csswg.org/css-timing-1/#typedef-timing-function">
+<meta name="assert" content="transition-timing-function supports only the grammar '<timing-function> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("transition-timing-function", "auto");
+test_invalid_value("transition-timing-function", "ease-in ease-out");
+test_invalid_value("transition-timing-function", "cubic-bezier(1, 2, 3)");
+test_invalid_value("transition-timing-function", "cubic-bezier(1, 2, 3, infinite)");
+test_invalid_value("transition-timing-function", "cubic-bezier(1, 2, 3, 4, 5)");
+test_invalid_value("transition-timing-function", "cubic-bezier(-0.1, 0.1, 0.5, 0.9)");
+test_invalid_value("transition-timing-function", "cubic-bezier(0.5, 0.1, 1.1, 0.9)");
+</script>
+</body>
+</html>

--- a/css/css-transitions/parsing/transition-timing-function-invalid.html
+++ b/css/css-transitions/parsing/transition-timing-function-invalid.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Animations Level 1: parsing transition-timing-function with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<title>CSS Animations: parsing transition-timing-function with invalid values</title>
 <link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-timing-function">
 <link rel="help" href="https://drafts.csswg.org/css-timing-1/#typedef-timing-function">
 <meta name="assert" content="transition-timing-function supports only the grammar '<timing-function> #'.">

--- a/css/css-transitions/parsing/transition-timing-function-valid.html
+++ b/css/css-transitions/parsing/transition-timing-function-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transitions: parsing transition-timing-function with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-timing-function">
 <link rel="help" href="https://drafts.csswg.org/css-timing-1/#typedef-timing-function">
 <meta name="assert" content="transition-timing-function supports the full grammar '<timing-function> #'.">

--- a/css/css-transitions/parsing/transition-timing-function-valid.html
+++ b/css/css-transitions/parsing/transition-timing-function-valid.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: parsing transition-timing-function with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-timing-function">
+<link rel="help" href="https://drafts.csswg.org/css-timing-1/#typedef-timing-function">
+<meta name="assert" content="transition-timing-function supports the full grammar '<timing-function> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("transition-timing-function", "linear");
+
+test_valid_value("transition-timing-function", "ease");
+test_valid_value("transition-timing-function", "ease-in");
+test_valid_value("transition-timing-function", "ease-out");
+test_valid_value("transition-timing-function", "ease-in-out");
+test_valid_value("transition-timing-function", "cubic-bezier(0.1, 0.2, 0.8, 0.9)");
+test_valid_value("transition-timing-function", "cubic-bezier(0, -2, 1, 3)");
+test_valid_value("transition-timing-function", "cubic-bezier(0, 0.7, 1, 1.3)");
+
+test_valid_value("transition-timing-function", "steps(4, start)");
+test_valid_value("transition-timing-function", "steps(2, end)");
+
+test_valid_value("transition-timing-function", "linear, ease, linear");
+</script>
+</body>
+</html>


### PR DESCRIPTION
Test the parsing and serialization of the longhand properties from
CSS Animations and CSS Transitions.

Relevant browser bugs:

Edge animation-duration should reject negatives
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18347049/

Edge and Safari incorrectly accept unitless 0 on `<time>` values
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18348525/
https://bugs.webkit.org/show_bug.cgi?id=113230