### PR TITLE
Make use of navigator.mediaDevices.getUserMedia instead of navigator.getUserMedia

### DIFF
--- a/mediacapture-streams/MediaStream-default-feature-policy.https.html
+++ b/mediacapture-streams/MediaStream-default-feature-policy.https.html
@@ -13,7 +13,7 @@
   // mic/camera has been explicitly allowed by feature policy.
   function promise_factory(allowed_features) {
     return new Promise((resolve, reject) => {
-      navigator.getUserMedia({video: true, audio: true}).then(
+      navigator.mediaDevices.getUserMedia({video: true, audio: true}).then(
           function(stream) {
             // If microphone is allowed, there should be at least one microphone
             // in the result. If camera is allowed, there should be at least one


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/12715 moved from callback based to promise based APIs but forgot to update navigator.getUserMedia to navigator.mediaDevices.getUserMedia