### PR TITLE
accname: tweak two tests for clarity

### DIFF
--- a/accname/name_test_case_659-manual.html
+++ b/accname/name_test_case_659-manual.html
@@ -66,7 +66,7 @@
     label:after { content: "baz"; }
   </style>
   <form>
-    <label for="test" title="bar"><input id="test" type="text" name="test" title="bar"></label>
+    <label for="test" title="bar"><input id="test" type="text" name="test" title="buz"></label>
   </form>
 
   <div id="manualMode"></div>

--- a/accname/name_test_case_660-manual.html
+++ b/accname/name_test_case_660-manual.html
@@ -66,7 +66,7 @@
     label:after { content: "baz"; }
   </style>
   <form>
-    <label for="test" title="bar"><input id="test" type="password" name="test" title="bar"></label>
+    <label for="test" title="bar"><input id="test" type="password" name="test" title="buz"></label>
   </form>
 
   <div id="manualMode"></div>


### PR DESCRIPTION
Don't use the same value for the title attribute for multiple elements
within a single test. Doing so makes it harder to tell which title was
used for the name computation.