### PR TITLE
Make tools/ci/jobs.py work on Windows

### DIFF
--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -35,15 +35,21 @@ job_path_map = {
 }
 
 
+def _path_norm(path):
+    """normalize a path for both case and slashes (to /)"""
+    path = os.path.normcase(path)
+    if os.path.sep != "/":
+        # this must be after the normcase call as that does slash normalization
+        path = path.replace(os.path.sep, "/")
+    return path
+
+
 class Ruleset(object):
     def __init__(self, rules):
         self.include = []
         self.exclude = []
         for rule in rules:
-            rule = os.path.normcase(rule)
-            if os.path.sep != "/":
-                # this must be after the normcase call as that does slash normalization
-                rule = rule.replace(os.path.sep, "/")
+            rule = self._path_norm(rule)
             self.add_rule(rule)
 
     def add_rule(self, rule):
@@ -56,10 +62,7 @@ class Ruleset(object):
         target.append(re.compile("^%s" % rule))
 
     def __call__(self, path):
-        path = os.path.normcase(path)
-        if os.path.sep != "/":
-            # this must be after the normcase call as that does slash normalization
-            path = path.replace(os.path.sep, "/")
+        path = _path_norm(path)
         for item in self.exclude:
             if item.match(path):
                 return False

--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -40,6 +40,10 @@ class Ruleset(object):
         self.include = []
         self.exclude = []
         for rule in rules:
+            rule = os.path.normcase(rule)
+            if os.path.sep != "/":
+                # this must be after the normcase call as that does slash normalization
+                rule = rule.replace(os.path.sep, "/")
             self.add_rule(rule)
 
     def add_rule(self, rule):
@@ -52,9 +56,10 @@ class Ruleset(object):
         target.append(re.compile("^%s" % rule))
 
     def __call__(self, path):
-        if os.path.sep != "/":
-            path = path.replace(os.path.sep, "/")
         path = os.path.normcase(path)
+        if os.path.sep != "/":
+            # this must be after the normcase call as that does slash normalization
+            path = path.replace(os.path.sep, "/")
         for item in self.exclude:
             if item.match(path):
                 return False

--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -49,7 +49,7 @@ class Ruleset(object):
         self.include = []
         self.exclude = []
         for rule in rules:
-            rule = self._path_norm(rule)
+            rule = _path_norm(rule)
             self.add_rule(rule)
 
     def add_rule(self, rule):

--- a/tools/ci/tests/test_jobs.py
+++ b/tools/ci/tests/test_jobs.py
@@ -1,14 +1,8 @@
-import sys
-
-import pytest
-
 from tools.ci import jobs
 
 default_jobs = set(["lint", "manifest_upload"])
 
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_testharness():
     assert jobs.get_jobs(["resources/testharness.js"]) == default_jobs | set(["resources_unittest"])
     assert jobs.get_jobs(["resources/testharness.js"],
@@ -19,8 +13,6 @@ def test_testharness():
                          includes=["resources_unittest"]) == set()
 
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_stability():
     assert jobs.get_jobs(["dom/historical.html"],
                          includes=["stability"]) == set(["stability"])
@@ -51,8 +43,6 @@ def test_default():
     assert jobs.get_jobs(["README.md"]) == default_jobs
 
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_tools_unittest():
     assert jobs.get_jobs(["tools/ci/test/test_jobs.py"],
                          includes=["tools_unittest"]) == set(["tools_unittest"])
@@ -62,8 +52,6 @@ def test_tools_unittest():
                          includes=["tools_unittest"]) == set()
 
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_wptrunner_unittest():
     assert jobs.get_jobs(["tools/wptrunner/wptrunner/wptrunner.py"],
                          includes=["wptrunner_unittest"]) == set(["wptrunner_unittest"])
@@ -71,8 +59,6 @@ def test_wptrunner_unittest():
                          includes=["wptrunner_unittest"]) == set()
 
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_build_css():
     assert jobs.get_jobs(["css/css-build-testsuites.sh"],
                          includes=["build_css"]) == set(["build_css"])
@@ -82,8 +68,6 @@ def test_build_css():
                          includes=["build_css"]) == set()
 
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_update_built():
     assert jobs.get_jobs(["2dcontext/foo.html"],
                          includes=["update_built"]) == set(["update_built"])
@@ -93,16 +77,12 @@ def test_update_built():
                          includes=["update_built"]) == set(["update_built"])
 
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_wpt_integration():
     assert jobs.get_jobs(["tools/wpt/wpt.py"],
                          includes=["wpt_integration"]) == set(["wpt_integration"])
     assert jobs.get_jobs(["tools/wptrunner/wptrunner/wptrunner.py"],
                          includes=["wpt_integration"]) == set(["wpt_integration"])
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12949")
 def test_wpt_infrastructure():
     assert jobs.get_jobs(["tools/hammer.html"],
                          includes=["wptrunner_infrastructure"]) == set(["wptrunner_infrastructure"])


### PR DESCRIPTION
We called os.path.normcase on the path to be compared, and not the
rules themselves. This fixes this by calling normcase on both the rule
and the path to be compared.

We also tried to do separator normalization before calling normcase,
which itself does slash normalization.