### PR TITLE
[service-workers] Ensure promises settle

### DIFF
--- a/service-workers/service-worker/fetch-cors-xhr.https.html
+++ b/service-workers/service-worker/fetch-cors-xhr.https.html
@@ -20,17 +20,22 @@ async_test(function(t) {
         })
       .then(function() { return with_iframe(SCOPE); })
       .then(function(frame) {
+          t.add_cleanup(function() {
+              frame.remove();
+            });
+
           return new Promise(function(resolve, reject) {
               var channel = new MessageChannel();
-              channel.port1.onmessage = t.step_func(function(e) {
-                  assert_equals(e.data.results, 'finish');
-                  frame.remove();
-                  service_worker_unregister_and_done(t, SCOPE);
-                });
+              channel.port1.onmessage = resolve;
+              channel.port1.onmessageerror = reject;
               frame.contentWindow.postMessage({},
                                               host_info['HTTPS_ORIGIN'],
                                               [channel.port2]);
             });
+        })
+      .then(function(e) {
+          assert_equals(e.data.results, 'finish');
+          service_worker_unregister_and_done(t, SCOPE);
         })
       .catch(unreached_rejection(t));
   }, 'Verify CORS XHR of fetch() in a Service Worker');

--- a/service-workers/service-worker/websocket.https.html
+++ b/service-workers/service-worker/websocket.https.html
@@ -25,19 +25,18 @@ async_test(function(t) {
         })
       .then(function() {
           return new Promise(function(resolve, reject) {
-            function onMessage(e) {
-              for (var url in e.data.urls) {
-                assert_equals(url.indexOf(get_websocket_url()), -1,
-                              "Observed an unexpected FetchEvent for the WebSocket handshake");
-              }
-              t.done();
-            }
             var channel = new MessageChannel();
-            channel.port1.onmessage = t.step_func(onMessage);
+            channel.port1.onmessage = resolve;
+            channel.port1.onmessageerror = reject;
             frame.contentWindow.navigator.serviceWorker.controller.postMessage({port: channel.port2}, [channel.port2]);
           });
         })
-      .then(function() {
+      .then(function(e) {
+          for (var url in e.data.urls) {
+            assert_equals(url.indexOf(get_websocket_url()), -1,
+                          "Observed an unexpected FetchEvent for the WebSocket handshake");
+          }
+
           frame.remove();
           return service_worker_unregister_and_done(t, scope);
         })


### PR DESCRIPTION
Previously, two tests written using the `promise_test` API created
Promises which never settled:

- `fetch-cors-xhr.https.html` - the unsettled promise did not effect
  execution and only detracted from the clarity of the test.
- `websocket.https.html` - the unsettled promise prevented the execution
  of the test's "cleanup" logic (iframe removal and worker
  de-registration).

Refactor the tests to help ensure that the Promises eventually settle.