### PR TITLE
Enable experimental web features for Chrome Dev (and improve help text)

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -251,6 +251,9 @@ class Chrome(BrowserSetup):
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
                 raise WptrunError("Unable to locate or install chromedriver binary")
+        if kwargs["browser_channel"] == "dev":
+            logger.info("Automatically turning on experimental features for Chrome Dev")
+            kwargs["binary_args"].append("--enable-experimental-web-platform-features")
 
 
 class ChromeAndroid(BrowserSetup):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -47,15 +47,17 @@ def create_parser():
     parser.add_argument("--yes", "-y", dest="prompt", action="store_false", default=True,
                         help="Don't prompt before installing components")
     parser.add_argument("--install-browser", action="store_true",
-                        help="Install the browser")
+                        help="Install the browser from the release channel specified by --channel "
+                        "(or the nightly channel by default).")
     parser.add_argument("--channel", action="store",
                         choices=install.channel_by_name.keys(),
-                        default=None, help='Name of browser release channel.'
-                        '"stable" and "release" are synonyms for the latest browser stable release,'
-                        '"nightly", "dev", "experimental", and "preview" are all synonyms for '
-                        'the latest available development release. For WebDriver installs, '
-                        'we attempt to select an appropriate, compatible, version for the '
-                        'latest browser release on the selected channel.')
+                        default=None, help='Name of browser release channel. '
+                        '"stable" and "release" are synonyms for the latest browser stable '
+                        'release, "nightly", "dev", "experimental", and "preview" are all '
+                        'synonyms for the latest available development release. (For WebDriver '
+                        'installs, we attempt to select an appropriate, compatible version for '
+                        'the latest browser release on the selected channel.) '
+                        'This flag overrides --browser-channel.')
     parser._add_container_actions(wptcommandline.create_parser())
     return parser
 
@@ -273,6 +275,7 @@ class ChromeAndroid(BrowserSetup):
             else:
                 raise WptrunError("Unable to locate or install chromedriver binary")
 
+
 class ChromeWebDriver(Chrome):
     name = "chrome_webdriver"
     browser_cls = browser.ChromeWebDriver
@@ -453,6 +456,7 @@ def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
     setup_cls.install_requirements()
 
     if install_browser and not kwargs["channel"]:
+        logger.info("--install-browser is given but --channel is not set, default to nightly channel")
         kwargs["channel"] = "nightly"
 
     if kwargs["channel"]:
@@ -480,7 +484,7 @@ def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
 
 
 def run(venv, **kwargs):
-    #Remove arguments that aren't passed to wptrunner
+    # Remove arguments that aren't passed to wptrunner
     prompt = kwargs.pop("prompt", True)
     install_browser = kwargs.pop("install_browser", False)
 


### PR DESCRIPTION
Document that `--channel` will override `--browser-channel` in help
text, and make it clear that `--install-browser` defaults to the nightly
channel if no `--channel` is specified (via both help text and log).

This change unconditionally adds the
"--enable-experimental-web-platform-features" flag to Chrome Dev, as we
believe most browser engineers would like to have these features enabled
if they are testing Chrome Dev, and it would make the default behaviour
more aligned with Blink layout tests. We may add a flag to explicitly
disable this in the future upon requests.