### PR TITLE
Move a comment in TestRunnerManager.wait_finished to make more sense

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -623,10 +623,10 @@ class TestRunnerManager(threading.Thread):
 
     def wait_finished(self):
         assert isinstance(self.state, RunnerManagerState.running)
-        # The browser should be stopped already, but this ensures we do any post-stop
-        # processing
         self.logger.debug("Wait finished")
 
+        # The browser should be stopped already, but this ensures we do any
+        # post-stop processing
         return self.after_test_end(self.state.test, True)
 
     def after_test_end(self, test, restart):


### PR DESCRIPTION
It's certaintly not the logging that does post-stop processing, but
`after_test_end` might, so the comment is accurate if moved.

The comment was added in commit 7f422ef4b1b1ecf09ff7ffc94b60c6b7bf7a41b4.