### PR TITLE
[service-workers] Refactor to use async cleanup

### DIFF
--- a/service-workers/service-worker/activation-after-registration.https.html
+++ b/service-workers/service-worker/activation-after-registration.https.html
@@ -5,25 +5,24 @@
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>
-var t = async_test('activation occurs after registration');
-t.step(function() {
+promise_test(function(t) {
     var scope = 'resources/blank.html';
     var registration;
 
-    service_worker_unregister_and_register(
+    return service_worker_unregister_and_register(
         t, 'resources/empty-worker.js', scope)
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = r;
           assert_equals(
               r.installing.state,
               'installing',
               'worker should be in the "installing" state upon registration');
           return wait_for_state(t, r.installing, 'activated');
-        })
-      .then(function() {
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
-});
+        });
+}, 'activation occurs after registration');
 </script>
 </body>

--- a/service-workers/service-worker/appcache-ordering-main.https.html
+++ b/service-workers/service-worker/appcache-ordering-main.https.html
@@ -60,8 +60,8 @@ function is_appcached() {
   });
 }
 
-async_test(function(t) {
-    service_worker_unregister(t, SERVICE_WORKER_SCOPE)
+promise_test(function(t) {
+    return service_worker_unregister(t, SERVICE_WORKER_SCOPE)
       .then(function() {
           return install_appcache();
         })
@@ -74,6 +74,10 @@ async_test(function(t) {
               t, SERVICE_WORKER_SCRIPT, SERVICE_WORKER_SCOPE);
         })
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SERVICE_WORKER_SCOPE);
+            });
+
           return wait_for_state(t, r.installing, 'activated');
         })
       .then(function() {
@@ -82,9 +86,7 @@ async_test(function(t) {
       .then(function(result) {
           assert_false(result, 'but serviceworkers should take priority');
           frames.forEach(function(f) { f.remove(); });
-          service_worker_unregister_and_done(t, SERVICE_WORKER_SCOPE);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'serviceworkers take priority over appcaches');
 
 </script>

--- a/service-workers/service-worker/client-id.https.html
+++ b/service-workers/service-worker/client-id.https.html
@@ -4,15 +4,17 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-var test;
 var scope = 'resources/blank.html?client-id';
 var frame1, frame2;
 
-async_test(function(t) {
-    test = t;
-    service_worker_unregister_and_register(
+promise_test(function(t) {
+    return service_worker_unregister_and_register(
         t, 'resources/client-id-worker.js', scope)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(scope + '#1'); })
@@ -25,11 +27,15 @@ async_test(function(t) {
       .then(function(f) {
           frame2 = f;
           var channel = new MessageChannel();
-          channel.port1.onmessage = t.step_func(on_message);
-          f.contentWindow.navigator.serviceWorker.controller.postMessage(
-              {port:channel.port2}, [channel.port2]);
+
+          return new Promise(function(resolve, reject) {
+              channel.port1.onmessage = resolve;
+              channel.port1.onmessageerror = reject;
+              f.contentWindow.navigator.serviceWorker.controller.postMessage(
+                  {port:channel.port2}, [channel.port2]);
+            });
         })
-      .catch(unreached_rejection(t));
+      .then(on_message);
   }, 'Client.id returns the client\'s ID.');
 
 function on_message(e) {
@@ -50,6 +56,5 @@ function on_message(e) {
   assert_equals(e.data[1], e.data[3]);
   frame1.remove();
   frame2.remove();
-  service_worker_unregister_and_done(test, scope);
 }
 </script>

--- a/service-workers/service-worker/clients-matchall-exact-controller.https.html
+++ b/service-workers/service-worker/clients-matchall-exact-controller.https.html
@@ -5,7 +5,6 @@
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 const scope = 'resources/blank.html?clients-matchAll';
-const t = async_test('Test Clients.matchAll() with exact controller');
 let frames = [];
 
 function checkWorkerClients(worker, expected) {
@@ -33,10 +32,12 @@ let expected = [
     ['visible', false, new URL(scope + '#2', location).toString(), 'window', 'nested']
 ];
 
-t.step(_ => {
+promise_test(t => {
     let script = 'resources/clients-matchall-worker.js';
-    service_worker_unregister_and_register(t, script, scope)
+    return service_worker_unregister_and_register(t, script, scope)
       .then(registration => {
+          t.add_cleanup(() => service_worker_unregister(t, scope));
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(_ => with_iframe(scope + '#1') )
@@ -61,8 +62,6 @@ t.step(_ => {
         })
       .then(_ => {
           frames.forEach(f => f.remove() );
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
-  });
+        });
+}, 'Test Clients.matchAll() with exact controller');
 </script>

--- a/service-workers/service-worker/clients-matchall-include-uncontrolled.https.html
+++ b/service-workers/service-worker/clients-matchall-include-uncontrolled.https.html
@@ -67,12 +67,16 @@ function test_matchall(frame, expected, query_options) {
 }
 
 // Run clients.matchAll without and with includeUncontrolled=true.
-// (We want to run the two tests sequentially in the same async_test
+// (We want to run the two tests sequentially in the same promise_test
 // so that we can use the same set of iframes without intefering each other.
-async_test(function(t) {
-    service_worker_unregister_and_register(
+promise_test(function(t) {
+    return service_worker_unregister_and_register(
         t, 'resources/clients-matchall-worker.js', scope)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return create_iframes(scope); })
@@ -85,9 +89,7 @@ async_test(function(t) {
         })
       .then(function() {
           frames.forEach(function(f) { f.remove() });
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Verify matchAll() respect includeUncontrolled');
 
 </script>

--- a/service-workers/service-worker/clients-matchall.https.html
+++ b/service-workers/service-worker/clients-matchall.https.html
@@ -5,12 +5,15 @@
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 var scope = 'resources/blank.html?clients-matchAll';
-var t = async_test('Test Clients.matchAll()');
 var frames = [];
-t.step(function() {
-    service_worker_unregister_and_register(
+promise_test(function(t) {
+    return service_worker_unregister_and_register(
         t, 'resources/clients-matchall-worker.js', scope)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(scope + '#1'); })
@@ -22,12 +25,15 @@ t.step(function() {
       .then(function(frame2) {
           frames.push(frame2);
           var channel = new MessageChannel();
-          channel.port1.onmessage = t.step_func(onMessage);
-          frame2.contentWindow.navigator.serviceWorker.controller.postMessage(
-              {port:channel.port2}, [channel.port2]);
+
+          return new Promise(function(resolve) {
+              channel.port1.onmessage = resolve;
+              frame2.contentWindow.navigator.serviceWorker.controller.postMessage(
+                  {port:channel.port2}, [channel.port2]);
+            });
         })
-      .catch(unreached_rejection(t));
-  });
+      .then(onMessage);
+}, 'Test Clients.matchAll()');
 
 var expected = [
     // visibilityState, focused, url, type, frameType
@@ -40,6 +46,5 @@ function onMessage(e) {
   assert_array_equals(e.data[0], expected[0]);
   assert_array_equals(e.data[1], expected[1]);
   frames.forEach(function(f) { f.remove(); });
-  service_worker_unregister_and_done(t, scope);
 }
 </script>

--- a/service-workers/service-worker/controller-on-disconnect.https.html
+++ b/service-workers/service-worker/controller-on-disconnect.https.html
@@ -5,22 +5,25 @@
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>
-var t = async_test('controller is cleared on disconnected window');
-t.step(function() {
+promise_test(function(t) {
     var url = 'resources/empty-worker.js';
     var scope = 'resources/blank.html';
     var registration;
     var controller;
     var frame;
-    service_worker_unregister_and_register(t, url, scope)
-      .then(t.step_func(function(swr) {
+    return service_worker_unregister_and_register(t, url, scope)
+      .then(function(swr) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = swr;
           return wait_for_state(t, registration.installing, 'activated');
-        }))
-      .then(t.step_func(function() {
+        })
+      .then(function() {
           return with_iframe(scope)
-        }))
-      .then(t.step_func(function(f) {
+        })
+      .then(function(f) {
           frame = f;
           var w = frame.contentWindow;
           var swc = w.navigator.serviceWorker;
@@ -31,10 +34,7 @@ t.step(function() {
 
           assert_equals(swc.controller, null,
                         'disconnected frame should not be controlled');
-
-          service_worker_unregister_and_done(t, scope);
-        }))
-      .catch(unreached_rejection(t));
-  });
+        });
+}, 'controller is cleared on disconnected window');
 </script>
 </body>

--- a/service-workers/service-worker/controller-on-load.https.html
+++ b/service-workers/service-worker/controller-on-load.https.html
@@ -5,22 +5,25 @@
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>
-var t = async_test('controller is set for a controlled document');
-t.step(function() {
+promise_test(function(t) {
     var url = 'resources/empty-worker.js';
     var scope = 'resources/blank.html';
     var registration;
     var controller;
     var frame;
-    service_worker_unregister_and_register(t, url, scope)
-      .then(t.step_func(function(swr) {
+    return service_worker_unregister_and_register(t, url, scope)
+      .then(function(swr) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = swr;
           return wait_for_state(t, registration.installing, 'activated');
-        }))
-      .then(t.step_func(function() {
+        })
+      .then(function() {
           return with_iframe(scope);
-        }))
-      .then(t.step_func(function(f) {
+        })
+      .then(function(f) {
           frame = f;
           var w = frame.contentWindow;
           controller = w.navigator.serviceWorker.controller;
@@ -32,14 +35,12 @@ t.step(function() {
           assert_not_equals(controller, registration.active);
 
           return w.navigator.serviceWorker.getRegistration();
-        }))
-      .then(t.step_func(function(frameRegistration) {
+        })
+      .then(function(frameRegistration) {
           // SW objects from same window should be equal
           assert_equals(frameRegistration.active, controller);
           frame.remove();
-          service_worker_unregister_and_done(t, scope);
-        }))
-      .catch(unreached_rejection(t));
-  });
+        });
+}, 'controller is set for a controlled document');
 </script>
 </body>

--- a/service-workers/service-worker/extendable-event-async-waituntil.https.html
+++ b/service-workers/service-worker/extendable-event-async-waituntil.https.html
@@ -22,15 +22,19 @@ function sync_message(worker, message, transfer) {
 function runTest(test, step, testBody) {
   var scope = './resources/' + step;
   var script = 'resources/extendable-event-async-waituntil.js?' + scope;
-  service_worker_unregister_and_register(test, script, scope)
+  return service_worker_unregister_and_register(test, script, scope)
     .then(function(registration) {
+        test.add_cleanup(function() {
+            return service_worker_unregister(test, scope);
+          });
+
         let worker = registration.installing;
         var channel = new MessageChannel();
         var saw_message = new Promise(function(resolve) {
           channel.port1.onmessage = function(e) { resolve(e.data); }
         });
 
-        wait_for_state(test, worker, 'activated')
+        return wait_for_state(test, worker, 'activated')
           .then(function() {
               return sync_message(worker, { step: 'init', port: channel.port2 },
                 [channel.port2]);
@@ -40,9 +44,7 @@ function runTest(test, step, testBody) {
           .then(function(output) {
               assert_equals(output.result, output.expected);
             })
-          .then(function() { return sync_message(worker, { step: 'done' }); })
-          .then(() => { service_worker_unregister_and_done(test, scope); })
-          .catch(unreached_rejection(test));
+          .then(function() { return sync_message(worker, { step: 'done' }); });
       });
 }
 
@@ -50,51 +52,51 @@ function msg_event_test(scope, test) {
   var testBody = function(worker) {
     return sync_message(worker, { step: scope });
   };
-  runTest(test, scope, testBody);
+  return runTest(test, scope, testBody);
 }
 
-async_test(msg_event_test.bind(this, 'no-current-extension-different-task'),
+promise_test(msg_event_test.bind(this, 'no-current-extension-different-task'),
   'Test calling waitUntil in a different task without an existing extension throws');
 
-async_test(msg_event_test.bind(this, 'no-current-extension-different-microtask'),
+promise_test(msg_event_test.bind(this, 'no-current-extension-different-microtask'),
   'Test calling waitUntil in a different microtask without an existing extension throws');
 
-async_test(msg_event_test.bind(this, 'current-extension-different-task'),
+promise_test(msg_event_test.bind(this, 'current-extension-different-task'),
   'Test calling waitUntil in a different task with an existing extension succeeds');
 
-async_test(msg_event_test.bind(this, 'current-extension-expired-same-microtask-turn'),
+promise_test(msg_event_test.bind(this, 'current-extension-expired-same-microtask-turn'),
   'Test calling waitUntil with an existing extension promise handler succeeds');
 
 // The promise handler will queue a new microtask after the check for new
 // extensions was performed.
-async_test(msg_event_test.bind(this, 'current-extension-expired-same-microtask-turn-extra'),
+promise_test(msg_event_test.bind(this, 'current-extension-expired-same-microtask-turn-extra'),
   'Test calling waitUntil at the end of the microtask turn throws');
 
-async_test(msg_event_test.bind(this, 'current-extension-expired-different-task'),
+promise_test(msg_event_test.bind(this, 'current-extension-expired-different-task'),
   'Test calling waitUntil after the current extension expired in a different task fails');
 
-async_test(msg_event_test.bind(this, 'script-extendable-event'),
+promise_test(msg_event_test.bind(this, 'script-extendable-event'),
   'Test calling waitUntil on a script constructed ExtendableEvent throws exception');
 
-async_test(function(t) {
+promise_test(function(t) {
     var testBody = function(worker) {
       return with_iframe('./resources/pending-respondwith-async-waituntil/dummy.html');
     }
-    runTest(t, 'pending-respondwith-async-waituntil', testBody);
+    return runTest(t, 'pending-respondwith-async-waituntil', testBody);
   }, 'Test calling waitUntil asynchronously with pending respondWith promise.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var testBody = function(worker) {
       return with_iframe('./resources/respondwith-microtask-sync-waituntil/dummy.html');
     }
-    runTest(t, 'respondwith-microtask-sync-waituntil', testBody);
+    return runTest(t, 'respondwith-microtask-sync-waituntil', testBody);
   }, 'Test calling waitUntil synchronously inside microtask of respondWith promise.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var testBody = function(worker) {
       return with_iframe('./resources/respondwith-microtask-async-waituntil/dummy.html');
     }
-    runTest(t, 'respondwith-microtask-async-waituntil', testBody);
+    return runTest(t, 'respondwith-microtask-async-waituntil', testBody);
   }, 'Test calling waitUntil asynchronously inside microtask of respondWith promise.');
 
 

--- a/service-workers/service-worker/extendable-event-waituntil.https.html
+++ b/service-workers/service-worker/extendable-event-waituntil.https.html
@@ -6,75 +6,88 @@
 <script>
 function runTest(test, scope, onRegister) {
   var script = 'resources/extendable-event-waituntil.js?' + scope;
-  service_worker_unregister_and_register(test, script, scope)
+  return service_worker_unregister_and_register(test, script, scope)
     .then(function(registration) {
-        onRegister(registration.installing);
+        test.add_cleanup(function() {
+            return service_worker_unregister(test, scope);
+          });
+
+        return onRegister(registration.installing);
       });
 }
 
 // Sends a SYN to the worker and asynchronously listens for an ACK; sets
 // |obj.synced| to true once ack'd.
-function syncWorker(test, worker, obj) {
+function syncWorker(worker, obj) {
   var channel = new MessageChannel();
   worker.postMessage({port: channel.port2}, [channel.port2]);
   return new Promise(function(resolve) {
-      channel.port1.onmessage = test.step_func(function(e) {
-          var message = e.data;
-          assert_equals(message, 'SYNC',
-                        'Should receive sync message from worker.');
-          obj.synced = true;
-          channel.port1.postMessage('ACK');
-          resolve();
-        });
+      channel.port1.onmessage = resolve;
+    }).then(function(e) {
+      var message = e.data;
+      assert_equals(message, 'SYNC',
+                    'Should receive sync message from worker.');
+      obj.synced = true;
+      channel.port1.postMessage('ACK');
     });
 }
 
-async_test(function(t) {
+promise_test(function(t) {
     // Passing scope as the test switch for worker script.
     var scope = 'resources/install-fulfilled';
     var onRegister = function(worker) {
         var obj = {};
-        wait_for_state(t, worker, 'installed')
-          .then(function() {
+
+
+        return Promise.all([
+            syncWorker(worker, obj),
+            wait_for_state(t, worker, 'installed')
+          ]).then(function() {
               assert_true(
                 obj.synced,
                 'state should be "installed" after the waitUntil promise ' +
                     'for "oninstall" is fulfilled.');
               service_worker_unregister_and_done(t, scope);
-            })
-          .catch(unreached_rejection(t));
-        syncWorker(t, worker, obj);
+            });
       };
-    runTest(t, scope, onRegister);
+    return runTest(t, scope, onRegister);
   }, 'Test install event waitUntil fulfilled');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/install-multiple-fulfilled';
     var onRegister = function(worker) {
         var obj1 = {};
         var obj2 = {};
-        wait_for_state(t, worker, 'installed')
-          .then(function() {
+
+
+        return Promise.all([
+            syncWorker(worker, obj1),
+            syncWorker(worker, obj2),
+            wait_for_state(t, worker, 'installed')
+          ]).then(function() {
               assert_true(
                 obj1.synced && obj2.synced,
                 'state should be "installed" after all waitUntil promises ' +
                     'for "oninstall" are fulfilled.');
-              service_worker_unregister_and_done(t, scope);
-            })
-          .catch(unreached_rejection(t));
-        syncWorker(t, worker, obj1);
-        syncWorker(t, worker, obj2);
+            });
       };
-    runTest(t, scope, onRegister);
+    return runTest(t, scope, onRegister);
   }, 'Test ExtendableEvent multiple waitUntil fulfilled.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/install-reject-precedence';
     var onRegister = function(worker) {
         var obj1 = {};
         var obj2 = {};
-        wait_for_state(t, worker, 'redundant')
-          .then(function() {
+
+
+        return Promise.all([
+            syncWorker(worker, obj1)
+              .then(function() {
+                  syncWorker(worker, obj2);
+                }),
+            wait_for_state(t, worker, 'redundant')
+          ]).then(function() {
               assert_true(
                 obj1.synced,
                 'The "redundant" state was entered after the first "extend ' +
@@ -85,61 +98,46 @@ async_test(function(t) {
                 'The "redundant" state was entered after the third "extend ' +
                   'lifetime promise" resolved.'
               );
-              service_worker_unregister_and_done(t, scope);
-            })
-          .catch(unreached_rejection(t));
-
-        syncWorker(t, worker, obj1)
-          .then(function() {
-              syncWorker(t, worker, obj2);
             });
       };
-    runTest(t, scope, onRegister);
+    return runTest(t, scope, onRegister);
   }, 'Test ExtendableEvent waitUntil reject precedence.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/activate-fulfilled';
     var onRegister = function(worker) {
         var obj = {};
-        wait_for_state(t, worker, 'activating')
+        return wait_for_state(t, worker, 'activating')
           .then(function() {
-              syncWorker(t, worker, obj);
-              return wait_for_state(t, worker, 'activated');
+              return Promise.all([
+                syncWorker(worker, obj),
+                wait_for_state(t, worker, 'activated')
+              ]);
             })
           .then(function() {
               assert_true(
                 obj.synced,
                 'state should be "activated" after the waitUntil promise ' +
                     'for "onactivate" is fulfilled.');
-              service_worker_unregister_and_done(t, scope);
-            })
-          .catch(unreached_rejection(t));
+            });
       };
-    runTest(t, scope, onRegister);
+    return runTest(t, scope, onRegister);
   }, 'Test activate event waitUntil fulfilled');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/install-rejected';
     var onRegister = function(worker) {
-        wait_for_state(t, worker, 'redundant')
-          .then(function() {
-              service_worker_unregister_and_done(t, scope);
-            })
-          .catch(unreached_rejection(t));
+        return wait_for_state(t, worker, 'redundant');
       };
-    runTest(t, scope, onRegister);
+    return runTest(t, scope, onRegister);
   }, 'Test install event waitUntil rejected');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/activate-rejected';
     var onRegister = function(worker) {
-        wait_for_state(t, worker, 'activated')
-          .then(function() {
-              service_worker_unregister_and_done(t, scope);
-            })
-          .catch(unreached_rejection(t));
+        return wait_for_state(t, worker, 'activated');
       };
-    runTest(t, scope, onRegister);
+    return runTest(t, scope, onRegister);
   }, 'Test activate event waitUntil rejected.');
 
 </script>

--- a/service-workers/service-worker/extendable-event-waituntil.https.html
+++ b/service-workers/service-worker/extendable-event-waituntil.https.html
@@ -38,7 +38,6 @@ promise_test(function(t) {
     var onRegister = function(worker) {
         var obj = {};
 
-
         return Promise.all([
             syncWorker(worker, obj),
             wait_for_state(t, worker, 'installed')
@@ -59,7 +58,6 @@ promise_test(function(t) {
         var obj1 = {};
         var obj2 = {};
 
-
         return Promise.all([
             syncWorker(worker, obj1),
             syncWorker(worker, obj2),
@@ -79,7 +77,6 @@ promise_test(function(t) {
     var onRegister = function(worker) {
         var obj1 = {};
         var obj2 = {};
-
 
         return Promise.all([
             syncWorker(worker, obj1)

--- a/service-workers/service-worker/fetch-cors-xhr.https.html
+++ b/service-workers/service-worker/fetch-cors-xhr.https.html
@@ -6,33 +6,39 @@
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <body>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var SCOPE = 'resources/fetch-cors-xhr-iframe.html';
     var SCRIPT = 'resources/fetch-rewrite-worker.js';
     var host_info = get_host_info();
 
-    login_https(t)
+    return login_https(t)
       .then(function() {
           return service_worker_unregister_and_register(t, SCRIPT, SCOPE);
         })
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SCOPE);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(SCOPE); })
       .then(function(frame) {
+          t.add_cleanup(function() {
+              frame.remove();
+            });
+
           return new Promise(function(resolve, reject) {
               var channel = new MessageChannel();
-              channel.port1.onmessage = t.step_func(function(e) {
-                  assert_equals(e.data.results, 'finish');
-                  frame.remove();
-                  service_worker_unregister_and_done(t, SCOPE);
-                });
+              channel.port1.onmessage = resolve;
               frame.contentWindow.postMessage({},
                                               host_info['HTTPS_ORIGIN'],
                                               [channel.port2]);
             });
         })
-      .catch(unreached_rejection(t));
+      .then(function(e) {
+          assert_equals(e.data.results, 'finish');
+        });
   }, 'Verify CORS XHR of fetch() in a Service Worker');
 </script>
 </body>

--- a/service-workers/service-worker/fetch-event-referrer-policy.https.html
+++ b/service-workers/service-worker/fetch-event-referrer-policy.https.html
@@ -238,11 +238,15 @@ function run_referrer_policy_tests(frame, referrer, href, origin) {
         });
 }
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/simple.html?referrerPolicy';
     var frame;
-    service_worker_unregister_and_register(t, worker, scope)
+    return service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, reg.installing, 'activated');
         })
       .then(function() { return with_iframe(scope); })
@@ -263,9 +267,7 @@ async_test(function(t) {
         })
       .then(function() {
           frame.remove();
-          return service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Service Worker responds to fetch event with the referrer policy');
 
 </script>

--- a/service-workers/service-worker/fetch-frame-resource.https.html
+++ b/service-workers/service-worker/fetch-frame-resource.https.html
@@ -73,11 +73,15 @@ function getLoadedWindowAsObject(win) {
     });
 }
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/fetch-frame-resource/frame-basic';
     var frame;
-    service_worker_unregister_and_register(t, worker, scope)
+    return service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, reg.installing, 'activated');
         })
       .then(function() {
@@ -94,16 +98,18 @@ async_test(function(t) {
             'success',
             'Basic type response could be loaded in the iframe.');
           frame.remove();
-          return service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Basic type response could be loaded in the iframe.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/fetch-frame-resource/frame-cors';
     var frame;
-    service_worker_unregister_and_register(t, worker, scope)
+    return service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, reg.installing, 'activated');
         })
       .then(function() {
@@ -122,16 +128,18 @@ async_test(function(t) {
             'success',
             'CORS type response could be loaded in the iframe.');
           frame.remove();
-          return service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'CORS type response could be loaded in the iframe.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/fetch-frame-resource/frame-opaque';
     var frame;
-    service_worker_unregister_and_register(t, worker, scope)
+    return service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, reg.installing, 'activated');
         })
       .then(function() {
@@ -148,15 +156,17 @@ async_test(function(t) {
             null,
             'Opaque type response could not be loaded in the iframe.');
           frame.remove();
-          return service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Opaque type response could not be loaded in the iframe.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/fetch-frame-resource/window-basic';
-    service_worker_unregister_and_register(t, worker, scope)
+    return service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, reg.installing, 'activated');
         })
       .then(function() {
@@ -170,15 +180,17 @@ async_test(function(t) {
             result.jsonpResult,
             'success',
             'Basic type response could be loaded in the new window.');
-          return service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Basic type response could be loaded in the new window.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/fetch-frame-resource/window-cors';
-    service_worker_unregister_and_register(t, worker, scope)
+    return service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, reg.installing, 'activated');
         })
       .then(function() {
@@ -194,15 +206,17 @@ async_test(function(t) {
             result.jsonpResult,
             'success',
             'CORS type response could be loaded in the new window.');
-          return service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'CORS type response could be loaded in the new window.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/fetch-frame-resource/window-opaque';
-    service_worker_unregister_and_register(t, worker, scope)
+    return service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, reg.installing, 'activated');
         })
       .then(function() {
@@ -216,9 +230,7 @@ async_test(function(t) {
             result,
             null,
             'Opaque type response could not be loaded in the new window.');
-          return service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Opaque type response could not be loaded in the new window.');
 </script>
 </body>

--- a/service-workers/service-worker/fetch-header-visibility.https.html
+++ b/service-workers/service-worker/fetch-header-visibility.https.html
@@ -11,10 +11,14 @@
   var host_info = get_host_info();
   var frame;
 
-  async_test(function(t) {
+  promise_test(function(t) {
     var scope = 'resources/fetch-header-visibility-iframe.html';
-    service_worker_unregister_and_register(t, worker, scope)
+    return service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
+        t.add_cleanup(function() {
+            return service_worker_unregister(t, scope);
+          });
+
         return wait_for_state(t, reg.installing, 'activated');
       })
       .then(function() {
@@ -44,9 +48,7 @@
       })
       .then(function(result) {
         frame.remove();
-        return service_worker_unregister_and_done(t, scope);
-      })
-      .catch(unreached_rejection(t));
+      });
   }, 'Visibility of defaulted headers during interception');
 </script>
 </body>

--- a/service-workers/service-worker/fetch-request-css-base-url.https.html
+++ b/service-workers/service-worker/fetch-request-css-base-url.https.html
@@ -5,7 +5,7 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var SCOPE = 'resources/fetch-request-css-base-url-iframe.html';
     var SCRIPT = 'resources/fetch-request-css-base-url-worker.js';
     var worker;
@@ -13,6 +13,10 @@ async_test(function(t) {
 
     return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SCOPE);
+            });
+
           worker = registration.installing;
           return wait_for_state(t, worker, 'activated');
         })
@@ -48,9 +52,7 @@ async_test(function(t) {
       .then(function(f) {
           return testDonePromise.then(function() {
             f.remove();
-            return service_worker_unregister_and_done(t, SCOPE);
           });
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'CSS\'s base URL must be the request URL even when fetched from other URL.');
 </script>

--- a/service-workers/service-worker/fetch-request-css-images.https.html
+++ b/service-workers/service-worker/fetch-request-css-images.https.html
@@ -35,20 +35,30 @@ function css_image_set_test(expected_results, frame, url, type,
   return frame.contentWindow.load_css_image_set(url, type);
 }
 
-function create_message_promise(t, expected_results, frame,
-                                worker, test_count, scope) {
+function waitForWorker(worker) {
   return new Promise(function(resolve) {
     var channel = new MessageChannel();
-    channel.port1.onmessage = t.step_func(function(msg) {
+    channel.port1.addEventListener('message', function(msg) {
       if (msg.data.ready) {
-        resolve();
-        return;
+        resolve(channel);
       }
+    });
+    channel.port1.start();
+    worker.postMessage({port: channel.port2}, [channel.port2]);
+  });
+}
+
+function create_message_promise(channel, expected_results, worker, scope) {
+  return new Promise(function(resolve) {
+    channel.port1.addEventListener('message', function(msg) {
       var result = msg.data;
-      var expected = expected_results[result.url];
-      if (!expected) {
+      if (!expected_results[result.url]) {
         return;
       }
+      resolve(result);
+    });
+  }).then(function(result) {
+      var expected = expected_results[result.url];
       assert_equals(
           result.mode, expected.mode,
           'mode of ' + expected.message +  ' must be ' +
@@ -57,120 +67,148 @@ function create_message_promise(t, expected_results, frame,
           result.credentials, expected.credentials,
           'credentials of ' + expected.message +  ' must be ' +
           expected.credentials + '.');
-      --test_count;
       delete expected_results[result.url];
-      if (test_count == 0) {
-        frame.remove();
-        service_worker_unregister_and_done(t, scope);
-      }
     });
-    worker.postMessage(
-      {port: channel.port2}, [channel.port2]);
-  });
 }
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = SCOPE + "?img=backgroundImage";
-    var test_count = 2;
     var expected_results = {};
     var worker;
     var frame;
-    service_worker_unregister_and_register(t, SCRIPT, scope)
+    return service_worker_unregister_and_register(t, SCRIPT, scope)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           worker = registration.installing;
           return wait_for_state(t, worker, 'activated');
         })
       .then(function() { return with_iframe(scope); })
       .then(function(f) {
+          t.add_cleanup(function() {
+              f.remove();
+            });
           frame = f;
-          return create_message_promise(t, expected_results, frame,
-                                        worker, test_count, scope);
+          return waitForWorker(worker);
         })
-      .then(function() {
-        css_image_test(expected_results, frame, LOCAL_URL + Date.now(),
-                       'backgroundImage', 'no-cors', 'include');
-        css_image_test(expected_results, frame, REMOTE_URL + Date.now(),
-                      'backgroundImage', 'no-cors', 'include');
-      })
-      .catch(unreached_rejection(t));
+      .then(function(channel) {
+          css_image_test(expected_results, frame, LOCAL_URL + Date.now(),
+                         'backgroundImage', 'no-cors', 'include');
+          css_image_test(expected_results, frame, REMOTE_URL + Date.now(),
+                        'backgroundImage', 'no-cors', 'include');
+
+          return Promise.all([
+              create_message_promise(channel, expected_results, worker, scope),
+              create_message_promise(channel, expected_results, worker, scope)
+            ]);
+        });
   }, 'Verify FetchEvent for css image (backgroundImage).');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = SCOPE + "?img=shapeOutside";
-    var test_count = 2;
     var expected_results = {};
     var worker;
     var frame;
-    service_worker_unregister_and_register(t, SCRIPT, scope)
+    return service_worker_unregister_and_register(t, SCRIPT, scope)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           worker = registration.installing;
           return wait_for_state(t, worker, 'activated');
         })
       .then(function() { return with_iframe(scope); })
       .then(function(f) {
+          t.add_cleanup(function() {
+              f.remove();
+            });
           frame = f;
-          return create_message_promise(t, expected_results, frame,
-                                        worker, test_count, scope);
+          return waitForWorker(worker);
         })
-      .then(function() {
-         css_image_test(expected_results, frame, LOCAL_URL + Date.now(),
-                        'shapeOutside', 'cors', 'same-origin');
-         css_image_test(expected_results, frame, REMOTE_URL + Date.now(),
-                        'shapeOutside', 'cors', 'same-origin');
-      })
-      .catch(unreached_rejection(t));
+      .then(function(channel) {
+          css_image_test(expected_results, frame, LOCAL_URL + Date.now(),
+                         'shapeOutside', 'cors', 'same-origin');
+          css_image_test(expected_results, frame, REMOTE_URL + Date.now(),
+                         'shapeOutside', 'cors', 'same-origin');
+
+          return Promise.all([
+              create_message_promise(channel, expected_results, worker, scope),
+              create_message_promise(channel, expected_results, worker, scope)
+            ]);
+      });
   }, 'Verify FetchEvent for css image (shapeOutside).');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = SCOPE + "?img_set=backgroundImage";
-    var test_count = 2;
     var expected_results = {};
     var worker;
     var frame;
-    service_worker_unregister_and_register(t, SCRIPT, scope)
+    return service_worker_unregister_and_register(t, SCRIPT, scope)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           worker = registration.installing;
           return wait_for_state(t, worker, 'activated');
         })
       .then(function() { return with_iframe(scope); })
       .then(function(f) {
+          t.add_cleanup(function() {
+              f.remove();;
+            });
           frame = f;
-          return create_message_promise(t, expected_results, frame,
-                                        worker, test_count, scope);
+          return waitForWorker(worker);
         })
-      .then(function() {
-         css_image_set_test(expected_results, frame, LOCAL_URL + Date.now(),
-                           'backgroundImage', 'no-cors', 'include');
-         css_image_set_test(expected_results, frame, REMOTE_URL + Date.now(),
-                           'backgroundImage', 'no-cors', 'include');
-      })
-      .catch(unreached_rejection(t));
+      .then(function(channel) {
+          css_image_set_test(expected_results, frame, LOCAL_URL + Date.now(),
+                            'backgroundImage', 'no-cors', 'include');
+          css_image_set_test(expected_results, frame, REMOTE_URL + Date.now(),
+                            'backgroundImage', 'no-cors', 'include');
+
+          return Promise.all([
+              create_message_promise(channel, expected_results, worker, scope),
+              create_message_promise(channel, expected_results, worker, scope)
+            ]);
+      });
   }, 'Verify FetchEvent for css image-set (backgroundImage).');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = SCOPE + "?img_set=shapeOutside";
-    var test_count = 2;
     var expected_results = {};
     var worker;
     var frame;
-    service_worker_unregister_and_register(t, SCRIPT, scope)
+    return service_worker_unregister_and_register(t, SCRIPT, scope)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           worker = registration.installing;
           return wait_for_state(t, worker, 'activated');
         })
       .then(function() { return with_iframe(scope); })
       .then(function(f) {
+          t.add_cleanup(function() {
+              f.remove();
+            });
           frame = f;
-          return create_message_promise(t, expected_results, frame,
-                                        worker, test_count, scope);
+          return waitForWorker(worker);
         })
-      .then(function() {
-         css_image_set_test(expected_results, frame, LOCAL_URL + Date.now(),
+      .then(function(channel) {
+          css_image_set_test(expected_results, frame, LOCAL_URL + Date.now(),
+                             'shapeOutside', 'cors', 'same-origin');
+          css_image_set_test(expected_results, frame, REMOTE_URL + Date.now(),
                             'shapeOutside', 'cors', 'same-origin');
-         css_image_set_test(expected_results, frame, REMOTE_URL + Date.now(),
-                           'shapeOutside', 'cors', 'same-origin');
-      })
-      .catch(unreached_rejection(t));
+
+          return Promise.all([
+              create_message_promise(channel, expected_results, worker, scope),
+              create_message_promise(channel, expected_results, worker, scope)
+            ]);
+        });
   }, 'Verify FetchEvent for css image-set (shapeOutside).');
 
 </script>

--- a/service-workers/service-worker/fetch-request-html-imports.https.html
+++ b/service-workers/service-worker/fetch-request-html-imports.https.html
@@ -5,12 +5,16 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var SCOPE = 'resources/fetch-request-html-imports-iframe.html';
     var SCRIPT = 'resources/fetch-request-html-imports-worker.js';
     var host_info = get_host_info();
-    service_worker_unregister_and_register(t, SCRIPT, SCOPE)
+    return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SCOPE);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(SCOPE); })
@@ -56,9 +60,6 @@ async_test(function(t) {
               'mode=cors credentials=same-origin',
               'The request mode and credentials for other origin HTMLImport ' +
               'from other origin HTMLImport must be set correctly.');
-
-          service_worker_unregister_and_done(t, SCOPE);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Verify the FetchEvent for HTMLImports');
 </script>

--- a/service-workers/service-worker/fetch-request-no-freshness-headers.https.html
+++ b/service-workers/service-worker/fetch-request-no-freshness-headers.https.html
@@ -4,12 +4,16 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var SCOPE = 'resources/fetch-request-no-freshness-headers-iframe.html';
     var SCRIPT = 'resources/fetch-request-no-freshness-headers-worker.js';
     var worker;
-    service_worker_unregister_and_register(t, SCRIPT, SCOPE)
+    return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SCOPE);
+            });
+
           worker = registration.installing;
           return wait_for_state(t, worker, 'activated');
         })
@@ -38,16 +42,14 @@ async_test(function(t) {
             'if-none-match': true,
             'if-modified-since': true
           };
-          msg.data.requests.forEach(t.step_func(function(request) {
-              request.headers.forEach(t.step_func(function(header) {
+          msg.data.requests.forEach(function(request) {
+              request.headers.forEach(function(header) {
                   assert_false(
                       !!freshness_headers[header[0]],
                       header[0] + ' header must not be set in the ' +
                       'FetchEvent\'s request. (url = ' + request.url + ')');
-                }));
-            }))
-          service_worker_unregister_and_done(t, SCOPE);
-        })
-      .catch(unreached_rejection(t));
+                });
+            })
+        });
   }, 'The headers of FetchEvent shouldn\'t contain freshness headers.');
 </script>

--- a/service-workers/service-worker/fetch-response-xhr.https.html
+++ b/service-workers/service-worker/fetch-response-xhr.https.html
@@ -5,7 +5,7 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var SCOPE = 'resources/fetch-response-xhr-iframe.https.html';
     var SCRIPT = 'resources/fetch-response-xhr-worker.js';
     var host_info = get_host_info();
@@ -16,8 +16,12 @@ async_test(function(t) {
       e.source.postMessage('ACK', host_info['HTTPS_ORIGIN']);
     }
 
-    service_worker_unregister_and_register(t, SCRIPT, SCOPE)
+    return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SCOPE);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(SCOPE); })
@@ -26,18 +30,21 @@ async_test(function(t) {
 
           t.add_cleanup(function() {
               frame.remove();
-              service_worker_unregister_and_done(t, SCOPE);
             });
 
           channel = new MessageChannel();
-          channel.port1.onmessage = t.step_func(function(e) {
-              assert_equals(e.data.results, 'finish');
-              t.done();
+          var onPortMsg = new Promise(function(resolve) {
+              channel.port1.onmessage = resolve;
             });
+
           frame.contentWindow.postMessage('START',
                                           host_info['HTTPS_ORIGIN'],
                                           [channel.port2]);
+
+          return onPortMsg;
         })
-      .catch(unreached_rejection(t));
+      .then(function(e) {
+          assert_equals(e.data.results, 'finish');
+        });
   }, 'Verify the response of FetchEvent using XMLHttpRequest');
 </script>

--- a/service-workers/service-worker/fetch-waits-for-activate.https.html
+++ b/service-workers/service-worker/fetch-waits-for-activate.https.html
@@ -13,11 +13,15 @@ var worker = 'resources/fetch-waits-for-activate-worker.js';
 var expected_url = normalizeURL(worker);
 var scope = 'resources/fetch-waits-for-activate/';
 
-async_test(function(t) {
+promise_test(function(t) {
   var registration;
   var frameLoadPromise;
   var frame;
-  service_worker_unregister_and_register(t, worker, scope).then(function(reg) {
+  return service_worker_unregister_and_register(t, worker, scope).then(function(reg) {
+    t.add_cleanup(function() {
+      return service_worker_unregister(t, scope);
+    });
+
     registration = reg;
     return wait_for_state(t, reg.installing, 'activating');
   }).then(function() {
@@ -55,8 +59,7 @@ async_test(function(t) {
     assert_equals(registration.active.state, 'activated',
                   'active worker should be in activated state');
     frame.remove();
-    return service_worker_unregister_and_done(t, scope);
-  }).catch(unreached_rejection(t));
+  });
 }, 'Fetch events should wait for the activate event to complete.');
 
 </script>

--- a/service-workers/service-worker/getregistration.https.html
+++ b/service-workers/service-worker/getregistration.https.html
@@ -14,12 +14,16 @@ async_test(function(t) {
       .catch(unreached_rejection(t));
   }, 'getRegistration');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/scope/getregistration/normal';
     var registration;
-    service_worker_unregister_and_register(t, 'resources/empty-worker.js',
-                                           scope)
+    return service_worker_unregister_and_register(t, 'resources/empty-worker.js',
+                                                  scope)
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = r;
           return navigator.serviceWorker.getRegistration(scope);
         })
@@ -27,18 +31,20 @@ async_test(function(t) {
           assert_equals(
               value, registration,
               'getRegistration should resolve to the same registration object');
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Register then getRegistration');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/scope/getregistration/url-with-fragment';
     var documentURL = scope + '#ref';
     var registration;
-    service_worker_unregister_and_register(t, 'resources/empty-worker.js',
-                                           scope)
+    return service_worker_unregister_and_register(t, 'resources/empty-worker.js',
+                                                  scope)
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = r;
           return navigator.serviceWorker.getRegistration(documentURL);
         })
@@ -46,9 +52,7 @@ async_test(function(t) {
           assert_equals(
               value, registration,
               'getRegistration should resolve to the same registration object');
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Register then getRegistration with a URL having a fragment');
 
 async_test(function(t) {

--- a/service-workers/service-worker/invalid-blobtype.https.html
+++ b/service-workers/service-worker/invalid-blobtype.https.html
@@ -5,26 +5,36 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var SCOPE = 'resources/invalid-blobtype-iframe.https.html';
     var SCRIPT = 'resources/invalid-blobtype-worker.js';
     var host_info = get_host_info();
-    service_worker_unregister_and_register(t, SCRIPT, SCOPE)
+    return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SCOPE);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(SCOPE); })
       .then(function(frame) {
-          var channel = new MessageChannel();
-          channel.port1.onmessage = t.step_func(function(e) {
-              assert_equals(e.data.results, 'finish');
+          t.add_cleanup(function() {
               frame.remove();
-              service_worker_unregister_and_done(t, SCOPE);
             });
+
+          var channel = new MessageChannel();
+          var onMsg = new Promise(function(resolve) {
+              channel.port1.onmessage = resolve;
+            });
+
           frame.contentWindow.postMessage({},
                                           host_info['HTTPS_ORIGIN'],
                                           [channel.port2]);
+          return onMsg;
         })
-      .catch(unreached_rejection(t));
+      .then(function(e) {
+          assert_equals(e.data.results, 'finish');
+        });
   }, 'Verify the response of FetchEvent using XMLHttpRequest');
 </script>

--- a/service-workers/service-worker/invalid-header.https.html
+++ b/service-workers/service-worker/invalid-header.https.html
@@ -5,26 +5,35 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var SCOPE = 'resources/invalid-header-iframe.https.html';
     var SCRIPT = 'resources/invalid-header-worker.js';
     var host_info = get_host_info();
-    service_worker_unregister_and_register(t, SCRIPT, SCOPE)
+    return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SCOPE);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(SCOPE); })
       .then(function(frame) {
-          var channel = new MessageChannel();
-          channel.port1.onmessage = t.step_func(function(e) {
-              assert_equals(e.data.results, 'finish');
+          t.add_cleanup(function() {
               frame.remove();
-              service_worker_unregister_and_done(t, SCOPE);
+            });
+
+          var channel = new MessageChannel();
+          var onMsg = new Promise(function(resolve) {
+              channel.port1.onmessage = resolve;
             });
           frame.contentWindow.postMessage({},
                                           host_info['HTTPS_ORIGIN'],
                                           [channel.port2]);
+          return onMsg;
         })
-      .catch(unreached_rejection(t));
+      .then(function(e) {
+          assert_equals(e.data.results, 'finish');
+        });
   }, 'Verify the response of FetchEvent using XMLHttpRequest');
 </script>

--- a/service-workers/service-worker/iso-latin1-header.https.html
+++ b/service-workers/service-worker/iso-latin1-header.https.html
@@ -5,12 +5,16 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var SCOPE = 'resources/iso-latin1-header-iframe.html';
     var SCRIPT = 'resources/iso-latin1-header-worker.js';
     var host_info = get_host_info();
-    service_worker_unregister_and_register(t, SCRIPT, SCOPE)
+    return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SCOPE);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(SCOPE); })
@@ -19,14 +23,18 @@ async_test(function(t) {
           t.add_cleanup(function() {
               frame.remove();
             });
-          channel.port1.onmessage = t.step_func(function(e) {
-              assert_equals(e.data.results, 'finish');
-              service_worker_unregister_and_done(t, SCOPE);
+
+          var onMsg = new Promise(function(resolve) {
+              channel.port1.onmessage = resolve;
             });
+
           frame.contentWindow.postMessage({},
                                           host_info['HTTPS_ORIGIN'],
                                           [channel.port2]);
+          return onMsg;
         })
-      .catch(unreached_rejection(t));
+      .then(function(e) {
+          assert_equals(e.data.results, 'finish');
+        });
   }, 'Verify the response of FetchEvent using XMLHttpRequest');
 </script>

--- a/service-workers/service-worker/postmessage-from-waiting-serviceworker.https.html
+++ b/service-workers/service-worker/postmessage-from-waiting-serviceworker.https.html
@@ -16,13 +16,15 @@ function echo(worker, data) {
   });
 }
 
-async_test(t => {
+promise_test(t => {
   let script = 'resources/echo-message-to-source-worker.js';
   let scope = 'resources/client-postmessage-from-wait-serviceworker';
   let registration;
   let frame;
-  service_worker_unregister_and_register(t, script, scope)
+  return service_worker_unregister_and_register(t, script, scope)
     .then(swr => {
+      t.add_cleanup(() => service_worker_unregister(t, scope));
+
       registration = swr;
       return wait_for_state(t, registration.installing, 'activated');
     }).then(_ => {
@@ -43,7 +45,6 @@ async_test(t => {
       assert_equals(evt.source, registration.active,
                     'message event source should be correct');
       frame.remove();
-    }).then(_ => service_worker_unregister_and_done(t, scope) )
-    .catch(unreached_rejection(t));
+    });
 }, 'Client.postMessage() from waiting serviceworker.');
 </script>

--- a/service-workers/service-worker/referer.https.html
+++ b/service-workers/service-worker/referer.https.html
@@ -5,26 +5,36 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var SCOPE = 'resources/referer-iframe.html';
     var SCRIPT = 'resources/fetch-rewrite-worker.js';
     var host_info = get_host_info();
-    service_worker_unregister_and_register(t, SCRIPT, SCOPE)
+    return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, SCOPE);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(SCOPE); })
       .then(function(frame) {
           var channel = new MessageChannel();
-          channel.port1.onmessage = t.step_func(function(e) {
-              assert_equals(e.data.results, 'finish');
+          t.add_cleanup(function() {
               frame.remove();
-              service_worker_unregister_and_done(t, SCOPE);
             });
+
+          var onMsg = new Promise(function(resolve) {
+              channel.port1.onmessage = resolve;
+            });
+
           frame.contentWindow.postMessage({},
                                           host_info['HTTPS_ORIGIN'],
                                           [channel.port2]);
+          return onMsg;
         })
-      .catch(unreached_rejection(t));
+      .then(function(e) {
+          assert_equals(e.data.results, 'finish');
+        });
   }, 'Verify the referer');
 </script>

--- a/service-workers/service-worker/registration-events.https.html
+++ b/service-workers/service-worker/registration-events.https.html
@@ -4,15 +4,17 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-var t = async_test('Registration: events');
-t.step(function() {
+promise_test(function(t) {
     var scope = 'resources/in-scope/';
-    service_worker_unregister_and_register(
+    return service_worker_unregister_and_register(
         t, 'resources/events-worker.js', scope)
-      .then(t.step_func(function(registration) {
-          onRegister(registration.installing);
-        }))
-      .catch(unreached_rejection(t));
+      .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+          });
+
+          return onRegister(registration.installing);
+        });
 
     function sendMessagePort(worker, from) {
         var messageChannel = new MessageChannel();
@@ -21,17 +23,20 @@ t.step(function() {
     }
 
     function onRegister(sw) {
-        sw.onstatechange = t.step_func(function() {
-            if (sw.state !== 'activated')
-                return;
-
-            sendMessagePort(sw, 'registering doc').onmessage = t.step_func(function (e) {
+        return new Promise(function(resolve) {
+            sw.onstatechange = function() {
+                if (sw.state === 'activated')
+                    resolve();
+            };
+        }).then(function() {
+            return new Promise(function(resolve) {
+                sendMessagePort(sw, 'registering doc').onmessage = resolve;
+            });
+        }).then(function(e) {
                 assert_array_equals(e.data.events,
                                     ['install', 'activate'],
                                    'Worker should see install then activate events');
-                service_worker_unregister_and_done(t, scope);
-            });
         });
     }
-});
+}, 'Registration: events');
 </script>

--- a/service-workers/service-worker/state.https.html
+++ b/service-workers/service-worker/state.https.html
@@ -4,21 +4,24 @@
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>
-(function () {
-    var t = async_test('Service Worker state property and "statechange" event');
+promise_test(function (t) {
     var currentState = 'test-is-starting';
     var scope = 'resources/state/';
 
-    service_worker_unregister_and_register(
+    return service_worker_unregister_and_register(
         t, 'resources/empty-worker.js', scope)
-      .then(t.step_func(function(registration) {
+      .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           var sw = registration.installing;
-          sw.addEventListener('statechange', t.step_func(onStateChange(sw)));
+
           assert_equals(sw.state, 'installing',
                         'the service worker should be in "installing" state.');
           checkStateTransition(sw.state);
-        }))
-      .catch(unreached_rejection(t));
+          return onStateChange(sw);
+        });
 
     function checkStateTransition(newState) {
         switch (currentState) {
@@ -49,7 +52,9 @@
     }
 
     function onStateChange(expectedTarget) {
-        return function(event) {
+      return new Promise(function(resolve) {
+            expectedTarget.addEventListener('statechange', resolve);
+          }).then(function(event) {
             assert_true(event.target instanceof ServiceWorker,
                         'the target of the statechange event should be a ' +
                         'ServiceWorker.');
@@ -61,9 +66,9 @@
 
             checkStateTransition(event.target.state);
 
-            if (event.target.state == 'activated')
-                service_worker_unregister_and_done(t, scope);
-        };
+            if (event.target.state != 'activated')
+                return onStateChange(expectedTarget);
+          });
     }
-}());
+}, 'Service Worker state property and "statechange" event');
 </script>

--- a/service-workers/service-worker/uncontrolled-page.https.html
+++ b/service-workers/service-worker/uncontrolled-page.https.html
@@ -19,10 +19,14 @@ function fetch_url(url) {
 }
 var worker = 'resources/fail-on-fetch-worker.js';
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/scope/uncontrolled-page/';
-    service_worker_unregister_and_register(t, worker, scope)
+    return service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, reg.installing, 'activated');
         })
       .then(function() {
@@ -30,10 +34,6 @@ async_test(function(t) {
         })
       .then(function(text) {
           assert_equals(text, 'a simple text file\n');
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(t.step_func(function(reason) {
-          assert_unreached(reason.message);
-        }));
+        });
   }, 'Fetch events should not go through uncontrolled page.');
 </script>

--- a/service-workers/service-worker/unregister-then-register.https.html
+++ b/service-workers/service-worker/unregister-then-register.https.html
@@ -5,12 +5,16 @@
 <script>
 var worker_url = 'resources/empty-worker.js';
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/scope/re-register-resolves-to-new-value';
     var registration;
 
-    service_worker_unregister_and_register(t, worker_url, scope)
+    return service_worker_unregister_and_register(t, worker_url, scope)
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = r;
           return wait_for_state(t, r.installing, 'activated');
         })
@@ -23,17 +27,19 @@ async_test(function(t) {
       .then(function(new_registration) {
           assert_not_equals(registration, new_registration,
                             'register should resolve to a new value');
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Unregister then register resolves to a new value');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/scope/re-register-while-old-registration-in-use';
     var registration;
 
-    service_worker_unregister_and_register(t, worker_url, scope)
+    return service_worker_unregister_and_register(t, worker_url, scope)
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = r;
           return wait_for_state(t, r.installing, 'activated');
         })
@@ -49,20 +55,22 @@ async_test(function(t) {
       .then(function(new_registration) {
           assert_equals(registration, new_registration,
                         'new registration should resolve to the same registration');
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Unregister then register resolves to the original value if the ' +
          'registration is in use.');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/scope/complete-unregistration-followed-by-' +
                 'reloading-controllee-iframe';
     var registration;
     var frame;
     var service_worker;
-    service_worker_unregister_and_register(t, worker_url, scope)
+    return service_worker_unregister_and_register(t, worker_url, scope)
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = r;
           return wait_for_state(t, r.installing, 'activated');
         })
@@ -88,20 +96,22 @@ async_test(function(t) {
       .then(function(r) {
           assert_equals(r, undefined, 'getRegistration should return ' +
                                       'undefined after unregistration');
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
 }, 'Reloading the last controlled iframe after unregistration should ensure ' +
    'the deletion of the registration');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/scope/re-register-does-not-affect-existing-controllee';
     var iframe;
     var registration;
     var controller;
 
-    service_worker_unregister_and_register(t, worker_url, scope)
+    return service_worker_unregister_and_register(t, worker_url, scope)
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = r;
           return wait_for_state(t, r.installing, 'activated');
         })
@@ -125,18 +135,20 @@ async_test(function(t) {
               controller,
               'the worker from the first registration is the controller');
           iframe.remove();
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Unregister then register does not affect existing controllee');
 
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/scope/resurrection';
     var iframe;
     var registration;
 
-    service_worker_unregister_and_register(t, worker_url, scope)
+    return service_worker_unregister_and_register(t, worker_url, scope)
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = r;
           return wait_for_state(t, r.installing, 'activated');
         })
@@ -159,8 +171,6 @@ async_test(function(t) {
               frame.contentWindow.navigator.serviceWorker.controller, null,
               'document should have a controller');
           frame.remove();
-          service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Unregister then register resurrects the registration');
 </script>

--- a/service-workers/service-worker/update-recovery.https.html
+++ b/service-workers/service-worker/update-recovery.https.html
@@ -5,7 +5,7 @@
 <script src="resources/testharness-helpers.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-async_test(function(t) {
+promise_test(function(t) {
     var scope = 'resources/simple.txt';
     var worker_url = 'resources/update-recovery-worker.py';
     var expected_url = normalizeURL(worker_url);
@@ -46,8 +46,12 @@ async_test(function(t) {
       });
     }
 
-    service_worker_unregister_and_register(t, worker_url, scope)
+    return service_worker_unregister_and_register(t, worker_url, scope)
       .then(function(r) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           registration = r;
           return wait_for_state(t, registration.installing, 'activated');
         })
@@ -64,8 +68,6 @@ async_test(function(t) {
           assert_equals(frame.contentWindow.navigator.serviceWorker.controller.scriptURL,
                         expected_url);
           frame.remove();
-          return service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Recover from a bad service worker by updating after a failed navigation.');
 </script>

--- a/service-workers/service-worker/websocket.https.html
+++ b/service-workers/service-worker/websocket.https.html
@@ -6,7 +6,7 @@
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 
-async_test(function(t) {
+promise_test(function(t) {
     var path = new URL(".", window.location).pathname
     var url = 'resources/websocket.js';
     var scope = 'resources/blank.html?websocket';
@@ -14,8 +14,12 @@ async_test(function(t) {
     var frameURL = host_info['HTTPS_ORIGIN'] + path + scope;
     var frame;
 
-    service_worker_unregister_and_register(t, url, scope)
+    return service_worker_unregister_and_register(t, url, scope)
       .then(function(registration) {
+          t.add_cleanup(function() {
+              return service_worker_unregister(t, scope);
+            });
+
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() { return with_iframe(frameURL); })
@@ -24,23 +28,18 @@ async_test(function(t) {
           return websocket(t, frame);
         })
       .then(function() {
-          return new Promise(function(resolve, reject) {
-            function onMessage(e) {
-              for (var url in e.data.urls) {
-                assert_equals(url.indexOf(get_websocket_url()), -1,
-                              "Observed an unexpected FetchEvent for the WebSocket handshake");
-              }
-              t.done();
-            }
-            var channel = new MessageChannel();
-            channel.port1.onmessage = t.step_func(onMessage);
+          var channel = new MessageChannel();
+          return new Promise(function(resolve) {
+            channel.port1.onmessage = resolve;
             frame.contentWindow.navigator.serviceWorker.controller.postMessage({port: channel.port2}, [channel.port2]);
           });
         })
-      .then(function() {
+      .then(function(e) {
+          for (var url in e.data.urls) {
+            assert_equals(url.indexOf(get_websocket_url()), -1,
+                          "Observed an unexpected FetchEvent for the WebSocket handshake");
+          }
           frame.remove();
-          return service_worker_unregister_and_done(t, scope);
-        })
-      .catch(unreached_rejection(t));
+        });
   }, 'Verify WebSocket handshake channel does not get intercepted');
 </script>


### PR DESCRIPTION
Previously, many tests un-registered service workers only after all
assertions had been satisfied. This meant that failing tests would *not*
un-register workers. In order to account for workers that persisted from
previous test failures, the tests included "setup" code to defensively
un-register such workers.

The `Test#add_cleanup` method was recently extended to support
asynchronous "clean up" operations [1], but the functionality is only
available to tests declared using `promise_test`. Update tests which
were previously declared with `async_test` and use the new "async
cleanup" API to schedule service worker un-registration so that it
occurs regardless of the result of each test.

[1] https://github.com/web-platform-tests/wpt/pull/8748

---

This patch is not intended to influence test results. To verify that, I used
the WPT CLI to run the affected tests in Chromium and Firefox, comparing the
summary it produced both on `master` and on this branch.

Chromium on `master`:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 96 checks (32 tests, 64 subtests)
    Expected results: 93
    Unexpected results: 3
      subtest: 3 (3 fail)

Chromium with patch applied:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 96 checks (32 tests, 64 subtests)
    Expected results: 93
    Unexpected results: 3
      subtest: 3 (3 fail)

Firefox on `master`:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 96 checks (32 tests, 64 subtests)
    Expected results: 89
    Unexpected results: 7
      test: 1 (1 timeout)
      subtest: 6 (4 fail, 2 timeout)

Firefox with patch applied:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 96 checks (32 tests, 64 subtests)
    Expected results: 89
    Unexpected results: 7
      test: 1 (1 timeout)
      subtest: 6 (4 fail, 1 notrun, 1 timeout)

The discrepancy in Firefox is expected. In `master`, two of the four
`async_tests` in `fetch-request-css-images.https.html` time out in Firefox.
This branch refactors all four into `promise_test`s. `promise_test`s run in
series (unlike the parallel `async_test`s), so the harness stops running the
tests following the first timeout and reports the final test as "NOT RUN".

I've attempted to ease the review process by splitting the work across a few
pull requests, but this patch is still pretty onerous. I'd be happy to break it
up further if desired.