### PR TITLE
[css-text] word-break:break-all does not affect punctuation

### DIFF
--- a/css/css-text/word-break/reference/word-break-break-all-020-ref.html
+++ b/css/css-text/word-break/reference/word-break-break-all-020-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS test reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<style>
+div {
+  border: 5px solid;
+  width: 2em;
+}
+
+div::nth-of-type(1) { border-color: blue; }
+div::nth-of-type(2) { border-color: green; }
+div::nth-of-type(3) { border-color: orange; }
+
+</style>
+
+<p>Test passes if the text in each of the following 3 boxes is broken into separate lines at the same points.
+
+<div lang=ja>あ<br>い）<br>あ<br>（い</div>
+<div lang=ja>あ<br>い）<br>あ<br>（い</div>
+<div lang=ja>あ<br>い）<br>あ<br>（い</div>

--- a/css/css-text/word-break/word-break-break-all-020.html
+++ b/css/css-text/word-break/word-break-break-all-020.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: break-all and punctuation</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#word-break-property">
+<link rel="match" href="reference/word-break-break-all-020-ref.html">
+<meta name="assert" content="work-break:break-all does not affect rules governing the soft wrap opportunities created by punctuation.">
+<style>
+div {
+  border: 5px solid;
+  width: 2em;
+}
+
+div::nth-of-type(1) { border-color: blue; }
+div::nth-of-type(2) { border-color: green; }
+div::nth-of-type(3) { border-color: orange; }
+
+div::nth-of-type(3) { word-break: break-word; }
+</style>
+
+<p>Test passes if the text in each of the following 3 boxes is broken into separate lines at the same points.
+<div lang=ja>あい）あ（い</div>
+<div lang=ja>あ<br>い）<br>あ<br>（い</div>
+<div lang=ja>あい）あ（い</div>
+
+<!--
+If the first box (blue) is wrong,
+customary rules for line breaking japanese are not implemented (or not correctly).
+
+If the third box (orange) is wrong,
+customary rules for line breaking japanese are discarded
+when applying 'word-break: break-all', which is a spec violation.
+-->


### PR DESCRIPTION
Turns into an proper wpt test case the test discussed in https://github.com/w3c/csswg-drafts/issues/785#issuecomment-374866706