### PR TITLE
Improve border images

### DIFF
--- a/css/css-backgrounds/border-image-width-008-ref.html
+++ b/css/css-backgrounds/border-image-width-008-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>border-image with different widths</title>
+<style>
+    #ref {
+        width: 360px;
+        height: 240px;
+        border-style: solid;
+        border-width: 40px 40px 20px 0px;
+        border-image-source: url("support/border.png");
+        border-image-slice: 27;
+    }
+</style>
+<body>
+    <div id="ref"></div>
+</body>

--- a/css/css-backgrounds/border-image-width-008.html
+++ b/css/css-backgrounds/border-image-width-008.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>border-image-width has the same effect as a border-width and the image is displayed even if border-width is zero</title>
+<link rel="match" href="border-image-width-008-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width" />
+<style>
+    #test {
+        width: 400px;
+        height: 300px;
+        border-style: solid;
+        /* Note: Chrome does not display an image if border-width is 0 */
+        border-width: 0px;
+        border-image-source: url("support/border.png");
+        border-image-width: 40px 40px 20px 0px;
+        border-image-slice: 27;
+    }
+</style>
+<body>
+    <div id="test"></div>
+</body>


### PR DESCRIPTION

Respect CSS border-image-width.
Properly support gradients as a border-image-source.
Only emit a border item if the border-width is non-zero
for simple borders but still emit one if the item is
an image as paint worklet that are not drawn cause servo
to hang and fail tests.

Add a new test and mark 4 more as passing.

Upstreamed from https://github.com/servo/servo/pull/21608 [ci skip]