### PR TITLE
Fix firefox find_binary_path to accomodate channels

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -102,6 +102,11 @@ class Firefox(Browser):
             "beta": "latest-beta",
             "nightly": "latest"
         }
+        application_name = {
+            "stable": "Firefox.app",
+            "beta": "Firefox.app",
+            "nightly": "Firefox Nightly.app"
+        }
         if channel not in branch:
             raise ValueError("Unrecognised release channel: %s" % channel)
 
@@ -131,10 +136,10 @@ class Firefox(Browser):
         try:
             mozinstall.install(filename, dest)
         except mozinstall.mozinstall.InstallError:
-            if platform == "mac" and os.path.exists(os.path.join(dest, "Firefox Nightly.app")):
+            if platform == "mac" and os.path.exists(os.path.join(dest, application_name[channel])):
                 # mozinstall will fail if nightly is already installed in the venv because
                 # mac installation uses shutil.copy_tree
-                mozinstall.uninstall(os.path.join(dest, "Firefox Nightly.app"))
+                mozinstall.uninstall(os.path.join(dest, application_name[channel]))
                 mozinstall.install(filename, dest)
             else:
                 raise
@@ -142,7 +147,7 @@ class Firefox(Browser):
         os.remove(filename)
         return self.find_binary_path(dest)
 
-    def find_binary_path(self, path=None):
+    def find_binary_path(self,path=None, channel="nightly"):
         """Looks for the firefox binary in the virtual environment"""
 
         platform = {
@@ -151,9 +156,15 @@ class Firefox(Browser):
             "Darwin": "mac"
         }.get(uname[0])
 
+        application_name = {
+            "stable": "Firefox.app",
+            "beta": "Firefox.app",
+            "nightly": "Firefox Nightly.app"
+        }.get(channel)
+
         if path is None:
             #os.getcwd() doesn't include the venv path
-            path = os.path.join(os.getcwd(), "_venv", "browsers")
+            path = os.path.join(os.getcwd(), "_venv", "browsers", channel)
 
         binary = None
 
@@ -163,7 +174,8 @@ class Firefox(Browser):
             import mozinstall
             binary = mozinstall.get_binary(path, "firefox")
         elif platform == "mac":
-            binary = find_executable("firefox", os.path.join(path, "Firefox Nightly.app", "Contents", "MacOS"))
+            binary = find_executable("firefox", os.path.join(path, application_name,
+                                                             "Contents", "MacOS"))
 
         return binary
 
@@ -171,14 +183,15 @@ class Firefox(Browser):
         if venv_path is None:
             venv_path = os.path.join(os.getcwd(), "_venv")
 
-        path = os.path.join(venv_path, "browsers")
-        if channel is not None:
-            path = os.path.join(path, channel)
-        binary = self.find_binary_path(path)
+        if channel is None:
+            channel = "nightly"
+
+        path = os.path.join(venv_path, "browsers", channel)
+        binary = self.find_binary_path(path, channel)
 
         if not binary and uname[0] == "Darwin":
-            macpaths = ["/Applications/FirefoxNightly.app/Contents/MacOS",
-                        os.path.expanduser("~/Applications/FirefoxNightly.app/Contents/MacOS"),
+            macpaths = ["/Applications/Firefox Nightly.app/Contents/MacOS",
+                        os.path.expanduser("~/Applications/Firefox Nightly.app/Contents/MacOS"),
                         "/Applications/Firefox Developer Edition.app/Contents/MacOS",
                         os.path.expanduser("~/Applications/Firefox Developer Edition.app/Contents/MacOS"),
                         "/Applications/Firefox.app/Contents/MacOS",

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -177,6 +177,9 @@ class Firefox(BrowserSetup):
 
     def setup_kwargs(self, kwargs):
         if kwargs["binary"] is None:
+            if kwargs["browser_channel"] is None:
+                logger.info("No browser channel specified. Running nightly instead.")
+
             binary = self.browser.find_binary(self.venv.path,
                                               kwargs["browser_channel"])
             if binary is None:


### PR DESCRIPTION
Firefox find_binary_path returned None since browser-channels were introduced
due to path differences. This fixes the same, along with a minor change to the
Nightly path on Mac as it contains a space.

The default for |wpt run firefox| without a channel specified is set to nightly,
along with a log message when this happens.