### PR TITLE
Find affected idlharness tests

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -265,7 +265,7 @@ def affected_testfiles(files_changed, skip_tests, manifest_path=None):
             if 'idlharness.js' in file_contents:
                 for interface in interfaces_changed_names:
                     regex = '[\'"]' + interface + '(\\.idl)?[\'"]'
-                    if re.match(regex, file_contents):
+                    if re.search(regex, file_contents):
                         affected_testfiles.add(test_full_path)
                         break
 

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -219,6 +219,11 @@ def affected_testfiles(files_changed, skip_tests, manifest_path=None):
     test_files = {os.path.join(wpt_root, path)
                   for _, path, _ in wpt_manifest.itertypes(*test_types)}
 
+    interface_dir = os.path.join(wpt_root, 'interfaces')
+    interfaces_files = {os.path.join(wpt_root, 'interfaces', filename)
+                        for filename in os.listdir(interface_dir)}
+
+    interfaces_changed = interfaces_files.intersection(nontests_changed)
     nontests_changed = nontests_changed.intersection(support_files)
 
     tests_changed = set(item for item in files_changed if item in test_files)
@@ -237,6 +242,9 @@ def affected_testfiles(files_changed, skip_tests, manifest_path=None):
             full_path = os.path.join(wpt_root, repo_path[1:].replace("/", os.path.sep))
         nontest_changed_paths.add((full_path, repo_path))
 
+    interface_name = lambda x: os.path.splitext(os.path.basename(x))[0]
+    interfaces_changed_names = map(interface_name, interfaces_changed)
+
     def affected_by_wdspec(test):
         affected = False
         if test in wdspec_test_files:
@@ -251,6 +259,15 @@ def affected_testfiles(files_changed, skip_tests, manifest_path=None):
                     affected = True
                     break
         return affected
+
+    def affected_by_interfaces(file_contents):
+        if len(interfaces_changed_names) > 0:
+            if 'idlharness.js' in file_contents:
+                for interface in interfaces_changed_names:
+                    regex = '[\'"]' + interface + '(\\.idl)?[\'"]'
+                    if re.match(regex, file_contents):
+                        affected_testfiles.add(test_full_path)
+                        break
 
     for root, dirs, fnames in os.walk(wpt_root):
         # Walk top_level_subdir looking for test files containing either the
@@ -277,7 +294,7 @@ def affected_testfiles(files_changed, skip_tests, manifest_path=None):
                     file_contents = file_contents.decode("utf8", "replace")
                 for full_path, repo_path in nontest_changed_paths:
                     rel_path = os.path.relpath(full_path, root).replace(os.path.sep, "/")
-                    if rel_path in file_contents or repo_path in file_contents:
+                    if rel_path in file_contents or repo_path in file_contents or affected_by_interfaces(file_contents):
                         affected_testfiles.add(test_full_path)
                         continue
 

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -394,6 +394,20 @@ def test_tests_affected(capsys, manifest_dir):
                    reason="Tests currently don't work on Windows for path reasons")
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="https://github.com/web-platform-tests/wpt/issues/12934")
+def test_tests_affected_idlharness(capsys, manifest_dir):
+    commit = "47cea8c38b88c0ddd3854e4edec0c5b6f2697e62"
+    with pytest.raises(SystemExit) as excinfo:
+        wpt.main(argv=["tests-affected", "--metadata", manifest_dir, "%s~..%s" % (commit, commit)])
+    assert excinfo.value.code == 0
+    out, err = capsys.readouterr()
+    assert "webrtc/idlharness.https.window.js\n" == out
+
+
+@pytest.mark.slow  # this updates the manifest
+@pytest.mark.xfail(sys.platform == "win32",
+                   reason="Tests currently don't work on Windows for path reasons")
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="https://github.com/web-platform-tests/wpt/issues/12934")
 def test_tests_affected_null(capsys, manifest_dir):
     # This doesn't really work properly for random commits because we test the files in
     # the current working directory for references to the changed files, not the ones at


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/wpt/issues/13024

Example output after tweaking `css-font-loading.idl` locally, and running `./wpt tests-affected --modified HEAD..master`

> INFO:manifest:Updating manifest
> css/css-font-loading/idlharness.https.html