### PR TITLE
[css-contain] Containment and stacking contexts for inline elements

### DIFF
--- a/css/css-contain/contain-layout-018.html
+++ b/css/css-contain/contain-layout-018.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Containment Test: Layout containment stacking context</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain-1/#containment-layout">
+<link rel="match" href="../reference/nothing.html">
+<meta name=assert content="Elements in which layout containment doesn't apply, do not create a stacking context.">
+<style>
+div {
+  display: inline;
+  contain: layout;
+  background: white;
+}
+span {
+  position: relative;
+  z-index: -1;
+}
+</style>
+
+<p>There should be nothing below.</p>
+<div><span>FAIL</span></div>

--- a/css/css-contain/contain-paint-025.html
+++ b/css/css-contain/contain-paint-025.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Containment Test: Paint containment stacking context</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain-1/#containment-paint">
+<link rel="match" href="../reference/nothing.html">
+<meta name=assert content="Elements in which paint containment doesn't apply, do not create a stacking context.">
+<style>
+div {
+  display: inline;
+  contain: paint;
+  background: white;
+}
+span {
+  position: relative;
+  z-index: -1;
+}
+</style>
+
+<p>There should be nothing below.</p>
+<div><span>FAIL</span></div>


### PR DESCRIPTION
This patch adds tests to verify that layout and paint containment
do not create a stacking context for inline elements.
