### PR TITLE
Avoid relying on ResourceTiming L2 for preload tests

### DIFF
--- a/preload/resources/preload_helper.js
+++ b/preload/resources/preload_helper.js
@@ -14,7 +14,7 @@ function verifyNumberOfDownloads(url, number)
 {
     var numDownloads = 0;
     performance.getEntriesByName(getAbsoluteURL(url)).forEach(entry => {
-        if (entry.transferSize > 0) {
+        if (entry.transferSize === undefined || entry.transferSize > 0) {
             numDownloads++;
         }
     });


### PR DESCRIPTION
This change makes sure that preload tests do not fail when ResourceTiming transferSize is not supported, as it is not essential for the tests.