### PR TITLE
Fix 'link' syntax in MISSING-LINK explainer

### DIFF
--- a/docs/_writing-tests/lint-tool.md
+++ b/docs/_writing-tests/lint-tool.md
@@ -58,7 +58,7 @@ below to fix all errors reported.
   element whose `content` attribute has a malformed value; **fix**: ensure
   the value of the `content` attribute starts with `?` or `#` or is empty.
 
-* **MISSING-LINK**: CSS test file is missing a link to a spec. **fix**: Ensure that there is a `<link rel="help" src="[url]">` for the spec.
+* **MISSING-LINK**: CSS test file is missing a link to a spec. **fix**: Ensure that there is a `<link rel="help" href="[url]">` for the spec.
   * Note: `MISSING-LINK` is designed to ensure that the CSS build tool can find the tests. Note that the CSS build system is primarily used by [test.csswg.org/](http://test.csswg.org/), which doesn't use `wptserve`, so `*.any.js` and similar tests won't work there; stick with the `.html` equivalent.
 
 * **MISSING-TESTHARNESSREPORT**: Test file is missing an instance of


### PR DESCRIPTION
The correct syntax for the 'link' element uses 'href', not 'src'.