### PR TITLE
[css-contain] Inheritance and initial value

### DIFF
--- a/css/css-contain/inheritance.html
+++ b/css/css-contain/inheritance.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS contain property</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain/#contain-property">
+<meta name="assert" content="Property 'contain' does not inherit.">
+<meta name="assert" content="Property 'contain' has initial value 'none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+<div id="target"></div>
+</div>
+<script>
+assert_not_inherited('contain', 'none', 'paint');
+</script>
+</body>
+</html>


### PR DESCRIPTION
The property 'contain' does not inherit,
and has initial value 'none'.
https://drafts.csswg.org/css-contain/#contain-property