### PR TITLE
Switch WebKit browser product to WebDriver executors

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -50,8 +50,8 @@ def capabilities_for_port(server_config, **kwargs):
         if capabilities.has_key("version"):
             capabilities["browserVersion"] = capabilities.pop("version")
 
-        # Force the 2.x release series to be used as the required version.
-        capabilities["browserVersion"] = "2.0.0"
+        # Force the 2.20 release series to be used as the required version.
+        capabilities["browserVersion"] = "2.20"
 
         return capabilities
 

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -31,27 +31,20 @@ def browser_kwargs(test_type, run_info_data, config, **kwargs):
 
 
 def capabilities_for_port(server_config, **kwargs):
-    from selenium.webdriver import DesiredCapabilities
-
     if kwargs["webkit_port"] == "gtk":
-        capabilities = dict(DesiredCapabilities.WEBKITGTK.copy())
-        capabilities["webkitgtk:browserOptions"] = {
-            "binary": kwargs["binary"],
-            "args": kwargs.get("binary_args", []),
-            "certificates": [
-                {"host": server_config["browser_host"],
-                 "certificateFile": kwargs["host_cert_path"]}
-            ]
+        capabilities = {
+            "browserName": "MiniBrowser",
+            "browserVersion": "2.20",
+            "platformName": "ANY",
+            "webkitgtk:browserOptions": {
+                "binary": kwargs["binary"],
+                "args": kwargs.get("binary_args", []),
+                "certificates": [
+                    {"host": server_config["browser_host"],
+                     "certificateFile": kwargs["host_cert_path"]}
+                ]
+            }
         }
-
-        # Manually map Selenium's key names to the corresponding W3C versions.
-        if capabilities.has_key("platform"):
-            capabilities["platformName"] = capabilities.pop("platform")
-        if capabilities.has_key("version"):
-            capabilities["browserVersion"] = capabilities.pop("version")
-
-        # Force the 2.20 release series to be used as the required version.
-        capabilities["browserVersion"] = "2.20"
 
         return capabilities
 

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -1,7 +1,7 @@
 from .base import Browser, ExecutorBrowser, require_arg
 from ..executors import executor_kwargs as base_executor_kwargs
-from ..executors.executorselenium import (SeleniumTestharnessExecutor,  # noqa: F401
-                                          SeleniumRefTestExecutor)  # noqa: F401
+from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
+                                           WebDriverRefTestExecutor)  # noqa: F401
 from ..executors.executorwebkit import WebKitDriverWdspecExecutor  # noqa: F401
 from ..webdriver_server import WebKitDriverServer
 
@@ -10,8 +10,8 @@ __wptrunner__ = {"product": "webkit",
                  "check_args": "check_args",
                  "browser": "WebKitBrowser",
                  "browser_kwargs": "browser_kwargs",
-                 "executor": {"testharness": "SeleniumTestharnessExecutor",
-                              "reftest": "SeleniumRefTestExecutor",
+                 "executor": {"testharness": "WebDriverTestharnessExecutor",
+                              "reftest": "WebDriverRefTestExecutor",
                               "wdspec": "WebKitDriverWdspecExecutor"},
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",
@@ -43,6 +43,16 @@ def capabilities_for_port(server_config, **kwargs):
                  "certificateFile": kwargs["host_cert_path"]}
             ]
         }
+
+        # Manually map Selenium's key names to the corresponding W3C versions.
+        if capabilities.has_key("platform"):
+            capabilities["platformName"] = capabilities.pop("platform")
+        if capabilities.has_key("version"):
+            capabilities["browserVersion"] = capabilities.pop("version")
+
+        # Force the 2.x release series to be used as the required version.
+        capabilities["browserVersion"] = "2.0.0"
+
         return capabilities
 
     return {}


### PR DESCRIPTION
Switch away from Selenium executors to WebDriverTestharnessExecutor and
WebDriverRefTestExecutor for the WebKit browser product.

For the moment this requires manually mapping Selenium-style capability names
to the W3C equivalents that can be handled by WebKit's WebDriver implementation.
The browserVersion value is also hard-coded to the 2.20 release series for the
GTK+ port of WebKit as that's when the WebDriver functionality was introduced.