### PR TITLE
Drop the use of the `hosts` addon in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,6 @@ language: python
 branches:
   only:
     - master
-addons:
-  hosts:
-    - web-platform.test
-    - www.web-platform.test
-    - www1.web-platform.test
-    - www2.web-platform.test
-    - xn--n8j6ds53lwwkrqhv28a.web-platform.test
-    - xn--lve-6lad.web-platform.test
 before_install:
   # This needs be sourced as it sets various env vars
   - . ./tools/ci/before_install.sh
@@ -64,7 +56,6 @@ matrix:
     - name: "stability (Chrome Dev)"
       if: type = pull_request
       os: linux
-      sudo: required
       python: "2.7"
       addons:
         apt:

--- a/tools/serve/test_functional.py
+++ b/tools/serve/test_functional.py
@@ -55,7 +55,7 @@ def test_subprocess_exit(server_subprocesses, tempfile_name):
         # which are relevant to this functionality. Disable the check so that
         # the constructor is only used to create relevant processes.
         with open(tempfile_name, 'w') as handle:
-            json.dump({"check_subdomains": False}, handle)
+            json.dump({"check_subdomains": False, "bind_address": False}, handle)
 
         # The `logger` module from the wptserver package uses a singleton
         # pattern which resists testing. In order to avoid conflicting with


### PR DESCRIPTION
The hosts list is out of date and this isn't needed, as
tools/ci/lib.sh does the hosts fixup when needed.
    
Drive-by: remove a redundant `sudo: required`.