### PR TITLE
Unbreak html/dom/interfaces.https.html

### DIFF
--- a/html/dom/interfaces.https.html
+++ b/html/dom/interfaces.https.html
@@ -37,7 +37,7 @@ const waitForLoad = new Promise(resolve => { addEventListener('load', resolve); 
 
 idl_test(
   ['html'],
-  ['SVG', 'cssom', 'touchevents', 'uievents', 'dom'],
+  ['SVG', 'cssom', 'touch-events', 'uievents', 'dom'],
   async idlArray => {
     idlArray.add_objects({
       NodeList: ['document.getElementsByName("name")'],


### PR DESCRIPTION
This change makes /interfaces/touch-events.idl get fetched, rather than /interfaces/touchevents.idl (which doesn't exist).