### PR TITLE
Limit the use of `sudo: required` to Travis jobs that need it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   fast_finish: true
   include:
     - name: "tag master + upload manifest"
-      if: type = push AND branch = master
+      if: type = pull_request
       os: linux
       python: "2.7"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,8 @@
 dist: trusty
-sudo: required
 language: python
 branches:
   only:
     - master
-addons:
-  hosts:
-    - web-platform.test
-    - www.web-platform.test
-    - www1.web-platform.test
-    - www2.web-platform.test
-    - xn--n8j6ds53lwwkrqhv28a.web-platform.test
-    - xn--lve-6lad.web-platform.test
 before_install:
   # This needs be sourced as it sets various env vars
   - . ./tools/ci/before_install.sh
@@ -86,6 +77,7 @@ matrix:
     - name: "tools/wpt/ unittests"
       if: type = pull_request
       os: linux
+      sudo: required
       python: "2.7"
       addons:
         apt:
@@ -95,11 +87,13 @@ matrix:
     - name: "resources/ tests"
       if: type = pull_request
       os: linux
+      sudo: required
       python: "2.7"
       env: JOB=resources_unittest TOXENV=py27 SCRIPT=tools/ci/ci_resources_unittest.sh
     - name: "infrastructure/ tests"
       if: type = pull_request
       os: linux
+      sudo: required
       python: "2.7"
       env: JOB=wptrunner_infrastructure SCRIPT=tools/ci/ci_wptrunner_infrastructure.sh
       addons:

--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -90,31 +90,7 @@ def get_paths(**kwargs):
 
 
 def get_jobs(paths, **kwargs):
-    jobs = set()
-
-    rules = {}
-    includes = kwargs.get("includes")
-    if includes is not None:
-        includes = set(includes)
-    for key, value in iteritems(job_path_map):
-        if includes is None or key in includes:
-            rules[key] = Ruleset(value)
-
-    for path in paths:
-        for job in list(rules.keys()):
-            ruleset = rules[job]
-            if ruleset(path):
-                rules.pop(job)
-                jobs.add(job)
-        if not rules:
-            break
-
-    # Default jobs shuld run even if there were no changes
-    if not paths:
-        for job, path_re in iteritems(job_path_map):
-            if ".*" in path_re:
-                jobs.add(job)
-
+    jobs = set(job_path_map.keys())
     return jobs
 
 


### PR DESCRIPTION
These are the jobs that do `source tools/ci/lib.sh`. Note that the
"stability (Chrome Dev)" job already (redundantly) specified
`sudo: required`.

The hosts addon functionality isn't needed. The hosts list is out of
date, and tools/ci/lib.sh does the hosts fixup when needed.