### PR TITLE
Add missing reject argument that is referenced.

### DIFF
--- a/css/cssom-view/scroll-behavior-smooth-positions.html
+++ b/css/cssom-view/scroll-behavior-smooth-positions.html
@@ -109,7 +109,7 @@
   }, "Scroll positions when aborting a smooth scrolling with another smooth scrolling");
 
   promise_test(() => {
-    return new Promise(function(resolve) {
+    return new Promise(function(resolve, reject) {
       resetScroll(overflowNode);
       var initialScrollAborted = false;
       var oldLeft = overflowNode.scrollLeft;


### PR DESCRIPTION
This allows the test to provide meaningful errors when it's not passing, rather than errors about reject being undefined.