### PR TITLE
Python 3: Don't decode ReplacementTokenizer results.

### DIFF
--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -88,19 +88,16 @@ class TestFileHandler(TestUsingServer):
             self.request("/document.txt", headers={"Range":"bytes=%i-%i" % (len(expected), len(expected) + 10)})
         self.assertEqual(cm.exception.code, 416)
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_config(self):
         resp = self.request("/sub.sub.txt")
         expected = b"localhost localhost %i" % self.server.port
         assert resp.read().rstrip() == expected
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_headers(self):
         resp = self.request("/sub_headers.sub.txt", headers={"X-Test": "PASS"})
         expected = b"PASS"
         assert resp.read().rstrip() == expected
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_params(self):
         resp = self.request("/sub_params.sub.txt", query="test=PASS")
         expected = b"PASS"

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -426,11 +426,12 @@ def template(request, content, escape_type="html"):
         tokens = deque(tokens)
 
         token_type, field = tokens.popleft()
-        field = field.decode("ascii")
+        assert isinstance(field, text_type)
 
         if token_type == "var":
             variable = field
             token_type, field = tokens.popleft()
+            assert isinstance(field, text_type)
         else:
             variable = None
 


### PR DESCRIPTION
ReplacementTokenizer was changed to always return text in a4b7841ea1345ffdcbd79e399f7ff1982fab5362, while this decode() call was added around the same time in 27406c9d238ac80c43bb62e87cd0305f59294527.

This changes the code to verify that the type of the field local is as expected.