### PR TITLE
[css-contain] check the effects of containment on baseline alignment

### DIFF
--- a/css/css-contain/contain-layout-baseline-001.html
+++ b/css/css-contain/contain-layout-baseline-001.html
@@ -16,7 +16,7 @@
   height: 100px;
   z-index: -1;
 }
-div {
+.green {
   display: inline-block;
   height: 100px;
   background: green;
@@ -27,5 +27,5 @@ div {
 </style>
 
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
-<aside id=red></div>
-<section><div id=d1></div><div id=d2>a</div></section>
+<div id=red></div>
+<div class=green></div><div class=green>a</div>

--- a/css/css-contain/contain-layout-baseline-001.html
+++ b/css/css-contain/contain-layout-baseline-001.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>CSS-contain test: layout containment and baselines</title>
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+  <meta name=assert content="With contain:layout, for the purpose of the vertical-align property, the containing element is treated as having no baseline.">
+  <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+  <link rel=help href="https://drafts.csswg.org/css-contain-1/#containment-layout">
+  <meta name="flags" content="">
+
+<style>
+#red {
+  position: absolute;
+  background: red;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+}
+div {
+  display: inline-block;
+  height: 100px;
+  background: green;
+  width: 50px;
+  contain: layout;
+  color: transparent;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<aside id=red></div>
+<section><div id=d1></div><div id=d2>a</div></section>

--- a/css/css-contain/contain-paint-baseline-001.html
+++ b/css/css-contain/contain-paint-baseline-001.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>CSS-contain test: paint containment and baselines</title>
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+  <meta name=assert content="contain:paint does not suppress baseline alignment">
+  <link rel="match" href="reference/contain-baseline-ref.html">
+  <link rel=help href="https://drafts.csswg.org/css-contain-1/#containment-paint">
+  <meta name="flags" content="">
+
+<style>
+div {
+  display: inline-block;
+  height: 5px;
+  background: blue;
+  width: 50px;
+  contain: paint;
+  color: transparent;
+  font-size: 100px;
+}
+</style>
+
+<p>Test passes if there are two, not one, blue lines below.</p>
+<section><div id=d1></div><div id=d2>a</div></section>

--- a/css/css-contain/contain-paint-baseline-001.html
+++ b/css/css-contain/contain-paint-baseline-001.html
@@ -21,4 +21,4 @@ div {
 </style>
 
 <p>Test passes if there are two, not one, blue lines below.</p>
-<section><div id=d1></div><div id=d2>a</div></section>
+<div></div><div>a</div>

--- a/css/css-contain/contain-size-baseline-001.html
+++ b/css/css-contain/contain-size-baseline-001.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>CSS-contain test: size containment and baselines</title>
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+  <meta name=assert content="contain:size does not suppress baseline alignment">
+  <link rel="match" href="reference/contain-baseline-ref.html">
+  <link rel=help href="https://drafts.csswg.org/css-contain-1/#containment-size">
+  <meta name="flags" content="">
+
+<style>
+div {
+  display: inline-block;
+  height: 5px;
+  background: blue;
+  width: 50px;
+  contain: size;
+  color: transparent;
+  font-size: 100px;
+}
+</style>
+
+<p>Test passes if there are two, not one, blue lines below.</p>
+<section><div id=d1></div><div id=d2>a</div></section>

--- a/css/css-contain/contain-size-baseline-001.html
+++ b/css/css-contain/contain-size-baseline-001.html
@@ -21,4 +21,4 @@ div {
 </style>
 
 <p>Test passes if there are two, not one, blue lines below.</p>
-<section><div id=d1></div><div id=d2>a</div></section>
+<div></div><div>a</div>

--- a/css/css-contain/contain-style-baseline-001.html
+++ b/css/css-contain/contain-style-baseline-001.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>CSS-contain test: style containment and baselines</title>
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+  <meta name=assert content="contain:style does not suppress baseline alignment">
+  <link rel="match" href="reference/contain-baseline-ref.html">
+  <link rel=help href="https://drafts.csswg.org/css-contain-1/#containment-style">
+  <meta name="flags" content="">
+
+<style>
+div {
+  display: inline-block;
+  height: 5px;
+  background: blue;
+  width: 50px;
+  contain: style;
+  color: transparent;
+  font-size: 100px;
+}
+</style>
+
+<p>Test passes if there are two, not one, blue lines below.</p>
+<section><div id=d1></div><div id=d2>a</div></section>

--- a/css/css-contain/contain-style-baseline-001.html
+++ b/css/css-contain/contain-style-baseline-001.html
@@ -21,4 +21,4 @@ div {
 </style>
 
 <p>Test passes if there are two, not one, blue lines below.</p>
-<section><div id=d1></div><div id=d2>a</div></section>
+<div></div><div>a</div>

--- a/css/css-contain/reference/contain-baseline-ref.html
+++ b/css/css-contain/reference/contain-baseline-ref.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang=en>
+<meta charset=utf-8>
+<title>CSS test reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<style>
+div {
+  display: inline-block;
+  height: 5px;
+  background: blue;
+  width: 50px;
+  color: transparent;
+  font-size: 100px;
+}
+</style>
+
+<p>Test passes if there are two, not one, blue lines below.</p>
+<section><div id=d1></div><div id=d2>a</div></section>

--- a/css/css-contain/reference/contain-baseline-ref.html
+++ b/css/css-contain/reference/contain-baseline-ref.html
@@ -15,4 +15,4 @@ div {
 </style>
 
 <p>Test passes if there are two, not one, blue lines below.</p>
-<section><div id=d1></div><div id=d2>a</div></section>
+<div></div><div>a</div>


### PR DESCRIPTION
Tests for https://github.com/w3c/csswg-drafts/issues/2995

Only the layout and size variant are needed to catch know bugs (in chrome) at the time of writing, and mistakes on paint or style would be surprising, but it doesn't hurt to be exhaustive.