### PR TITLE
Added whitespace test and template system fix for UTF-8 whitespace

### DIFF
--- a/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
+++ b/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
@@ -1,0 +1,66 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+  <script>
+    var tests = [
+      // Make sure that csp works properly in normal situations
+      { "csp": "", "expected": true, "name": "Should load image without any CSP" },
+      { "csp": "img-src 'none';", "expected": false, "name": "Should not load image with 'none' CSP" },
+      // Ensure ASCII whitespaces are properly parsed
+      // ASCII whitespace is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020 SPACE.
+
+      // between directive name and value
+      { "csp": "img-src\u0009'none';", "expected": false, "name": "U+0009 TAB   should be properly parsed between directive name and value" },
+      { "csp": "img-src\u000C'none';", "expected": false, "name": "U+000C FF    should be properly parsed between directive name and value" },
+      { "csp": "img-src\u000A'none';", "expected": false, "name": "U+000A LF    should be properly parsed between directive name and value" },
+      { "csp": "img-src\u000D'none';", "expected": false, "name": "U+000D CR    should be properly parsed between directive name and value" },
+      { "csp": "img-src\u0020'none';", "expected": false, "name": "U+0020 SPACE should be properly parsed between directive name and value" },
+
+      // inside directive value
+      { "csp": "img-src http://example.com\u0009http://example2.com;", "expected": false, "name": "U+0009 TAB   should be properly parsed inside directive value" },
+      { "csp": "img-src http://example.com\u000Chttp://example2.com;", "expected": false, "name": "U+000C FF    should be properly parsed inside directive value" },
+      { "csp": "img-src http://example.com\u000Ahttp://example2.com;", "expected": false, "name": "U+000A LF    should be properly parsed inside directive value" },
+      { "csp": "img-src http://example.com\u000Dhttp://example2.com;", "expected": false, "name": "U+000D CR    should be properly parsed inside directive value" },
+      { "csp": "img-src http://example.com\u0020http://example2.com;", "expected": false, "name": "U+0020 SPACE should be properly parsed inside directive value" },
+
+      // Ensure nbsp (U+00A0) is not considered a valid whitespace
+      { "csp": "img-src\u00A0'none';", "expected": false, "name": "U+00A0 NBSP  should be properly parsed between directive name and value" },
+      { "csp": "img-src http://example.com\u00A0http://example2.com;", "expected": false, "name": "U+00A0 NBSP  should be properly parsed inside directive value" },
+    ];
+
+    tests.forEach(test => {
+      async_test(t => {
+        var url = "support/load_img_and_post_result_meta.sub.html?csp=" + encodeURIComponent(test.csp);
+        test_image_loads_as_expected(test, t, url);
+      }, test.name + " - meta tag");
+
+      // We can't test csp delivered in an HTTP header if we're testing CR/LF characters
+      if (test.csp.indexOf("\u000A") == -1 && test.csp.indexOf("\u000D") == -1) {
+        async_test(t => {
+          var url = "support/load_img_and_post_result_meta.sub.html?csp=" + encodeURIComponent(test.csp);
+          test_image_loads_as_expected(test, t, url);
+        }, test.name + " - HTTP header");
+      }
+    });
+
+    function test_image_loads_as_expected(test, t, url) {
+      var i = document.createElement('iframe');
+      i.src = url;
+      window.addEventListener('message', t.step_func(function(e) {
+        if (e.source != i.contentWindow) return;
+        if (test.expected) {
+          assert_equals(e.data, "img loaded");
+        } else {
+          assert_equals(e.data, "img not loaded");
+        }
+        t.done();
+      }));
+      document.body.appendChild(i);
+    }
+  </script>
+</body>
+</html>

--- a/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
+++ b/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
@@ -28,7 +28,7 @@
       { "csp": "img-src http://example.com\u0020http://example2.com;", "expected": false, "name": "U+0020 SPACE should be properly parsed inside directive value" },
 
       // Ensure nbsp (U+00A0) is not considered a valid whitespace
-      // https://github.com/webcompat/web-bugs/issues/18902 has more details about why this particulalry relevant
+      // https://github.com/webcompat/web-bugs/issues/18902 has more details about why this particularly relevant
       { "csp": "img-src\u00A0'none';", "expected": true, "name": "U+00A0 NBSP  should not be parsed between directive name and value" },
       { "csp": "img-src http://example.com\u00A0http://example2.com;", "expected": true, "name": "U+00A0 NBSP  should not be parsed inside directive value" },
     ];

--- a/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
+++ b/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
@@ -28,8 +28,8 @@
       { "csp": "img-src http://example.com\u0020http://example2.com;", "expected": false, "name": "U+0020 SPACE should be properly parsed inside directive value" },
 
       // Ensure nbsp (U+00A0) is not considered a valid whitespace
-      { "csp": "img-src\u00A0'none';", "expected": false, "name": "U+00A0 NBSP  should be properly parsed between directive name and value" },
-      { "csp": "img-src http://example.com\u00A0http://example2.com;", "expected": false, "name": "U+00A0 NBSP  should be properly parsed inside directive value" },
+      { "csp": "img-src\u00A0'none';", "expected": true, "name": "U+00A0 NBSP  should not be parsed between directive name and value" },
+      { "csp": "img-src http://example.com\u00A0http://example2.com;", "expected": true, "name": "U+00A0 NBSP  should not be parsed inside directive value" },
     ];
 
     tests.forEach(test => {

--- a/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
+++ b/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
@@ -28,6 +28,7 @@
       { "csp": "img-src http://example.com\u0020http://example2.com;", "expected": false, "name": "U+0020 SPACE should be properly parsed inside directive value" },
 
       // Ensure nbsp (U+00A0) is not considered a valid whitespace
+      // https://github.com/webcompat/web-bugs/issues/18902 has more details about why this particulalry relevant
       { "csp": "img-src\u00A0'none';", "expected": true, "name": "U+00A0 NBSP  should not be parsed between directive name and value" },
       { "csp": "img-src http://example.com\u00A0http://example2.com;", "expected": true, "name": "U+00A0 NBSP  should not be parsed inside directive value" },
     ];

--- a/content-security-policy/generic/support/load_img_and_post_result_header.html
+++ b/content-security-policy/generic/support/load_img_and_post_result_header.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+  <script>
+    var img = document.createElement("img");
+    img.src = "/content-security-policy/support/pass.png";
+    img.onload = function() { parent.postMessage('img loaded', '*'); }
+    img.onerror = function() { parent.postMessage('img not loaded', '*'); }
+    document.body.appendChild(img);
+  </script>
+</body>
+</html>

--- a/content-security-policy/generic/support/load_img_and_post_result_header.html.sub.headers
+++ b/content-security-policy/generic/support/load_img_and_post_result_header.html.sub.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: {{GET[csp]}}

--- a/content-security-policy/generic/support/load_img_and_post_result_meta.sub.html
+++ b/content-security-policy/generic/support/load_img_and_post_result_meta.sub.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+  <meta http-equiv="Content-Security-Policy" content="{{GET[csp]}}">
+</head>
+<body>
+  <script>
+    var img = document.createElement("img");
+    img.src = "/content-security-policy/support/pass.png";
+    img.onload = function() { parent.postMessage('img loaded', '*'); }
+    img.onerror = function() { parent.postMessage('img not loaded', '*'); }
+    document.body.appendChild(img);
+  </script>
+</body>
+</html>

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -486,7 +486,7 @@ def template(request, content, escape_type="html"):
         if variable is not None:
             variables[variable] = value
 
-        if field == "GET":
+        if field == "GET" and not isinstance(value, str):
             value = value.decode("utf-8")
 
         escape_func = {"html": lambda x:escape(x, quote=True),

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -471,20 +471,23 @@ def template(request, content, escape_type="html"):
             raise Exception("Undefined template variable %s" % field)
 
         while tokens:
-            ttype, field = tokens.popleft()
+            ttype, ffield = tokens.popleft()
             if ttype == "index":
-                value = value[field]
+                value = value[ffield]
             elif ttype == "arguments":
-                value = value(request, *field)
+                value = value(request, *ffield)
             else:
                 raise Exception(
-                    "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, field)
+                    "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, ffield)
                 )
 
         assert isinstance(value, (int, (binary_type, text_type))), tokens
 
         if variable is not None:
             variables[variable] = value
+
+        if field == "GET":
+            value = value.decode("utf-8")
 
         escape_func = {"html": lambda x:escape(x, quote=True),
                        "none": lambda x:x}[escape_type]

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -471,14 +471,14 @@ def template(request, content, escape_type="html"):
             raise Exception("Undefined template variable %s" % field)
 
         while tokens:
-            ttype, ffield = tokens.popleft()
+            ttype, tfield = tokens.popleft()
             if ttype == "index":
-                value = value[ffield]
+                value = value[tfield]
             elif ttype == "arguments":
-                value = value(request, *ffield)
+                value = value(request, *tfield)
             else:
                 raise Exception(
-                    "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, ffield)
+                    "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, tfield)
                 )
 
         assert isinstance(value, (int, (binary_type, text_type))), tokens


### PR DESCRIPTION
Hi @foolip 
This is in relation to the whitespace issue in https://github.com/webcompat/web-bugs/issues/18902

It contains a test (with some support files) and a small fix for the template system.

Normally I would have fixed this is chrome and added a test and let it upstream naturally but unfortunately the test also requires a tiny fix to the template system to allow non-ASCII characters in the request GET dictionary so I had to submit a manual PR.

I have run this test in chrome and firefox and the results are almost as expected. Interestingly enough, firefox allows NBSP (U+00A0) in between the directive name and value, but not inside the directive value which I believe will need fixing as it can't be right.

Firefox

PASS Should load image without any CSP - meta tag
PASS Should load image without any CSP - HTTP header
PASS Should not load image with 'none' CSP - meta tag
PASS Should not load image with 'none' CSP - HTTP header
PASS U+0009 TAB   should be properly parsed between directive name and value - meta tag
PASS U+0009 TAB   should be properly parsed between directive name and value - HTTP header
PASS U+000C FF    should be properly parsed between directive name and value - meta tag
PASS U+000C FF    should be properly parsed between directive name and value - HTTP header
PASS U+000A LF    should be properly parsed between directive name and value - meta tag
PASS U+000D CR    should be properly parsed between directive name and value - meta tag
PASS U+0020 SPACE should be properly parsed between directive name and value - meta tag
PASS U+0020 SPACE should be properly parsed between directive name and value - HTTP header
PASS U+0009 TAB   should be properly parsed inside directive value - meta tag
PASS U+0009 TAB   should be properly parsed inside directive value - HTTP header
PASS U+000C FF    should be properly parsed inside directive value - meta tag
PASS U+000C FF    should be properly parsed inside directive value - HTTP header
PASS U+000A LF    should be properly parsed inside directive value - meta tag
PASS U+000D CR    should be properly parsed inside directive value - meta tag
PASS U+0020 SPACE should be properly parsed inside directive value - meta tag
PASS U+0020 SPACE should be properly parsed inside directive value - HTTP header
FAIL U+00A0 NBSP  should be properly parsed between directive name and value - meta tag 
FAIL U+00A0 NBSP  should be properly parsed between directive name and value - HTTP header 
PASS U+00A0 NBSP  should be properly parsed inside directive value - meta tag
PASS U+00A0 NBSP  should be properly parsed inside directive value - HTTP header

Chrome
PASS Should load image without any CSP - meta tag
PASS Should load image without any CSP - HTTP header
PASS Should not load image with 'none' CSP - meta tag
PASS Should not load image with 'none' CSP - HTTP header
PASS U+0009 TAB   should be properly parsed between directive name and value - meta tag
PASS U+0009 TAB   should be properly parsed between directive name and value - HTTP header
PASS U+000C FF    should be properly parsed between directive name and value - meta tag
PASS U+000C FF    should be properly parsed between directive name and value - HTTP header
PASS U+000A LF    should be properly parsed between directive name and value - meta tag
PASS U+000D CR    should be properly parsed between directive name and value - meta tag
PASS U+0020 SPACE should be properly parsed between directive name and value - meta tag
PASS U+0020 SPACE should be properly parsed between directive name and value - HTTP header
PASS U+0009 TAB   should be properly parsed inside directive value - meta tag
PASS U+0009 TAB   should be properly parsed inside directive value - HTTP header
PASS U+000C FF    should be properly parsed inside directive value - meta tag
PASS U+000C FF    should be properly parsed inside directive value - HTTP header
PASS U+000A LF    should be properly parsed inside directive value - meta tag
PASS U+000D CR    should be properly parsed inside directive value - meta tag
PASS U+0020 SPACE should be properly parsed inside directive value - meta tag
PASS U+0020 SPACE should be properly parsed inside directive value - HTTP header
FAIL U+00A0 NBSP  should be properly parsed between directive name and value - meta tag 
FAIL U+00A0 NBSP  should be properly parsed between directive name and value - HTTP header 
FAIL U+00A0 NBSP  should be properly parsed inside directive value - meta tag
FAIL U+00A0 NBSP  should be properly parsed inside directive value - HTTP header