### PR TITLE
[css-text-decor] Inheritance and initial values

### DIFF
--- a/css/css-text-decor/inheritance.html
+++ b/css/css-text-decor/inheritance.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Text Decoration properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#property-index">
+<meta name="assert" content="Properties inherit or not according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+<div id="target"></div>
+</div>
+<style>
+#container {
+  color: rgba(2, 3, 4, 0.5);
+}
+</style>
+<script>
+assert_not_inherited('text-decoration-color', 'rgba(2, 3, 4, 0.5)', 'rgba(42, 53, 64, 0.75)');
+assert_not_inherited('text-decoration-line', 'none', 'line-through');
+assert_not_inherited('text-decoration-style', 'solid', 'dashed');
+assert_inherited('text-emphasis-color', 'rgba(2, 3, 4, 0.5)', 'rgba(42, 53, 64, 0.75)');
+assert_inherited('text-emphasis-position', 'over right', 'under left');
+assert_inherited('text-emphasis-style', 'none', 'filled triangle');
+assert_inherited('text-shadow', 'none', 'rgba(42, 53, 64, 0.75) 10px 20px 0px');
+assert_inherited('text-underline-position', 'auto', 'under');
+</script>
+</body>
+</html>

--- a/css/support/inheritance-testcommon.js
+++ b/css/support/inheritance-testcommon.js
@@ -24,10 +24,10 @@ function assert_inherited(property, initial, other) {
     assert_equals(getComputedStyle(container)[property], other);
     assert_equals(getComputedStyle(target)[property], other);
     target.style[property] = 'initial';
-    assert_not_equals(getComputedStyle(container)[property], other);
+    assert_equals(getComputedStyle(container)[property], other);
     assert_not_equals(getComputedStyle(target)[property], other);
     target.style[property] = 'inherit';
-    assert_equals(getComputedStyle(container)[property], other);
+    assert_equals(getComputedStyle(target)[property], other);
     container.style[property] = '';
     target.style[property] = '';
   }, 'Property ' + property + ' inherits');


### PR DESCRIPTION
Test that CSS Text Decoration properties inherit or not
according to spec. Test that they have the expected
initial values.

https://drafts.csswg.org/css-text-decor-3/#property-index

Fix asserts in inheritance-testcommon.js
https://github.com/web-platform-tests/wpt/commit/677dfdd2337fd9b2cf50b371e5be7600f73a3a99#r30547730