### PR TITLE
Fix stability check when tests are skipped

### DIFF
--- a/tools/wptrunner/wptrunner/tests/test_stability.py
+++ b/tools/wptrunner/wptrunner/tests/test_stability.py
@@ -29,3 +29,5 @@ def test_find_slow_status():
     assert stability.find_slow_status({
         "longest_duration": {"TIMEOUT": 10, "FAIL": 81},
         "timeout": 100}) == "FAIL"
+    assert stability.find_slow_status({
+        "longest_duration": {"SKIP": 0}}) is None


### PR DESCRIPTION
In https://github.com/web-platform-tests/wpt/pull/11570, we added a
check to reject slow tests in stability checks. The code didn't consider
an edge case where tests are skipped and don't contain "extra" info.

This change silently skips a test in this check if it does not have
necessary extra information.