### PR TITLE
[css-text] white-space collapse at start/end of line

### DIFF
--- a/css/css-text/white-space/line-edge-white-space-collapse-001.html
+++ b/css/css-text/white-space/line-edge-white-space-collapse-001.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<meta charset=utf-8>
+<link rel="author" title="Mike Bremford" href="mailto:mike@bfo.com">
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/line-edge-white-space-collapse-001-ref.html">
+<meta name="flags" content="">
+<title>White space collapse at end of line collapses through an inline</title>
+<style>
+div { font: 30px/30px monospace; }
+span span { border-left: 30px solid green }
+aside {
+  font: 30px/30px monospace;
+  width: 30px;
+  background: red;
+  position: absolute;
+  z-index:-1;
+  height: 300px;
+
+  /* to avoid accidental bleeding at the edges by a pixel or a sub pixel*/
+  box-sizing: border-box;
+  border: solid white 5px;
+  margin-left: 1ch;
+}
+</style>
+
+<p>Test passes if there is a single green rectangle next to ABCDEFGHIJ, and no red.
+
+<aside></aside>
+<div><span>A   <span>  </span>   </span></div>
+<div><span>B  <span>  </span>  </span></div>
+<div><span>C  <span>  </span> </span></div>
+<div><span>D  <span>  </span></span></div>
+<div><span>E <span>  </span>  </span></div>
+<div><span>F <span>  </span> </span></div>
+<div><span>G <span>  </span></span></div>
+<div><span>H<span>  </span> </span></div>
+<div><span>I<span>  </span></span></div>
+<div><span>J<span></span></span></div>

--- a/css/css-text/white-space/line-edge-white-space-collapse-002.html
+++ b/css/css-text/white-space/line-edge-white-space-collapse-002.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<meta charset=utf-8>
+<link rel="author" title="Mike Bremford" href="mailto:mike@bfo.com">
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/line-edge-white-space-collapse-002-ref.html">
+<meta name="flags" content="">
+<title>White space collapse at start of line collapses through an inline</title>
+<style>
+div { font: 30px/30px monospace; }
+span span { border-left: 30px solid green }
+aside {
+  font: 30px/30px monospace;
+  width: 30px;
+  background: red;
+  position: absolute;
+  z-index:-1;
+  height: 300px;
+
+  /* to avoid accidental bleeding at the edges by a pixel or a sub pixel*/
+  box-sizing: border-box;
+  border: solid white 5px;
+}
+</style>
+
+<p>Test passes if there is a single green rectangle, and no red. The letters KLMNOPQRST must be immediately to its right, vertically aligned with each other.
+
+<aside></aside>
+<div><span>   <span>  </span>  K</span></div>
+<div><span>  <span>  </span>  L</span></div>
+<div><span> <span>  </span>  M</span></div>
+<div><span><span>  </span>  N</span></div>
+<div><span>  <span>  </span> O </span></div>
+<div><span> <span>  </span> P</span></div>
+<div><span><span>  </span> Q</span></div>
+<div><span> <span>  </span>R</span></div>
+<div><span><span>  </span>S</span></div>
+<div><span><span></span>T</span></div>
+

--- a/css/css-text/white-space/reference/line-edge-white-space-collapse-001-ref.html
+++ b/css/css-text/white-space/reference/line-edge-white-space-collapse-001-ref.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<meta charset=utf-8>
+<link rel="author" title="Mike Bremford" href="mailto:mike@bfo.com">
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<title>CSS test reference</title>
+<style>
+div { font: 30px/30px monospace; }
+span { border-left: 30px solid green }
+</style>
+
+<p>Test passes if there is a single green rectangle next to ABCDEFGHIJ, and no red.
+
+<div>A<span></span></div>
+<div>B<span></span></div>
+<div>C<span></span></div>
+<div>D<span></span></div>
+<div>E<span></span></div>
+<div>F<span></span></div>
+<div>G<span></span></div>
+<div>H<span></span></div>
+<div>I<span></span></div>
+<div>J<span></span></div>

--- a/css/css-text/white-space/reference/line-edge-white-space-collapse-002-ref.html
+++ b/css/css-text/white-space/reference/line-edge-white-space-collapse-002-ref.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<meta charset=utf-8>
+<link rel="author" title="Mike Bremford" href="mailto:mike@bfo.com">
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<title>CSS test reference</title>
+<style>
+div { font: 30px/30px monospace; }
+span { border-left: 30px solid green }
+</style>
+
+<p>Test passes if there is a single green rectangle, and no red. The letters KLMNOPQRST must be immediately to its right, vertically aligned with each other.
+
+<div><span>K</span></div>
+<div><span>L</span></div>
+<div><span>M</span></div>
+<div><span>N</span></div>
+<div><span>O</span></div>
+<div><span>P</span></div>
+<div><span>Q</span></div>
+<div><span>R</span></div>
+<div><span>S</span></div>
+<div><span>T</span></div>
+


### PR DESCRIPTION
Related to https://github.com/w3c/csswg-drafts/issues/1997

Based on the test case by @faceless2 in [this mail](https://lists.w3.org/Archives/Public/www-style/2017Nov/0009.html), converted to the reftest format and with red added to make failures obvious.