### PR TITLE
[css-text] Control characters should be visible

### DIFF
--- a/css/css-text/white-space/control-chars-000.html
+++ b/css/css-text/white-space/control-chars-000.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0000</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0000, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0000" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-001.html
+++ b/css/css-text/white-space/control-chars-001.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0001</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0001, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0001" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-002.html
+++ b/css/css-text/white-space/control-chars-002.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0002</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0002, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0002" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-003.html
+++ b/css/css-text/white-space/control-chars-003.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0003</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0003, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0003" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-004.html
+++ b/css/css-text/white-space/control-chars-004.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0004</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0004, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0004" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-005.html
+++ b/css/css-text/white-space/control-chars-005.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0005</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0005, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0005" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-006.html
+++ b/css/css-text/white-space/control-chars-006.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0006</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0006, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0006" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-007.html
+++ b/css/css-text/white-space/control-chars-007.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0007</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0007, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0007" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-008.html
+++ b/css/css-text/white-space/control-chars-008.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0008</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0008, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0008" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-00B.html
+++ b/css/css-text/white-space/control-chars-00B.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+000B</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+000B, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\000B" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-00D.html
+++ b/css/css-text/white-space/control-chars-00D.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+000D</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+000D, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\000D" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-00E.html
+++ b/css/css-text/white-space/control-chars-00E.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+000E</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+000E, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\000E" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-00F.html
+++ b/css/css-text/white-space/control-chars-00F.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+000F</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+000F, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\000F" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-010.html
+++ b/css/css-text/white-space/control-chars-010.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0010</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0010, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0010" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-011.html
+++ b/css/css-text/white-space/control-chars-011.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0011</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0011, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0011" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-012.html
+++ b/css/css-text/white-space/control-chars-012.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0012</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0012, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0012" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-013.html
+++ b/css/css-text/white-space/control-chars-013.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0013</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0013, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0013" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-014.html
+++ b/css/css-text/white-space/control-chars-014.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0014</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0014, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0014" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-015.html
+++ b/css/css-text/white-space/control-chars-015.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0015</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0015, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0015" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-016.html
+++ b/css/css-text/white-space/control-chars-016.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0016</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0016, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0016" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-017.html
+++ b/css/css-text/white-space/control-chars-017.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0017</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0017, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0017" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-018.html
+++ b/css/css-text/white-space/control-chars-018.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0018</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0018, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0018" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-019.html
+++ b/css/css-text/white-space/control-chars-019.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0019</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0019, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0019" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-01A.html
+++ b/css/css-text/white-space/control-chars-01A.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+001A</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+001A, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\001A" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-01B.html
+++ b/css/css-text/white-space/control-chars-01B.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+001B</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+001B, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\001B" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-01C.html
+++ b/css/css-text/white-space/control-chars-01C.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+001C</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+001C, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\001C" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-01D.html
+++ b/css/css-text/white-space/control-chars-01D.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+001D</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+001D, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\001D" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-01E.html
+++ b/css/css-text/white-space/control-chars-01E.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+001E</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+001E, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\001E" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-01F.html
+++ b/css/css-text/white-space/control-chars-01F.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+001F</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+001F, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\001F" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-07F.html
+++ b/css/css-text/white-space/control-chars-07F.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+007F</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+007F, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\007F" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-080.html
+++ b/css/css-text/white-space/control-chars-080.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0080</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0080, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0080" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-081.html
+++ b/css/css-text/white-space/control-chars-081.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0081</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0081, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0081" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-082.html
+++ b/css/css-text/white-space/control-chars-082.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0082</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0082, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0082" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-083.html
+++ b/css/css-text/white-space/control-chars-083.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0083</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0083, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0083" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-084.html
+++ b/css/css-text/white-space/control-chars-084.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0084</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0084, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0084" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-085.html
+++ b/css/css-text/white-space/control-chars-085.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0085</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0085, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0085" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-086.html
+++ b/css/css-text/white-space/control-chars-086.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0086</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0086, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0086" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-087.html
+++ b/css/css-text/white-space/control-chars-087.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0087</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0087, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0087" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-088.html
+++ b/css/css-text/white-space/control-chars-088.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0088</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0088, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0088" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-089.html
+++ b/css/css-text/white-space/control-chars-089.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0089</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0089, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0089" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-08A.html
+++ b/css/css-text/white-space/control-chars-08A.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+008A</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+008A, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\008A" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-08B.html
+++ b/css/css-text/white-space/control-chars-08B.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+008B</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+008B, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\008B" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-08C.html
+++ b/css/css-text/white-space/control-chars-08C.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+008C</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+008C, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\008C" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-08D.html
+++ b/css/css-text/white-space/control-chars-08D.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+008D</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+008D, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\008D" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-08E.html
+++ b/css/css-text/white-space/control-chars-08E.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+008E</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+008E, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\008E" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-08F.html
+++ b/css/css-text/white-space/control-chars-08F.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+008F</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+008F, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\008F" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-090.html
+++ b/css/css-text/white-space/control-chars-090.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0090</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0090, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0090" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-091.html
+++ b/css/css-text/white-space/control-chars-091.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0091</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0091, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0091" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-092.html
+++ b/css/css-text/white-space/control-chars-092.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0092</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0092, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0092" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-093.html
+++ b/css/css-text/white-space/control-chars-093.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0093</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0093, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0093" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-094.html
+++ b/css/css-text/white-space/control-chars-094.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0094</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0094, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0094" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-095.html
+++ b/css/css-text/white-space/control-chars-095.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0095</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0095, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0095" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-096.html
+++ b/css/css-text/white-space/control-chars-096.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0096</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0096, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0096" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-097.html
+++ b/css/css-text/white-space/control-chars-097.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0097</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0097, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0097" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-098.html
+++ b/css/css-text/white-space/control-chars-098.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0098</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0098, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0098" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-099.html
+++ b/css/css-text/white-space/control-chars-099.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+0099</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+0099, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\0099" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-09A.html
+++ b/css/css-text/white-space/control-chars-09A.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+009A</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+009A, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\009A" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-09B.html
+++ b/css/css-text/white-space/control-chars-09B.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+009B</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+009B, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\009B" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-09C.html
+++ b/css/css-text/white-space/control-chars-09C.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+009C</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+009C, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\009C" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-09D.html
+++ b/css/css-text/white-space/control-chars-09D.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+009D</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+009D, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\009D" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-09E.html
+++ b/css/css-text/white-space/control-chars-09E.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+009E</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+009E, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\009E" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/control-chars-09F.html
+++ b/css/css-text/white-space/control-chars-09F.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+009F</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+009F, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\009F" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>

--- a/css/css-text/white-space/reference/control-chars-000-ref.html
+++ b/css/css-text/white-space/reference/control-chars-000-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS test mismatch reference</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+
+<p>Test passes if there is a visible character below.


### PR DESCRIPTION
Tests for https://github.com/w3c/csswg-drafts/issues/1990 and https://github.com/w3c/csswg-drafts/issues/855