### PR TITLE
Fix import of serve.serve in servo runner

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -8,7 +8,7 @@ import uuid
 
 from mozprocess import ProcessHandler
 
-from serve.serve import make_hosts_file
+from tools.serve.serve import make_hosts_file
 
 from .base import (ConnectionlessProtocol,
                    RefTestImplementation,


### PR DESCRIPTION
This fixes `./wpt run servo <..> --install-browser`