### PR TITLE
Unlock the lock in the logging module instead of reloading it

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -19,7 +19,6 @@ from collections import defaultdict, OrderedDict
 from multiprocessing import Process, Event
 
 from localpaths import repo_root
-from six.moves import reload_module
 
 from manifest.sourcefile import read_script_metadata, js_meta_re, parse_variants
 from wptserve import server as wptserve, handlers
@@ -630,9 +629,12 @@ class WebSocketDaemon(object):
 
 
 def start_ws_server(host, port, paths, routes, bind_address, config, **kwargs):
-    # Ensure that when we start this in a new process we don't inherit the
-    # global lock in the logging module
-    reload_module(logging)
+    # Ensure that when we start this in a new process we have the global lock
+    # in the logging module unlocked
+    try:
+        logging._releaseLock()
+    except RuntimeError:
+        pass
     return WebSocketDaemon(host,
                            str(port),
                            repo_root,
@@ -643,9 +645,12 @@ def start_ws_server(host, port, paths, routes, bind_address, config, **kwargs):
 
 
 def start_wss_server(host, port, paths, routes, bind_address, config, **kwargs):
-    # Ensure that when we start this in a new process we don't inherit the
-    # global lock in the logging module
-    reload_module(logging)
+    # Ensure that when we start this in a new process we have the global lock
+    # in the logging module unlocked
+    try:
+        logging._releaseLock()
+    except RuntimeError:
+        pass
     return WebSocketDaemon(host,
                            str(port),
                            repo_root,


### PR DESCRIPTION
Since 2ae9668bd0f23edf15d0591aeb90060dbd2565c2, the logging module is
reload in both `start_ws_server` and `start_wss_server`. This was done
to fix failing tests in gecko caused by a locked lock in the logging
module being inherited in new processes. Unfortunately this caused servo
tests to start failing.

This commits unlocks the logging global lock if it's still held instead
of reloading the whole module limiting the side effects and fixing the
tests in servo while keeping the gecko tests green.

The function `_releaseLock` is not public but has been there for a long
time and is still there in python 3.8 so I don't think we should worry
about it disappearing.