### PR TITLE
[doc] Update doc regarding exp. features on Chrome

### DIFF
--- a/docs/_running-tests/chrome.md
+++ b/docs/_running-tests/chrome.md
@@ -2,32 +2,27 @@
 layout: page
 title: Chrome
 ---
-When running Chrome, there are some additional useful command line arguments.
+When running Chrome, there are some useful command line arguments.
 
-As with most products, you can use a different binary with `--binary`, e.g., to
-run Chrome Dev on Linux:
-
-```
-./wpt run --binary `which google-chrome-unstable` chrome
-```
-
-Extra arguments to Chrome can be passed with `--binary-args`.
-
-To enable all [experimental web platform features](https://www.chromium.org/blink/runtime-enabled-features) (chrome://flags/#enable-experimental-web-platform-features):
+You can inform `wpt` of the release channel of Chrome using `--channel`.
+However, `wpt` currently does not support installing Chrome or finding the
+Chrome binary of a specific channel, so you would also need to specify the path
+to the Chrome binary with `--binary`. For example, to run Chrome Dev on Linux:
 
 ```
-./wpt run --binary-arg=--enable-experimental-web-platform-features chrome fullscreen/
+./wpt run --channel dev --binary `which google-chrome-unstable` chrome
 ```
 
-To enable a specific [runtime enabled feature](http://dev.chromium.org/blink/runtime-enabled-features):
+Note: when the channel is "dev", `wpt` will *automatically* enable all
+[experimental web platform features][1]
+(chrome://flags/#enable-experimental-web-platform-features) by passing
+`--enable-experimental-web-platform-features` to Chrome.
+
+If you want to enable a specific [runtime enabled feature][1], use
+`--binary-arg` to specify the flag(s) that you want to pass to Chrome:
 
 ```
 ./wpt run --binary-arg=--enable-blink-features=AsyncClipboard chrome clipboard-apis/
 ```
 
-Some of the above are most useful in combination, e.g., to run all tests in
-Chrome Dev with experimental web platform features enabled:
-
-```
-./wpt run --binary `which google-chrome-unstable` --binary-arg=--enable-experimental-web-platform-features chrome
-```
+[1]: https://www.chromium.org/blink/runtime-enabled-features


### PR DESCRIPTION
Following https://github.com/web-platform-tests/wpt/pull/13011, `wpt`
automatically turns on experimental web platform features on Chrome if
the channel is "dev". Update the doc to reflect this change.