### PR TITLE
Make TravisCI always run the lint on all files.

### DIFF
--- a/tools/ci/ci_lint.sh
+++ b/tools/ci/ci_lint.sh
@@ -6,4 +6,4 @@ cd $WPT_ROOT
 
 mkdir -p ~/meta
 ./wpt manifest -p ~/meta/MANIFEST.json
-./wpt lint
+./wpt lint --all


### PR DESCRIPTION
This will prevent problems like https://github.com/web-platform-tests/wpt/issues/9171 from sneaking into master.