### PR TITLE
[css-text] word-break:keep-all with U+3000 (space) and U+3001 (punctuation)

### DIFF
--- a/css/css-text/word-break/reference/word-break-keep-all-005-ref.html
+++ b/css/css-text/word-break/reference/word-break-keep-all-005-ref.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS-Text reference file</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+
+<p>This test passes if the four characters below are arranged in a two-by-two square.
+<div>字字<br>字字</div>

--- a/css/css-text/word-break/word-break-keep-all-005.html
+++ b/css/css-text/word-break/word-break-keep-all-005.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS-Text test: word-break keep-all does not affect U+3000</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<meta name=flags content="">
+<meta name=assert content="U+3000, despite being called Ideographic Space, does not belong to the ID line breaking class, or any other class whose wrapping opportunities are suppressed by word-break:keep-all. A break after it should still be allowed.">
+<link rel="match" href="reference/word-break-keep-all-005-ref.html">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#valdef-word-break-keep-all">
+<style>
+div {
+  width: 4em;
+  word-break: keep-all;
+}
+</style>
+
+<p>This test passes if the four characters below are arranged in a two-by-two square.
+<div lang=ja>字字　字字</div>
+<!--
+If keep-all has no effect at all, breaks are allowed everywhere,
+and the result will be:
+  字字　字
+  字
+
+If keep-all correctly suppresses wrapping opportunities between CJK ideographs
+but also incorrectly suppresses the wrapping opportunity after U+3000,
+no wrapping is possible, and the result will be:
+  字字　字字
+-->

--- a/css/css-text/word-break/word-break-keep-all-006.html
+++ b/css/css-text/word-break/word-break-keep-all-006.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS-Text test: word-break keep-all does not affect punctuation</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<meta name=flags content="">
+<meta name=assert content="word-break:keep-all does not affect rules governing the soft wrap opportunities created by punctuation">
+<link rel="match" href="reference/word-break-keep-all-005-ref.html">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#propdef-word-break">
+<style>
+div {
+  width: 4em;
+  word-break: keep-all;
+}
+span { color: transparent }
+</style>
+
+<p>This test passes if the four characters below are arranged in a two-by-two square.
+<div lang=ja>字字<span>、</span>字字</div>
+<!--
+U+3001 : IDEOGRAPHIC COMMA is made transparent for visual simplicity,
+the change in color has no effect on layout.
+
+If keep-all has no effect at all, breaks are allowed everywhere
+(except before U+3001, but this has no incidence in this case)
+and the result will be:
+  字字、字
+  字
+
+If keep-all correctly suppresses wrapping opportunities between CJK ideographs
+but also incorrectly suppresses the wrapping opportunity after U+3001,
+no wrapping is possible, and the result will be:
+  字字、字字
+-->


### PR DESCRIPTION
At the time of writing, Chrome passes, but Firefox and Safari fail.

Related to https://github.com/w3c/csswg-drafts/issues/3142