### PR TITLE
Sync Mozilla CSS tests as of 2018-09-11

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-formatting-context-margin-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-formatting-context-margin-001.html
@@ -6,7 +6,7 @@
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
   <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
   <link rel="help" href="http://www.w3.org/TR/css-containment-1/#containment-layout">
-  <link rel="match" href="contain-paint-formatting-context-margin-001-ref.html">
+  <link rel="match" href="contain-layout-formatting-context-margin-001-ref.html">
   <style>
   #a {
       contain:layout;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-grid-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-grid-001-ref.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gerald Squelart" href="mailto:gsquelart@mozilla.com">
+  <style>
+  .basic {
+    display: grid;
+    border: 1em solid green;
+  }
+  .height-ref {
+    height: 40px;
+    background: lightblue;
+  }
+  .width-ref {
+    width: 40px;
+  }
+  .floatLBasic-ref {
+    float: left;
+  }
+  .floatLWidth-ref {
+    float: left;
+    width: 40px;
+  }
+  </style>
+</head>
+<body>
+  <div class="basic"></div>
+  <br>
+
+  <div class="basic height-ref"></div>
+  <br>
+
+  <div class="basic height-ref"></div>
+  <br>
+
+  <div class="basic width-ref"></div>
+  <br>
+
+  <div class="basic width-ref"></div>
+  <br>
+
+  <div class="basic floatLBasic-ref"></div>
+  <br>
+
+  <div class="basic floatLWidth-ref"></div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-grid-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-grid-001.html
@@ -1,0 +1,72 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: 'contain: size' on grid elements should cause them to be sized and baseline-aligned as if they had no contents.</title>
+  <link rel="author" title="Gerald Squelart" href="mailto:gsquelart@mozilla.com">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-size">
+  <link rel="match" href="contain-size-grid-001-ref.html">
+  <style>
+  .contain {
+    display: grid;
+    contain:size;
+    border: 1em solid green;
+    background: red;
+  }
+  .innerContents {
+    color: transparent;
+    height: 100px;
+    width: 100px;
+  }
+  .minHeight {
+    min-height: 40px;
+    background: lightblue;
+  }
+  .height {
+    height: 40px;
+    background: lightblue;
+  }
+  .maxWidth {
+    max-width: 40px;
+  }
+  .width {
+    width: 40px;
+  }
+  .floatLBasic {
+    float: left;
+  }
+  .floatLWidth {
+    float: left;
+    width: 40px;
+  }
+  </style>
+</head>
+<body>
+  <!--CSS Test: A size-contained grid element with no specified size should render at 0 height regardless of content.-->
+  <div class="contain"><div class="innerContents">inner</div></div>
+  <br>
+
+  <!--CSS Test: A size-contained grid element with specified min-height should render at given min-height regardless of content.-->
+  <div class="contain minHeight"><div class="innerContents">inner</div></div>
+  <br>
+
+  <!--CSS Test: A size-contained grid element with specified height should render at given height regardless of content.-->
+  <div class="contain height"><div class="innerContents">inner</div></div>
+  <br>
+
+  <!--CSS Test: A size-contained grid element with specified max-width should render at given max-width and zero height regardless of content.-->
+  <div class="contain maxWidth"><div class="innerContents">inner</div></div>
+  <br>
+
+  <!--CSS Test: A size-contained grid element with specified width should render at given width and zero height regardless of content.-->
+  <div class="contain width"><div class="innerContents">inner</div></div>
+  <br>
+
+  <!--CSS Test: A size-contained floated grid element with no specified size should render at 0px by 0px regardless of content.-->
+  <div class="contain floatLBasic"><div class="innerContents">inner</div></div>
+  <br>
+
+  <!--CSS Test: A size-contained floated grid element with specified width and no specified height should render at given width and 0 height regardless of content.-->
+  <div class="contain floatLWidth"><div class="innerContents">inner</div></div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
@@ -21,6 +21,7 @@
 == contain-size-inline-block-001.html contain-size-inline-block-001-ref.html
 == contain-size-flex-001.html contain-size-flex-001-ref.html
 == contain-size-inline-flex-001.html contain-size-inline-flex-001-ref.html
+== contain-size-grid-001.html contain-size-grid-001-ref.html
 == contain-size-multicol-001.html contain-size-multicol-001-ref.html
 == contain-size-fieldset-001.html contain-size-fieldset-001-ref.html
 == contain-size-fieldset-002.html contain-size-fieldset-002-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-writing-mode-016-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-writing-mode-016-ref.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <title>CSS Reftest Reference</title>
+  <meta charset="utf-8">
+  <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+  <style>
+  .container {
+    display: block;
+    border: 2px solid purple;
+    margin: 3px;
+    /* This red should't be visible, because each container should shrinkwrap
+       its sole child (and the child should cover up this background). */
+    background: red;
+    /* Float the containers, to test in "rows", with 1 row per writing-mode. */
+    float: left;
+  }
+  br { clear: both; }
+
+  .container > * {
+    width: 10px;
+    height: 10px;
+    background: teal;
+    border: 1px solid yellow;
+  }
+  .container > * > * {
+    background: pink;
+    height: 4px;
+    width: 4px;
+    border: 1px solid black;
+  }
+
+  .pad_top    { padding-top:    3px; }
+  .pad_right  { padding-right:  4px; }
+  .pad_bottom { padding-bottom: 5px; }
+  .pad_left   { padding-left:   6px; }
+
+  .hl  { writing-mode: horizontal-tb;  direction: ltr; }
+  .hr  { writing-mode: horizontal-tb;  direction: rtl; }
+  .vl  { writing-mode: vertical-lr;    direction: ltr; }
+  .vr  { writing-mode: vertical-rl;    direction: ltr; }
+  .vl_rtl { writing-mode: vertical-lr; direction: rtl; }
+  .vr_rtl { writing-mode: vertical-rl; direction: rtl; }
+  </style>
+</head>
+<body>
+  <!-- Here, we test padding on each side of a flex item, across 6 different
+       writing-mode combinations (writing-mode X direction). -->
+  <div class="container hl">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container hl">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container hl">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container hl">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container hr">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container hr">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container hr">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container hr">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container vl">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container vl">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container vl">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container vl">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container vr">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container vr">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container vr">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container vr">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container vl_rtl">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container vl_rtl">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container vl_rtl">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container vl_rtl">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container vr_rtl">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container vr_rtl">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container vr_rtl">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container vr_rtl">
+    <div class="pad_left"><div></div></div>
+  </div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-writing-mode-016.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-writing-mode-016.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <title>
+    CSS Test: Testing auto-sized flex containers
+    with various 'writing-mode' values
+    and various padding amounts on flex items.
+  </title>
+  <meta charset="utf-8">
+  <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+  <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
+  <link rel="match" href="flexbox-writing-mode-016-ref.html">
+  <style>
+  .container {
+    display: flex;
+    flex-direction: row;
+    border: 2px solid purple;
+    margin: 3px;
+    /* This red should't be visible, because each container should shrinkwrap
+       its sole child (and the child should cover up this background). */
+    background: red;
+    /* Float the containers, to test in "rows", with 1 row per writing-mode. */
+    float: left;
+  }
+  br { clear: both; }
+
+  .container > * {
+    width: 10px;
+    height: 10px;
+    background: teal;
+    border: 1px solid yellow;
+  }
+  .container > * > * {
+    background: pink;
+    height: 4px;
+    width: 4px;
+    border: 1px solid black;
+  }
+
+  .pad_top    { padding-top:    3px; }
+  .pad_right  { padding-right:  4px; }
+  .pad_bottom { padding-bottom: 5px; }
+  .pad_left   { padding-left:   6px; }
+
+  .hl  { writing-mode: horizontal-tb;  direction: ltr; }
+  .hr  { writing-mode: horizontal-tb;  direction: rtl; }
+  .vl  { writing-mode: vertical-lr;    direction: ltr; }
+  .vr  { writing-mode: vertical-rl;    direction: ltr; }
+  .vl_rtl { writing-mode: vertical-lr; direction: rtl; }
+  .vr_rtl { writing-mode: vertical-rl; direction: rtl; }
+  </style>
+</head>
+<body>
+  <!-- Here, we test padding on each side of a flex item, across 6 different
+       writing-mode combinations (writing-mode X direction). -->
+  <div class="container hl">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container hl">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container hl">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container hl">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container hr">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container hr">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container hr">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container hr">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container vl">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container vl">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container vl">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container vl">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container vr">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container vr">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container vr">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container vr">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container vl_rtl">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container vl_rtl">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container vl_rtl">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container vl_rtl">
+    <div class="pad_left"><div></div></div>
+  </div>
+  <br>
+
+  <div class="container vr_rtl">
+    <div class="pad_top"><div></div></div>
+  </div>
+  <div class="container vr_rtl">
+    <div class="pad_right"><div></div></div>
+  </div>
+  <div class="container vr_rtl">
+    <div class="pad_bottom"><div></div></div>
+  </div>
+  <div class="container vr_rtl">
+    <div class="pad_left"><div></div></div>
+  </div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
@@ -261,6 +261,7 @@
 == flexbox-writing-mode-013.html flexbox-writing-mode-013-ref.html
 == flexbox-writing-mode-014.html flexbox-writing-mode-014-ref.html
 == flexbox-writing-mode-015.html flexbox-writing-mode-015-ref.html
+== flexbox-writing-mode-016.html flexbox-writing-mode-016-ref.html
 
 # Single-line size clamping
 == flexbox-single-line-clamp-1.html flexbox-single-line-clamp-1-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/sync-tests.sh
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/sync-tests.sh
@@ -25,4 +25,4 @@ rsync -avz --delete --filter=". ./sync-tests-filter" "$MOZTREE"/layout/reftests/
 sed -i -e 's/^\(\(fails\|needs-focus\|random\|skip\|asserts\|slow\|require-or\|silentfail\|pref\|test-pref\|ref-pref\|fuzzy\)[^ ]* *\?\)\+//;/^default-preferences /d;s/ \?# \?\(TC: \)\?[bB]ug.*//;s/ # Initial mulet triage:.*//' $(find . -name reftest.list)
 sed -i -e 's/-moz-crisp-edges/pixelated/g;s/-moz-min-content/min-content/g;s/-moz-max-content/max-content/g' $(find . -regex ".*\.\(xht\|xhtml\|html\|css\)")
 git add -A .
-git commit -m"Sync Mozilla tests as of https://hg.mozilla.org/mozilla-central/rev/$MOZREV ." -e .
+git commit -m"Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/$MOZREV ." -e .


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/423bdf7a802b0d302244492b423609187de39f56 .

This contains three test changes:
* [bug 1490111](https://bugzilla.mozilla.org/show_bug.cgi?id=1490111) (typo fix in rel=match) by @dholbert, reviewed by me
* [bug 1470462](https://bugzilla.mozilla.org/show_bug.cgi?id=1470462) (contain:size for grid) by @squelart, reviewed by @dholbert
* [bug 1486086](https://bugzilla.mozilla.org/show_bug.cgi?id=1486086) (switch to use logical axes, for stale physical-axis-based flex-item border/padding calculation) by @dholbert, reviewed by @MatsPalmgren

I also changed the script-generated commit message slightly to say "CSS tests".