### PR TITLE
Typo: seperated → separated

### DIFF
--- a/resource-timing/resources/TAOResponse.py
+++ b/resource-timing/resources/TAOResponse.py
@@ -17,22 +17,22 @@ def main(request, response):
     # case-sensitive match for origin, pass
         response.headers.set('Timing-Allow-Origin', origin)
     elif tao == 'space':
-    # space seperated list of origin and wildcard, fail
+    # space separated list of origin and wildcard, fail
         response.headers.set('Timing-Allow-Origin', (origin + ' *'))
     elif tao == 'multi':
-    # more than one TAO values, seperated by comma, pass
+    # more than one TAO values, separated by comma, pass
         response.headers.set('Timing-Allow-Origin', origin)
         response.headers.append('Timing-Allow-Origin', '*')
     elif tao == 'multi_wildcard':
-    # multiple wildcards, seperated by comma, pass
+    # multiple wildcards, separated by comma, pass
         response.headers.set('Timing-Allow-Origin', '*')
         response.headers.append('Timing-Allow-Origin', '*')
     elif tao == 'match_origin':
-    # contains a match of origin, seperated by comma, pass
+    # contains a match of origin, separated by comma, pass
         response.headers.set('Timing-Allow-Origin', origin)
         response.headers.append('Timing-Allow-Origin', "fake")
     elif tao == 'match_wildcard':
-    # contains a wildcard, seperated by comma, pass
+    # contains a wildcard, separated by comma, pass
         response.headers.set('Timing-Allow-Origin', "fake")
         response.headers.append('Timing-Allow-Origin', '*')
     elif tao == 'uppercase':

--- a/svg/import/animate-elem-83-t-manual.svg
+++ b/svg/import/animate-elem-83-t-manual.svg
@@ -43,7 +43,7 @@
       <p>
         The third test validates a simple values-animation on a path's d attribute
         made of M, C and Z commands where the values attribute is specified and
-        specifies three seperate values.
+        specifies three separate values.
         The attribute is compatible with the path element's d attribute.
       </p>
       <p>

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -210,7 +210,7 @@ class BrowserManager(object):
         self.command_queue.put((command, args))
 
     def init_timeout(self):
-        # This is called from a seperate thread, so we send a message to the
+        # This is called from a separate thread, so we send a message to the
         # main loop so we get back onto the manager thread
         self.logger.debug("init_failed called from timer")
         self.send_message("init_failed")


### PR DESCRIPTION
Found by https://chromium-review.googlesource.com/c/chromium/src/+/1240181#message-2a9347bd8ccd79130eb02de97600c0faf4d429ce

But the same typo also made elsewhere.