### PR TITLE
Don't switch back to the harness window during testharness tests.

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -526,27 +526,22 @@ class CallbackHandler(object):
         return True, rv
 
     def process_action(self, url, payload):
-        parent = self.protocol.base.current_window
+        action = payload["action"]
+        self.logger.debug("Got action: %s" % action)
         try:
-            self.protocol.base.set_window(self.test_window)
-            action = payload["action"]
-            self.logger.debug("Got action: %s" % action)
-            try:
-                action_handler = self.actions[action]
-            except KeyError:
-                raise ValueError("Unknown action %s" % action)
-            try:
-                action_handler(payload)
-            except Exception:
-                self.logger.warning("Action %s failed" % action)
-                self.logger.warning(traceback.format_exc())
-                self._send_message("complete", "error")
-                raise
-            else:
-                self.logger.debug("Action %s completed" % action)
-                self._send_message("complete", "success")
-        finally:
-            self.protocol.base.set_window(parent)
+            action_handler = self.actions[action]
+        except KeyError:
+            raise ValueError("Unknown action %s" % action)
+        try:
+            action_handler(payload)
+        except Exception:
+            self.logger.warning("Action %s failed" % action)
+            self.logger.warning(traceback.format_exc())
+            self._send_message("complete", "error")
+            raise
+        else:
+            self.logger.debug("Action %s completed" % action)
+            self._send_message("complete", "success")
 
         return False, None
 

--- a/tools/wptrunner/wptrunner/executors/testharness_webdriver.js
+++ b/tools/wptrunner/wptrunner/executors/testharness_webdriver.js
@@ -1,6 +1,13 @@
+var callback = arguments[arguments.length - 1];
+var loaded = false;
+
 window.timeout_multiplier = %(timeout_multiplier)d;
 window.url = "%(url)s";
 window.win = window.open("%(abs_url)s", "%(window_id)s");
+window.win.addEventListener('DOMContentLoaded', (e) => {
+  callback();
+});
+
 
 window.message_queue = [];
 window.testdriver_callback = null;
@@ -8,6 +15,5 @@ window.testdriver_callback = null;
 if (%(timeout)s != null) {
   window.timer = setTimeout(function() {
     window.win.timeout();
-    window.win.close();
   }, %(timeout)s);
 }

--- a/tools/wptrunner/wptrunner/executors/testharness_webdriver_resume.js
+++ b/tools/wptrunner/wptrunner/executors/testharness_webdriver_resume.js
@@ -1,3 +1,3 @@
 var callback = arguments[arguments.length - 1];
-window.testdriver_callback = callback;
-window.process_next_event();
+window.opener.testdriver_callback = callback;
+window.opener.process_next_event();


### PR DESCRIPTION
Previously we kept switching back and forth between the harness window
and the window containing the test as we processed WebDriver
callbacks. But this is unnecessary; we can use the fact that we have
access to window.opener to set the callback on the opener window and
run it there, yes still have it block a WebDriver call in the test
window. This means that during the test we can keep the focus on the
test window, but put all the complex logic in the parent and retain
the ability to close the test window after each test to create a clean
environment.