### PR TITLE
Add tests for mediacapture-image

### DIFF
--- a/mediacapture-image/ImageCapture-creation.https.html
+++ b/mediacapture-image/ImageCapture-creation.https.html
@@ -73,4 +73,23 @@ var testAudio = async_test(function() {
     this.unreached_func('Error creating MediaStream.'));
 }, 'verifies that an ImageCapture cannot be created out of an Audio Track');
 
+var testParameter = test(function() {
+  const invalidParameters = [
+    "invalid",
+    null,
+    123,
+    {},
+    "",
+    true
+  ];
+  assert_throws(new TypeError(),
+                function() { var capturer = new ImageCapture(); },
+               'an ImageCapturer can not be created with no parameter');
+  invalidParameters.map(parameter => {
+    assert_throws(new TypeError(),
+                  function() { var capturer = new ImageCapture(parameter); },
+                 `an ImageCapturer can not be created with a ${parameter} parameter`);
+  });
+}, 'throw "TypeError" if parameter is not MediaStreamTrack.');
+
 </script>

--- a/mediacapture-image/ImageCapture-track.html
+++ b/mediacapture-image/ImageCapture-track.html
@@ -16,17 +16,16 @@ test(t => {
 
   let stream = canvas.captureStream();
   let videoTrack = stream.getVideoTracks()[0];
-  assert_equals(videoTrack.readyState, "live");
-  assert_true(videoTrack.enabled);
 
   let capturer = new ImageCapture(videoTrack);
   assert_true(capturer.track instanceof MediaStreamTrack);
   assert_equals(capturer.track, videoTrack);
 
-  capturer.track.enabled = false;
-  assert_true(videoTrack.enabled, "track enabled");
-  capturer.track.stop();
-  assert_equals(videoTrack.readyState, "live", "track readyState");
+  let cloneTrack = videoTrack.clone();
+  assert_not_equals(videoTrack, cloneTrack);
+
+  capturer.track = cloneTrack;
+  assert_equals(capturer.track, videoTrack);
 }, "ImageCapture track attribute is readonly")
 
 </script>

--- a/mediacapture-image/ImageCapture-track.html
+++ b/mediacapture-image/ImageCapture-track.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>ImageCapture track</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="https://w3c.github.io/mediacapture-image/#dom-imagecapture-track">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<canvas id='canvas' width=10 height=10></canvas>
+<script>
+
+test(t => {
+  let canvas = document.getElementById('canvas');
+  let context = canvas.getContext('2d');
+  context.fillStyle = 'red';
+  context.fillRect(0, 0, 10, 10);
+
+  let stream = canvas.captureStream();
+  let videoTrack = stream.getVideoTracks()[0];
+  assert_equals(videoTrack.readyState, "live");
+  assert_true(videoTrack.enabled);
+
+  let capturer = new ImageCapture(videoTrack);
+  assert_true(capturer.track instanceof MediaStreamTrack);
+  assert_equals(capturer.track, videoTrack);
+
+  capturer.track.enabled = false;
+  assert_true(videoTrack.enabled, "track enabled");
+  capturer.track.stop();
+  assert_equals(videoTrack.readyState, "live", "track readyState");
+}, "ImageCapture track attribute is readonly")
+
+</script>

--- a/mediacapture-image/getPhotoCapabilities.html
+++ b/mediacapture-image/getPhotoCapabilities.html
@@ -42,4 +42,20 @@ image_capture_test(async (t, imageCaptureTest) => {
 
 }, 'exercises ImageCapture.getPhotoCapabilities()');
 
+promise_test(t => {
+  let canvas = document.getElementById('canvas');
+  let context = canvas.getContext('2d');
+  context.fillStyle = 'red';
+  context.fillRect(0, 0, 10, 10);
+  let stream = canvas.captureStream();
+  let videoTrack = stream.getVideoTracks()[0];
+  videoTrack.stop();
+
+  let capturer = new ImageCapture(videoTrack);
+  assert_equals(videoTrack.readyState, 'ended');
+
+  return promise_rejects(t, 'InvalidStateError', capturer.getPhotoCapabilities())
+
+}, 'getPhotoCapabilities() of an ended Track should throw "InvalidStateError"');
+
 </script>

--- a/mediacapture-image/getPhotoSettings.html
+++ b/mediacapture-image/getPhotoSettings.html
@@ -27,4 +27,20 @@ image_capture_test(async (t, imageCaptureTest) => {
 
 }, 'exercises ImageCapture.getPhotoSettings()');
 
+promise_test(t => {
+  let canvas = document.getElementById('canvas');
+  let context = canvas.getContext('2d');
+  context.fillStyle = 'red';
+  context.fillRect(0, 0, 10, 10);
+  let stream = canvas.captureStream();
+  let videoTrack = stream.getVideoTracks()[0];
+  videoTrack.stop();
+
+  let capturer = new ImageCapture(videoTrack);
+  assert_equals(videoTrack.readyState, 'ended');
+
+  return promise_rejects(t, 'InvalidStateError', capturer.getPhotoSettings())
+
+}, 'getPhotoSettings() of an ended Track should throw "InvalidStateError"');
+
 </script>

--- a/mediacapture-image/takePhoto.html
+++ b/mediacapture-image/takePhoto.html
@@ -26,4 +26,36 @@ image_capture_test(async t => {
 
 }, 'exercises ImageCapture.takePhoto()');
 
+image_capture_test(async t => {
+  let canvas = document.getElementById('canvas');
+  let context = canvas.getContext('2d');
+  context.fillStyle = 'red';
+  context.fillRect(0, 0, 10, 10);
+  let stream = canvas.captureStream();
+
+  let capturer = new ImageCapture(stream.getVideoTracks()[0]);
+  let blob = await capturer.takePhoto(null);
+
+  // JS Blob is almost-opaque, can only check |type| and |size|.
+  assert_equals(blob.type, 'image/cat');
+  assert_equals(blob.size, 2);
+
+}, 'exercises ImageCapture.takePhoto(null)');
+
+promise_test(t => {
+  let canvas = document.getElementById('canvas');
+  let context = canvas.getContext('2d');
+  context.fillStyle = 'red';
+  context.fillRect(0, 0, 10, 10);
+  let stream = canvas.captureStream();
+  let videoTrack = stream.getVideoTracks()[0];
+  videoTrack.stop();
+
+  let capturer = new ImageCapture(videoTrack);
+  assert_equals(videoTrack.readyState, 'ended');
+
+  return promise_rejects(t, 'InvalidStateError', capturer.takePhoto())
+
+}, 'takePhoto() of an ended Track should throw "InvalidStateError"');
+
 </script>


### PR DESCRIPTION
Cover following checkpoints:
- throw TypeError when ImageCapture parameter is not mediaStramTrack
- ImageCapture track attribute is readonly
- getPhotoCapabilities() of an ended Track should throw InvalidStateError
- getPhotoSettings() of an ended Track should throw InvalidStateError
- takePhoto() of an ended Track should throw InvalidStateError
- the parameter of takePhoto() is nullable