### PR TITLE
Revert pipes change made in PR#13228

### DIFF
--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -471,23 +471,20 @@ def template(request, content, escape_type="html"):
             raise Exception("Undefined template variable %s" % field)
 
         while tokens:
-            ttype, tfield = tokens.popleft()
+            ttype, field = tokens.popleft()
             if ttype == "index":
-                value = value[tfield]
+                value = value[field]
             elif ttype == "arguments":
-                value = value(request, *tfield)
+                value = value(request, *field)
             else:
                 raise Exception(
-                    "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, tfield)
+                    "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, field)
                 )
 
         assert isinstance(value, (int, (binary_type, text_type))), tokens
 
         if variable is not None:
             variables[variable] = value
-
-        if field == "GET" and not isinstance(value, str):
-            value = value.decode("utf-8")
 
         escape_func = {"html": lambda x:escape(x, quote=True),
                        "none": lambda x:x}[escape_type]


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/13228 introduces a change to `tools/wptserve/wptserve/pipes.py` that is actually unnecessary.

https://github.com/web-platform-tests/wpt/pull/13228#discussion_r220970276

This PR reverts it.