### PR TITLE
Allow Firefox & Chrome to use fake media stream

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -222,7 +222,7 @@ Consider installing certutil via your OS package manager or directly.""")
             kwargs["prefs_root"] = prefs_root
 
         # Allow WebRTC tests to call getUserMedia.
-        kwargs["binary_args"].append("--setpref=media.navigator.streams.fake=true")
+        kwargs["extra_prefs"].append("media.navigator.streams.fake=true")
 
 
 class Fennec(BrowserSetup):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -221,6 +221,9 @@ Consider installing certutil via your OS package manager or directly.""")
                                                     channel=kwargs["browser_channel"])
             kwargs["prefs_root"] = prefs_root
 
+        # Allow WebRTC tests to call getUserMedia.
+        kwargs["binary_args"].append("--setpref=media.navigator.streams.fake=true")
+
 
 class Fennec(BrowserSetup):
     name = "fennec"
@@ -254,6 +257,9 @@ class Chrome(BrowserSetup):
         if kwargs["browser_channel"] == "dev":
             logger.info("Automatically turning on experimental features for Chrome Dev")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
+
+        # Allow WebRTC tests to call getUserMedia.
+        kwargs["binary_args"] += ["--use-fake-ui-for-media-stream", "--use-fake-device-for-media-stream"]
 
 
 class ChromeAndroid(BrowserSetup):


### PR DESCRIPTION
This is yet another difference in results I observed between BuildBot and Taskcluster.

This was added to wpt.fyi in https://github.com/web-platform-tests/results-collection/pull/504 .