### PR TITLE
Ignore "runner_teardown" messages in `TestRunnerManager.cleanup()`

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -716,6 +716,11 @@ class TestRunnerManager(threading.Thread):
             else:
                 if cmd == "log":
                     self.log(*data)
+                elif cmd == "runner_teardown":
+                    # It's OK for the "runner_teardown" message to be left in
+                    # the queue during cleanup, as we will already have tried
+                    # to stop the TestRunner in `stop_runner`.
+                    pass
                 else:
                     self.logger.warning("Command left in command_queue during cleanup: %r, %r" % (cmd, data))
         while True:


### PR DESCRIPTION
This is an alternative to https://github.com/web-platform-tests/wpt/pull/13409,
which adds more handling around this rather than removing it.

Fixes https://github.com/web-platform-tests/wpt/issues/13407.