### PR TITLE
[testharness.js] Remove deprecated API

### DIFF
--- a/docs/_writing-tests/testharness-api.md
+++ b/docs/_writing-tests/testharness-api.md
@@ -793,14 +793,6 @@ asserts that one `assert_func(actual, expected_array_N, extra_arg1, ..., extra_a
   allows multiple behaviours. Test authors should not use this method simply to hide
   UA bugs.
 
-### `assert_exists(object, property_name, description)`
-**deprecated**
-asserts that object has an own property `property_name`
-
-### `assert_not_exists(object, property_name, description)`
-**deprecated**
-assert that object does not have own property `property_name`
-
 ## Metadata ##
 
 It is possible to add optional metadata to tests; this can be done in

--- a/eventsource/eventsource-prototype.htm
+++ b/eventsource/eventsource-prototype.htm
@@ -12,7 +12,7 @@
         EventSource.prototype.ReturnTrue = function() { return true }
         var source = new EventSource("resources/message.py")
         assert_true(source.ReturnTrue())
-        assert_exists(window, "EventSource")
+        assert_own_property(window, "EventSource")
         source.close()
       })
     </scrIpt>

--- a/fetch/corb/script-html-via-cross-origin-blob-url.sub.html
+++ b/fetch/corb/script-html-via-cross-origin-blob-url.sub.html
@@ -19,7 +19,7 @@ async_test(function(t) {
   }
 
   function step2_processSubframeMsg(msg) {
-    assert_not_exists(msg, 'error');
+    assert_false(msg.haOwnProperty('error'), 'unexpected property found: "error"');
     assert_equals(msg.blob_type, 'text/html');
     assert_equals(msg.blob_size, 147);
 

--- a/fetch/corb/script-html-via-cross-origin-blob-url.sub.html
+++ b/fetch/corb/script-html-via-cross-origin-blob-url.sub.html
@@ -19,7 +19,7 @@ async_test(function(t) {
   }
 
   function step2_processSubframeMsg(msg) {
-    assert_false(msg.haOwnProperty('error'), 'unexpected property found: "error"');
+    assert_false(msg.hasOwnProperty('error'), 'unexpected property found: "error"');
     assert_equals(msg.blob_type, 'text/html');
     assert_equals(msg.blob_size, 147);
 

--- a/html/browsers/history/the-history-interface/001.html
+++ b/html/browsers/history/the-history-interface/001.html
@@ -44,7 +44,7 @@ function reportload() {
         test(function () {
             assert_equals( history.length, histlength + 1, 'make sure that you loaded the test in a new tab/window' );
         }, 'history.length should update when setting location.hash');
-        test(function () { assert_true( !!history.pushState, 'critical test; ignore any failures after this' ); }, 'history.pushState must exist'); //assert_exists does not allow prototype inheritance
+        test(function () { assert_true( !!history.pushState, 'critical test; ignore any failures after this' ); }, 'history.pushState must exist'); //assert_own_property does not allow prototype inheritance
         test(function () { assert_true( !!iframe.contentWindow.history.pushState, 'critical test; ignore any failures after this' ); }, 'history.pushState must exist within iframes');
         test(function () {
             assert_equals( iframe.contentWindow.history.state, null );
@@ -250,7 +250,7 @@ function reportload() {
             assert_equals( ev.state.numdata, 1, 'state numeric data was not correct' );
             assert_equals( ev.state.strdata, 'string data', 'state string data was not correct' );
             assert_true( !!ev.state.datedata.getTime, 'state date data was not correct' );
-            assert_exists( ev.state, 'regdata', 'state regex data was not correct' );
+            assert_own_property( ev.state, 'regdata', 'state regex data was not correct' );
             assert_equals( ev.state.regdata.source, 'a', 'state regex pattern data was not correct' );
             assert_true( ev.state.regdata.global, 'state regex flag data was not correct' );
             assert_equals( ev.state.regdata.lastIndex, 0, 'state regex lastIndex data was not correct' );

--- a/html/browsers/history/the-history-interface/002.html
+++ b/html/browsers/history/the-history-interface/002.html
@@ -43,7 +43,7 @@ function reportload() {
         test(function () {
             assert_equals( history.length, histlength + 1, 'make sure that you loaded the test in a new tab/window' );
         }, 'history.length should update when setting location.hash');
-        test(function () { assert_true( !!history.replaceState, 'critical test; ignore any failures after this' ); }, 'history.replaceState must exist'); //assert_exists does not allow prototype inheritance
+        test(function () { assert_true( !!history.replaceState, 'critical test; ignore any failures after this' ); }, 'history.replaceState must exist'); //assert_own_property does not allow prototype inheritance
         test(function () { assert_true( !!iframe.contentWindow.history.replaceState, 'critical test; ignore any failures after this' ); }, 'history.replaceState must exist within iframes');
         test(function () {
             assert_equals( iframe.contentWindow.history.state, null );
@@ -225,7 +225,7 @@ function reportload() {
             assert_equals( ev.state.numdata, 1, 'state numeric data was not correct' );
             assert_equals( ev.state.strdata, 'string data', 'state string data was not correct' );
             assert_true( !!ev.state.datedata.getTime, 'state date data was not correct' );
-            assert_exists( ev.state, 'regdata', 'state regex data was not correct' );
+            assert_own_property( ev.state, 'regdata', 'state regex data was not correct' );
             assert_equals( ev.state.regdata.source, 'a', 'state regex pattern data was not correct' );
             assert_true( ev.state.regdata.global, 'state regex flag data was not correct' );
             assert_equals( ev.state.regdata.lastIndex, 0, 'state regex lastIndex data was not correct' );

--- a/html/semantics/embedded-content/media-elements/track/track-element/track-change-event.html
+++ b/html/semantics/embedded-content/media-elements/track/track-element/track-change-event.html
@@ -15,7 +15,7 @@ async_test(function(t) {
     video.textTracks.onchange = t.step_func_done(function() {
         assert_equals(event.target, video.textTracks);
         assert_true(event instanceof Event, 'instanceof');
-        assert_not_exists(event, 'track');
+        assert_false(event.hasOwnProperty('track'), 'unexpected property found: "track"');
     });
 });
 </script>

--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -147,8 +147,8 @@
         var A = function(){this.a = "a"}
         A.prototype = {b:"b"}
         var a = new A();
-        assert_exists(a, "a");
-        assert_not_exists(a, "b");
+        assert_own_property(a, "a");
+        assert_false(a.hasOwnProperty("b"), "unexpected property found: \"b\"");
         assert_inherits(a, "b");
     }
     test(testAssertInherits, "test for assert[_not]_exists and insert_inherits")

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1240,7 +1240,7 @@ policies and contribution forms [3].
     expose(assert_class_string, "assert_class_string");
 
 
-    function assert_own_property(object, property_name, description)
+    function assert_own_property(object, property_name, description) {
         assert(object.hasOwnProperty(property_name),
                "assert_own_property", description,
                "expected property ${p} missing", {p:property_name});

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1240,24 +1240,12 @@ policies and contribution forms [3].
     expose(assert_class_string, "assert_class_string");
 
 
-    function _assert_own_property(name) {
-        return function(object, property_name, description)
-        {
-            assert(object.hasOwnProperty(property_name),
-                   name, description,
-                   "expected property ${p} missing", {p:property_name});
-        };
+    function assert_own_property(object, property_name, description)
+        assert(object.hasOwnProperty(property_name),
+               "assert_own_property", description,
+               "expected property ${p} missing", {p:property_name});
     }
-    expose(_assert_own_property("assert_exists"), "assert_exists");
-    expose(_assert_own_property("assert_own_property"), "assert_own_property");
-
-    function assert_not_exists(object, property_name, description)
-    {
-        assert(!object.hasOwnProperty(property_name),
-               "assert_not_exists", description,
-               "unexpected property ${p} found", {p:property_name});
-    }
-    expose(assert_not_exists, "assert_not_exists");
+    expose(assert_own_property, "assert_own_property");
 
     function _assert_inherits(name) {
         return function (object, property_name, description)

--- a/webrtc/getstats.html
+++ b/webrtc/getstats.html
@@ -71,7 +71,7 @@ This test uses data only, and thus does not require fake media devices.
       assert_not_equals(report, null, 'No report');
       let sessionStat = getStatsRecordByType(report, 'peer-connection');
       assert_not_equals(sessionStat, null, 'Did not find peer-connection stats');
-      assert_exists(sessionStat, 'dataChannelsOpened', 'no dataChannelsOpened stat');
+      assert_own_property(sessionStat, 'dataChannelsOpened', 'no dataChannelsOpened stat');
       // Once every 4000 or so tests, the datachannel won't be opened when the getStats
       // function is done, so allow both 0 and 1 datachannels.
       assert_true(sessionStat.dataChannelsOpened == 1 || sessionStat.dataChannelsOpened == 0,

--- a/webrtc/tools/.eslintrc.js
+++ b/webrtc/tools/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     assert_unreached: true,
     assert_throws: true,
     assert_idl_attribute: true,
-    assert_exists: true,
+    assert_own_property: true,
     assert_greater_than: true,
     assert_less_than: true,
     assert_greater_than_equal: true,

--- a/xhr/resources/responseXML-unavailable-in-worker.js
+++ b/xhr/resources/responseXML-unavailable-in-worker.js
@@ -2,8 +2,8 @@ self.importScripts('/resources/testharness.js');
 
 test(function() {
     let xhr = new XMLHttpRequest();
-    assert_not_exists(xhr, "responseXML", "responseXML should not be available on instances.");
-    assert_not_exists(XMLHttpRequest.prototype, "responseXML", "responseXML should not be on the prototype.");
+    assert_false(xhr.hasOwnProperty("responseXML"), "responseXML should not be available on instances.");
+    assert_false(XMLHttpRequest.prototype.hasOwnProperty("responseXML"), "responseXML should not be on the prototype.");
 }, "XMLHttpRequest's responseXML property should not be exposed in workers.");
 
 done();


### PR DESCRIPTION
The testharness.js functions `assert_exists` and `assert_not_exists`
have been labeled "deprecated" since 2012-01-31 [1]. Remove the
functions and replace all existing references with equivalent
assertions.

[1] 1780607fc4582b65b7fcdded3e39e79e95c8d915