### PR TITLE
Set default channel count for AnalyserNode to 2

### DIFF
--- a/webaudio/the-audio-api/the-analysernode-interface/ctor-analyser.html
+++ b/webaudio/the-audio-api/the-analysernode-interface/ctor-analyser.html
@@ -32,7 +32,7 @@
           prefix: prefix,
           numberOfInputs: 1,
           numberOfOutputs: 1,
-          channelCount: 1,
+          channelCount: 2,
           channelCountMode: 'max',
           channelInterpretation: 'speakers'
         });

--- a/webaudio/the-audio-api/the-analysernode-interface/test-analysernode.html
+++ b/webaudio/the-audio-api/the-analysernode-interface/test-analysernode.html
@@ -27,8 +27,8 @@
 
       assert_equals(
         analyser.channelCount,
-        1,
-        "analyser node has 1 input channels by default"
+        2,
+        "analyser node has 2 input channels by default"
       );
       assert_equals(
         analyser.channelCountMode,
@@ -131,8 +131,8 @@
       var analyser = new AnalyserNode(context);
       assert_equals(
         analyser.channelCount,
-        1,
-        "analyser node has 1 input channels by default"
+        2,
+        "analyser node has 2 input channels by default"
       );
       assert_equals(
         analyser.channelCountMode,


### PR DESCRIPTION

This was deliberately changed
(https://github.com/WebAudio/web-audio-api/pull/1397 ) but the tests
have not been updated

Upstreamed from https://github.com/servo/servo/pull/21712 [ci skip]