### PR TITLE
HTML: test different block margins on legend

### DIFF
--- a/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-block-margins-ref.html
+++ b/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-block-margins-ref.html
@@ -4,7 +4,7 @@
 body { margin: 0; }
 .fieldset { margin: 2em 1em 1em 1em; border: 1em solid green; }
 .legend { position: absolute; margin-top: -1em; margin-left: 1em; background: white; height: 1em; }
-.inner { margin: 2em 1em 1em 1em; height: 1em; }
+.inner { margin: 3em 1em 1em 1em; height: 1em; }
 </style>
 <p>There should be no red.</p>
 <div class=fieldset>

--- a/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-block-margins.html
+++ b/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-block-margins.html
@@ -4,9 +4,9 @@
 <style>
  body { margin: 0; }
  fieldset { margin: 1em; border: 1em solid green; padding: 0; background: white; }
- legend { margin: 1em; height: 1em; padding: 0; }
+ legend { margin: 1em 1em 2em 1em; height: 1em; padding: 0; }
  .inner { margin: 1em; height: 1em; }
- .behind { position: absolute; left: 1em; right: 1em; margin-top: 1em; height: 6em; background: red; z-index: -1; }
+ .behind { position: absolute; left: 1em; right: 1em; margin-top: 1em; height: 7em; background: red; z-index: -1; }
 </style>
 <p>There should be no red.</p>
 <div class=behind></div>


### PR DESCRIPTION
This causes the test to fail in Firefox since it uses the margin box instead of the border box for placing the legend.

It also fails in Edge because it collapses the legend's margin with the inner divs margin.