### PR TITLE
Fix syntax and typos in tests from #12956

### DIFF
--- a/css/cssom/getComputedStyle-insets-absolute.html
+++ b/css/cssom/getComputedStyle-insets-absolute.html
@@ -3,7 +3,7 @@
 <title>CSSOM: resolved values of the inset properties for absolute positioning</title>
 <link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
 <link rel="help" href="https://drafts.csswg.org/css-position/#pos-sch">
-<link rel="author" title="Oriol Brufau" href="mailto:obrufau@crisal.io">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script type="module">

--- a/css/cssom/getComputedStyle-insets-fixed.html
+++ b/css/cssom/getComputedStyle-insets-fixed.html
@@ -3,7 +3,7 @@
 <title>CSSOM: resolved values of the inset properties for fixed positioning</title>
 <link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
 <link rel="help" href="https://drafts.csswg.org/css-position/#pos-sch">
-<link rel="author" title="Oriol Brufau" href="mailto:obrufau@crisal.io">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script type="module">

--- a/css/cssom/getComputedStyle-insets-nobox.html
+++ b/css/cssom/getComputedStyle-insets-nobox.html
@@ -3,7 +3,7 @@
 <title>CSSOM: resolved values of the inset properties when the element generates no box</title>
 <link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
 <link rel="help" href="https://drafts.csswg.org/css-position/#pos-sch">
-<link rel="author" title="Oriol Brufau" href="mailto:obrufau@crisal.io">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script type="module">

--- a/css/cssom/getComputedStyle-insets-relative.html
+++ b/css/cssom/getComputedStyle-insets-relative.html
@@ -3,7 +3,7 @@
 <title>CSSOM: resolved values of the inset properties for relative positioning</title>
 <link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
 <link rel="help" href="https://drafts.csswg.org/css-position/#pos-sch">
-<link rel="author" title="Oriol Brufau" href="mailto:obrufau@crisal.io">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script type="module">

--- a/css/cssom/getComputedStyle-insets-static.html
+++ b/css/cssom/getComputedStyle-insets-static.html
@@ -3,7 +3,7 @@
 <title>CSSOM: resolved values of the inset properties for static positioning</title>
 <link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
 <link rel="help" href="https://drafts.csswg.org/css-position/#pos-sch">
-<link rel="author" title="Oriol Brufau" href="mailto:obrufau@crisal.io">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script type="module">

--- a/css/cssom/getComputedStyle-insets-sticky.html
+++ b/css/cssom/getComputedStyle-insets-sticky.html
@@ -3,7 +3,7 @@
 <title>CSSOM: resolved values of the inset properties for sticky positioning</title>
 <link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
 <link rel="help" href="https://drafts.csswg.org/css-position/#pos-sch">
-<link rel="author" title="Oriol Brufau" href="mailto:obrufau@crisal.io">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script type="module">

--- a/css/cssom/support/getComputedStyle-insets.js
+++ b/css/cssom/support/getComputedStyle-insets.js
@@ -89,9 +89,9 @@ function runTestsWithWM(data, testWM, cbWM) {
 
   function checkStyle(declarations, expected, msg) {
     test(function() {
-      testEl.style.cssText = style + "; " + serialize({...declarations, ...testWM.style});
+      testEl.style.cssText = style + "; " + serialize(Object.assign({}, declarations, testWM.style));
       if (containingBlockElement) {
-        containingBlockElement.style.cssText = serialize({...cbWM.style});
+        containingBlockElement.style.cssText = serialize(Object.assign({}, cbWM.style));
       }
       const cs = getComputedStyle(testEl);
       for (let [prop, value] of Object.entries(expected)) {


### PR DESCRIPTION
Edge doesn't support spread syntax in object initializers, so use `Object.assign` instead.
Also I didn't write my email correctly