### PR TITLE
[css-align] Property inheritance, initial values

### DIFF
--- a/css/css-align/inheritance.html
+++ b/css/css-align/inheritance.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Box Alignment properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#property-index">
+<meta name="assert" content="Properties inherit or not according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+<div id="target"></div>
+</div>
+<style>
+#container {
+  justify-items: legacy center;
+}
+</style>
+<script>
+assert_not_inherited('align-content', 'normal', 'last baseline');
+assert_not_inherited('align-items', 'normal', 'last baseline');
+assert_not_inherited('align-self', 'auto', 'last baseline');
+assert_not_inherited('column-gap', 'normal', '10px');
+assert_not_inherited('justify-content', 'normal', 'space-evenly');
+assert_not_inherited('justify-items', 'legacy center', 'last baseline');
+assert_not_inherited('justify-self', 'auto', 'last baseline');
+assert_not_inherited('row-gap', 'normal', '10px');
+</script>
+</body>
+</html>


### PR DESCRIPTION
CSS Box Alignment properties are not inherited.

The initial values match the spec
https://drafts.csswg.org/css-align-3/#property-index