### PR TITLE
[css-text] Advance width of a tab must be at least 0.5ch

### DIFF
--- a/css/css-text/white-space/reference/tab-stop-threshold-001-ref.html
+++ b/css/css-text/white-space/reference/tab-stop-threshold-001-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<style>
+div {
+  white-space: pre;
+  font-family: monospace;
+}
+</style>
+
+<p>Test passes if the 4 letters bellow are vertically aligned.
+<div>        P</div>
+<div>        A</div>
+<div>        S</div>
+<div>        S</div>

--- a/css/css-text/white-space/reference/tab-stop-threshold-002-ref.html
+++ b/css/css-text/white-space/reference/tab-stop-threshold-002-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS test reference</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+div {
+  white-space: pre;
+  font-family: monospace;
+  tab-size: 8; /* the initial value, but since we're measuring against it, we might as well be sure */
+}
+</style>
+<p>Test passes if the 4 letters bellow are vertically aligned.
+<div>                P</div>
+<div>                A</div>
+<div>                S</div>
+<div>                S</div>

--- a/css/css-text/white-space/tab-stop-threshold-001.html
+++ b/css/css-text/white-space/tab-stop-threshold-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: the nearest tab stop is more than 0.5 ch away</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#tab-size-property">
+<link rel="match" href="reference/tab-stop-threshold-001-ref.html">
+<meta name="assert" content="A preserved tab pushes to the nearest tap stop as long as we're not closer to it than 0.5ch.">
+<style>
+div {
+  white-space: pre;
+  font-family: monospace;
+  tab-size: 8; /* the initial value, but since we're measuring against it, we might as well be sure */
+}
+span { display: inline-block; }
+#s1 { width: 6ch; }
+#s2 { width: 7ch; }
+#s3 { width: 7.3ch; }
+</style>
+
+<p>Test passes if the 4 letters bellow are vertically aligned.
+<div><span id=s1></span>&#9;P</div>
+<div><span id=s2></span>&#9;A</div>
+<div><span id=s3></span>&#9;S</div>
+<div>        S</div>

--- a/css/css-text/white-space/tab-stop-threshold-002.html
+++ b/css/css-text/white-space/tab-stop-threshold-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: the nearest tab stop is less than 0.5 ch away</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#tab-size-property">
+<link rel="match" href="reference/tab-stop-threshold-002-ref.html">
+<meta name="assert" content="A preserved tab pushes to the tab stop after the nearest one as long as we're closer to the nearest one than 0.5ch.">
+<style>
+div {
+  white-space: pre;
+  font-family: monospace;
+  tab-size: 8; /* the initial value, but since we're measuring against it, we might as well be sure */
+}
+span { display: inline-block; }
+#s1 { width: 7.6ch; }
+#s2 { width: 7.8ch; }
+#s3 { width: 7.9ch; }
+</style>
+
+<p>Test passes if the 4 letters bellow are vertically aligned.
+<div><span id=s1></span>&#9;P</div>
+<div><span id=s2></span>&#9;A</div>
+<div><span id=s3></span>&#9;S</div>
+<div>                S</div>


### PR DESCRIPTION
Relates to https://github.com/w3c/csswg-drafts/issues/2883