### PR TITLE
Sync Mozilla CSS tests as of 2018-09-18

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-text-indent-intrinsic-1-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-text-indent-intrinsic-1-ref.html
@@ -12,9 +12,9 @@ body > div { margin: 0 0 1px 0; background: blue; color: white; height: 5px }
 </head>
 <body>
 
-<div style="width: 10px"></div>
+<div style="width: 7px"></div>
 <div style="width: 57px"></div>
-<div style="width: 10px"></div>
+<div style="width: 60px"></div>
 <div style="width: 10px"></div>
 <div style="width: 60px"></div>
 <div style="width: 10px"></div>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/3701bbe68f257a13322bb30f3898230ca2779e54 .

This contains changes from [bug 1491731](https://bugzilla.mozilla.org/show_bug.cgi?id=1491731) by @MatsPalmgren, reviewed by @dholbert.