### PR TITLE
Expect InvalidStateError instead of InvalidAccessError in document.open

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/document.open-02.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/document.open-02.html
@@ -20,7 +20,7 @@ test(function() {
   var parser = new DOMParser();
   var doc = parser.parseFromString("", "text/html");
   assert_equals(doc.defaultView, null);
-  assert_throws("INVALID_ACCESS_ERR", function() {
+  assert_throws("INVALID_STATE_ERR", function() {
     doc.open("/resources/testharness.js", "", "");
   });
 }, "document.open should throw when it has no window and is called with three arguments");


### PR DESCRIPTION
While working on https://github.com/servo/servo/pull/21882, I noticed that the [spec for `document.open(url, name, features)`](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-open-window) states that it should throw an InvalidStateError, but tests expect an InvalidAccessError. I changed the expectation to align with the spec, but that may not be correct -- here's some additional information:

I believe the error was changed in this PR: https://github.com/whatwg/html/pull/2672

Chrome, Safari, Firefox throw `InvalidAccessError`: https://wpt.fyi/results/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/document.open-02.html

InvalidAccessError is deprecated: https://heycam.github.io/webidl/#invalidaccesserror