### PR TITLE
Consider .headers files as non tests

### DIFF
--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -267,6 +267,7 @@ class SourceFile(object):
                 self.name_prefix("MANIFEST") or
                 self.filename == "META.yml" or
                 self.filename.startswith(".") or
+                self.filename.endswith(".headers") or
                 self.type_flag == "support" or
                 self.in_non_test_dir())
 

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -36,6 +36,7 @@ def items(s):
     "foo/resources/test.html",
     "foo/support/test.html",
     "foo/test-support.html",
+    "foo/foo-manual.html.headers",
     "css/common/test.html",
     "css/CSS2/archive/test.html",
 ])
@@ -64,6 +65,7 @@ def test_not_name_is_non_test(rel_path):
 
 
 @pytest.mark.parametrize("rel_path", [
+    "foo/foo-manual.html",
     "html/test-manual.html",
     "html/test-manual.xhtml",
     "html/test-manual.https.html",


### PR DESCRIPTION
Consider all the .headers files as non tests so the files like
"foo-manual.html.headers" will be classified into the support ones.

Fix: #12880