### PR TITLE
Remove last remnants of chrome_webdriver

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/elementPosition.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/elementPosition.html.ini
@@ -1,3 +1,3 @@
 [elementPosition.html]
   expected:
-    if product == "chrome" or product == "chrome_webdriver": ERROR
+    if product == "chrome": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/actions/elementTiming.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/elementTiming.html.ini
@@ -1,3 +1,3 @@
 [elementTiming.html]
   expected:
-    if product == "chrome" or product == "chrome_webdriver": ERROR
+    if product == "chrome": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
@@ -1,3 +1,3 @@
 [eventOrder.html]
   expected:
-    if product == "chrome" or product == "chrome_webdriver": ERROR
+    if product == "chrome": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiDevice.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiDevice.html.ini
@@ -1,3 +1,3 @@
 [multiDevice.html]
   expected:
-    if product == "chrome" or product == "chrome_webdriver": ERROR
+    if product == "chrome": ERROR


### PR DESCRIPTION
It got left here because of two concurrent PRs:
https://github.com/web-platform-tests/wpt/pull/12726
https://www.google.com/url?q=https://github.com/web-platform-tests/wpt/pull/13277