### PR TITLE
Make --venv work again

### DIFF
--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -101,9 +101,6 @@ def main(prog=None, argv=None):
 
     main_args, command_args = parse_args(argv, commands)
 
-    if not(len(argv) and argv[0] in commands):
-        sys.exit(1)
-
     command = main_args.command
     props = commands[command]
     venv = None


### PR DESCRIPTION
wpt was interpreting --venv as a command and exiting early because it's
not a valid command.

$ ./wpt --venv linux_venv run [...]

Further, these lines seem to be redundant with argparse, which dies if
the argument is invalid.