### PR TITLE
[testharness.js] Disallow `test` return value

### DIFF
--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -206,6 +206,9 @@
     test(function() {assert_equals(window.global, undefined)},
          "Test that cleanup handlers from previous test ran");
 
+
+    test(function() { return false; },
+        "synchronous test that suspiciously returns a non-undefined value (should FAIL)");
 </script>
 <script type="text/json" id="expected">
 {
@@ -414,6 +417,12 @@
       "status_string": "TIMEOUT",
       "name": "test should timeout (fail) with the default of 2 seconds",
       "message": "Test timed out",
+      "properties": {}
+    },
+    {
+      "status_string": "FAIL",
+      "name": "synchronous test that suspiciously returns a non-undefined value (should FAIL)",
+      "message": "test: tests defined via `test` may not return a value",
       "properties": {}
     },
     {

--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -206,9 +206,6 @@
     test(function() {assert_equals(window.global, undefined)},
          "Test that cleanup handlers from previous test ran");
 
-
-    test(function() { return false; },
-        "synchronous test that suspiciously returns a non-undefined value (should FAIL)");
 </script>
 <script type="text/json" id="expected">
 {
@@ -417,12 +414,6 @@
       "status_string": "TIMEOUT",
       "name": "test should timeout (fail) with the default of 2 seconds",
       "message": "Test timed out",
-      "properties": {}
-    },
-    {
-      "status_string": "FAIL",
-      "name": "synchronous test that suspiciously returns a non-undefined value (should FAIL)",
-      "message": "test: tests defined via `test` may not return a value",
       "properties": {}
     },
     {

--- a/resources/test/tests/unit/test-return-restrictions.html
+++ b/resources/test/tests/unit/test-return-restrictions.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE HTML>
 <html>
 <head>

--- a/resources/test/tests/unit/test-return-restrictions.html
+++ b/resources/test/tests/unit/test-return-restrictions.html
@@ -1,0 +1,156 @@
+
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <title>Restrictions on return value from `test`</title>
+</head>
+<body>
+<script>
+function makeTest(...bodies) {
+  const closeScript = '<' + '/script>';
+  let src = `
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Document title</title>
+<script src="/resources/testharness.js?${Math.random()}">${closeScript}
+</head>
+
+<body>
+<div id="log"></div>`;
+  bodies.forEach((body) => {
+    src += '<script>(' + body + ')();' + closeScript;
+  });
+
+  const iframe = document.createElement('iframe');
+
+  document.body.appendChild(iframe);
+  iframe.contentDocument.write(src);
+
+  return new Promise((resolve) => {
+    window.addEventListener('message', function onMessage(e) {
+      if (e.source !== iframe.contentWindow) {
+        return;
+      }
+      if (!e.data || e.data.type !=='complete') {
+        return;
+      }
+      window.removeEventListener('message', onMessage);
+      resolve(e.data);
+    });
+
+    iframe.contentDocument.close();
+  }).then(({ tests, status }) => {
+    const summary = {
+      harness: {
+        status: getEnumProp(status, status.status),
+        message: status.message
+      },
+      tests: {}
+    };
+
+    tests.forEach((test) => {
+      summary.tests[test.name] = getEnumProp(test, test.status);
+    });
+
+    return summary;
+  });
+}
+
+function getEnumProp(object, value) {
+  for (let property in object) {
+    if (!/^[A-Z]+$/.test(property)) {
+      continue;
+    }
+
+    if (object[property] === value) {
+      return property;
+    }
+  }
+}
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        test(() => undefined, 'before');
+        test(() => null, 'null');
+        test(() => undefined, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness.status, 'ERROR');
+      assert_equals(
+        harness.message,
+        'test named "null" inappropriately returned a value'
+      );
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.null, 'PASS');
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'test returning `null`');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        test(() => undefined, 'before');
+        test(() => ({}), 'object');
+        test(() => undefined, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness.status, 'ERROR');
+      assert_equals(
+        harness.message,
+        'test named "object" inappropriately returned a value'
+      );
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.object, 'PASS');
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'test returning an ordinary object');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        test(() => undefined, 'before');
+        test(() => ({ then() {} }), 'thenable');
+        test(() => undefined, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness.status, 'ERROR');
+      assert_equals(
+        harness.message,
+        'test named "thenable" inappropriately returned a value, consider using `promise_test` instead'
+      );
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.thenable, 'PASS');
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'test returning a thenable object');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        test(() => undefined, 'before');
+        test(() => {
+          const iframe = document.createElement('iframe');
+          iframe.setAttribute('sandbox', '');
+          document.body.appendChild(iframe);
+          return iframe.contentWindow;
+        }, 'restricted');
+        test(() => undefined, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness.status, 'ERROR');
+      assert_equals(
+        harness.message,
+        'test named "restricted" inappropriately returned a value'
+      );
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.restricted, 'PASS');
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'test returning a restricted object');
+</script>
+</body>
+</html>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -548,7 +548,7 @@ policies and contribution forms [3].
                 "\" inappropriately returned a value";
 
             try {
-                if (value && value.hasOwnProperty('then')) {
+                if (value && value.hasOwnProperty("then")) {
                     msg += ", consider using `promise_test` instead";
                 }
             } catch (err) {}

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -543,12 +543,19 @@ policies and contribution forms [3].
         var test_obj = new Test(test_name, properties);
         var value = test_obj.step(func, test_obj, test_obj);
 
-        test_obj.step(function() {
-            assert(value === undefined,
-                   "test", null,
-                   "tests defined via `test` may not return a value",
-                   null);
-        });
+        if (value !== undefined) {
+            var msg = "test named \"" + test_name +
+                "\" inappropriately returned a value";
+
+            try {
+                if (value && value.hasOwnProperty('then')) {
+                    msg += ", consider using `promise_test` instead";
+                }
+            } catch (err) {}
+
+            tests.status.status = tests.status.ERROR;
+            tests.status.message = msg;
+        }
 
         if (test_obj.phase === test_obj.phases.STARTED) {
             test_obj.done();

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -541,7 +541,15 @@ policies and contribution forms [3].
         var test_name = name ? name : test_environment.next_default_test_name();
         properties = properties ? properties : {};
         var test_obj = new Test(test_name, properties);
-        test_obj.step(func, test_obj, test_obj);
+        var value = test_obj.step(func, test_obj, test_obj);
+
+        test_obj.step(function() {
+            assert(value === undefined,
+                   "test", null,
+                   "tests defined via `test` may not return a value",
+                   null);
+        });
+
         if (test_obj.phase === test_obj.phases.STARTED) {
             test_obj.done();
         }

--- a/web-animations/timing-model/animations/setting-the-target-effect-of-an-animation.html
+++ b/web-animations/timing-model/animations/setting-the-target-effect-of-an-animation.html
@@ -113,7 +113,7 @@ test(t => {
    'existing animation, the target effect\'s timing is updated to reflect ' +
    'the current time of the new animation.');
 
-test(async t => {
+promise_test(async t => {
   const anim = createDiv(t).animate(null, 100 * MS_PER_SEC);
   anim.updatePlaybackRate(2);
   assert_equals(anim.playbackRate, 1);


### PR DESCRIPTION
As a follow up to gh-12898, I wondered about similar test authoring mistakes
that we could avoid from within testharness.js. Are there any synchronous tests
that return a value? This would generally be harmless, but it that value were a
thenable, then it could be an unintentional use of `test` instead of
`promise_test`. TaskCluster again helped to answer the question:

    $ ./wpt tc-download --ref suspicious-sync --repo bocoup/wpt --artifact-name suspicious.txt --out-dir suspicious
    INFO:tc-download:suspicious-2/wpt-firefox-nightly-testharness-4-DlCidQw0SvOYFb_9dvqWLg-suspicious.txt
    INFO:tc-download:suspicious-2/wpt-chrome-dev-testharness-4-P0O_249FTdGyXlloowzNRQ-suspicious.txt
    cat suspicious/*
    http://web-platform.test:8000/dom/events/CustomEvent.html - this is likely a falsey mistake
    http://web-platform.test:8000/web-animations/timing-model/animations/setting-the-target-effect-of-an-animation.html - Setting the target effect to null causes a pending playback rate to be applied
    http://web-platform.test:8000/dom/events/CustomEvent.html - this is likely a falsey mistake
    http://web-platform.test:8000/web-animations/timing-model/animations/setting-the-target-effect-of-an-animation.html - Setting the target effect to null causes a pending playback rate to be applied

---

The `test` function does not recognize the return value of the provided
test body. Authors may mistakenly use this API instead of
`promise_test`, a function which is designed to respond to promise
values. Previously, mistakes like this would produce tests that
spuriously passed.

Update the `test` function to fail immediately in response to a body
that returns a value. Also correct a test which exhibited the
programming mistake that this change is intended to discourage (a survey
using both the Chrome and Firefox browsers indicated that this is the
only test in WPT which would be affected by this change).