### PR TITLE
[service-workers] Return value in cleanup

### DIFF
--- a/service-workers/service-worker/fetch-request-xhr-sync.https.html
+++ b/service-workers/service-worker/fetch-request-xhr-sync.https.html
@@ -14,7 +14,7 @@ promise_test(function(t) {
     return service_worker_unregister_and_register(t, url, scope)
       .then(function(registration) {
           t.add_cleanup(function() {
-              registration.unregister();
+              return registration.unregister();
             });
 
           return wait_for_state(t, registration.installing, 'activated');

--- a/service-workers/service-worker/interfaces-window.https.html
+++ b/service-workers/service-worker/interfaces-window.https.html
@@ -40,7 +40,7 @@ promise_test(async (t) => {
       t, 'resources/empty-worker.js', scope)
     .then(function(registration) {
         t.add_cleanup(function() {
-            registration.unregister();
+            return registration.unregister();
           });
 
         window.registrationInstance = registration;

--- a/service-workers/service-worker/onactivate-script-error.https.html
+++ b/service-workers/service-worker/onactivate-script-error.https.html
@@ -35,7 +35,7 @@ function make_test(name, script) {
             registration = r;
 
             t.add_cleanup(function() {
-                r.unregister();
+                return r.unregister();
               });
 
             return wait_for_install(registration.installing);

--- a/service-workers/service-worker/postmessage.https.html
+++ b/service-workers/service-worker/postmessage.https.html
@@ -13,11 +13,7 @@ promise_test(t => {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(r => {
-          // TODO: return the Promise created by `r.unregister`once
-          // `testharness.js` has been updated to honor thenables returned by
-          // cleanup functions.
-          // See https://github.com/web-platform-tests/wpt/pull/8748
-          t.add_cleanup(() => { r.unregister(); });
+          t.add_cleanup(() => r.unregister());
           registration = r;
           worker = registration.installing;
 
@@ -66,11 +62,7 @@ promise_test(t => {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(r => {
-          // TODO: return the Promise created by `r.unregister`once
-          // `testharness.js` has been updated to honor thenables returned by
-          // cleanup functions.
-          // See https://github.com/web-platform-tests/wpt/pull/8748
-          t.add_cleanup(() => { r.unregister(); });
+          t.add_cleanup(() => r.unregister());
 
           var ab = text_encoder.encode(message);
           assert_equals(ab.byteLength, message.length);
@@ -110,11 +102,7 @@ promise_test(t => {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(r => {
-          // TODO: return the Promise created by `r.unregister`once
-          // `testharness.js` has been updated to honor thenables returned by
-          // cleanup functions.
-          // See https://github.com/web-platform-tests/wpt/pull/8748
-          t.add_cleanup(() => { r.unregister(); });
+          t.add_cleanup(() => r.unregister());
 
           var channel = new MessageChannel;
           port = channel.port1;

--- a/service-workers/service-worker/registration-service-worker-attributes.https.html
+++ b/service-workers/service-worker/registration-service-worker-attributes.https.html
@@ -14,7 +14,7 @@ promise_test(function(t) {
     return service_worker_unregister_and_register(t, worker_url, scope)
       .then(function(r) {
           t.add_cleanup(function() {
-              r.unregister();
+              return r.unregister();
             });
           registration = r;
           newest_worker = registration.installing;

--- a/service-workers/service-worker/resources/worker-testharness.js
+++ b/service-workers/service-worker/resources/worker-testharness.js
@@ -20,7 +20,7 @@ importScripts('/resources/testharness.js');
     var cache_name = self.location.pathname + '/' + uniquifier;
 
     test.add_cleanup(function() {
-        self.caches.delete(cache_name);
+        return self.caches.delete(cache_name);
       });
 
     return self.caches.delete(cache_name)

--- a/service-workers/service-worker/skip-waiting-using-registration.https.html
+++ b/service-workers/service-worker/skip-waiting-using-registration.https.html
@@ -51,7 +51,7 @@ promise_test(function(t) {
       .then(function(registration) {
           sw_registration = registration;
           t.add_cleanup(function() {
-              registration.unregister();
+              return registration.unregister();
             });
           return saw_controllerchanged;
         })

--- a/service-workers/service-worker/skip-waiting-without-using-registration.https.html
+++ b/service-workers/service-worker/skip-waiting-without-using-registration.https.html
@@ -27,7 +27,7 @@ promise_test(function(t) {
       .then(function(registration) {
           sw_registration = registration;
           t.add_cleanup(function() {
-              registration.unregister();
+              return registration.unregister();
             });
           return wait_for_state(t, registration.installing, 'activated');
         })

--- a/service-workers/service-worker/synced-state.https.html
+++ b/service-workers/service-worker/synced-state.https.html
@@ -33,7 +33,7 @@ promise_test(function(t) {
           worker = registration.installing;
 
           t.add_cleanup(function() {
-              r.unregister();
+              return r.unregister();
             });
 
           return nextChange(worker);


### PR DESCRIPTION
Previously, many tests un-registered service workers using the
testharness.js API `add_cleanup` without returning the promise which
tracked the operation. While this ensured the operation was started at
the completion of the test, it did not guarantee that the operation
would be completed before the test was considered "complete."

In automation scenarios where many tests are executed in rapid
succession, this enabled a race condition: the navigation could
interrupt the un-registration process. In order to account for the
possibility of registrations that persisted from previous test failures,
the tests included "setup" code to defensively un-register such workers.

The `Test#add_cleanup` method was recently extended to support
asynchronous "clean up" operations [1]. Use that API to ensure tests are
not considered "complete" until after service worker un-registration is
done.

[1] https://github.com/web-platform-tests/wpt/pull/8748

---

This patch is not intended to influence test results. To verify that, I used
the WPT CLI to run the affected tests in Chromium and Firefox, comparing the
summary it produced both on `master` and on this branch.

Chromium on `master`:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 96 checks (8 tests, 88 subtests)
    Expected results: 85
    Unexpected results: 11
      subtest: 11 (11 fail)

Chromium with patch applied:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 96 checks (8 tests, 88 subtests)
    Expected results: 85
    Unexpected results: 11
      subtest: 11 (11 fail)

Firefox on `master`:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 96 checks (8 tests, 88 subtests)
    Expected results: 88
    Unexpected results: 8
      subtest: 8 (8 fail)

Firefox with patch applied:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 96 checks (8 tests, 88 subtests)
    Expected results: 88
    Unexpected results: 8
      subtest: 8 (8 fail)