### PR TITLE
Make is_html actually work in Output#resolve_log().

### DIFF
--- a/resources/test/tests/functional/log-insertion.html
+++ b/resources/test/tests/functional/log-insertion.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<title>Log insertion</title>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
+<script src="../../variants.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(function(t) {
+  window.onload = t.step_func_done(function() {
+    var body = document.body;
+    assert_not_equals(body, null);
+
+    var log = document.getElementById("log");
+    assert_equals(log.parentNode, body);
+  });
+});
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [{
+    "status_string": "PASS",
+    "name": "Log insertion",
+    "message": null,
+    "properties": {}
+  }],
+  "type": "complete"
+}
+</script>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2559,27 +2559,24 @@ policies and contribution forms [3].
             if (output_document.body) {
                 output_document.body.appendChild(node);
             } else {
-                var is_html = false;
-                var is_svg = false;
-                var output_window = output_document.defaultView;
-                if (output_window && "SVGSVGElement" in output_window) {
-                    is_svg = output_document.documentElement instanceof output_window.SVGSVGElement;
-                } else if (output_window) {
-                    is_html = (output_document.namespaceURI == "http://www.w3.org/1999/xhtml" &&
-                               output_document.localName == "html");
-                }
+                var root = output_document.documentElement;
+                var is_html = (root &&
+                               root.namespaceURI == "http://www.w3.org/1999/xhtml" &&
+                               root.localName == "html");
+                var is_svg = (output_document.defaultView &&
+                              "SVGSVGElement" in output_document.defaultView &&
+                              root instanceof output_document.defaultView.SVGSVGElement);
                 if (is_svg) {
                     var foreignObject = output_document.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
                     foreignObject.setAttribute("width", "100%");
                     foreignObject.setAttribute("height", "100%");
-                    output_document.documentElement.appendChild(foreignObject);
+                    root.appendChild(foreignObject);
                     foreignObject.appendChild(node);
                 } else if (is_html) {
-                    var body = output_document.createElementNS("http://www.w3.org/1999/xhtml", "body");
-                    output_document.documentElement.appendChild(body);
-                    body.appendChild(node);
+                    root.appendChild(output_document.createElementNS("http://www.w3.org/1999/xhtml", "body"))
+                        .appendChild(node);
                 } else {
-                    output_document.documentElement.appendChild(node);
+                    root.appendChild(node);
                 }
             }
         }


### PR DESCRIPTION
In particular, is_html would never become true if SVGSVGElement was supported
at all.

Even if SVGSVGElement was not supported, it would never become true because
we were checking the namespace and localName of the Document object, rather
than the root element.