### PR TITLE
Sync Mozilla CSS tests as of 2018-09-27

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-dyn-resize-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-dyn-resize-001-ref.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>
+    CSS Reftest Reference
+  </title>
+  <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+  <style>
+    .container {
+      width: 100px;
+      display: flex;
+      border: 1px solid purple;
+      margin-bottom: 15px;
+    }
+    .item {
+       margin: 2px;
+       background: lightblue;
+    }
+    .inline-box {
+      display: inline-block;
+      height: 10px;
+      width: 10px;
+      background: lightgray;
+      border: 1px solid black;
+     }
+    #change-width {
+      /* Using hardcoded CSS as reference for testcase's tweak: */
+      width: 300px;
+    }
+    #change-flex {
+      /* Using hardcoded CSS as reference for testcase's tweak: */
+      flex: 0 0 75px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="item" id="change-width">
+      <div class="inline-box"></div><div class="inline-box"></div>
+    </div>
+    <div class="item">
+      <div class="inline-box"></div><div class="inline-box"></div>
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="item" id="change-flex">
+      <div class="inline-box"></div><div class="inline-box"></div>
+    </div>
+    <div class="item">
+      <div class="inline-box"></div><div class="inline-box"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-dyn-resize-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-dyn-resize-001.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>
+    CSS Test: Testing how a sizing change to one flex item impacts its sibling
+  </title>
+  <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+  <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#layout-algorithm">
+  <link rel="match" href="flexbox-dyn-resize-001-ref.html">
+  <style>
+    .container {
+      width: 100px;
+      display: flex;
+      border: 1px solid purple;
+      margin-bottom: 15px;
+    }
+    .item {
+       margin: 2px;
+       background: lightblue;
+    }
+    .inline-box {
+      display: inline-block;
+      height: 10px;
+      width: 10px;
+      background: lightgray;
+      border: 1px solid black;
+     }
+  </style>
+  <script>
+  function go() {
+    // Make this item steal all the spare width (forcing its sibling to shrink)
+    // by giving it a huge 'width' and therefore huge flex-basis:
+    document.getElementById("change-width").style.width = "300px";
+
+    // Make this item steal all the spare width (forcing its sibling to shrink)
+    // by giving it a pretty big flex-basis and no shrinkability:
+    document.getElementById("change-flex").style.flex = "0 0 75px"
+  }
+  </script>
+</head>
+<body onload="go()">
+  <div class="container">
+    <div class="item" id="change-width">
+      <div class="inline-box"></div><div class="inline-box"></div>
+    </div>
+    <div class="item">
+      <div class="inline-box"></div><div class="inline-box"></div>
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="item" id="change-flex">
+      <div class="inline-box"></div><div class="inline-box"></div>
+    </div>
+    <div class="item">
+      <div class="inline-box"></div><div class="inline-box"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
@@ -108,6 +108,9 @@
 == flexbox-column-row-gap-003.html flexbox-column-row-gap-003-ref.html
 == flexbox-column-row-gap-004.html flexbox-column-row-gap-004-ref.html
 
+# Tests with dynamic changes that impact sizing:
+== flexbox-dyn-resize-001.html flexbox-dyn-resize-001-ref.html
+
 # Tests for "flex-basis: content"
 == flexbox-flex-basis-content-001a.html flexbox-flex-basis-content-001-ref.html
 == flexbox-flex-basis-content-001b.html flexbox-flex-basis-content-001-ref.html


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/ba2b3ed1eb96065af623415366a7729cac877350 .

This contains a single change, from [bug 1493645](https://bugzilla.mozilla.org/show_bug.cgi?id=1493645), by @dholbert, reviewed by @emilio.