### PR TITLE
[css-position] Inheritance and initial values

### DIFF
--- a/css/css-position/inheritance.html
+++ b/css/css-position/inheritance.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Positioned Layout properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-position/#property-index">
+<meta name="assert" content="Properties inherit or not according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+<div id="target"></div>
+</div>
+<style>
+#container, #target {
+  position: sticky;
+}
+</style>
+<script>
+assert_not_inherited('position', 'static', 'absolute');
+assert_not_inherited('top', 'auto', '10px');
+assert_not_inherited('right', 'auto', '10px');
+assert_not_inherited('bottom', 'auto', '10px');
+assert_not_inherited('left', 'auto', '10px');
+assert_not_inherited('offset-before', 'auto', '10px');
+assert_not_inherited('offset-after', 'auto', '10px');
+assert_not_inherited('offset-start', 'auto', '10px');
+assert_not_inherited('offset-end', 'auto', '10px');
+assert_not_inherited('z-index', 'auto', '123');
+</script>
+</body>
+</html>

--- a/css/css-position/inheritance.html
+++ b/css/css-position/inheritance.html
@@ -25,10 +25,10 @@ assert_not_inherited('top', 'auto', '10px');
 assert_not_inherited('right', 'auto', '10px');
 assert_not_inherited('bottom', 'auto', '10px');
 assert_not_inherited('left', 'auto', '10px');
-assert_not_inherited('offset-before', 'auto', '10px');
-assert_not_inherited('offset-after', 'auto', '10px');
-assert_not_inherited('offset-start', 'auto', '10px');
-assert_not_inherited('offset-end', 'auto', '10px');
+assert_not_inherited('inset-before', 'auto', '10px');
+assert_not_inherited('inset-after', 'auto', '10px');
+assert_not_inherited('inset-start', 'auto', '10px');
+assert_not_inherited('inset-end', 'auto', '10px');
 assert_not_inherited('z-index', 'auto', '123');
 </script>
 </body>


### PR DESCRIPTION
Test that the CSS Positioned Layout properties do not inherit.
Test their initial values against the spec.
https://drafts.csswg.org/css-position/#property-index