### PR TITLE
Switch to GroupingFormatter by default for wpt run.

### DIFF
--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -14,7 +14,7 @@ test_infrastructure() {
     else
         ARGS=$1
     fi
-    ./wpt run --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts $ARGS $PRODUCT infrastructure/
+    ./wpt run --log-tbpl - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts $ARGS $PRODUCT infrastructure/
 }
 
 main() {

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -444,6 +444,7 @@ product_setup = {
 
 def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
     from wptrunner import wptrunner, wptcommandline
+    import mozlog
 
     global logger
 
@@ -453,7 +454,12 @@ def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
     kwargs["product"] = product_parts[0]
     sub_product = product_parts[1:]
 
-    wptrunner.setup_logging(kwargs, {"mach": sys.stdout})
+    # Use the grouped formatter by default where mozlog 3.9+ is installed
+    if hasattr(mozlog.formatters, "GroupingFormatter"):
+        default_formatter = "grouped"
+    else:
+        default_formatter = "mach"
+    wptrunner.setup_logging(kwargs, {default_formatter: sys.stdout})
     logger = wptrunner.logger
 
     check_environ(kwargs["product"])


### PR DESCRIPTION
This provides very low-verbosity output, just recording the current test, any unexpected
failures, and a summary of results at the end. It's not very suitable for CI where log
messages and timestamps are desirable, but may be the best choice for local testruns.