### PR TITLE
service workers: Simplified tests with async/await - Part 1

### DIFF
--- a/service-workers/service-worker/navigation-preload/broken-chunked-encoding.https.html
+++ b/service-workers/service-worker/navigation-preload/broken-chunked-encoding.https.html
@@ -5,38 +5,48 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    var script = 'resources/broken-chunked-encoding-worker.js';
-    var scope = 'resources/broken-chunked-encoding-scope.asis';
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(registration => {
-          add_completion_callback(_ => registration.unregister());
-          var worker = registration.installing;
-          return wait_for_state(t, worker, 'activated');
-        })
-      .then(_ => with_iframe(scope))
-      .then(frame => {
-          assert_equals(
-            frame.contentDocument.body.textContent,
-            'PASS: preloadResponse resolved');
-        });
-  }, 'FetchEvent#preloadResponse resolves even if the body is sent with broken chunked encoding.');
+promise_test(async t => {
+  const SCRIPT = 'resources/broken-chunked-encoding-worker.js';
+  const SCOPE = 'resources/broken-chunked-encoding-scope.asis';
 
-promise_test(t => {
-    var script = 'resources/broken-chunked-encoding-worker.js';
-    var scope = 'resources/chunked-encoding-scope.py?use_broken_body';
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(registration => {
-          add_completion_callback(_ => registration.unregister());
-          var worker = registration.installing;
-          return wait_for_state(t, worker, 'activated');
-        })
-      .then(_ => with_iframe(scope))
-      .then(frame => {
-          assert_equals(
-            frame.contentDocument.body.textContent,
-            'PASS: preloadResponse resolved');
-        });
-  }, 'FetchEvent#preloadResponse resolves even if the body is sent with broken chunked encoding with some delays');
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const worker = registration.installing;
+  await wait_for_state(t, worker, 'activated');
+  const frame = await with_iframe(SCOPE);
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+    if (frame)
+      frame.remove();
+  });
+
+  assert_equals(frame.contentDocument.body.textContent,
+                'PASS: preloadResponse resolved');
+}, 'FetchEvent#preloadResponse resolves even if the body is sent with ' +
+   'broken chunked encoding.');
+
+promise_test(async t => {
+  const SCRIPT = 'resources/broken-chunked-encoding-worker.js';
+  const SCOPE = 'resources/chunked-encoding-scope.py?use_broken_body';
+
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const worker = registration.installing;
+  await wait_for_state(t, worker, 'activated');
+  const frame = await with_iframe(SCOPE);
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+    if (frame)
+      frame.remove();
+  });
+
+  assert_equals(frame.contentDocument.body.textContent,
+                'PASS: preloadResponse resolved');
+}, 'FetchEvent#preloadResponse resolves even if the body is sent with ' +
+   'broken chunked encoding with some delays');
 
 </script>

--- a/service-workers/service-worker/navigation-preload/broken-chunked-encoding.https.html
+++ b/service-workers/service-worker/navigation-preload/broken-chunked-encoding.https.html
@@ -6,47 +6,51 @@
 <script src="../resources/test-helpers.sub.js"></script>
 <script>
 promise_test(async t => {
-  const SCRIPT = 'resources/broken-chunked-encoding-worker.js';
-  const SCOPE = 'resources/broken-chunked-encoding-scope.asis';
+  const SCRIPT = "resources/broken-chunked-encoding-worker.js";
+  const SCOPE = "resources/broken-chunked-encoding-scope.asis";
 
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
   const worker = registration.installing;
-  await wait_for_state(t, worker, 'activated');
+  await wait_for_state(t, worker, "activated");
   const frame = await with_iframe(SCOPE);
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
-    if (frame)
-      frame.remove();
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
   });
 
-  assert_equals(frame.contentDocument.body.textContent,
-                'PASS: preloadResponse resolved');
-}, 'FetchEvent#preloadResponse resolves even if the body is sent with ' +
-   'broken chunked encoding.');
+  assert_equals(
+    frame.contentDocument.body.textContent,
+    "PASS: preloadResponse resolved"
+  );
+}, "FetchEvent#preloadResponse resolves even if the body is sent with broken chunked encoding.");
 
 promise_test(async t => {
-  const SCRIPT = 'resources/broken-chunked-encoding-worker.js';
-  const SCOPE = 'resources/chunked-encoding-scope.py?use_broken_body';
+  const SCRIPT = "resources/broken-chunked-encoding-worker.js";
+  const SCOPE = "resources/chunked-encoding-scope.py?use_broken_body";
 
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
   const worker = registration.installing;
-  await wait_for_state(t, worker, 'activated');
+  await wait_for_state(t, worker, "activated");
   const frame = await with_iframe(SCOPE);
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
-    if (frame)
-      frame.remove();
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
   });
 
-  assert_equals(frame.contentDocument.body.textContent,
-                'PASS: preloadResponse resolved');
-}, 'FetchEvent#preloadResponse resolves even if the body is sent with ' +
-   'broken chunked encoding with some delays');
+  assert_equals(
+    frame.contentDocument.body.textContent,
+    "PASS: preloadResponse resolved"
+  );
+}, "FetchEvent#preloadResponse resolves even if the body is sent with broken chunked encoding with some delays");
 
 </script>

--- a/service-workers/service-worker/navigation-preload/chunked-encoding.https.html
+++ b/service-workers/service-worker/navigation-preload/chunked-encoding.https.html
@@ -6,23 +6,24 @@
 <script src="../resources/test-helpers.sub.js"></script>
 <script>
 promise_test(async t => {
-  const SCRIPT = 'resources/chunked-encoding-worker.js';
-  const SCOPE = 'resources/chunked-encoding-scope.py';
+  const SCRIPT = "resources/chunked-encoding-worker.js";
+  const SCOPE = "resources/chunked-encoding-scope.py";
 
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
   const worker = registration.installing;
-  await wait_for_state(t, worker, 'activated');
+  await wait_for_state(t, worker, "activated");
   const frame = await with_iframe(SCOPE);
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
-    if (frame)
-      frame.remove();
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
   })
 
-  assert_equals(frame.contentDocument.body.textContent, '0123456789');
-}, 'Navigation Preload must work with chunked encoding.');
+  assert_equals(frame.contentDocument.body.textContent, "0123456789");
+}, "Navigation Preload must work with chunked encoding.");
 
 </script>

--- a/service-workers/service-worker/navigation-preload/chunked-encoding.https.html
+++ b/service-workers/service-worker/navigation-preload/chunked-encoding.https.html
@@ -5,21 +5,24 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    var script = 'resources/chunked-encoding-worker.js';
-    var scope = 'resources/chunked-encoding-scope.py';
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(registration => {
-          add_completion_callback(_ => registration.unregister());
-          var worker = registration.installing;
-          return wait_for_state(t, worker, 'activated');
-        })
-      .then(_ => with_iframe(scope))
-      .then(frame => {
-          assert_equals(
-            frame.contentDocument.body.textContent,
-            '0123456789');
-        });
-  }, 'Navigation Preload must work with chunked encoding.');
+promise_test(async t => {
+  const SCRIPT = 'resources/chunked-encoding-worker.js';
+  const SCOPE = 'resources/chunked-encoding-scope.py';
+
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const worker = registration.installing;
+  await wait_for_state(t, worker, 'activated');
+  const frame = await with_iframe(SCOPE);
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+    if (frame)
+      frame.remove();
+  })
+
+  assert_equals(frame.contentDocument.body.textContent, '0123456789');
+}, 'Navigation Preload must work with chunked encoding.');
 
 </script>

--- a/service-workers/service-worker/navigation-preload/empty-preload-response-body.https.html
+++ b/service-workers/service-worker/navigation-preload/empty-preload-response-body.https.html
@@ -5,21 +5,23 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    var script = 'resources/empty-preload-response-body-worker.js';
-    var scope = 'resources/empty-preload-response-body-scope.html';
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(registration => {
-          add_completion_callback(_ => registration.unregister());
-          var worker = registration.installing;
-          return wait_for_state(t, worker, 'activated');
-        })
-      .then(_ => with_iframe(scope))
-      .then(frame => {
-          assert_equals(
-            frame.contentDocument.body.textContent,
-            '[]');
-        });
-  }, 'Navigation Preload empty response body.');
+promise_test(async t => {
+  const SCRIPT = 'resources/empty-preload-response-body-worker.js';
+  const SCOPE = 'resources/empty-preload-response-body-scope.html';
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const worker = registration.installing;
+  await wait_for_state(t, worker, 'activated');
+  const frame = await with_iframe(SCOPE);
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+    if (frame)
+      frame.remove();
+  })
+
+  assert_equals(frame.contentDocument.body.textContent, '[]');
+}, 'Navigation Preload empty response body.');
 
 </script>

--- a/service-workers/service-worker/navigation-preload/empty-preload-response-body.https.html
+++ b/service-workers/service-worker/navigation-preload/empty-preload-response-body.https.html
@@ -6,22 +6,23 @@
 <script src="../resources/test-helpers.sub.js"></script>
 <script>
 promise_test(async t => {
-  const SCRIPT = 'resources/empty-preload-response-body-worker.js';
-  const SCOPE = 'resources/empty-preload-response-body-scope.html';
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const SCRIPT = "resources/empty-preload-response-body-worker.js";
+  const SCOPE = "resources/empty-preload-response-body-scope.html";
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
   const worker = registration.installing;
-  await wait_for_state(t, worker, 'activated');
+  await wait_for_state(t, worker, "activated");
   const frame = await with_iframe(SCOPE);
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
-    if (frame)
-      frame.remove();
-  })
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
 
-  assert_equals(frame.contentDocument.body.textContent, '[]');
-}, 'Navigation Preload empty response body.');
+  assert_equals(frame.contentDocument.body.textContent, "[]");
+}, "Navigation Preload empty response body.");
 
 </script>

--- a/service-workers/service-worker/navigation-preload/get-state.https.html
+++ b/service-workers/service-worker/navigation-preload/get-state.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>NavigationPreloadManager.getState</title>
+<title>managerManager.getState</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/test-helpers.sub.js"></script>
@@ -14,204 +14,159 @@ function post_and_wait_for_reply(worker, message) {
     });
 }
 
-promise_test(t => {
+promise_test(async t => {
   const scope = '../resources/get-state';
   const script = '../resources/empty-worker.js';
-  var np;
 
-  return service_worker_unregister_and_register(t, script, scope)
-    .then(r => {
-        np = r.navigationPreload;
-        add_completion_callback(() => r.unregister());
-        return wait_for_state(t, r.installing, 'activated');
-      })
-    .then(() => np.getState())
-    .then(state => {
-        expect_navigation_preload_state(state, false, 'true', 'default state');
-        return np.enable();
-      })
-    .then(result => {
-        assert_equals(result, undefined,
-                      'enable() should resolve to undefined');
-        return np.getState();
-      })
-    .then(state => {
-        expect_navigation_preload_state(state, true, 'true',
-                                        'state after enable()');
-        return np.disable();
-      })
-    .then(result => {
-        assert_equals(result, undefined,
-                      'disable() should resolve to undefined');
-        return np.getState();
-      })
-    .then(state => {
-        expect_navigation_preload_state(state, false, 'true',
-                                        'state after disable()');
-        return np.setHeaderValue('dreams that cannot be');
-      })
-    .then(result => {
-        assert_equals(result, undefined,
-                      'setHeaderValue() should resolve to undefined');
-        return np.getState();
-      })
-    .then(state => {
-        expect_navigation_preload_state(state, false, 'dreams that cannot be',
-                                        'state after setHeaderValue()');
-        return np.setHeaderValue('').then(() => np.getState());
-      })
-    .then(state => {
-        expect_navigation_preload_state(state, false, '',
-                                        'after setHeaderValue to empty string');
-        return np.setHeaderValue(null).then(() => np.getState());
-      })
-    .then(state => {
-        expect_navigation_preload_state(state, false, 'null',
-                                        'after setHeaderValue to null');
-        return promise_rejects(t,
+  const registration =
+      await service_worker_unregister_and_register(t, script, scope);
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+  })
+
+  const manager = registration.navigationPreload;
+  await wait_for_state(t, registration.installing, 'activated');
+  let state = await manager.getState();
+  expect_navigation_preload_state(state, false, 'true', 'default state');
+  let result = await manager.enable();
+  assert_equals(result, undefined, 'enable() should resolve to undefined');
+  state = await manager.getState();
+  expect_navigation_preload_state(state, true, 'true', 'state after enable()');
+  result = await manager.disable();
+  assert_equals(result, undefined, 'disable() should resolve to undefined');
+  state = await manager.getState();
+  expect_navigation_preload_state(state, false, 'true',
+                                  'state after disable()');
+  result = await manager.setHeaderValue('dreams that cannot be');
+  assert_equals(result, undefined,
+                'setHeaderValue() should resolve to undefined');
+  state = await manager.getState();
+  expect_navigation_preload_state(state, false, 'dreams that cannot be',
+                                  'state after setHeaderValue()');
+  await manager.setHeaderValue('');
+  state = await manager.getState();
+  expect_navigation_preload_state(state, false, '',
+                                  'after setHeaderValue to empty string');
+  await manager.setHeaderValue(null);
+  state = await manager.getState();
+  expect_navigation_preload_state(state, false, 'null',
+                                  'after setHeaderValue to null');
+  await promise_rejects(t,
             new TypeError,
-            np.setHeaderValue('what\uDC00\uD800this'),
+            manager.setHeaderValue('what\uDC00\uD800this'),
             'setHeaderValue() should throw if passed surrogates');
-      })
-    .then(() => {
-        return promise_rejects(t,
+  await promise_rejects(t,
             new TypeError,
-            np.setHeaderValue('zer\0o'),
+            manager.setHeaderValue('zer\0o'),
             'setHeaderValue() should throw if passed \\0');
-      })
-    .then(() => {
-        return promise_rejects(t,
+  await promise_rejects(t,
             new TypeError,
-            np.setHeaderValue('\rcarriage'),
+            manager.setHeaderValue('\rcarriage'),
             'setHeaderValue() should throw if passed \\r');
-      })
-    .then(() => {
-        return promise_rejects(t,
+  await promise_rejects(t,
             new TypeError,
-            np.setHeaderValue('newline\n'),
+            manager.setHeaderValue('newline\n'),
             'setHeaderValue() should throw if passed \\n');
-      })
-    .then(() => {
-        return promise_rejects(t,
+  await promise_rejects(t,
             new TypeError,
-            np.setHeaderValue(),
+            manager.setHeaderValue(),
             'setHeaderValue() should throw if passed undefined');
-      })
-    .then(() => np.enable().then(() => np.getState()))
-    .then(state => {
-        expect_navigation_preload_state(state, true, 'null',
-                                        'enable() should not change header');
-      });
-  }, 'getState');
+  await manager.enable();
+  state = await manager.getState();
+  expect_navigation_preload_state(state, true, 'null',
+                                  'enable() should not change header');
+}, 'getState');
 
 // This test sends commands to a worker to call enable()/disable()/getState().
 // It checks the results from the worker and verifies that they match the
 // navigation preload state accessible from the page.
-promise_test(t => {
-  const scope = 'resources/get-state-worker';
-  const script = 'resources/get-state-worker.js';
-  var worker;
-  var registration;
+promise_test(async t => {
+  const SCOPE = 'resources/get-state-worker';
+  const SCRIPT = 'resources/get-state-worker.js';
 
-  return service_worker_unregister_and_register(t, script, scope)
-    .then(r => {
-        registration = r;
-        add_completion_callback(() => registration.unregister());
-        worker = registration.installing;
-        return wait_for_state(t, worker, 'activated');
-      })
-    .then(() => {
-        // Call getState().
-        return post_and_wait_for_reply(worker, 'getState');
-      })
-    .then(data => {
-        return Promise.all([data, registration.navigationPreload.getState()]);
-      })
-    .then(states => {
-        expect_navigation_preload_state(states[0], false, 'true',
-                                        'default state (from worker)');
-        expect_navigation_preload_state(states[1], false, 'true',
-                                        'default state (from page)');
-        // Call enable() and then getState().
-        return post_and_wait_for_reply(worker, 'enable');
-      })
-    .then(data => {
-        assert_equals(data, undefined, 'enable() should resolve to undefined');
-        return Promise.all([
-            post_and_wait_for_reply(worker, 'getState'),
-            registration.navigationPreload.getState()
-          ]);
-      })
-    .then(states => {
-        expect_navigation_preload_state(states[0], true, 'true',
-                                        'state after enable() (from worker)');
-        expect_navigation_preload_state(states[1], true, 'true',
-                                        'state after enable() (from page)');
-        // Call disable() and then getState().
-        return post_and_wait_for_reply(worker, 'disable');
-      })
-    .then(data => {
-        assert_equals(data, undefined,
-                      '.disable() should resolve to undefined');
-        return Promise.all([
-            post_and_wait_for_reply(worker, 'getState'),
-            registration.navigationPreload.getState()
-          ]);
-      })
-    .then(states => {
-        expect_navigation_preload_state(states[0], false, 'true',
-                                        'state after disable() (from worker)');
-        expect_navigation_preload_state(states[1], false, 'true',
-                                        'state after disable() (from page)');
-        return post_and_wait_for_reply(worker, 'setHeaderValue');
-      })
-    .then(data => {
-        assert_equals(data, undefined,
-                      '.setHeaderValue() should resolve to undefined');
-        return Promise.all([
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+  })
+
+  const worker = registration.installing;
+  await wait_for_state(t, worker, 'activated');
+  let data = await post_and_wait_for_reply(worker, 'getState');
+  let states = await Promise.all([data,
+                                 registration.navigationPreload.getState()]);
+  expect_navigation_preload_state(states[0], false, 'true',
+                                  'default state (from worker)');
+  expect_navigation_preload_state(states[1], false, 'true',
+                                  'default state (from page)');
+
+  data = await post_and_wait_for_reply(worker, 'enable');
+  assert_equals(data, undefined, 'enable() should resolve to undefined');
+  states = await Promise.all([
             post_and_wait_for_reply(worker, 'getState'),
             registration.navigationPreload.getState()]);
-      })
-    .then(states => {
-        expect_navigation_preload_state(
-            states[0], false, 'insightful',
-            'state after setHeaderValue() (from worker)');
-        expect_navigation_preload_state(
-            states[1], false, 'insightful',
-            'state after setHeaderValue() (from page)');
-      });
-  }, 'getState from a worker');
+  expect_navigation_preload_state(states[0], true, 'true',
+                                  'state after enable() (from worker)');
+  expect_navigation_preload_state(states[1], true, 'true',
+                                  'state after enable() (from page)');
+
+  // Call disable() and then getState().
+  data = await post_and_wait_for_reply(worker, 'disable');
+  assert_equals(data, undefined,
+                '.disable() should resolve to undefined');
+  states = await Promise.all([
+      post_and_wait_for_reply(worker, 'getState'),
+      registration.navigationPreload.getState()]);
+  expect_navigation_preload_state(states[0], false, 'true',
+                                  'state after disable() (from worker)');
+  expect_navigation_preload_state(states[1], false, 'true',
+                                  'state after disable() (from page)');
+
+  data = await post_and_wait_for_reply(worker, 'setHeaderValue');
+  states = await Promise.all([
+           post_and_wait_for_reply(worker, 'getState'),
+           registration.navigationPreload.getState()]);
+  expect_navigation_preload_state(states[0], false, 'insightful',
+      'state after setHeaderValue() (from worker)');
+  expect_navigation_preload_state(states[1], false, 'insightful',
+      'state after setHeaderValue() (from page)');
+}, 'getState from a worker');
 
 // This tests navigation preload API when there is no active worker. It calls
 // the API from the main page and then from the worker itself.
-promise_test(t => {
-  const scope = 'resources/wait-for-activate-worker';
-  const script = 'resources/wait-for-activate-worker.js';
-  var registration;
-  var np;
-  return service_worker_unregister_and_register(t, script, scope)
-    .then(r => {
-        registration = r;
-        np = registration.navigationPreload;
-        add_completion_callback(() => registration.unregister());
-        return Promise.all([
-            promise_rejects(
-                t, 'InvalidStateError', np.enable(),
-                'enable should reject if there is no active worker'),
-            promise_rejects(
-                t, 'InvalidStateError', np.disable(),
-                'disable should reject if there is no active worker'),
-            promise_rejects(
-                t, 'InvalidStateError', np.setHeaderValue('umm'),
-                'setHeaderValue should reject if there is no active worker')]);
-      })
-    .then(() => np.getState())
-    .then(state => {
-        expect_navigation_preload_state(state, false, 'true',
-                                        'state before activation');
-        return post_and_wait_for_reply(registration.installing, 'ping');
-      })
-    .then(result => assert_equals(result, 'PASS'));
-  }, 'no active worker');
+promise_test(async t => {
+  const SCOPE = 'resources/wait-for-activate-worker';
+  const SCRIPT = 'resources/wait-for-activate-worker.js';
+
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const manager = registration.navigationPreload;
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+  });
+
+  await Promise.all([
+        promise_rejects(
+            t, 'InvalidStateError', manager.enable(),
+            'enable should reject if there is no active worker'),
+        promise_rejects(
+            t, 'InvalidStateError', manager.disable(),
+            'disable should reject if there is no active worker'),
+        promise_rejects(
+            t, 'InvalidStateError', manager.setHeaderValue('umm'),
+            'setHeaderValue should reject if there is no active worker')]);
+  const state = await manager.getState();
+  expect_navigation_preload_state(state, false, 'true',
+                                  'state before activation');
+  const result = await post_and_wait_for_reply(registration.installing,
+                                               'ping');
+  assert_equals(result, 'PASS');
+}, 'no active worker');
 </script>
 </body>

--- a/service-workers/service-worker/navigation-preload/get-state.https.html
+++ b/service-workers/service-worker/navigation-preload/get-state.https.html
@@ -9,164 +9,254 @@
 <script>
 function post_and_wait_for_reply(worker, message) {
   return new Promise(resolve => {
-      navigator.serviceWorker.onmessage = e => { resolve(e.data); };
-      worker.postMessage(message);
-    });
+    navigator.serviceWorker.onmessage = e => {
+      resolve(e.data);
+    };
+    worker.postMessage(message);
+  });
 }
 
 promise_test(async t => {
-  const scope = '../resources/get-state';
-  const script = '../resources/empty-worker.js';
+  const scope = "../resources/get-state";
+  const script = "../resources/empty-worker.js";
 
-  const registration =
-      await service_worker_unregister_and_register(t, script, scope);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    script,
+    scope
+  );
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
-  })
+  t.add_cleanup(async () => {
+    if (registration) await registration.unregister();
+  });
 
   const manager = registration.navigationPreload;
-  await wait_for_state(t, registration.installing, 'activated');
+  await wait_for_state(t, registration.installing, "activated");
   let state = await manager.getState();
-  expect_navigation_preload_state(state, false, 'true', 'default state');
+  expect_navigation_preload_state(state, false, "true", "default state");
   let result = await manager.enable();
-  assert_equals(result, undefined, 'enable() should resolve to undefined');
+  assert_equals(result, undefined, "enable() should resolve to undefined");
   state = await manager.getState();
-  expect_navigation_preload_state(state, true, 'true', 'state after enable()');
+  expect_navigation_preload_state(state, true, "true", "state after enable()");
   result = await manager.disable();
-  assert_equals(result, undefined, 'disable() should resolve to undefined');
+  assert_equals(result, undefined, "disable() should resolve to undefined");
   state = await manager.getState();
-  expect_navigation_preload_state(state, false, 'true',
-                                  'state after disable()');
-  result = await manager.setHeaderValue('dreams that cannot be');
-  assert_equals(result, undefined,
-                'setHeaderValue() should resolve to undefined');
+  expect_navigation_preload_state(
+    state,
+    false,
+    "true",
+    "state after disable()"
+  );
+  result = await manager.setHeaderValue("dreams that cannot be");
+  assert_equals(
+    result,
+    undefined,
+    "setHeaderValue() should resolve to undefined"
+  );
   state = await manager.getState();
-  expect_navigation_preload_state(state, false, 'dreams that cannot be',
-                                  'state after setHeaderValue()');
-  await manager.setHeaderValue('');
+  expect_navigation_preload_state(
+    state,
+    false,
+    "dreams that cannot be",
+    "state after setHeaderValue()"
+  );
+  await manager.setHeaderValue("");
   state = await manager.getState();
-  expect_navigation_preload_state(state, false, '',
-                                  'after setHeaderValue to empty string');
+  expect_navigation_preload_state(
+    state,
+    false,
+    "",
+    "after setHeaderValue to empty string"
+  );
   await manager.setHeaderValue(null);
   state = await manager.getState();
-  expect_navigation_preload_state(state, false, 'null',
-                                  'after setHeaderValue to null');
-  await promise_rejects(t,
-            new TypeError,
-            manager.setHeaderValue('what\uDC00\uD800this'),
-            'setHeaderValue() should throw if passed surrogates');
-  await promise_rejects(t,
-            new TypeError,
-            manager.setHeaderValue('zer\0o'),
-            'setHeaderValue() should throw if passed \\0');
-  await promise_rejects(t,
-            new TypeError,
-            manager.setHeaderValue('\rcarriage'),
-            'setHeaderValue() should throw if passed \\r');
-  await promise_rejects(t,
-            new TypeError,
-            manager.setHeaderValue('newline\n'),
-            'setHeaderValue() should throw if passed \\n');
-  await promise_rejects(t,
-            new TypeError,
-            manager.setHeaderValue(),
-            'setHeaderValue() should throw if passed undefined');
+  expect_navigation_preload_state(
+    state,
+    false,
+    "null",
+    "after setHeaderValue to null"
+  );
+  await promise_rejects(
+    t,
+    new TypeError,
+    manager.setHeaderValue("what\uDC00\uD800this"),
+    "setHeaderValue() should throw if passed surrogates"
+  );
+  await promise_rejects(
+    t,
+    new TypeError,
+    manager.setHeaderValue("zer\0o"),
+    "setHeaderValue() should throw if passed \\0"
+  );
+  await promise_rejects(
+    t,
+    new TypeError,
+    manager.setHeaderValue("\rcarriage"),
+    "setHeaderValue() should throw if passed \\r"
+  );
+  await promise_rejects(
+    t,
+    new TypeError,
+    manager.setHeaderValue("newline\n"),
+    "setHeaderValue() should throw if passed \\n"
+  );
+  await promise_rejects(
+    t,
+    new TypeError,
+    manager.setHeaderValue(),
+    "setHeaderValue() should throw if passed undefined"
+  );
   await manager.enable();
   state = await manager.getState();
-  expect_navigation_preload_state(state, true, 'null',
-                                  'enable() should not change header');
-}, 'getState');
+  expect_navigation_preload_state(
+    state,
+    true,
+    "null",
+    "enable() should not change header"
+  );
+}, "getState");
 
 // This test sends commands to a worker to call enable()/disable()/getState().
 // It checks the results from the worker and verifies that they match the
 // navigation preload state accessible from the page.
 promise_test(async t => {
-  const SCOPE = 'resources/get-state-worker';
-  const SCRIPT = 'resources/get-state-worker.js';
+  const SCOPE = "resources/get-state-worker";
+  const SCRIPT = "resources/get-state-worker.js";
 
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
-  })
+  t.add_cleanup(async () => {
+    if (registration) await registration.unregister();
+  });
 
   const worker = registration.installing;
-  await wait_for_state(t, worker, 'activated');
-  let data = await post_and_wait_for_reply(worker, 'getState');
-  let states = await Promise.all([data,
-                                 registration.navigationPreload.getState()]);
-  expect_navigation_preload_state(states[0], false, 'true',
-                                  'default state (from worker)');
-  expect_navigation_preload_state(states[1], false, 'true',
-                                  'default state (from page)');
+  await wait_for_state(t, worker, "activated");
+  let data = await post_and_wait_for_reply(worker, "getState");
+  let states = await Promise.all([
+    data,
+    registration.navigationPreload.getState()
+  ]);
+  expect_navigation_preload_state(
+    states[0],
+    false,
+    "true",
+    "default state (from worker)"
+  );
+  expect_navigation_preload_state(
+    states[1],
+    false,
+    "true",
+    "default state (from page)"
+  );
 
-  data = await post_and_wait_for_reply(worker, 'enable');
-  assert_equals(data, undefined, 'enable() should resolve to undefined');
+  data = await post_and_wait_for_reply(worker, "enable");
+  assert_equals(data, undefined, "enable() should resolve to undefined");
   states = await Promise.all([
-            post_and_wait_for_reply(worker, 'getState'),
-            registration.navigationPreload.getState()]);
-  expect_navigation_preload_state(states[0], true, 'true',
-                                  'state after enable() (from worker)');
-  expect_navigation_preload_state(states[1], true, 'true',
-                                  'state after enable() (from page)');
+    post_and_wait_for_reply(worker, "getState"),
+    registration.navigationPreload.getState()
+  ]);
+  expect_navigation_preload_state(
+    states[0],
+    true,
+    "true",
+    "state after enable() (from worker)"
+  );
+  expect_navigation_preload_state(
+    states[1],
+    true,
+    "true",
+    "state after enable() (from page)"
+  );
 
   // Call disable() and then getState().
-  data = await post_and_wait_for_reply(worker, 'disable');
-  assert_equals(data, undefined,
-                '.disable() should resolve to undefined');
+  data = await post_and_wait_for_reply(worker, "disable");
+  assert_equals(data, undefined, ".disable() should resolve to undefined");
   states = await Promise.all([
-      post_and_wait_for_reply(worker, 'getState'),
-      registration.navigationPreload.getState()]);
-  expect_navigation_preload_state(states[0], false, 'true',
-                                  'state after disable() (from worker)');
-  expect_navigation_preload_state(states[1], false, 'true',
-                                  'state after disable() (from page)');
+      post_and_wait_for_reply(worker, "getState"),
+      registration.navigationPreload.getState()
+  ]);
+  expect_navigation_preload_state(
+    states[0],
+    false,
+    "true",
+    "state after disable() (from worker)"
+  );
+  expect_navigation_preload_state(
+    states[1],
+    false,
+    "true",
+    "state after disable() (from page)"
+  );
 
-  data = await post_and_wait_for_reply(worker, 'setHeaderValue');
+  data = await post_and_wait_for_reply(worker, "setHeaderValue");
   states = await Promise.all([
-           post_and_wait_for_reply(worker, 'getState'),
-           registration.navigationPreload.getState()]);
-  expect_navigation_preload_state(states[0], false, 'insightful',
-      'state after setHeaderValue() (from worker)');
-  expect_navigation_preload_state(states[1], false, 'insightful',
-      'state after setHeaderValue() (from page)');
-}, 'getState from a worker');
+    post_and_wait_for_reply(worker, "getState"),
+    registration.navigationPreload.getState()
+  ]);
+  expect_navigation_preload_state(
+    states[0],
+    false,
+    "insightful",
+    "state after setHeaderValue() (from worker)"
+  );
+  expect_navigation_preload_state(
+    states[1],
+    false,
+    "insightful",
+    "state after setHeaderValue() (from page)"
+  );
+}, "getState from a worker");
 
 // This tests navigation preload API when there is no active worker. It calls
 // the API from the main page and then from the worker itself.
 promise_test(async t => {
-  const SCOPE = 'resources/wait-for-activate-worker';
-  const SCRIPT = 'resources/wait-for-activate-worker.js';
+  const SCOPE = "resources/wait-for-activate-worker";
+  const SCRIPT = "resources/wait-for-activate-worker.js";
 
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
   const manager = registration.navigationPreload;
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
+  t.add_cleanup(async () => {
+    if (registration) await registration.unregister();
   });
 
   await Promise.all([
-        promise_rejects(
-            t, 'InvalidStateError', manager.enable(),
-            'enable should reject if there is no active worker'),
-        promise_rejects(
-            t, 'InvalidStateError', manager.disable(),
-            'disable should reject if there is no active worker'),
-        promise_rejects(
-            t, 'InvalidStateError', manager.setHeaderValue('umm'),
-            'setHeaderValue should reject if there is no active worker')]);
+    promise_rejects(
+      t, 
+      "InvalidStateError",
+      manager.enable(),
+     "enable should reject if there is no active worker"
+    ),
+    promise_rejects(
+      t,
+      "InvalidStateError",
+       manager.disable(),
+       "disable should reject if there is no active worker"
+    ),
+    promise_rejects(
+      t,
+      "InvalidStateError",
+      manager.setHeaderValue("umm"),
+      "setHeaderValue should reject if there is no active worker"
+    )
+  ]);
   const state = await manager.getState();
-  expect_navigation_preload_state(state, false, 'true',
-                                  'state before activation');
-  const result = await post_and_wait_for_reply(registration.installing,
-                                               'ping');
-  assert_equals(result, 'PASS');
-}, 'no active worker');
+  expect_navigation_preload_state(
+    state,
+    false,
+    "true",
+    "state before activation"
+  );
+  const result = await post_and_wait_for_reply(registration.installing, "ping");
+  assert_equals(result, "PASS");
+}, "no active worker");
 </script>
 </body>

--- a/service-workers/service-worker/navigation-preload/redirect.https.html
+++ b/service-workers/service-worker/navigation-preload/redirect.https.html
@@ -15,10 +15,9 @@ function check_opaqueredirect(response_info, scope) {
   assert_equals(response_info.headers.length, 0);
 }
 
-function redirect_response_test(t, scope, expected_body, expected_urls) {
-  var script = 'resources/redirect-worker.js';
-  var registration;
-  var message_resolvers = [];
+async function redirect_response_test(t, scope, expected_body, expected_urls) {
+  const SCRIPT = 'resources/redirect-worker.js';
+  let message_resolvers = [];
   function wait_for_message(count) {
     var promises = [];
     message_resolvers = [];
@@ -32,29 +31,30 @@ function redirect_response_test(t, scope, expected_body, expected_urls) {
     if (resolve)
       resolve(e.data);
   }
-  return service_worker_unregister_and_register(t, script, scope)
-    .then(reg => {
-        registration = reg;
-        add_completion_callback(_ => registration.unregister());
-        var worker = registration.installing;
-        return wait_for_state(t, worker, 'activated');
-      })
-    .then(_ => with_iframe(scope + '&base'))
-    .then(frame => {
-        assert_equals(frame.contentDocument.body.textContent, 'OK');
-        frame.contentWindow.navigator.serviceWorker.onmessage = on_message;
-        return Promise.all(wait_for_message(expected_urls.length)
-                               .concat(with_iframe(scope)));
-      })
-    .then(results => {
-      var frame = results[expected_urls.length];
-      assert_equals(frame.contentDocument.body.textContent, expected_body);
-      for (var i = 0; i < expected_urls.length; ++i) {
-        check_opaqueredirect(results[i], expected_urls[i]);
-      }
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, scope);
+  const worker = registration.installing;
+  await wait_for_state(t, worker, 'activated');
+  const frame = await with_iframe(scope + '&base');
+  assert_equals(frame.contentDocument.body.textContent, 'OK');
+  frame.contentWindow.navigator.serviceWorker.onmessage = on_message;
+  const results = await Promise.all(wait_for_message(expected_urls.length)
+                    .concat(with_iframe(scope)));
+  const result = results[expected_urls.length];
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+    if (frame)
       frame.remove();
-      return registration.unregister();
-    });
+    if (result)
+      result.remove();
+  })
+
+  assert_equals(result.contentDocument.body.textContent, expected_body);
+  for (var i = 0; i < expected_urls.length; ++i) {
+    check_opaqueredirect(results[i], expected_urls[i]);
+  }
 }
 
 promise_test(t => {
@@ -65,7 +65,7 @@ promise_test(t => {
         ['resources/redirect-scope.py?type=normal']);
   }, 'Navigation Preload redirect response.');
 
-promise_test(t => {
+promise_test(async t => {
     return redirect_response_test(
         t,
         'resources/redirect-scope.py?type=no-location',
@@ -73,7 +73,7 @@ promise_test(t => {
         ['resources/redirect-scope.py?type=no-location']);
   }, 'Navigation Preload no-location redirect response.');
 
-promise_test(t => {
+promise_test(async t => {
     return redirect_response_test(
         t,
         'resources/redirect-scope.py?type=no-location-with-body',
@@ -81,7 +81,7 @@ promise_test(t => {
         ['resources/redirect-scope.py?type=no-location-with-body']);
   }, 'Navigation Preload no-location redirect response with body.');
 
-promise_test(t => {
+promise_test(async t => {
     return redirect_response_test(
         t,
         'resources/redirect-scope.py?type=redirect-to-scope',

--- a/service-workers/service-worker/navigation-preload/redirect.https.html
+++ b/service-workers/service-worker/navigation-preload/redirect.https.html
@@ -7,16 +7,16 @@
 <script>
 
 function check_opaqueredirect(response_info, scope) {
-  assert_equals(response_info.type, 'opaqueredirect');
-  assert_equals(response_info.url, '' + new URL(scope, location));
+  assert_equals(response_info.type, "opaqueredirect");
+  assert_equals(response_info.url, "" + new URL(scope, location));
   assert_equals(response_info.status, 0);
   assert_equals(response_info.ok, false);
-  assert_equals(response_info.statusText, '');
+  assert_equals(response_info.statusText, "");
   assert_equals(response_info.headers.length, 0);
 }
 
 async function redirect_response_test(t, scope, expected_body, expected_urls) {
-  const SCRIPT = 'resources/redirect-worker.js';
+  const SCRIPT = "resources/redirect-worker.js";
   let message_resolvers = [];
   function wait_for_message(count) {
     var promises = [];
@@ -28,28 +28,28 @@ async function redirect_response_test(t, scope, expected_body, expected_urls) {
   }
   function on_message(e) {
     var resolve = message_resolvers.shift();
-    if (resolve)
-      resolve(e.data);
+    if (resolve) resolve(e.data);
   }
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, scope);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    scope
+  );
   const worker = registration.installing;
-  await wait_for_state(t, worker, 'activated');
-  const frame = await with_iframe(scope + '&base');
-  assert_equals(frame.contentDocument.body.textContent, 'OK');
+  await wait_for_state(t, worker, "activated");
+  const frame = await with_iframe(scope + "&base");
+  assert_equals(frame.contentDocument.body.textContent, "OK");
   frame.contentWindow.navigator.serviceWorker.onmessage = on_message;
-  const results = await Promise.all(wait_for_message(expected_urls.length)
-                    .concat(with_iframe(scope)));
+  const results = await Promise.all(
+    wait_for_message(expected_urls.length).concat(with_iframe(scope))
+  );
   const result = results[expected_urls.length];
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
-    if (frame)
-      frame.remove();
-    if (result)
-      result.remove();
-  })
+  t.add_cleanup(async() => {
+    if (frame) frame.remove();
+    if (result) result.remove();
+    if (registration) await registration.unregister();
+  });
 
   assert_equals(result.contentDocument.body.textContent, expected_body);
   for (var i = 0; i < expected_urls.length; ++i) {
@@ -58,36 +58,42 @@ async function redirect_response_test(t, scope, expected_body, expected_urls) {
 }
 
 promise_test(t => {
-    return redirect_response_test(
-        t,
-        'resources/redirect-scope.py?type=normal',
-        'redirected\n',
-        ['resources/redirect-scope.py?type=normal']);
-  }, 'Navigation Preload redirect response.');
+  return redirect_response_test(
+    t,
+    "resources/redirect-scope.py?type=normal",
+    "redirected\n",
+    ["resources/redirect-scope.py?type=normal"]
+  );
+}, "Navigation Preload redirect response.");
 
 promise_test(async t => {
-    return redirect_response_test(
-        t,
-        'resources/redirect-scope.py?type=no-location',
-        '',
-        ['resources/redirect-scope.py?type=no-location']);
-  }, 'Navigation Preload no-location redirect response.');
+  return redirect_response_test(
+    t,
+    "resources/redirect-scope.py?type=no-location",
+    "",
+    ["resources/redirect-scope.py?type=no-location"]
+  );
+}, "Navigation Preload no-location redirect response.");
 
 promise_test(async t => {
-    return redirect_response_test(
-        t,
-        'resources/redirect-scope.py?type=no-location-with-body',
-        'BODY',
-        ['resources/redirect-scope.py?type=no-location-with-body']);
-  }, 'Navigation Preload no-location redirect response with body.');
+  return redirect_response_test(
+    t,
+    "resources/redirect-scope.py?type=no-location-with-body",
+    "BODY",
+    ["resources/redirect-scope.py?type=no-location-with-body"]
+  );
+}, "Navigation Preload no-location redirect response with body.");
 
 promise_test(async t => {
-    return redirect_response_test(
-        t,
-        'resources/redirect-scope.py?type=redirect-to-scope',
-        'redirected\n',
-        ['resources/redirect-scope.py?type=redirect-to-scope',
-         'resources/redirect-scope.py?type=redirect-to-scope2',
-         'resources/redirect-scope.py?type=redirect-to-scope3',]);
-  }, 'Navigation Preload redirect to the same scope.');
+  return redirect_response_test(
+    t,
+    "resources/redirect-scope.py?type=redirect-to-scope",
+    "redirected\n",
+    [
+      "resources/redirect-scope.py?type=redirect-to-scope",
+      "resources/redirect-scope.py?type=redirect-to-scope2",
+      "resources/redirect-scope.py?type=redirect-to-scope3"
+    ]
+  );
+}, "Navigation Preload redirect to the same scope.");
 </script>

--- a/service-workers/service-worker/navigation-preload/request-headers.https.html
+++ b/service-workers/service-worker/navigation-preload/request-headers.https.html
@@ -5,37 +5,37 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    var script = 'resources/request-headers-worker.js';
-    var scope = 'resources/request-headers-scope.py';
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(registration => {
-          add_completion_callback(_ => registration.unregister());
-          var worker = registration.installing;
-          return wait_for_state(t, worker, 'activated');
-        })
-      .then(_ => with_iframe(scope))
-      .then(frame => {
-          var headers = JSON.parse(frame.contentDocument.body.textContent);
-          assert_true(
-            'SERVICE-WORKER-NAVIGATION-PRELOAD' in headers,
-            'The Navigation Preload request must specify a ' +
-            '"Service-Worker-Navigation-Preload" header.');
-          assert_array_equals(
-            headers['SERVICE-WORKER-NAVIGATION-PRELOAD'],
-            ['hello'],
-            'The Navigation Preload request must specify the correct value ' +
-            'for the "Service-Worker-Navigation-Preload" header.');
-          assert_true(
-            'UPGRADE-INSECURE-REQUESTS' in headers,
-            'The Navigation Preload request must specify an ' +
-            '"Upgrade-Insecure-Requests" header.');
-          assert_array_equals(
-            headers['UPGRADE-INSECURE-REQUESTS'],
-            ['1'],
-            'The Navigation Preload request must specify the correct value ' +
-            'for the "Upgrade-Insecure-Requests" header.');
-        });
-  }, 'Navigation Preload request headers.');
+promise_test(async t => {
+  const SCRIPT = 'resources/request-headers-worker.js';
+  const SCOPE = 'resources/request-headers-scope.py';
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const worker = registration.installing;
+  await wait_for_state(t, worker, 'activated');
+  const frame = await with_iframe(SCOPE);
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+    if (frame)
+      frame.remove();
+  })
+
+  const headers = JSON.parse(frame.contentDocument.body.textContent);
+  assert_true('SERVICE-WORKER-NAVIGATION-PRELOAD' in headers,
+              'The Navigation Preload request must specify a ' +
+              '"Service-Worker-Navigation-Preload" header.');
+  assert_array_equals(headers['SERVICE-WORKER-NAVIGATION-PRELOAD'], ['hello'],
+                      'The Navigation Preload request must specify the ' +
+                      'correct value for the ' +
+                      '"Service-Worker-Navigation-Preload" header.');
+  assert_true('UPGRADE-INSECURE-REQUESTS' in headers,
+              'The Navigation Preload request must specify an ' +
+              '"Upgrade-Insecure-Requests" header.');
+  assert_array_equals(headers['UPGRADE-INSECURE-REQUESTS'], ['1'],
+                      'The Navigation Preload request must specify the ' +
+                      'correct value for the ' +
+                      '"Upgrade-Insecure-Requests" header.');
+}, 'Navigation Preload request headers.');
 
 </script>

--- a/service-workers/service-worker/navigation-preload/request-headers.https.html
+++ b/service-workers/service-worker/navigation-preload/request-headers.https.html
@@ -6,36 +6,41 @@
 <script src="../resources/test-helpers.sub.js"></script>
 <script>
 promise_test(async t => {
-  const SCRIPT = 'resources/request-headers-worker.js';
-  const SCOPE = 'resources/request-headers-scope.py';
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const SCRIPT = "resources/request-headers-worker.js";
+  const SCOPE = "resources/request-headers-scope.py";
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
   const worker = registration.installing;
-  await wait_for_state(t, worker, 'activated');
+  await wait_for_state(t, worker, "activated");
   const frame = await with_iframe(SCOPE);
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
-    if (frame)
-      frame.remove();
-  })
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
 
   const headers = JSON.parse(frame.contentDocument.body.textContent);
-  assert_true('SERVICE-WORKER-NAVIGATION-PRELOAD' in headers,
-              'The Navigation Preload request must specify a ' +
-              '"Service-Worker-Navigation-Preload" header.');
-  assert_array_equals(headers['SERVICE-WORKER-NAVIGATION-PRELOAD'], ['hello'],
-                      'The Navigation Preload request must specify the ' +
-                      'correct value for the ' +
-                      '"Service-Worker-Navigation-Preload" header.');
-  assert_true('UPGRADE-INSECURE-REQUESTS' in headers,
-              'The Navigation Preload request must specify an ' +
-              '"Upgrade-Insecure-Requests" header.');
-  assert_array_equals(headers['UPGRADE-INSECURE-REQUESTS'], ['1'],
-                      'The Navigation Preload request must specify the ' +
-                      'correct value for the ' +
-                      '"Upgrade-Insecure-Requests" header.');
-}, 'Navigation Preload request headers.');
+  assert_true(
+    "SERVICE-WORKER-NAVIGATION-PRELOAD" in headers,
+    "The Navigation Preload request must specify a Service-Worker-Navigation-Preload header."
+  );
+  assert_array_equals(
+    headers["SERVICE-WORKER-NAVIGATION-PRELOAD"],
+    ["hello"],
+    "The Navigation Preload request must specify the correct value for the Service-Worker-Navigation-Preload header."
+  );
+  assert_true(
+    "UPGRADE-INSECURE-REQUESTS" in headers,
+    "The Navigation Preload request must specify an Upgrade-Insecure-Requests header."
+  );
+  assert_array_equals(
+    headers["UPGRADE-INSECURE-REQUESTS"],
+    ["1"],
+    "The Navigation Preload request must specify the correct value for the Upgrade-Insecure-Requests header."
+  );
+}, "Navigation Preload request headers.");
 
 </script>

--- a/service-workers/service-worker/navigation-preload/resource-timing.https.html
+++ b/service-workers/service-worker/navigation-preload/resource-timing.https.html
@@ -56,37 +56,37 @@ function check_timing_entry(entry, url, decodedBodySize, encodedBodySize) {
   assert_greater_than(entry.duration, 0, 'duration of ' + url);
 }
 
-promise_test(t => {
-    var script = 'resources/resource-timing-worker.js';
-    var scope = 'resources/resource-timing-scope.py';
-    var registration;
-    var frames = [];
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(reg => {
-          registration = reg;
-          add_completion_callback(_ => registration.unregister());
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(_ => with_iframe(scope + '?type=normal'))
-      .then(frame => {
-          frames.push(frame);
-          return with_iframe(scope + '?type=redirect');
-        })
-      .then(frame => {
-          frames.push(frame);
-          frames.forEach(frame => {
-            var result = JSON.parse(frame.contentDocument.body.textContent);
-            assert_equals(
-              result.timingEntries.length, 1,
-              'performance.getEntriesByName() must returns one ' +
-              'PerformanceResourceTiming entry for the navigation preload.');
-            var entry = result.timingEntries[0];
-            check_timing_entry(entry, frame.src, result.decodedBodySize,
-                               result.encodedBodySize);
-            frame.remove();
-          });
-          return registration.unregister();
-        });
-  }, 'Navigation Preload Resource Timing.');
+promise_test(async t => {
+  const SCRIPT = 'resources/resource-timing-worker.js';
+  const SCOPE = 'resources/resource-timing-scope.py';
+  let frames = [];
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame1 = await with_iframe(SCOPE + '?type=normal');
+  frames.push(frame1);
+  const frame2 = await with_iframe(SCOPE + '?type=redirect');
+  frames.push(frame2);
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+    if (frame1)
+      frame1.remove();
+    if (frame2)
+      frame2.remove();
+  })
+
+  frames.forEach(frame => {
+    const result = JSON.parse(frame.contentDocument.body.textContent);
+    assert_equals(result.timingEntries.length, 1,
+      'performance.getEntriesByName() must returns one ' +
+      'PerformanceResourceTiming entry for the navigation preload.');
+    const entry = result.timingEntries[0];
+    check_timing_entry(entry, frame.src, result.decodedBodySize,
+                       result.encodedBodySize);
+    frame.remove();
+  });
+}, 'Navigation Preload Resource Timing.');
 
 </script>

--- a/service-workers/service-worker/navigation-preload/resource-timing.https.html
+++ b/service-workers/service-worker/navigation-preload/resource-timing.https.html
@@ -7,86 +7,132 @@
 <script>
 
 function check_timing_entry(entry, url, decodedBodySize, encodedBodySize) {
-  assert_equals(entry.name, url, 'The entry name of '+ url);
+  assert_equals(entry.name, url, "The entry name of "+ url);
 
   assert_equals(
-    entry.entryType, 'resource',
-    'The entryType of preload response timing entry must be "resource' +
-    '" :' + url);
+    entry.entryType,
+    "resource",
+    "The entryType of preload response timing entry must be 'resource':" + url
+  );
   assert_equals(
-    entry.initiatorType, 'navigation',
-    'The initiatorType of preload response timing entry must be ' +
-    '"navigation":' + url);
+    entry.initiatorType,
+    "navigation",
+    "The initiatorType of preload response timing entry must be 'navigation':" + url
+  );
 
   // If the server returns the redirect response, |decodedBodySize| is null and
   // |entry.decodedBodySize| shuld be 0. Otherwise |entry.decodedBodySize| must
   // same as |decodedBodySize|
   assert_equals(
-    entry.decodedBodySize, Number(decodedBodySize),
-    'decodedBodySize must same as the decoded size in the server:' + url);
+    entry.decodedBodySize,
+    Number(decodedBodySize),
+    "decodedBodySize must same as the decoded size in the server:" + url
+  );
 
   // If the server returns the redirect response, |encodedBodySize| is null and
   // |entry.encodedBodySize| shuld be 0. Otherwise |entry.encodedBodySize| must
   // same as |encodedBodySize|
   assert_equals(
-    entry.encodedBodySize, Number(encodedBodySize),
-    'encodedBodySize must same as the encoded size in the server:' + url);
+    entry.encodedBodySize,
+    Number(encodedBodySize),
+    "encodedBodySize must same as the encoded size in the server:" + url
+  );
 
   assert_greater_than(
-    entry.transferSize, entry.decodedBodySize,
-    'transferSize must greater then encodedBodySize.');
+    entry.transferSize,
+    entry.decodedBodySize,
+    "transferSize must greater then encodedBodySize."
+  );
 
-  assert_greater_than(entry.startTime, 0, 'startTime of ' + url);
-  assert_greater_than_equal(entry.fetchStart, entry.startTime,
-                            'fetchStart >= startTime of ' + url);
-  assert_greater_than_equal(entry.domainLookupStart, entry.fetchStart,
-                            'domainLookupStart >= fetchStart of ' + url);
-  assert_greater_than_equal(entry.domainLookupEnd, entry.domainLookupStart,
-                            'domainLookupEnd >= domainLookupStart of ' + url);
-  assert_greater_than_equal(entry.connectStart, entry.domainLookupEnd,
-                            'connectStart >= domainLookupEnd of ' + url);
-  assert_greater_than_equal(entry.connectEnd, entry.connectStart,
-                            'connectEnd >= connectStart of ' + url);
-  assert_greater_than_equal(entry.requestStart, entry.connectEnd,
-                            'requestStart >= connectEnd of ' + url);
-  assert_greater_than_equal(entry.responseStart, entry.requestStart,
-                            'domainLookupStart >= requestStart of ' + url);
-  assert_greater_than_equal(entry.responseEnd, entry.responseStart,
-                            'responseEnd >= responseStart of ' + url);
-  assert_greater_than(entry.duration, 0, 'duration of ' + url);
+  assert_greater_than(
+    entry.startTime,
+    0,
+    "startTime of " + url
+  );
+  assert_greater_than_equal(
+    entry.fetchStart,
+    entry.startTime,
+    "fetchStart >= startTime of " + url
+  );
+  assert_greater_than_equal(
+    entry.domainLookupStart,
+    entry.fetchStart,
+    "domainLookupStart >= fetchStart of " + url
+  );
+  assert_greater_than_equal(
+    entry.domainLookupEnd,
+    entry.domainLookupStart,
+    "domainLookupEnd >= domainLookupStart of " + url
+  );
+  assert_greater_than_equal(
+    entry.connectStart,
+    entry.domainLookupEnd,
+    "connectStart >= domainLookupEnd of " + url
+  );
+  assert_greater_than_equal(
+    entry.connectEnd,
+    entry.connectStart,
+    "connectEnd >= connectStart of " + url
+  );
+  assert_greater_than_equal(
+    entry.requestStart,
+    entry.connectEnd,
+    "requestStart >= connectEnd of " + url
+  );
+  assert_greater_than_equal(
+    entry.responseStart,
+    entry.requestStart,
+    "domainLookupStart >= requestStart of " + url
+  );
+  assert_greater_than_equal(
+    entry.responseEnd,
+    entry.responseStart,
+    "responseEnd >= responseStart of " + url
+  );
+  assert_greater_than(
+    entry.duration,
+    0,
+    "duration of " + url
+  );
 }
 
 promise_test(async t => {
-  const SCRIPT = 'resources/resource-timing-worker.js';
-  const SCOPE = 'resources/resource-timing-scope.py';
+  const SCRIPT = "resources/resource-timing-worker.js";
+  const SCOPE = "resources/resource-timing-scope.py";
   let frames = [];
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
-  await wait_for_state(t, registration.installing, 'activated');
-  const frame1 = await with_iframe(SCOPE + '?type=normal');
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, "activated");
+  const frame1 = await with_iframe(SCOPE + "?type=normal");
   frames.push(frame1);
-  const frame2 = await with_iframe(SCOPE + '?type=redirect');
+  const frame2 = await with_iframe(SCOPE + "?type=redirect");
   frames.push(frame2);
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
-    if (frame1)
-      frame1.remove();
-    if (frame2)
-      frame2.remove();
+  t.add_cleanup(async () => {
+    if (frame1) frame1.remove();
+    if (frame2) frame2.remove();
+    if (registration) await registration.unregister();
   })
 
   frames.forEach(frame => {
     const result = JSON.parse(frame.contentDocument.body.textContent);
-    assert_equals(result.timingEntries.length, 1,
-      'performance.getEntriesByName() must returns one ' +
-      'PerformanceResourceTiming entry for the navigation preload.');
+    assert_equals(
+      result.timingEntries.length,
+      1,
+      "performance.getEntriesByName() must returns one PerformanceResourceTiming entry for the navigation preload."
+    );
     const entry = result.timingEntries[0];
-    check_timing_entry(entry, frame.src, result.decodedBodySize,
-                       result.encodedBodySize);
+    check_timing_entry(
+      entry,
+      frame.src,
+      result.decodedBodySize,
+      result.encodedBodySize
+    );
     frame.remove();
   });
-}, 'Navigation Preload Resource Timing.');
+}, "Navigation Preload Resource Timing.");
 
 </script>

--- a/service-workers/service-worker/postmessage-blob-url.https.html
+++ b/service-workers/service-worker/postmessage-blob-url.https.html
@@ -5,26 +5,30 @@
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 promise_test(async t => {
-  const script = 'resources/postmessage-blob-url.js';
-  const scope = 'resources/blank.html';
-  const blobText = 'Blob text';
+  const script = "resources/postmessage-blob-url.js";
+  const scope = "resources/blank.html";
+  const blobText = "Blob text";
 
-  const registration =
-      await service_worker_unregister_and_register(t, script, scope);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    script,
+    scope
+  );
 
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
+  t.add_cleanup(async () => {
+    if (registration) await registration.unregister();
   });
 
   const worker = registration.installing;
   const blob = new Blob([blobText]);
   const blobUrl = URL.createObjectURL(blob);
   const response = await new Promise(resolve => {
-    navigator.serviceWorker.onmessage = e => { resolve(e.data); }
+    navigator.serviceWorker.onmessage = e => {
+      resolve(e.data);
+    }
     worker.postMessage(blobUrl);
   });
-  assert_equals(response, 'Worker reply:' + blobText);
+  assert_equals(response, "Worker reply:" + blobText);
   URL.revokeObjectURL(blobUrl);
-}, 'postMessage Blob URL to a ServiceWorker');
+}, "postMessage Blob URL to a ServiceWorker");
 </script>

--- a/service-workers/service-worker/postmessage-blob-url.https.html
+++ b/service-workers/service-worker/postmessage-blob-url.https.html
@@ -4,30 +4,27 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    let script = 'resources/postmessage-blob-url.js';
-    let scope = 'resources/blank.html';
-    let registration;
-    let blobText = 'Blob text';
-    let blob;
-    let blobUrl;
+promise_test(async t => {
+  const script = 'resources/postmessage-blob-url.js';
+  const scope = 'resources/blank.html';
+  const blobText = 'Blob text';
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(r => {
-          add_completion_callback(() => r.unregister());
-          registration = r;
-          let worker = registration.installing;
-          blob = new Blob([blobText]);
-          blobUrl = URL.createObjectURL(blob);
-          return new Promise(resolve => {
-            navigator.serviceWorker.onmessage = e => { resolve(e.data); }
-            worker.postMessage(blobUrl);
-          });
-        })
-      .then(response => {
-          assert_equals(response, 'Worker reply:' + blobText);
-          URL.revokeObjectURL(blobUrl);
-          return registration.unregister();
-        });
-  }, 'postMessage Blob URL to a ServiceWorker');
+  const registration =
+      await service_worker_unregister_and_register(t, script, scope);
+
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+  });
+
+  const worker = registration.installing;
+  const blob = new Blob([blobText]);
+  const blobUrl = URL.createObjectURL(blob);
+  const response = await new Promise(resolve => {
+    navigator.serviceWorker.onmessage = e => { resolve(e.data); }
+    worker.postMessage(blobUrl);
+  });
+  assert_equals(response, 'Worker reply:' + blobText);
+  URL.revokeObjectURL(blobUrl);
+}, 'postMessage Blob URL to a ServiceWorker');
 </script>

--- a/service-workers/service-worker/postmessage-msgport-to-client.https.html
+++ b/service-workers/service-worker/postmessage-msgport-to-client.https.html
@@ -4,40 +4,38 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    var script = 'resources/postmessage-msgport-to-client-worker.js';
-    var scope = 'resources/blank.html';
-    var port;
+promise_test(async t => {
+  const SCRIPT = 'resources/postmessage-msgport-to-client-worker.js';
+  const SCOPE = 'resources/blank.html';
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(registration => {
-          add_completion_callback(() => registration.unregister());
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(() => with_iframe(scope))
-      .then(frame => {
-          t.add_cleanup(() => frame.remove());
-          return new Promise(resolve => {
-              var w = frame.contentWindow;
-              w.navigator.serviceWorker.onmessage = resolve;
-              w.navigator.serviceWorker.controller.postMessage('ping');
-            });
-        })
-      .then(e => {
-          port = e.ports[0];
-          port.postMessage({value: 1});
-          port.postMessage({value: 2});
-          port.postMessage({done: true});
-          return new Promise(resolve => { port.onmessage = resolve; });
-        })
-      .then(e => {
-          assert_equals(e.data.ack, 'Acking value: 1');
-          return new Promise(resolve => { port.onmessage = resolve; });
-        })
-      .then(e => {
-          assert_equals(e.data.ack, 'Acking value: 2');
-          return new Promise(resolve => { port.onmessage = resolve; });
-        })
-      .then(e => { assert_true(e.data.done, 'done'); });
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE);
+
+  t.add_cleanup(async() => {
+    if (frame)
+      frame.remove();
+    if (registration)
+      await registration.unregister();
+  });
+
+  let e = await new Promise(resolve => {
+    const contentWindow = frame.contentWindow;
+    contentWindow.navigator.serviceWorker.onmessage = resolve;
+    contentWindow.navigator.serviceWorker.controller.postMessage('ping');
+  });
+
+  const port = e.ports[0];
+  port.postMessage({value: 1});
+  port.postMessage({value: 2});
+  port.postMessage({done: true});
+  e = await new Promise(resolve => { port.onmessage = resolve; });
+  assert_equals(e.data.ack, 'Acking value: 1');
+  e = await new Promise(resolve => { port.onmessage = resolve; });
+  assert_equals(e.data.ack, 'Acking value: 2');
+  e = await new Promise(resolve => { port.onmessage = resolve; });
+  assert_true(e.data.done, 'done');
+
   }, 'postMessage MessagePorts from ServiceWorker to Client');
 </script>

--- a/service-workers/service-worker/postmessage-msgport-to-client.https.html
+++ b/service-workers/service-worker/postmessage-msgport-to-client.https.html
@@ -8,16 +8,17 @@ promise_test(async t => {
   const SCRIPT = 'resources/postmessage-msgport-to-client-worker.js';
   const SCOPE = 'resources/blank.html';
 
-  const registration =
-      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
   await wait_for_state(t, registration.installing, 'activated');
   const frame = await with_iframe(SCOPE);
 
-  t.add_cleanup(async() => {
-    if (frame)
-      frame.remove();
-    if (registration)
-      await registration.unregister();
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
   });
 
   let e = await new Promise(resolve => {
@@ -27,15 +28,20 @@ promise_test(async t => {
   });
 
   const port = e.ports[0];
-  port.postMessage({value: 1});
-  port.postMessage({value: 2});
-  port.postMessage({done: true});
-  e = await new Promise(resolve => { port.onmessage = resolve; });
+  port.postMessage({ value: 1 });
+  port.postMessage({ value: 2 });
+  port.postMessage({ done: true });
+  e = await new Promise(resolve => {
+    port.onmessage = resolve;
+  });
   assert_equals(e.data.ack, 'Acking value: 1');
-  e = await new Promise(resolve => { port.onmessage = resolve; });
+  e = await new Promise(resolve => {
+    port.onmessage = resolve;
+  });
   assert_equals(e.data.ack, 'Acking value: 2');
-  e = await new Promise(resolve => { port.onmessage = resolve; });
+  e = await new Promise(resolve => {
+    port.onmessage = resolve;
+  });
   assert_true(e.data.done, 'done');
-
-  }, 'postMessage MessagePorts from ServiceWorker to Client');
+}, 'postMessage MessagePorts from ServiceWorker to Client');
 </script>

--- a/service-workers/service-worker/postmessage-to-client.https.html
+++ b/service-workers/service-worker/postmessage-to-client.https.html
@@ -6,37 +6,55 @@
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 promise_test(async t => {
-  const script = 'resources/postmessage-to-client-worker.js';
-  const scope = 'resources/blank.html';
+  const script = "resources/postmessage-to-client-worker.js";
+  const scope = "resources/blank.html";
 
-  const registration =
-      await service_worker_unregister_and_register(t, script, scope);
-  t.add_cleanup(() => registration.unregister());
-  await wait_for_state(t, registration.installing, 'activated');
+  const registration = await service_worker_unregister_and_register(
+    t,
+    script,
+    scope
+  );
+  await wait_for_state(t, registration.installing, "activated");
   const frame = await with_iframe(scope);
-  t.add_cleanup(() => frame.remove());
+
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+
   const w = frame.contentWindow;
 
-  w.navigator.serviceWorker.controller.postMessage('ping');
+  w.navigator.serviceWorker.controller.postMessage("ping");
   let e = await new Promise(r => w.navigator.serviceWorker.onmessage = r);
 
-  assert_equals(e.constructor, w.MessageEvent,
-                'message events should use MessageEvent interface.');
-  assert_equals(e.type, 'message', 'type should be "message".');
-  assert_false(e.bubbles, 'message events should not bubble.');
-  assert_false(e.cancelable, 'message events should not be cancelable.');
-  assert_equals(e.origin, location.origin,
-                'origin of message should be origin of Service Worker.');
-  assert_equals(e.lastEventId, '',
-                'lastEventId should be an empty string.');
-  assert_equals(e.source.constructor, w.ServiceWorker,
-                'source should use ServiceWorker interface.');
-  assert_equals(e.source, w.navigator.serviceWorker.controller,
-                'source should be the service worker that sent the message.');
-  assert_equals(e.ports.length, 0, 'ports should be an empty array.');
-  assert_equals(e.data, 'Sending message via clients');
+  assert_equals(
+    e.constructor,
+    w.MessageEvent,
+    "message events should use MessageEvent interface."
+  );
+  assert_equals(e.type, "message", "type should be 'message'.");
+  assert_false(e.bubbles, "message events should not bubble.");
+  assert_false(e.cancelable, "message events should not be cancelable.");
+  assert_equals(
+    e.origin,
+    location.origin,
+    "origin of message should be origin of Service Worker."
+  );
+  assert_equals(e.lastEventId, "", "lastEventId should be an empty string.");
+  assert_equals(
+    e.source.constructor,
+    w.ServiceWorker,
+    "source should use ServiceWorker interface."
+  );
+  assert_equals(
+    e.source,
+    w.navigator.serviceWorker.controller,
+    "source should be the service worker that sent the message."
+  );
+  assert_equals(e.ports.length, 0, "ports should be an empty array.");
+  assert_equals(e.data, "Sending message via clients");
 
   e = await new Promise(r => w.navigator.serviceWorker.onmessage = r);
-  assert_equals(e.data, 'quit');
-}, 'postMessage from ServiceWorker to Client.');
+  assert_equals(e.data, "quit");
+}, "postMessage from ServiceWorker to Client.");
 </script>

--- a/service-workers/service-worker/postmessage.https.html
+++ b/service-workers/service-worker/postmessage.https.html
@@ -4,178 +4,127 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    var script = 'resources/postmessage-worker.js';
-    var scope = 'resources/blank.html';
-    var registration;
-    var worker;
-    var port;
+const SCOPE = 'resources/blank.html';
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(r => {
-          t.add_cleanup(() => r.unregister());
-          registration = r;
-          worker = registration.installing;
+promise_test(async t => {
+  const SCRIPT = 'resources/postmessage-worker.js';
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
 
-          var messageChannel = new MessageChannel();
-          port = messageChannel.port1;
-          return new Promise(resolve => {
-              port.onmessage = resolve;
-              worker.postMessage({port: messageChannel.port2},
-                                 [messageChannel.port2]);
-              worker.postMessage({value: 1});
-              worker.postMessage({value: 2});
-              worker.postMessage({done: true});
-            });
-        })
-      .then(e => {
-          assert_equals(e.data, 'Acking value: 1');
-          return new Promise(resolve => { port.onmessage = resolve; });
-        })
-      .then(e => {
-          assert_equals(e.data, 'Acking value: 2');
-          return new Promise(resolve => { port.onmessage = resolve; });
-        })
-      .then(e => {
-          assert_equals(e.data, 'quit');
-          return registration.unregister(scope);
-        })
-      .then(() => { return wait_for_state(t, worker, 'redundant'); })
-      .then(() => {
-          assert_equals(worker.state, 'redundant');
-          assert_throws(
-            {name:'InvalidStateError'},
-            function() { worker.postMessage(''); },
-            'Calling postMessage on a redundant ServiceWorker should ' +
-                'throw InvalidStateError.');
-        });
-  }, 'postMessage to a ServiceWorker (and back via MessagePort)');
+  t.add_cleanup(async() => {
+    if (registration)
+      await registration.unregister();
+  });
 
-promise_test(t => {
-    var script = 'resources/postmessage-transferables-worker.js';
-    var scope = 'resources/blank.html';
-    var sw = navigator.serviceWorker;
+  const worker = registration.installing;
+  const messageChannel = new MessageChannel();
+  const port = messageChannel.port1;
 
-    var message = 'Hello, world!';
-    var text_encoder = new TextEncoder;
-    var text_decoder = new TextDecoder;
+  let event = await new Promise(resolve => {
+                port.onmessage = resolve;
+                worker.postMessage({port: messageChannel.port2},
+                                   [messageChannel.port2]);
+                worker.postMessage({value: 1});
+                worker.postMessage({value: 2});
+                worker.postMessage({done: true});
+              });
+  assert_equals(event.data, 'Acking value: 1');
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(r => {
-          t.add_cleanup(() => r.unregister());
+  event = await new Promise(resolve => { port.onmessage = resolve; });
+  assert_equals(event.data, 'Acking value: 2');
 
-          var ab = text_encoder.encode(message);
-          assert_equals(ab.byteLength, message.length);
-          r.installing.postMessage(ab, [ab.buffer]);
-          assert_equals(text_decoder.decode(ab), '');
-          assert_equals(ab.byteLength, 0);
+  event = await new Promise(resolve => { port.onmessage = resolve; });
+  assert_equals(event.data, 'quit');
 
-          return new Promise(resolve => { sw.onmessage = resolve; });
-        })
-      .then(e => {
-          // Verify the integrity of the transferred array buffer.
-          assert_equals(e.data.content, message);
-          assert_equals(e.data.byteLength, message.length);
-          return new Promise(resolve => { sw.onmessage = resolve; });
-        })
-      .then(e => {
-          // Verify the integrity of the array buffer sent back from
-          // ServiceWorker via Client.postMessage.
-          assert_equals(text_decoder.decode(e.data), message);
-          assert_equals(e.data.byteLength, message.length);
-          return new Promise(resolve => { sw.onmessage = resolve; });
-        })
-      .then(e => {
-          // Verify that the array buffer on ServiceWorker is neutered.
-          assert_equals(e.data.content, '');
-          assert_equals(e.data.byteLength, 0);
-        });
+  await registration.unregister();
+  await wait_for_state(t, worker, 'redundant');
+  assert_equals(worker.state, 'redundant');
+  assert_throws(
+    {name:'InvalidStateError'},
+    function() { worker.postMessage(''); },
+    'Calling postMessage on a redundant ServiceWorker should ' +
+    'throw InvalidStateError.');
+
+}, 'postMessage to a ServiceWorker (and back via MessagePort)');
+
+promise_test(async t => {
+  const SCRIPT = 'resources/postmessage-transferables-worker.js';
+  const MESSAGE = 'Hello, world!';
+
+  const worker = navigator.serviceWorker;
+  const text_encoder = new TextEncoder;
+  const text_decoder = new TextDecoder;
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+
+  t.add_cleanup(async() => {
+    if (registration)
+      await registration.unregister();
+  });
+
+  const code = text_encoder.encode(MESSAGE);
+  assert_equals(code.byteLength, MESSAGE.length);
+  registration.installing.postMessage(code, [code.buffer]);
+  assert_equals(text_decoder.decode(code), '');
+  assert_equals(code.byteLength, 0);
+
+  // Verify the integrity of the transferred array buffer.
+  let event = await new Promise(resolve => { worker.onmessage = resolve; });
+  assert_equals(event.data.content, MESSAGE);
+  assert_equals(event.data.byteLength, MESSAGE.length);
+
+  // Verify the integrity of the array buffer sent back from
+  // ServiceWorker via Client.postMessage.
+  event = await new Promise(resolve => { worker.onmessage = resolve; });
+  assert_equals(text_decoder.decode(event.data), MESSAGE);
+  assert_equals(event.data.byteLength, MESSAGE.length);
+
+  // Verify that the array buffer on ServiceWorker is neutered.
+  event = await new Promise(resolve => { worker.onmessage = resolve; });
+  assert_equals(event.data.content, '');
+  assert_equals(event.data.byteLength, 0)
+
   }, 'postMessage a transferable ArrayBuffer between ServiceWorker and Client');
 
-promise_test(t => {
-    var script = 'resources/postmessage-transferables-worker.js';
-    var scope = 'resources/blank.html';
-    var message = 'Hello, world!';
-    var text_encoder = new TextEncoder;
-    var text_decoder = new TextDecoder;
-    var port;
+promise_test(async t => {
+  const SCRIPT = 'resources/postmessage-transferables-worker.js';
+  const MESSAGE = 'Hello, world!';
+  const text_encoder = new TextEncoder;
+  const text_decoder = new TextDecoder;
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(r => {
-          t.add_cleanup(() => r.unregister());
+  const registration = await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
 
-          var channel = new MessageChannel;
-          port = channel.port1;
-          r.installing.postMessage(undefined, [channel.port2]);
+  t.add_cleanup(async() => {
+    if (registration)
+      await registration.unregister();
+  });
 
-          var ab = text_encoder.encode(message);
-          assert_equals(ab.byteLength, message.length);
-          port.postMessage(ab, [ab.buffer]);
-          assert_equals(text_decoder.decode(ab), '');
-          assert_equals(ab.byteLength, 0);
+  const channel = new MessageChannel;
+  const port = channel.port1;
+  registration.installing.postMessage(undefined, [channel.port2]);
 
-          return new Promise(resolve => { port.onmessage = resolve; });
-        })
-      .then(e => {
-          // Verify the integrity of the transferred array buffer.
-          assert_equals(e.data.content, message);
-          assert_equals(e.data.byteLength, message.length);
-          return new Promise(resolve => { port.onmessage = resolve; });
-        })
-      .then(e => {
-          // Verify the integrity of the array buffer sent back from
-          // ServiceWorker via Client.postMessage.
-          assert_equals(text_decoder.decode(e.data), message);
-          assert_equals(e.data.byteLength, message.length);
-          return new Promise(resolve => { port.onmessage = resolve; });
-        })
-      .then(e => {
-          // Verify that the array buffer on ServiceWorker is neutered.
-          assert_equals(e.data.content, '');
-          assert_equals(e.data.byteLength, 0);
-        });
-  }, 'postMessage a transferable ArrayBuffer between ServiceWorker and Client' +
-     ' over MessagePort');
+  const code = text_encoder.encode(MESSAGE);
+  assert_equals(code.byteLength, MESSAGE.length);
+  port.postMessage(code, [code.buffer]);
+  assert_equals(text_decoder.decode(code), '');
+  assert_equals(code.byteLength, 0);
 
-  promise_test(t => {
-    var script = 'resources/postmessage-dictionary-transferables-worker.js';
-    var scope = 'resources/blank.html';
-    var sw = navigator.serviceWorker;
+  // Verify the integrity of the transferred array buffer.
+  let event = await new Promise(resolve => { port.onmessage = resolve; });
+  assert_equals(event.data.content, MESSAGE);
+  assert_equals(event.data.byteLength, MESSAGE.length);
 
-    var message = 'Hello, world!';
-    var text_encoder = new TextEncoder;
-    var text_decoder = new TextDecoder;
+  // Verify the integrity of the array buffer sent back from
+  // ServiceWorker via Client.postMessage.
+  event = await new Promise(resolve => { port.onmessage = resolve; });
+  assert_equals(text_decoder.decode(event.data), MESSAGE);
+  assert_equals(event.data.byteLength, MESSAGE.length);
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(r => {
-          t.add_cleanup(() => r.unregister());
+  // Verify that the array buffer on ServiceWorker is neutered.
+  event = await new Promise(resolve => { port.onmessage = resolve; });
+  assert_equals(event.data.content, '');
+  assert_equals(event.data.byteLength, 0);
 
-          var ab = text_encoder.encode(message);
-          assert_equals(ab.byteLength, message.length);
-          r.installing.postMessage(ab, {transfer: [ab.buffer]});
-          assert_equals(text_decoder.decode(ab), '');
-          assert_equals(ab.byteLength, 0);
-
-          return new Promise(resolve => { sw.onmessage = resolve; });
-        })
-      .then(e => {
-          // Verify the integrity of the transferred array buffer.
-          assert_equals(e.data.content, message);
-          assert_equals(e.data.byteLength, message.length);
-          return new Promise(resolve => { sw.onmessage = resolve; });
-        })
-      .then(e => {
-          // Verify the integrity of the array buffer sent back from
-          // ServiceWorker via Client.postMessage.
-          assert_equals(text_decoder.decode(e.data), message);
-          assert_equals(e.data.byteLength, message.length);
-          return new Promise(resolve => { sw.onmessage = resolve; });
-        })
-      .then(e => {
-          // Verify that the array buffer on ServiceWorker is neutered.
-          assert_equals(e.data.content, '');
-          assert_equals(e.data.byteLength, 0);
-        });
-  }, 'postMessage with dictionary a transferable ArrayBuffer between ServiceWorker and Client');
-
+}, 'postMessage a transferable ArrayBuffer between ServiceWorker and Client' +
+   ' over MessagePort');
 </script>

--- a/service-workers/service-worker/synced-state.https.html
+++ b/service-workers/service-worker/synced-state.https.html
@@ -22,72 +22,41 @@ function nextChange(worker) {
     });
 }
 
-promise_test(function(t) {
-    var scope = 'resources/synced-state';
-    var script = 'resources/empty-worker.js';
-    var registration, worker;
+promise_test(async t => {
+  const SCOPE = 'resources/synced-state';
+  const SCRIPT = 'resources/empty-worker.js';
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(function(r) {
-          registration = r;
-          worker = registration.installing;
+  t.add_cleanup(async() => {
+    if (registration)
+      await registration.unregister();
+  })
 
-          t.add_cleanup(function() {
-              return r.unregister();
-            });
+  const worker = await registration.installing;
+  let state = await nextChange(worker);
+  assert_equals(state, 'installed', 'state - installed');
+  assert_equals(registration.installing, null, 'registration.installing');
+  assert_equals(registration.waiting, worker, 'registration.waiting');
+  assert_equals(registration.waiting.state, 'installed',
+                'registration.waiting.state');
+  assert_equals(registration.active, null, 'registration.active');
 
-          return nextChange(worker);
-        })
-      .then(function(state) {
-          assert_equals(state, 'installed',
-                        'original SW should be installed');
-          assert_equals(registration.installing, null,
-                        'in installed, .installing should be null');
-          assert_equals(registration.waiting, worker,
-                        'in installed, .waiting should be equal to the ' +
-                          'original worker');
-          assert_equals(registration.waiting.state, 'installed',
-                        'in installed, .waiting should be installed');
-          assert_equals(registration.active, null,
-                        'in installed, .active should be null');
+  state = await nextChange(worker);
+  assert_equals(state, 'activating', 'state - activating');
+  assert_equals(registration.installing, null, 'registration.installing');
+  assert_equals(registration.waiting, null, 'registration.waiting');
+  assert_equals(registration.active, worker, 'registration.active');
+  assert_equals(registration.active.state, 'activating',
+                'registration.active.state');
 
-          return nextChange(worker);
-        })
-      .then(function(state) {
-          assert_equals(state, 'activating',
-                        'original SW should be activating');
-          assert_equals(registration.installing, null,
-                        'in activating, .installing should be null');
-          assert_equals(registration.waiting, null,
-                        'in activating, .waiting should be null');
-          assert_equals(registration.active, worker,
-                        'in activating, .active should be equal to the ' +
-                          'original worker');
-          assert_equals(
-              registration.active.state, 'activating',
-              'in activating, .active should be activating');
+  state = await nextChange(worker);
+  assert_equals(state, 'activated', 'state - activated');
+  assert_equals(registration.installing, null, 'registration.installing');
+  assert_equals(registration.waiting, null, 'registration.waiting');
+  assert_equals(registration.active, worker, 'registration.active');
+  assert_equals(registration.active.state, 'activated',
+                'registration.active.state');
 
-          return nextChange(worker);
-        })
-      .then(function(state) {
-          assert_equals(state, 'activated',
-                        'original SW should be activated');
-          assert_equals(registration.installing, null,
-                        'in activated, .installing should be null');
-          assert_equals(registration.waiting, null,
-                        'in activated, .waiting should be null');
-          assert_equals(registration.active, worker,
-                        'in activated, .active should be equal to the ' +
-                          'original worker');
-          assert_equals(registration.active.state, 'activated',
-                        'in activated .active should be activated');
-        })
-      .then(function() {
-          return navigator.serviceWorker.getRegistration(scope);
-        })
-      .then(function(r) {
-          assert_equals(r, registration, 'getRegistration should return the ' +
-                                         'same object');
-        });
-  }, 'worker objects for the same entity have the same state');
+}, 'worker objects for the same entity have the same state');
 </script>


### PR DESCRIPTION
- Fix a couple of tests with function t.add_cleanup() as it supports promise, see detail in #8748.
- The usage of unregister() method in some tests is not rigorous.  As [spec]\(https://w3c.github.io/ServiceWorker/#dom-serviceworkerregistration-unregister):
>>   [NewObject] Promise<boolean> unregister();
  unregister() method must run these steps:
>> 1. Let promise be a promise.
...
>> 4. Return promise.