### PR TITLE
[docs] Remove obviated instructions

### DIFF
--- a/docs/_running-tests/chrome.md
+++ b/docs/_running-tests/chrome.md
@@ -25,14 +25,6 @@ To enable a specific [runtime enabled feature](http://dev.chromium.org/blink/run
 ./wpt run --binary-arg=--enable-blink-features=AsyncClipboard chrome clipboard-apis/
 ```
 
-To bypass device selection and use mock media for tests using `getUserMedia`:
-
-```
-./wpt run --binary-arg=--use-fake-ui-for-media-stream --binary-arg=--use-fake-device-for-media-stream chrome mediacapture-streams/
-```
-
-Note: there's an [open issue for doing this using WebDriver](https://github.com/web-platform-tests/wpt/issues/7424).
-
 Some of the above are most useful in combination, e.g., to run all tests in
 Chrome Dev with experimental web platform features enabled:
 


### PR DESCRIPTION
As of [1], the WPT CLI automatically inserts the
`--use-fake-ui-for-media-stream` and
`--use-fake-device-for-media-stream` arguments for the Chrome browser.

[1] a4eaa46ffebe5785562b930316a300423f23707e