### PR TITLE
[wptrunner] Fix support for `--binary-arg` in Fx

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -189,6 +189,30 @@ def test_run_firefox(manifest_dir):
 
 
 @pytest.mark.slow
+@pytest.mark.remote_network
+@pytest.mark.xfail(sys.platform == "win32",
+                   reason="Tests currently don't work on Windows for path reasons")
+def test_run_firefox_binary_args(manifest_dir):
+    if is_port_8000_in_use():
+        pytest.skip("port 8000 already in use")
+
+    if sys.platform == "darwin":
+        fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "nightly", "Firefox Nightly.app")
+    else:
+        fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "nightly", "firefox")
+    if os.path.exists(fx_path):
+        shutil.rmtree(fx_path)
+    with pytest.raises(SystemExit) as excinfo:
+        wpt.main(argv=["run", "--no-pause", "--install-browser", "--yes",
+                       "--metadata", manifest_dir,
+                       "--binary-arg=-headless",
+                       "firefox", "/dom/nodes/Element-tagName.html"])
+    assert os.path.exists(fx_path)
+    shutil.rmtree(fx_path)
+    assert excinfo.value.code == 0
+
+
+@pytest.mark.slow
 @pytest.mark.xfail(sys.platform == "win32",
                    reason="Tests currently don't work on Windows for path reasons")
 def test_run_chrome(manifest_dir):

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -169,33 +169,6 @@ def test_run_firefox(manifest_dir):
     if is_port_8000_in_use():
         pytest.skip("port 8000 already in use")
 
-    os.environ["MOZ_HEADLESS"] = "1"
-    try:
-        if sys.platform == "darwin":
-            fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "nightly", "Firefox Nightly.app")
-        else:
-            fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "nightly", "firefox")
-        if os.path.exists(fx_path):
-            shutil.rmtree(fx_path)
-        with pytest.raises(SystemExit) as excinfo:
-            wpt.main(argv=["run", "--no-pause", "--install-browser", "--yes",
-                           "--metadata", manifest_dir,
-                           "firefox", "/dom/nodes/Element-tagName.html"])
-        assert os.path.exists(fx_path)
-        shutil.rmtree(fx_path)
-        assert excinfo.value.code == 0
-    finally:
-        del os.environ["MOZ_HEADLESS"]
-
-
-@pytest.mark.slow
-@pytest.mark.remote_network
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="Tests currently don't work on Windows for path reasons")
-def test_run_firefox_binary_args(manifest_dir):
-    if is_port_8000_in_use():
-        pytest.skip("port 8000 already in use")
-
     if sys.platform == "darwin":
         fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "nightly", "Firefox Nightly.app")
     else:
@@ -204,8 +177,13 @@ def test_run_firefox_binary_args(manifest_dir):
         shutil.rmtree(fx_path)
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--no-pause", "--install-browser", "--yes",
-                       "--metadata", manifest_dir,
+                       # The use of `--binary-args` is intentional: it
+                       # demonstrates that internally-managed command-line
+                       # arguments are properly merged with those specified by
+                       # the user. See
+                       # https://github.com/web-platform-tests/wpt/pull/13154
                        "--binary-arg=-headless",
+                       "--metadata", manifest_dir,
                        "firefox", "/dom/nodes/Element-tagName.html"])
     assert os.path.exists(fx_path)
     shutil.rmtree(fx_path)

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -251,9 +251,11 @@ class FirefoxBrowser(Browser):
         if self.ca_certificate_path is not None:
             self.setup_ssl()
 
+        args = self.binary_args[:] if self.binary_args else []
+        args += [cmd_arg("marionette"), "about:blank"]
+
         debug_args, cmd = browser_command(self.binary,
-                                          self.binary_args if self.binary_args else [] +
-                                          [cmd_arg("marionette"), "about:blank"],
+                                          args,
                                           self.debug_info)
 
         self.runner = FirefoxRunner(profile=self.profile,


### PR DESCRIPTION
In order to automate Firefox, wptrunner requires the browser's internal
module "Marionette" to be enabled. This is a requirement regardless of
any custom configuration specified by the user, including additional
command-line flags via the `--binary-arg` argument.

Previously, this project would omit the `-marionette` argument in the
presence of any user-specified arguments. Because this interferes with
normal operation (and because the source code is formatted in a way that
conflicts with the order of operations), this is likely an unintentional
behavior.

Modify the code which derives the command-line arguments to always
include the `-marionette` argument.