### PR TITLE
Allow all pull requests to trigger Taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,6 +1,6 @@
 version: 1
 policy:
-  pullRequests: collaborators
+  pullRequests: public
 tasks:
   $flattenDeep:
     - $if: tasks_for == "github-push"


### PR DESCRIPTION
It was previously limited to collaborators only, i.e. members of the
web-platform-tests org.

Fixes https://github.com/web-platform-tests/wpt/issues/13280.