### PR TITLE
Add tests for mediacapture-image

### DIFF
--- a/mediacapture-image/getPhotoCapabilities.html
+++ b/mediacapture-image/getPhotoCapabilities.html
@@ -58,4 +58,19 @@ promise_test(t => {
 
 }, 'getPhotoCapabilities() of an ended Track should throw "InvalidStateError"');
 
+async_test(t => {
+  let canvas = document.getElementById('canvas');
+  let context = canvas.getContext('2d');
+  context.fillStyle = 'red';
+  context.fillRect(0, 0, 10, 10);
+  let stream = canvas.captureStream();
+  let videoTrack = stream.getVideoTracks()[0];
+
+  let capturer = new ImageCapture(videoTrack);
+  capturer.getPhotoCapabilities()
+  .then(t.step_func_done(() => assert_unreached('should throw "OperationError"')))
+  .catch(t.step_func_done(e => assert_equals(e.name, 'OperationError')))
+  videoTrack.stop();
+}, 'throw "OperationError" when the MediaStreamTrack being ended asynchronously');
+
 </script>

--- a/mediacapture-image/getPhotoCapabilities.html
+++ b/mediacapture-image/getPhotoCapabilities.html
@@ -71,6 +71,6 @@ async_test(t => {
   .then(t.step_func_done(() => assert_unreached('should throw "OperationError"')))
   .catch(t.step_func_done(e => assert_equals(e.name, 'OperationError')))
   videoTrack.stop();
-}, 'throw "OperationError" when the MediaStreamTrack being ended asynchronously');
+}, 'throw "OperationError" when the MediaStreamTrack is stopped while getting photo capabilities');
 
 </script>

--- a/mediacapture-image/getPhotoSettings.html
+++ b/mediacapture-image/getPhotoSettings.html
@@ -43,4 +43,19 @@ promise_test(t => {
 
 }, 'getPhotoSettings() of an ended Track should throw "InvalidStateError"');
 
+async_test(t => {
+  let canvas = document.getElementById('canvas');
+  let context = canvas.getContext('2d');
+  context.fillStyle = 'red';
+  context.fillRect(0, 0, 10, 10);
+  let stream = canvas.captureStream();
+  let videoTrack = stream.getVideoTracks()[0];
+
+  let capturer = new ImageCapture(videoTrack);
+  capturer.getPhotoSettings()
+  .then(t.step_func_done(() => assert_unreached('should throw "OperationError"')))
+  .catch(t.step_func_done(e => assert_equals(e.name, 'OperationError')))
+  videoTrack.stop();
+}, 'throw "OperationError" when the MediaStreamTrack being ended asynchronously');
+
 </script>

--- a/mediacapture-image/getPhotoSettings.html
+++ b/mediacapture-image/getPhotoSettings.html
@@ -56,6 +56,6 @@ async_test(t => {
   .then(t.step_func_done(() => assert_unreached('should throw "OperationError"')))
   .catch(t.step_func_done(e => assert_equals(e.name, 'OperationError')))
   videoTrack.stop();
-}, 'throw "OperationError" when the MediaStreamTrack being ended asynchronously');
+}, 'throw "OperationError" when the MediaStreamTrack is stopped while getting photo settings');
 
 </script>


### PR DESCRIPTION
Cover following checkpoints:

- getPhotoCapabilities() should throw "OperationError" when the MediaStreamTrack being ended asynchronously
- getPhotoSettings() should throw "OperationError" when the MediaStreamTrack being ended asynchronously