### PR TITLE
Remove runner_teardown message/method in TestRunner/Manager

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -75,7 +75,6 @@ class TestRunner(object):
 
     def teardown(self):
         self.executor.teardown()
-        self.send_message("runner_teardown")
         self.result_queue = None
         self.command_queue = None
         self.browser = None
@@ -395,7 +394,6 @@ class TestRunnerManager(threading.Thread):
             RunnerManagerState.error: {},
             RunnerManagerState.stop: {},
             None: {
-                "runner_teardown": self.runner_teardown,
                 "log": self.log,
                 "error": self.error
             }
@@ -697,10 +695,6 @@ class TestRunnerManager(threading.Thread):
         else:
             self.logger.debug("Runner process exited with code %i" % self.test_runner_proc.exitcode)
 
-    def runner_teardown(self):
-        self.ensure_runner_stopped()
-        return RunnerManagerState.stop()
-
     def send_message(self, command, *args):
         self.remote_queue.put((command, args))
 
@@ -716,11 +710,6 @@ class TestRunnerManager(threading.Thread):
             else:
                 if cmd == "log":
                     self.log(*data)
-                elif cmd == "runner_teardown":
-                    # It's OK for the "runner_teardown" message to be left in
-                    # the queue during cleanup, as we will already have tried
-                    # to stop the TestRunner in `stop_runner`.
-                    pass
                 else:
                     self.logger.warning("Command left in command_queue during cleanup: %r, %r" % (cmd, data))
         while True:


### PR DESCRIPTION
The relationship between `TestRunnerManager` and `TestRunner` is
described in //tools/wptrunner/docs/design.rst.

In a new process (in `start_runner`) a `TestRunner` instance is created
as `with TestRunner(...) as runner`, and leaving the scope of this
`with` statement is what causes `TestRunner. __exit__` and `teardown()`
to be invoked, sending the "runner_teardown" message. At this point,
`start_runner` is just about to return and the process exit.

There was originally a warning around this which was silenced:
https://github.com/web-platform-tests/wpt/issues/13407
https://github.com/web-platform-tests/wpt/pull/13417

This reverts https://github.com/web-platform-tests/wpt/pull/13417.

The warning occured when the `run` loop had already ended and the
message was still in the queue during `TestRunnerManager.cleanup`.
(See https://github.com/web-platform-tests/wpt/issues/13413 on naming.)

If the message arrived before the cleanup stage, the `runner_teardown`
handler would call `ensure_runner_stopped()` and change runner manager
state to stopped in the `run` loop, which is what would happen anyway.