### PR TITLE
[testharness.js] Reject non-thenable values

### DIFF
--- a/docs/_writing-tests/testharness-api.md
+++ b/docs/_writing-tests/testharness-api.md
@@ -161,9 +161,9 @@ Test is finished.
 promise_test(test_function, name, properties)
 ```
 
-`test_function` is a function that receives a test as an argument and returns a
-promise. The test completes when the returned promise resolves. The test fails
-if the returned promise rejects.
+`test_function` is a function that receives a test as an argument. It must
+return a promise. The test completes when the returned promise resolves. The
+test fails if the returned promise rejects.
 
 E.g.:
 

--- a/resources/test/tests/functional/promise.html
+++ b/resources/test/tests/functional/promise.html
@@ -100,10 +100,14 @@ promise_test(
     function() {
         return true;
     },
-    "promise_test with function that doesn't return a Promise");
+    "promise_test with function that doesn't return a Promise (should FAIL)");
 
 promise_test(function(){},
              "promise_test with function that doesn't return anything");
+
+promise_test(
+    function() { return { then: 23 }; },
+    "promise_test that returns a non-thenable (should FAIL)");
 
 promise_test(
     function() {
@@ -170,15 +174,21 @@ promise_test(
       "properties": {}
     },
     {
-      "status_string": "PASS",
-      "name": "promise_test with function that doesn't return a Promise",
-      "message": null,
+      "status_string": "FAIL",
+      "name": "promise_test with function that doesn't return a Promise (should FAIL)",
+      "message": "promise_test: test body must return a 'thenable' object (received an object with no `then` method)",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "promise_test with function that doesn't return anything",
-      "message": "assert_not_equals: got disallowed value undefined",
+      "message": "promise_test: test body must return a 'thenable' object (received undefined)",
+      "properties": {}
+    },
+    {
+      "status_string": "FAIL",
+      "name": "promise_test that returns a non-thenable (should FAIL)",
+      "message": "promise_test: test body must return a 'thenable' object (received an object with no `then` method)",
       "properties": {}
     },
     {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -576,7 +576,12 @@ policies and contribution forms [3].
                 var promise = test.step(func, test, test);
 
                 test.step(function() {
-                    assert_not_equals(promise, undefined);
+                    assert(!!promise, "promise_test", null,
+                           "test body must return a 'thenable' object (received ${value})",
+                           {value:promise});
+                    assert(typeof promise.then === "function", "promise_test", null,
+                           "test body must return a 'thenable' object (received an object with no `then` method)",
+                           null);
                 });
 
                 // Test authors may use the `step` method within a


### PR DESCRIPTION
[testharness.js] Reject non-thenable values
    
Previously, any test defined via the `promise_test` API would fail
immediately if its body returned the value `undefined`. The test would
*not* fail if it returned any other value. Because the motivation for
using `promise_test` is to track resolution with a "thenable" value
(i.e. an object with a "then" method), this was overly permissive and
allowed contributors to write tests which spuriously passed [1].
    
Update testharness.js to enforce more stringent criteria on the value
return by `promise_test` bodies: that it is a "thenable" value. This
change is incompatible with an exiting functional test, but it does not
effect any tests in WPT (as verified by a survey using both the Chrome
and Firefox browsers). Update the functional test accordingly.
    
[1] cca6b6845678d9b5f792b886f3f7045d1d2cf0a7

---

As noted in the commit message, the current leniency recently allowed test bugs that could have been avoided.

Because there is no use case for a `promise_test` that does not return a thenable, I've also tried to verify that no other tests in WPT exhibit this problem. [I modified testharness.js and wptserve to log those cases, introduced an intentional infraction](54c71baa55408df584d12086b49acc5b8c7161bd), and [ran those changes through Chrome dev and Firefox Nightly on Taskcluster](https://tools.taskcluster.net/groups/RNMSCl4pQLa856S4zlKHoA). I used the new `tc-download` feature to inspect the result:

    $ ./wpt tc-download --repo-name bocoup/wpt --ref suspicious-promise --out-dir koo --artifact-name suspicious.txt
    $ ls koo
    wpt-chrome-dev-testharness-4-0-suspicious.txt  wpt-firefox-nightly-testharness-4-0-suspicious.txt
    $ cat koo/*
    http://web-platform.test:8000/dom/events/CustomEvent.html - CustomEvent
    http://web-platform.test:8000/dom/events/CustomEvent.html - CustomEvent

Since Firefox and Chrome reported the intentional infraction, I think the process is sound. Since they reported no other infractions, I don't think their are any previously-existing errors.