### PR TITLE
Replace deprecated pytest marker 'skip_if' with 'skipif'.

### DIFF
--- a/webdriver/tests/new_session/platform_name.py
+++ b/webdriver/tests/new_session/platform_name.py
@@ -4,7 +4,7 @@ from tests.support import platform_name
 from tests.support.asserts import assert_success
 
 
-@pytest.mark.skip_if(platform_name is None, reason="Unsupported platform {}".format(platform_name))
+@pytest.mark.skipif(platform_name is None, reason="Unsupported platform {}".format(platform_name))
 def test_corresponds_to_local_system(new_session, add_browser_capabilities):
     response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({})}})
     value = assert_success(response)


### PR DESCRIPTION
This no longer works in pytest >= 3.7, so migrate to the supported name.