### PR TITLE
HTML: Fix test when run through ./wpt run

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/reload.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/reload.window.js
@@ -15,13 +15,13 @@
 // as the test file and as part of the test file. The `if (!opener)` condition
 // controls what role this file plays.
 
-if (!opener) {
+if (window.name !== "opened-dummy-window") {
   async_test(t => {
     const testURL = document.URL;
     const dummyURL = new URL("resources/dummy.html", document.URL).href;
 
     // 1. Open an auxiliary window.
-    const win = window.open("resources/dummy.html");
+    const win = window.open("resources/dummy.html", "opened-dummy-window");
     t.add_cleanup(() => { win.close(); });
 
     win.addEventListener("load", t.step_func(() => {

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/reload.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/reload.window.js
@@ -12,8 +12,8 @@
 // that restriction.
 //
 // In any case, this test as the caller of `document.open()` would be used both
-// as the test file and as part of the test file. The `if (!opener)` condition
-// controls what role this file plays.
+// as the test file and as part of the test file. The `if (window.name !==
+// "opened-dummy-window")` condition controls what role this file plays.
 
 if (window.name !== "opened-dummy-window") {
   async_test(t => {


### PR DESCRIPTION
When run through `./wpt run`, the test window is created by another window through `window.open()`, so `opener` is not `null` in the main page (when we expect it to be `null`).

@foolip, can you double check this looks correct? 