### PR TITLE
[resource-timing] Add TAO test for multiple wildcards

### DIFF
--- a/resource-timing/resource_TAO_match_origin.htm
+++ b/resource-timing/resource_TAO_match_origin.htm
@@ -35,6 +35,7 @@ function onload_test() {
     var context = new PerformanceContext(iframe.contentWindow.performance);
     var entries = context.getEntriesByType('resource');
 
+    assert_greater_than(entries.length, 0, "The iframe should have at least one resource timing entry.");
     if(entries.length > 0) {
         entry = entries[0];
 

--- a/resource-timing/resource_TAO_match_wildcard.htm
+++ b/resource-timing/resource_TAO_match_wildcard.htm
@@ -35,6 +35,7 @@ function onload_test() {
     var context = new PerformanceContext(iframe.contentWindow.performance);
     var entries = context.getEntriesByType('resource');
 
+    assert_greater_than(entries.length, 0, "The iframe should have at least one resource timing entry.");
     if(entries.length > 0) {
         entry = entries[0];
 

--- a/resource-timing/resource_TAO_multi.htm
+++ b/resource-timing/resource_TAO_multi.htm
@@ -35,6 +35,7 @@ function onload_test() {
     var context = new PerformanceContext(iframe.contentWindow.performance);
     var entries = context.getEntriesByType('resource');
 
+    assert_greater_than(entries.length, 0, "The iframe should have at least one resource timing entry.");
     if(entries.length > 0) {
         entry = entries[0];
 

--- a/resource-timing/resource_TAO_multi_wildcard.html
+++ b/resource-timing/resource_TAO_multi_wildcard.html
@@ -39,7 +39,7 @@ function onload_test() {
     if(entries.length > 0) {
         entry = entries[0];
 
-        test_equals((entry.redirectStart + entry.redirectEnd + entry.domainLookupStart + entry.domainLookupEnd + entry.connectStart + entry.connectEnd + entry.secureConnectionStart + entry.requestStart + entry.responseStart), 0, 'redirectStart, redirectEnd, domainLookupStart, domainLookupEnd, connectStart, connectEnd, secureConnectionStart, requestStart, and responseStart -- should be all returned as 0 when the value of Timing-Allow-Origin is NOT a case-sensitive match for the value of the origin of the current document and TAO algorithm passes');
+        test_not_equals((entry.redirectStart + entry.redirectEnd + entry.domainLookupStart + entry.domainLookupEnd + entry.connectStart + entry.connectEnd + entry.secureConnectionStart + entry.requestStart + entry.responseStart), 0, 'redirectStart, redirectEnd, domainLookupStart, domainLookupEnd, connectStart, connectEnd, secureConnectionStart, requestStart, and responseStart -- should not be all returned as 0 when the HTTP response has multiple Timing-Allow-Origin header fields and the subsequent field value is separated by a comma, i.e. TAO algorithm passes');
     }
 
     done();
@@ -49,8 +49,8 @@ window.setup_iframe = setup_iframe;
 </head>
 <body>
 <h1>Description</h1>
-<p>This test validates that for a cross origin resource, the timing allow check algorithm will fail when the value of Timing-Allow-Origin is NOT a case-sensitive match for the value of the origin of the current document.</p>
+<p>This test validates that for a cross origin resource, the timing allow check algorithm will pass when the HTTP response has multiple Timing-Allow-Origin header fields and the subsequent field value is separated by a comma.</p>
 <div id="log"></div>
-<iframe id="frameContext" src="resources/iframe_TAO_origin_uppercase.html"></iframe>
+<iframe id="frameContext" src="resources/iframe_TAO_multi_wildcard.html"></iframe>
 </body>
 </html>

--- a/resource-timing/resource_TAO_null.htm
+++ b/resource-timing/resource_TAO_null.htm
@@ -35,6 +35,7 @@ function onload_test() {
     var context = new PerformanceContext(iframe.contentWindow.performance);
     var entries = context.getEntriesByType('resource');
 
+    assert_greater_than(entries.length, 0, "The iframe should have at least one resource timing entry.");
     if(entries.length > 0) {
         entry = entries[0];
 

--- a/resource-timing/resource_TAO_space.htm
+++ b/resource-timing/resource_TAO_space.htm
@@ -35,6 +35,7 @@ function onload_test() {
     var context = new PerformanceContext(iframe.contentWindow.performance);
     var entries = context.getEntriesByType('resource');
 
+    assert_greater_than(entries.length, 0, "The iframe should have at least one resource timing entry.");
     if(entries.length > 0) {
         entry = entries[0];
 

--- a/resource-timing/resource_TAO_wildcard.htm
+++ b/resource-timing/resource_TAO_wildcard.htm
@@ -35,6 +35,7 @@ function onload_test() {
     var context = new PerformanceContext(iframe.contentWindow.performance);
     var entries = context.getEntriesByType('resource');
 
+    assert_greater_than(entries.length, 0, "The iframe should have at least one resource timing entry.");
     if(entries.length > 0) {
         entry = entries[0];
 

--- a/resource-timing/resources/TAOResponse.py
+++ b/resource-timing/resources/TAOResponse.py
@@ -23,6 +23,10 @@ def main(request, response):
     # more than one TAO values, seperated by comma, pass
         response.headers.set('Timing-Allow-Origin', origin)
         response.headers.append('Timing-Allow-Origin', '*')
+    elif tao == 'multi_wildcard':
+    # multiple wildcards, seperated by comma, pass
+        response.headers.set('Timing-Allow-Origin', '*')
+        response.headers.append('Timing-Allow-Origin', '*')
     elif tao == 'match_origin':
     # contains a match of origin, seperated by comma, pass
         response.headers.set('Timing-Allow-Origin', origin)

--- a/resource-timing/resources/iframe_TAO_multi_wildcard.html
+++ b/resource-timing/resources/iframe_TAO_multi_wildcard.html
@@ -1,0 +1,21 @@
+<body>
+<script>
+function dirname(path) {
+    return path.replace(/\/[^\/]*$/, '/');
+}
+
+function request() {
+  var dirName = dirname(location.href);
+  // create a cross-origin request
+  var url = dirName.replace('://', '://www.') + 'TAOResponse.py?tao=multi_wildcard';
+  var img = new Image();
+  img.crossOrigin = "anonymous";
+  img.src = url;
+}
+
+if(window.parent.setup_iframe) {
+  window.parent.setup_iframe();
+  request();
+}
+</script>
+</body>


### PR DESCRIPTION
This PR adds a test for multiple TAO wildcards, to make sure it passes the timing allow check.
It also adds asserts to make sure TAO tests fail if the relevant RT entry is missing.