### PR TITLE
Fix #8581: add extra subdomains for cookie tests

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -16,6 +16,7 @@ import traceback
 from six.moves import urllib
 import uuid
 from collections import defaultdict, OrderedDict
+from itertools import chain, product
 from multiprocessing import Process, Event
 
 from localpaths import repo_root
@@ -720,6 +721,9 @@ def build_config(override_path=None, **kwargs):
 
     return rv
 
+def _make_subdomains_product(s, depth=2):
+    return set(u".".join(x) for x in chain(*(product(s, repeat=i) for i in range(1, depth+1))))
+
 _subdomains = {u"www",
                u"www1",
                u"www2",
@@ -727,6 +731,10 @@ _subdomains = {u"www",
                u"élève"}
 
 _not_subdomains = {u"nonexistent"}
+
+_subdomains = _make_subdomains_product(_subdomains)
+
+_not_subdomains = _make_subdomains_product(_not_subdomains)
 
 
 class ConfigBuilder(config.ConfigBuilder):

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -79,8 +79,8 @@ def test_pickle():
 
 
 def test_config_json_length():
-    # on Windows, we serialize the config as JSON for pytestrunner and put it
-    # in an env variable, which on Windows must have a length <= 0x7FFF (int16)
+    # we serialize the config as JSON for pytestrunner and put it in an env
+    # variable, which on Windows must have a length <= 0x7FFF (int16)
     with ConfigBuilder() as c:
         data = json.dumps(c.as_dict())
     assert len(data) <= 0x7FFF

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -1,6 +1,7 @@
+import json
+import os
 import pickle
 import platform
-import os
 
 import pytest
 
@@ -75,3 +76,11 @@ def test_pickle():
     # Ensure that the config object can be pickled
     with ConfigBuilder() as c:
         pickle.dumps(c)
+
+
+def test_config_json_length():
+    # on Windows, we serialize the config as JSON for pytestrunner and put it
+    # in an env variable, which on Windows must have a length <= 0x7FFF (int16)
+    with ConfigBuilder() as c:
+        data = json.dumps(c.as_dict())
+    assert len(data) <= 0x7FFF

--- a/tools/wptserve/tests/test_config.py
+++ b/tools/wptserve/tests/test_config.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import pickle
 
@@ -41,6 +42,16 @@ def test_logger_preserved():
 
     with config.ConfigBuilder(logger=logger) as c:
         assert c.logger is logger
+
+
+def test_as_dict():
+    with config.ConfigBuilder() as c:
+        assert c.as_dict() is not None
+
+
+def test_as_dict_is_json():
+    with config.ConfigBuilder() as c:
+        assert json.dumps(c.as_dict()) is not None
 
 
 def test_init_basic_prop():

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -75,7 +75,9 @@ def json_types(obj):
         return {key: json_types(value) for key, value in iteritems(obj)}
     if (isinstance(obj, string_types) or
         isinstance(obj, integer_types) or
-        isinstance(obj, float)):
+        isinstance(obj, float) or
+        isinstance(obj, bool) or
+        obj is None):
         return obj
     if isinstance(obj, list) or hasattr(obj, "__iter__"):
         return [json_types(value) for value in obj]


### PR DESCRIPTION
This relands the second commit from #10953, which was reverted as a result of #12461 in #12462. See also the discussion in #12459. Fixes #8581.