### PR TITLE
Removes tests for XRStageBoundsPoint

### DIFF
--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -112,7 +112,6 @@ function forEachWebxrObject(callback) {
   callback(window.XRCoordinateSystem, 'XRCoordinateSystem');
   callback(window.XRFrameOfReference, 'XRFrameOfReference');
   callback(window.XRStageBounds, 'XRStageBounds');
-  callback(window.XRStageBoundsPoint, 'XRStageBoundsPoint');
   callback(window.XRSessionEvent, 'XRSessionEvent');
   callback(window.XRCoordinateSystemEvent, 'XRCoordinateSystemEvent');
 }


### PR DESCRIPTION
This PR removes tests for `XRStageBoundsPoint`
Fixes #12445 

r? @foolip @marcoscaceres 