### PR TITLE
Test new SpeechSynthesisUtterance(null/undefined)

### DIFF
--- a/speech-api/SpeechSynthesisUtterance-basics.https.html
+++ b/speech-api/SpeechSynthesisUtterance-basics.https.html
@@ -31,6 +31,16 @@ test(function() {
 }, 'new SpeechSynthesisUtterance("hello") text and defaults');
 
 test(function() {
+  const utt = new SpeechSynthesisUtterance(null);
+  assert_equals(utt.text, 'null');
+}, 'new SpeechSynthesisUtterance(null)');
+
+test(function() {
+  const utt = new SpeechSynthesisUtterance(undefined);
+  assert_equals(utt.text, 'undefined');
+}, 'new SpeechSynthesisUtterance(undefined)');
+
+test(function() {
   const utt = new SpeechSynthesisUtterance();
   utt.text = 'word';
   assert_equals(utt.text, 'word');

--- a/speech-api/SpeechSynthesisUtterance-basics.https.html
+++ b/speech-api/SpeechSynthesisUtterance-basics.https.html
@@ -37,7 +37,8 @@ test(function() {
 
 test(function() {
   const utt = new SpeechSynthesisUtterance(undefined);
-  assert_equals(utt.text, 'undefined');
+  // See https://github.com/w3c/speech-api/pull/48.
+  assert_equals(utt.text, '');
 }, 'new SpeechSynthesisUtterance(undefined)');
 
 test(function() {


### PR DESCRIPTION
Spec: https://w3c.github.io/speech-api/#tts-section

This is targeting a mundane difference in `new
SpeechSynthesisUtterance(undefined)` depending on whether the IDL definition of
the construtor uses a single constructor with an optional argument, or two
constructor overloads with zero and one argument respectively.

This is not equivalent because
https://heycam.github.io/webidl/#dfn-overload-resolution-algorithm first
considers the number of arguments, so given one argument the
`Constructor(DOMString text)` overload is used. With optional arguments,
however, trailing undefined arguments are ignored so that `foo(undefined)` will
be indistinguishable from `foo()`.

In other words, `new SpeechSynthesisUtterance(undefined)` should result in a
`text` of "undefined" because the spec uses two contructor overloads, but
Blink/WebKit have a single constructor. Edge and Firefox pass the added test, so
align with them rather than changing the spec. (It doesn't really matter.)