### PR TITLE
Use document.scrollingElement to access scroll properties of the view…

### DIFF
--- a/conformance-checkers/html-aria/_functional/tree/js/prototype.js
+++ b/conformance-checkers/html-aria/_functional/tree/js/prototype.js
@@ -2705,8 +2705,8 @@ document.viewport = {
 
   getScrollOffsets: function() {
     return Element._returnOffset(
-      window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft,
-      window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop);
+      window.pageXOffset || document.scrollingElement.scrollLeft,
+      window.pageYOffset || document.scrollingElement.scrollTop);
   }
 };
 /* Portions of the Selector class are derived from Jack Slocumâ€™s DomQuery,
@@ -3751,10 +3751,8 @@ Event.Methods = (function() {
 
     pointer: function(event) {
       return {
-        x: event.pageX || (event.clientX +
-          (document.documentElement.scrollLeft || document.body.scrollLeft)),
-        y: event.pageY || (event.clientY +
-          (document.documentElement.scrollTop || document.body.scrollTop))
+        x: event.pageX || (event.clientX + document.scrollingElement.scrollLeft),
+        y: event.pageY || (event.clientY + document.scrollingElement.scrollTop)
       };
     },
 
@@ -4034,12 +4032,10 @@ var Position = {
   // page is scrolled
   prepare: function() {
     this.deltaX =  window.pageXOffset
-                || document.documentElement.scrollLeft
-                || document.body.scrollLeft
+                || document.scrollingElement.scrollLeft
                 || 0;
     this.deltaY =  window.pageYOffset
-                || document.documentElement.scrollTop
-                || document.body.scrollTop
+                || document.scrollingElement.scrollTop
                 || 0;
   },
 

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-004-ref.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-004-ref.xht
@@ -41,7 +41,7 @@
   <div>01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 00</div>
 
 <script>
-  document.documentElement.scrollLeft=document.documentElement.scrollWidth;
+  document.scrollingElement.scrollLeft=document.scrollingElement.scrollWidth;
 </script>
  </body>
 </html>

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-004.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-004.xht
@@ -101,7 +101,7 @@
   </div>
 
 <script>
-  document.documentElement.scrollLeft=document.documentElement.scrollWidth;
+  document.scrollingElement.scrollLeft=document.scrollingElement.scrollWidth;
 </script>
  </body>
 </html>

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-001-ref.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-001-ref.xht
@@ -75,7 +75,7 @@
   </table>
 
 <script>
-  document.documentElement.scrollLeft=document.documentElement.scrollWidth;
+  document.scrollingElement.scrollLeft=document.scrollingElement.scrollWidth;
 </script>
  </body>
 </html>

--- a/css/css-writing-modes/wm-propagation-body-scroll-offset-vertical-lr.html
+++ b/css/css-writing-modes/wm-propagation-body-scroll-offset-vertical-lr.html
@@ -18,19 +18,19 @@
 <body>
 <script>
   test(function() {
-    assert_equals(document.documentElement.scrollLeft, 0, "scrollLeft should be 0.");
+    assert_equals(document.scrollingElement.scrollLeft, 0, "scrollLeft should be 0.");
   }, "Check initial scroll position of viewport.");
 
   test(function() {
-    document.documentElement.scrollLeft = -1000;
-    assert_equals(document.documentElement.scrollLeft, 0, "scrollLeft should be 0.");
+    document.scrollingElement.scrollLeft = -1000;
+    assert_equals(document.scrollingElement.scrollLeft, 0, "scrollLeft should be 0.");
   }, "Scroll to scrollLeft = -1000 should not be possible.");
 
   test(function() {
-    document.documentElement.scrollLeft = 1000;
-    assert_equals(document.documentElement.scrollLeft, 1000, "scrollLeft should be 1000.");
+    document.scrollingElement.scrollLeft = 1000;
+    assert_equals(document.scrollingElement.scrollLeft, 1000, "scrollLeft should be 1000.");
   }, "Scroll to scrollLeft = 1000 should be possible.");
 
   // Reset back to horizontal-tb to make the result readable on-screen.
-  document.documentElement.className = "result-wm";
+  document.scrollingElement.className = "result-wm";
 </script>

--- a/css/css-writing-modes/wm-propagation-body-scroll-offset-vertical-rl.html
+++ b/css/css-writing-modes/wm-propagation-body-scroll-offset-vertical-rl.html
@@ -18,19 +18,19 @@
 <body>
 <script>
   test(function() {
-    assert_equals(document.documentElement.scrollLeft, 0, "scrollLeft should be 0.");
+    assert_equals(document.scrollingElement.scrollLeft, 0, "scrollLeft should be 0.");
   }, "Check initial scroll position of viewport.");
 
   test(function() {
-    document.documentElement.scrollLeft = -1000;
-    assert_equals(document.documentElement.scrollLeft, -1000, "scrollLeft should be -1000.");
+    document.scrollingElement.scrollLeft = -1000;
+    assert_equals(document.scrollingElement.scrollLeft, -1000, "scrollLeft should be -1000.");
   }, "Scroll to scrollLeft = -1000 should be possible.");
 
   test(function() {
-    document.documentElement.scrollLeft = 1000;
-    assert_equals(document.documentElement.scrollLeft, 0, "scrollLeft should be 0.");
+    document.scrollingElement.scrollLeft = 1000;
+    assert_equals(document.scrollingElement.scrollLeft, 0, "scrollLeft should be 0.");
   }, "Scroll to scrollLeft = 1000 should not be possible.");
 
   // Reset back to horizontal-tb to make the result readable on-screen.
-  document.documentElement.className = "result-wm";
+  document.scrollingElement.className = "result-wm";
 </script>

--- a/element-timing/scroll-to-text.html
+++ b/element-timing/scroll-to-text.html
@@ -25,7 +25,7 @@
       // We scroll to the end of the document so that the paragraph becomes visible.
       // A user agent could paint the text before or after scrolling, but either way
       // it must produce an entry for it.
-      window.scrollTo(0,document.body.scrollHeight);
+      window.scrollTo(0,document.scrollingElement.scrollHeight);
     };
   }, 'Paragraph with elementtiming attribute is observed even when not initially visible.');
 </script>

--- a/html/browsers/browsing-the-web/scroll-to-fragid/scroll-frag-percent-encoded.html
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/scroll-frag-percent-encoded.html
@@ -15,30 +15,26 @@
 var steps = [{
     fragid:'has%20two%20spaces',
       handler: function(){
-        assert_equals( scrollPosition(), 100 );
+        assert_equals( document.scrollingElement.scrollTop, 100 );
       }
     },{
       fragid:'escape%20collision',
       handler: function(){
-        assert_equals( scrollPosition(), 200 );
+        assert_equals( document.scrollingElement.scrollTop, 200 );
         document.getElementById("%20has%20two%20spaces").setAttribute("id", "has%20two%20spaces");
       }
     },{
       fragid:'has%20two%20spaces',
       handler: function(){
-        assert_equals( scrollPosition(), 300 );
+        assert_equals( document.scrollingElement.scrollTop, 300 );
       }
     },{
       fragid:'do%20not%20go%20here',
       handler: function(){
         // don't move
-        assert_equals( scrollPosition(), 400 );
+        assert_equals( document.scrollingElement.scrollTop, 400 );
       }
     }];
-
-function scrollPosition(){
-  return document.documentElement.scrollTop || document.body.scrollTop;
-}
 
 function runNextStep(){
     if( steps.length > 0 ) {

--- a/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-top.html
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-top.html
@@ -11,28 +11,24 @@
 var steps = [{
     fragid:'not-the-top',
     handler: function(){
-      assert_not_equals( scrollPosition(), 0 );
+      assert_not_equals( document.scrollingElement.scrollTop, 0 );
     }
   },{
     fragid:'top',
     handler: function(){
-      assert_equals( scrollPosition(), 0 );
+      assert_equals( document.scrollingElement.scrollTop, 0 );
     }
   },{
     fragid:'not-the-top',
     handler: function(){
-      assert_not_equals( scrollPosition(), 0 );
+      assert_not_equals( document.scrollingElement.scrollTop, 0 );
     }
   },{
     fragid:'TOP',
     handler: function(){
-      assert_equals( scrollPosition(), 0 );
+      assert_equals( document.scrollingElement.scrollTop, 0 );
     }
   }];
-
-function scrollPosition(){
-  return document.documentElement.scrollTop || document.body.scrollTop;
-}
 
 function runNextStep(){
     if( steps.length > 0 ) {

--- a/webdriver/tests/element_click/scroll_into_view.py
+++ b/webdriver/tests/element_click/scroll_into_view.py
@@ -64,9 +64,9 @@ def test_partially_visible_does_not_scroll(session, offset):
         </script>
         """.format(offset=offset))
     target = session.find.css("div", all=False)
-    assert session.execute_script("return window.scrollY || document.scrollingElement.scrollTop") == 0
+    assert session.execute_script("return window.scrollY || document.documentElement.scrollTop") == 0
     response = element_click(session, target)
     assert_success(response)
-    assert session.execute_script("return window.scrollY || document.scrollingElement.scrollTop") == 0
+    assert session.execute_script("return window.scrollY || document.documentElement.scrollTop") == 0
     click_point = assert_one_click(session)
     assert click_point == center_point(target)

--- a/webdriver/tests/element_click/scroll_into_view.py
+++ b/webdriver/tests/element_click/scroll_into_view.py
@@ -64,9 +64,9 @@ def test_partially_visible_does_not_scroll(session, offset):
         </script>
         """.format(offset=offset))
     target = session.find.css("div", all=False)
-    assert session.execute_script("return window.scrollY || document.documentElement.scrollTop") == 0
+    assert session.execute_script("return window.scrollY || document.scrollingElement.scrollTop") == 0
     response = element_click(session, target)
     assert_success(response)
-    assert session.execute_script("return window.scrollY || document.documentElement.scrollTop") == 0
+    assert session.execute_script("return window.scrollY || document.scrollingElement.scrollTop") == 0
     click_point = assert_one_click(session)
     assert click_point == center_point(target)


### PR DESCRIPTION
…port

See https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement

Please do not merge until someone confirms document.scrollingElement is supported by Microsoft Edge.

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17744174/ seems to suggest it always returns the body.