### PR TITLE
[service-workers] Refactor tautological tests

### DIFF
--- a/service-workers/service-worker/worker-interception.https.html
+++ b/service-workers/service-worker/worker-interception.https.html
@@ -69,16 +69,9 @@ promise_test(function(t) {
           return wait_for_state(t, r.installing, 'activated');
         })
       .then(function() {
-          return new Promise(function(resolve, reject) {
-              var w = new Worker(worker_url);
-              w.onmessage = function() {
-                reject(new Error('intercepted cors response to a same-origin ' +
-                                 'mode worker load should fail'));
-              }
-
-              // The DOM error is expected.
-              w.onerror = resolve;
-            });
+          var w = new Worker(worker_url);
+          var watcher = new EventWatcher(t, w, ['message', 'error']);
+          return watcher.wait_for('error');
         })
       .then(function() {
           service_worker_unregister_and_done(t, scope);
@@ -95,19 +88,9 @@ promise_test(function(t) {
           return wait_for_state(t, r.installing, 'activated');
         })
       .then(function() {
-          return new Promise(function(resolve, reject) {
-              var w = new Worker(worker_url);
-              w.onmessage = function(e) {
-                reject(new Error('intercepted no-cors worker load should ' +
-                                 'fail'));
-              }
-
-              // The DOM error is expected.
-              w.onerror = function() {
-                resolve();
-                return true;
-              }
-            });
+          var w = new Worker(worker_url);
+          var watcher = new EventWatcher(t, w, ['message', 'error']);
+          return watcher.wait_for('error');
         })
       .then(function() {
           service_worker_unregister_and_done(t, scope);

--- a/service-workers/service-worker/worker-interception.https.html
+++ b/service-workers/service-worker/worker-interception.https.html
@@ -71,21 +71,16 @@ promise_test(function(t) {
       .then(function() {
           return new Promise(function(resolve, reject) {
               var w = new Worker(worker_url);
-              w.onmessage = function(e) {
-                resolve(e.data);
+              w.onmessage = function() {
+                reject(new Error('intercepted cors response to a same-origin ' +
+                                 'mode worker load should fail'));
               }
 
-              w.onerror = function(e) {
-                reject(e.message);
-              }
+              // The DOM error is expected.
+              w.onerror = resolve;
             });
         })
-      .then(function(data) {
-          assert_unreached('intercepted cors response to a same-origin mode ' +
-                           'worker load should fail');
-        }, function() {
-          assert_true(true, 'intercepted cors response to a same-origin mode ' +
-                            'worker load should fail');
+      .then(function() {
           service_worker_unregister_and_done(t, scope);
        });
   }, 'Verify worker script intercepted by cors response fails');
@@ -103,19 +98,18 @@ promise_test(function(t) {
           return new Promise(function(resolve, reject) {
               var w = new Worker(worker_url);
               w.onmessage = function(e) {
-                resolve(e.data);
+                reject(new Error('intercepted no-cors worker load should ' +
+                                 'fail'));
               }
 
-              w.onerror = function(e) {
-                reject(e);
+              // The DOM error is expected.
+              w.onerror = function() {
+                resolve();
                 return true;
               }
             });
         })
-      .then(function(data) {
-          assert_unreached('intercepted no-cors worker load should fail');
-        }, function() {
-          assert_true(true, 'intercepted no-cors worker load should fail');
+      .then(function() {
           service_worker_unregister_and_done(t, scope);
        });
   }, 'Verify worker script intercepted by no-cors cross-origin response fails');

--- a/service-workers/service-worker/worker-interception.https.html
+++ b/service-workers/service-worker/worker-interception.https.html
@@ -83,9 +83,7 @@ promise_test(function(t) {
       .then(function(data) {
           assert_unreached('intercepted cors response to a same-origin mode ' +
                            'worker load should fail');
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(function(e) {
+        }, function() {
           assert_true(true, 'intercepted cors response to a same-origin mode ' +
                             'worker load should fail');
           service_worker_unregister_and_done(t, scope);
@@ -116,9 +114,7 @@ promise_test(function(t) {
         })
       .then(function(data) {
           assert_unreached('intercepted no-cors worker load should fail');
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(function(e) {
+        }, function() {
           assert_true(true, 'intercepted no-cors worker load should fail');
           service_worker_unregister_and_done(t, scope);
        });


### PR DESCRIPTION
Previously, these tests created Promise values which would be fulfilled
even when expectations were violated. This would cause the test harness
to interpret them as "passing" regardless of implementation status.

Remove the use of `Promise.prototype.catch` to ensure that promise
rejections which occur during test execution lead to test failure.