### PR TITLE
Remove the "W3C WebSocket API" prefix from websockets/ tests

### DIFF
--- a/websockets/Close-1000-reason.any.js
+++ b/websockets/Close-1000-reason.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - close(1000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("Create WebSocket - Close the Connection - Connection should be opened");
+var testClose = async_test("Create WebSocket - Close the Connection - close(1000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(false, false, false);
 var isOpenCalled = false;

--- a/websockets/Close-1000.any.js
+++ b/websockets/Close-1000.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create WebSocket - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - close(1000) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("Create WebSocket - Connection should be opened");
+var testClose = async_test("Create WebSocket - Close the Connection - close(1000) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(false, false, false);
 var isOpenCalled = false;

--- a/websockets/Close-1000.any.js
+++ b/websockets/Close-1000.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create WebSocket - Connection should be opened");
-var testClose = async_test("Create WebSocket - Close the Connection - close(1000) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create WebSocket - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - close(1000) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(false, false, false);
 var isOpenCalled = false;

--- a/websockets/Close-Reason-124Bytes.any.js
+++ b/websockets/Close-Reason-124Bytes.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - close(code, 'reason more than 123 bytes') - SYNTAX_ERR is thrown");
+var test = async_test("Create WebSocket - Close the Connection - close(code, 'reason more than 123 bytes') - SYNTAX_ERR is thrown");
 
 var wsocket = CreateWebSocket(false, false, false);
 var isOpenCalled = false;

--- a/websockets/Close-Reason-124Bytes.any.js
+++ b/websockets/Close-Reason-124Bytes.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("Create WebSocket - Close the Connection - close(code, 'reason more than 123 bytes') - SYNTAX_ERR is thrown");
+var test = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - close(code, 'reason more than 123 bytes') - SYNTAX_ERR is thrown");
 
 var wsocket = CreateWebSocket(false, false, false);
 var isOpenCalled = false;

--- a/websockets/Close-reason-unpaired-surrogates.any.js
+++ b/websockets/Close-reason-unpaired-surrogates.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get opened");
-var testClose = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed");
+var testOpen = async_test("Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get opened");
+var testClose = async_test("Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed");
 
 var wsocket = CreateWebSocket(false, false, false);
 var isOpenCalled = false;

--- a/websockets/Close-reason-unpaired-surrogates.any.js
+++ b/websockets/Close-reason-unpaired-surrogates.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get opened");
-var testClose = async_test("Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed");
+var testOpen = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get opened");
+var testClose = async_test("W3C WebSocket API - Create WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed");
 
 var wsocket = CreateWebSocket(false, false, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-extensions-empty.any.js
+++ b/websockets/Create-Secure-extensions-empty.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-extensions-empty.any.js
+++ b/websockets/Create-Secure-extensions-empty.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-url-with-space.any.js
+++ b/websockets/Create-Secure-url-with-space.any.js
@@ -6,4 +6,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithSpaceInUrl(spaceUrl)
   });
-}, "W3C WebSocket API - Create Secure WebSocket - Pass a URL with a space - SYNTAX_ERR should be thrown")
+}, "Create Secure WebSocket - Pass a URL with a space - SYNTAX_ERR should be thrown")

--- a/websockets/Create-Secure-url-with-space.any.js
+++ b/websockets/Create-Secure-url-with-space.any.js
@@ -6,4 +6,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithSpaceInUrl(spaceUrl)
   });
-}, "Create Secure WebSocket - Pass a URL with a space - SYNTAX_ERR should be thrown")
+}, "W3C WebSocket API - Create Secure WebSocket - Pass a URL with a space - SYNTAX_ERR should be thrown")

--- a/websockets/Create-Secure-valid-url-array-protocols.any.js
+++ b/websockets/Create-Secure-valid-url-array-protocols.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and array of protocol strings - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and array of protocol strings - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Pass a valid URL and array of protocol strings - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Pass a valid URL and array of protocol strings - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, true);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-valid-url-array-protocols.any.js
+++ b/websockets/Create-Secure-valid-url-array-protocols.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Pass a valid URL and array of protocol strings - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Pass a valid URL and array of protocol strings - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and array of protocol strings - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and array of protocol strings - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, true);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-valid-url-binaryType-blob.any.js
+++ b/websockets/Create-Secure-valid-url-binaryType-blob.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - wsocket.binaryType should be set to 'blob' after connection is established - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - wsocket.binaryType should be set to 'blob' after connection is established - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - wsocket.binaryType should be set to 'blob' after connection is established - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - wsocket.binaryType should be set to 'blob' after connection is established - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-valid-url-binaryType-blob.any.js
+++ b/websockets/Create-Secure-valid-url-binaryType-blob.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - wsocket.binaryType should be set to 'blob' after connection is established - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - wsocket.binaryType should be set to 'blob' after connection is established - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - wsocket.binaryType should be set to 'blob' after connection is established - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - wsocket.binaryType should be set to 'blob' after connection is established - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-valid-url-protocol-setCorrectly.any.js
+++ b/websockets/Create-Secure-valid-url-protocol-setCorrectly.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and protocol string - protocol should be set correctly - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and protocol string - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Pass a valid URL and protocol string - protocol should be set correctly - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Pass a valid URL and protocol string - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, true, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-valid-url-protocol-setCorrectly.any.js
+++ b/websockets/Create-Secure-valid-url-protocol-setCorrectly.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Pass a valid URL and protocol string - protocol should be set correctly - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Pass a valid URL and protocol string - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and protocol string - protocol should be set correctly - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and protocol string - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, true, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-valid-url-protocol-string.any.js
+++ b/websockets/Create-Secure-valid-url-protocol-string.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Check readyState is 1");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and protocol string - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Check readyState is 1");
+var testClose = async_test("Create Secure WebSocket - Pass a valid URL and protocol string - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, true, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-valid-url-protocol-string.any.js
+++ b/websockets/Create-Secure-valid-url-protocol-string.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Check readyState is 1");
-var testClose = async_test("Create Secure WebSocket - Pass a valid URL and protocol string - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Check readyState is 1");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL and protocol string - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, true, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-valid-url.any.js
+++ b/websockets/Create-Secure-valid-url.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL  - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Pass a valid URL  - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Pass a valid URL - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-valid-url.any.js
+++ b/websockets/Create-Secure-valid-url.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Pass a valid URL  - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Pass a valid URL - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL  - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Pass a valid URL - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Create-Secure-verify-url-set-non-default-port.any.js
+++ b/websockets/Create-Secure-verify-url-set-non-default-port.any.js
@@ -4,4 +4,4 @@ test(function() {
   var urlNonDefaultPort = "wss://" + __SERVER__NAME + ":" + __NEW__SECURE__PORT + "/" + __PATH;
   var wsocket = new WebSocket(urlNonDefaultPort);
   assert_equals(wsocket.url, urlNonDefaultPort, "wsocket.url is set correctly");
-}, "W3C WebSocket API - Create Secure WebSocket - wsocket.url should be set correctly")
+}, "Create Secure WebSocket - wsocket.url should be set correctly")

--- a/websockets/Create-Secure-verify-url-set-non-default-port.any.js
+++ b/websockets/Create-Secure-verify-url-set-non-default-port.any.js
@@ -4,4 +4,4 @@ test(function() {
   var urlNonDefaultPort = "wss://" + __SERVER__NAME + ":" + __NEW__SECURE__PORT + "/" + __PATH;
   var wsocket = new WebSocket(urlNonDefaultPort);
   assert_equals(wsocket.url, urlNonDefaultPort, "wsocket.url is set correctly");
-}, "Create Secure WebSocket - wsocket.url should be set correctly")
+}, "W3C WebSocket API - Create Secure WebSocket - wsocket.url should be set correctly")

--- a/websockets/Create-asciiSep-protocol-string.any.js
+++ b/websockets/Create-asciiSep-protocol-string.any.js
@@ -6,4 +6,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithAsciiSep(asciiWithSep)
   });
-}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string with an ascii separator character - SYNTAX_ERR is thrown")
+}, "Create WebSocket - Pass a valid URL and a protocol string with an ascii separator character - SYNTAX_ERR is thrown")

--- a/websockets/Create-asciiSep-protocol-string.any.js
+++ b/websockets/Create-asciiSep-protocol-string.any.js
@@ -6,4 +6,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithAsciiSep(asciiWithSep)
   });
-}, "Create WebSocket - Pass a valid URL and a protocol string with an ascii separator character - SYNTAX_ERR is thrown")
+}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string with an ascii separator character - SYNTAX_ERR is thrown")

--- a/websockets/Create-non-absolute-url.any.js
+++ b/websockets/Create-non-absolute-url.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketNonAbsolute()
   });
-}, "W3C WebSocket API - Create WebSocket - Pass a non absolute URL - SYNTAX_ERR is thrown")
+}, "Create WebSocket - Pass a non absolute URL - SYNTAX_ERR is thrown")

--- a/websockets/Create-non-absolute-url.any.js
+++ b/websockets/Create-non-absolute-url.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketNonAbsolute()
   });
-}, "Create WebSocket - Pass a non absolute URL - SYNTAX_ERR is thrown")
+}, "W3C WebSocket API - Create WebSocket - Pass a non absolute URL - SYNTAX_ERR is thrown")

--- a/websockets/Create-nonAscii-protocol-string.any.js
+++ b/websockets/Create-nonAscii-protocol-string.any.js
@@ -6,4 +6,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketNonAsciiProtocol(nonAsciiProtocol)
   });
-}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string with non-ascii values - SYNTAX_ERR is thrown")
+}, "Create WebSocket - Pass a valid URL and a protocol string with non-ascii values - SYNTAX_ERR is thrown")

--- a/websockets/Create-nonAscii-protocol-string.any.js
+++ b/websockets/Create-nonAscii-protocol-string.any.js
@@ -6,4 +6,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketNonAsciiProtocol(nonAsciiProtocol)
   });
-}, "Create WebSocket - Pass a valid URL and a protocol string with non-ascii values - SYNTAX_ERR is thrown")
+}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string with non-ascii values - SYNTAX_ERR is thrown")

--- a/websockets/Create-protocol-with-space.any.js
+++ b/websockets/Create-protocol-with-space.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithSpaceInProtocol("ec ho")
   });
-}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string with a space in it - SYNTAX_ERR is thrown")
+}, "Create WebSocket - Pass a valid URL and a protocol string with a space in it - SYNTAX_ERR is thrown")

--- a/websockets/Create-protocol-with-space.any.js
+++ b/websockets/Create-protocol-with-space.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithSpaceInProtocol("ec ho")
   });
-}, "Create WebSocket - Pass a valid URL and a protocol string with a space in it - SYNTAX_ERR is thrown")
+}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string with a space in it - SYNTAX_ERR is thrown")

--- a/websockets/Create-protocols-repeated-case-insensitive.any.js
+++ b/websockets/Create-protocols-repeated-case-insensitive.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithRepeatedProtocolsCaseInsensitive()
   });
-}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and an array of protocol strings with repeated values but different case - SYNTAX_ERR is thrown")
+}, "Create WebSocket - Pass a valid URL and an array of protocol strings with repeated values but different case - SYNTAX_ERR is thrown")

--- a/websockets/Create-protocols-repeated-case-insensitive.any.js
+++ b/websockets/Create-protocols-repeated-case-insensitive.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithRepeatedProtocolsCaseInsensitive()
   });
-}, "Create WebSocket - Pass a valid URL and an array of protocol strings with repeated values but different case - SYNTAX_ERR is thrown")
+}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and an array of protocol strings with repeated values but different case - SYNTAX_ERR is thrown")

--- a/websockets/Create-protocols-repeated.any.js
+++ b/websockets/Create-protocols-repeated.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithRepeatedProtocols()
   });
-}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and an array of protocol strings with repeated values - SYNTAX_ERR is thrown")
+}, "Create WebSocket - Pass a valid URL and an array of protocol strings with repeated values - SYNTAX_ERR is thrown")

--- a/websockets/Create-protocols-repeated.any.js
+++ b/websockets/Create-protocols-repeated.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketWithRepeatedProtocols()
   });
-}, "Create WebSocket - Pass a valid URL and an array of protocol strings with repeated values - SYNTAX_ERR is thrown")
+}, "W3C WebSocket API - Create WebSocket - Pass a valid URL and an array of protocol strings with repeated values - SYNTAX_ERR is thrown")

--- a/websockets/Create-valid-url-array-protocols.any.js
+++ b/websockets/Create-valid-url-array-protocols.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL and array of protocol strings - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL and array of protocol strings - Connection should be closed");
+var testOpen = async_test("Create WebSocket - Pass a valid URL and array of protocol strings - Connection should be opened");
+var testClose = async_test("Create WebSocket - Pass a valid URL and array of protocol strings - Connection should be closed");
 
 var wsocket = CreateWebSocket(false, false, true);
 var isOpenCalled = false;

--- a/websockets/Create-valid-url-array-protocols.any.js
+++ b/websockets/Create-valid-url-array-protocols.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create WebSocket - Pass a valid URL and array of protocol strings - Connection should be opened");
-var testClose = async_test("Create WebSocket - Pass a valid URL and array of protocol strings - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL and array of protocol strings - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL and array of protocol strings - Connection should be closed");
 
 var wsocket = CreateWebSocket(false, false, true);
 var isOpenCalled = false;

--- a/websockets/Create-valid-url-protocol-empty.any.js
+++ b/websockets/Create-valid-url-protocol-empty.any.js
@@ -4,4 +4,4 @@ test(function() {
   var wsocket = CreateWebSocket(false, true, false);
   assert_equals(wsocket.protocol, "", "protocol should be empty");
   wsocket.close();
-}, "W3C WebSocket API - Create WebSocket - wsocket.protocol should be empty before connection is established")
+}, "Create WebSocket - wsocket.protocol should be empty before connection is established")

--- a/websockets/Create-valid-url-protocol-empty.any.js
+++ b/websockets/Create-valid-url-protocol-empty.any.js
@@ -4,4 +4,4 @@ test(function() {
   var wsocket = CreateWebSocket(false, true, false);
   assert_equals(wsocket.protocol, "", "protocol should be empty");
   wsocket.close();
-}, "Create WebSocket - wsocket.protocol should be empty before connection is established")
+}, "W3C WebSocket API - Create WebSocket - wsocket.protocol should be empty before connection is established")

--- a/websockets/Create-valid-url-protocol.any.js
+++ b/websockets/Create-valid-url-protocol.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string - Connection should be closed");
+var testOpen = async_test("Create WebSocket - Pass a valid URL and a protocol string - Connection should be opened");
+var testClose = async_test("Create WebSocket - Pass a valid URL and a protocol string - Connection should be closed");
 
 var wsocket = CreateWebSocket(false, true, false);
 var isOpenCalled = false;

--- a/websockets/Create-valid-url-protocol.any.js
+++ b/websockets/Create-valid-url-protocol.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create WebSocket - Pass a valid URL and a protocol string - Connection should be opened");
-var testClose = async_test("Create WebSocket - Pass a valid URL and a protocol string - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL and a protocol string - Connection should be closed");
 
 var wsocket = CreateWebSocket(false, true, false);
 var isOpenCalled = false;

--- a/websockets/Create-valid-url.any.js
+++ b/websockets/Create-valid-url.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL - Connection should be closed");
+var testOpen = async_test("Create WebSocket - Pass a valid URL - Connection should be opened");
+var testClose = async_test("Create WebSocket - Pass a valid URL - Connection should be closed");
 
 var wsocket = CreateWebSocket(false, false, false);
 var isOpenCalled = false;

--- a/websockets/Create-valid-url.any.js
+++ b/websockets/Create-valid-url.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create WebSocket - Pass a valid URL - Connection should be opened");
-var testClose = async_test("Create WebSocket - Pass a valid URL - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create WebSocket - Pass a valid URL - Connection should be closed");
 
 var wsocket = CreateWebSocket(false, false, false);
 var isOpenCalled = false;

--- a/websockets/Create-verify-url-set-non-default-port.any.js
+++ b/websockets/Create-verify-url-set-non-default-port.any.js
@@ -4,4 +4,4 @@ test(function() {
   var urlNonDefaultPort = "ws://" + __SERVER__NAME + ":" + __NEW__PORT + "/" + __PATH;
   var wsocket = new WebSocket(urlNonDefaultPort);
   assert_equals(wsocket.url, urlNonDefaultPort, "wsocket.url is set correctly");
-}, "W3C WebSocket API - Create WebSocket - wsocket.url should be set correctly");
+}, "Create WebSocket - wsocket.url should be set correctly");

--- a/websockets/Create-verify-url-set-non-default-port.any.js
+++ b/websockets/Create-verify-url-set-non-default-port.any.js
@@ -4,4 +4,4 @@ test(function() {
   var urlNonDefaultPort = "ws://" + __SERVER__NAME + ":" + __NEW__PORT + "/" + __PATH;
   var wsocket = new WebSocket(urlNonDefaultPort);
   assert_equals(wsocket.url, urlNonDefaultPort, "wsocket.url is set correctly");
-}, "Create WebSocket - wsocket.url should be set correctly");
+}, "W3C WebSocket API - Create WebSocket - wsocket.url should be set correctly");

--- a/websockets/Create-wrong-scheme.any.js
+++ b/websockets/Create-wrong-scheme.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketNonWsScheme()
   });
-}, "W3C WebSocket API - Create WebSocket - Pass a URL with a non ws/wss scheme - SYNTAX_ERR is thrown")
+}, "Create WebSocket - Pass a URL with a non ws/wss scheme - SYNTAX_ERR is thrown")

--- a/websockets/Create-wrong-scheme.any.js
+++ b/websockets/Create-wrong-scheme.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("SYNTAX_ERR", function() {
     wsocket = CreateWebSocketNonWsScheme()
   });
-}, "Create WebSocket - Pass a URL with a non ws/wss scheme - SYNTAX_ERR is thrown")
+}, "W3C WebSocket API - Create WebSocket - Pass a URL with a non ws/wss scheme - SYNTAX_ERR is thrown")

--- a/websockets/Secure-Close-1000-reason.any.js
+++ b/websockets/Secure-Close-1000-reason.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000, reason) - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(1000, reason) - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Close the Connection - close(1000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-1000-reason.any.js
+++ b/websockets/Secure-Close-1000-reason.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(1000, reason) - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Close the Connection - close(1000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000, reason) - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-1000-verify-code.any.js
+++ b/websockets/Secure-Close-1000-verify-code.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000, reason) - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000, reason) - event.code == 1000 and event.reason = 'Clean Close'");
+var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(1000, reason) - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Close the Connection - close(1000, reason) - event.code == 1000 and event.reason = 'Clean Close'");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-1000-verify-code.any.js
+++ b/websockets/Secure-Close-1000-verify-code.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(1000, reason) - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Close the Connection - close(1000, reason) - event.code == 1000 and event.reason = 'Clean Close'");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000, reason) - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000, reason) - event.code == 1000 and event.reason = 'Clean Close'");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-1000.any.js
+++ b/websockets/Secure-Close-1000.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000) - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(1000) - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Close the Connection - close(1000) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-1000.any.js
+++ b/websockets/Secure-Close-1000.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(1000) - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Close the Connection - close(1000) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000) - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1000) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-1005-verify-code.any.js
+++ b/websockets/Secure-Close-1005-verify-code.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close() - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close() - return close code is 1005 - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Close the Connection - close() - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Close the Connection - close() - return close code is 1005 - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-1005-verify-code.any.js
+++ b/websockets/Secure-Close-1005-verify-code.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Close the Connection - close() - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Close the Connection - close() - return close code is 1005 - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close() - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close() - return close code is 1005 - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-1005.any.js
+++ b/websockets/Secure-Close-1005.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1005) - see '7.1.5.  The WebSocket Connection Close Code' in http://www.ietf.org/rfc/rfc6455.txt");
+var test = async_test("Create Secure WebSocket - Close the Connection - close(1005) - see '7.1.5.  The WebSocket Connection Close Code' in http://www.ietf.org/rfc/rfc6455.txt");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-1005.any.js
+++ b/websockets/Secure-Close-1005.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("Create Secure WebSocket - Close the Connection - close(1005) - see '7.1.5.  The WebSocket Connection Close Code' in http://www.ietf.org/rfc/rfc6455.txt");
+var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(1005) - see '7.1.5.  The WebSocket Connection Close Code' in http://www.ietf.org/rfc/rfc6455.txt");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-2999-reason.any.js
+++ b/websockets/Secure-Close-2999-reason.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(2999, reason) - INVALID_ACCESS_ERR is thrown");
+var test = async_test("Create Secure WebSocket - Close the Connection - close(2999, reason) - INVALID_ACCESS_ERR is thrown");
 
 var wsocket = CreateWebSocket(true, false, false);
 

--- a/websockets/Secure-Close-2999-reason.any.js
+++ b/websockets/Secure-Close-2999-reason.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("Create Secure WebSocket - Close the Connection - close(2999, reason) - INVALID_ACCESS_ERR is thrown");
+var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(2999, reason) - INVALID_ACCESS_ERR is thrown");
 
 var wsocket = CreateWebSocket(true, false, false);
 

--- a/websockets/Secure-Close-3000-reason.any.js
+++ b/websockets/Secure-Close-3000-reason.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(3000, reason) - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(3000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(3000, reason) - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Close the Connection - close(3000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-3000-reason.any.js
+++ b/websockets/Secure-Close-3000-reason.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(3000, reason) - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Close the Connection - close(3000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(3000, reason) - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(3000, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-3000-verify-code.any.js
+++ b/websockets/Secure-Close-3000-verify-code.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(3000, reason) - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(3000, reason) - verify return code is 3000 - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(3000, reason) - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Close the Connection - close(3000, reason) - verify return code is 3000 - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-3000-verify-code.any.js
+++ b/websockets/Secure-Close-3000-verify-code.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(3000, reason) - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Close the Connection - close(3000, reason) - verify return code is 3000 - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(3000, reason) - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(3000, reason) - verify return code is 3000 - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-4999-reason.any.js
+++ b/websockets/Secure-Close-4999-reason.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(4999, reason) - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(4999, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(4999, reason) - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Close the Connection - close(4999, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-4999-reason.any.js
+++ b/websockets/Secure-Close-4999-reason.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(4999, reason) - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Close the Connection - close(4999, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(4999, reason) - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(4999, reason) - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-Reason-124Bytes.any.js
+++ b/websockets/Secure-Close-Reason-124Bytes.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(code, 'reason more than 123 bytes') - SYNTAX_ERR is thrown");
+var test = async_test("Create Secure WebSocket - Close the Connection - close(code, 'reason more than 123 bytes') - SYNTAX_ERR is thrown");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-Reason-124Bytes.any.js
+++ b/websockets/Secure-Close-Reason-124Bytes.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("Create Secure WebSocket - Close the Connection - close(code, 'reason more than 123 bytes') - SYNTAX_ERR is thrown");
+var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(code, 'reason more than 123 bytes') - SYNTAX_ERR is thrown");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-Reason-Unpaired-surrogates.any.js
+++ b/websockets/Secure-Close-Reason-Unpaired-surrogates.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed");
+var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get opened");
+var testClose = async_test("Create Secure WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-Reason-Unpaired-surrogates.any.js
+++ b/websockets/Secure-Close-Reason-Unpaired-surrogates.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get opened");
-var testClose = async_test("Create Secure WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(reason with unpaired surrogates) - connection should get closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-onlyReason.any.js
+++ b/websockets/Secure-Close-onlyReason.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(only reason) - INVALID_ACCESS_ERR is thrown");
+var test = async_test("Create Secure WebSocket - Close the Connection - close(only reason) - INVALID_ACCESS_ERR is thrown");
 
 var wsocket = CreateWebSocket(true, false, false);
 

--- a/websockets/Secure-Close-onlyReason.any.js
+++ b/websockets/Secure-Close-onlyReason.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("Create Secure WebSocket - Close the Connection - close(only reason) - INVALID_ACCESS_ERR is thrown");
+var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - close(only reason) - INVALID_ACCESS_ERR is thrown");
 
 var wsocket = CreateWebSocket(true, false, false);
 

--- a/websockets/Secure-Close-readyState-Closed.any.js
+++ b/websockets/Secure-Close-readyState-Closed.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Close the Connection - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Close the Connection - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-readyState-Closed.any.js
+++ b/websockets/Secure-Close-readyState-Closed.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Close the Connection - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Close the Connection - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-readyState-Closing.any.js
+++ b/websockets/Secure-Close-readyState-Closing.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - readyState should be in CLOSING state just before onclose is called");
+var test = async_test("Create Secure WebSocket - Close the Connection - readyState should be in CLOSING state just before onclose is called");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-readyState-Closing.any.js
+++ b/websockets/Secure-Close-readyState-Closing.any.js
@@ -1,6 +1,6 @@
 // META: script=websocket.sub.js
 
-var test = async_test("Create Secure WebSocket - Close the Connection - readyState should be in CLOSING state just before onclose is called");
+var test = async_test("W3C WebSocket API - Create Secure WebSocket - Close the Connection - readyState should be in CLOSING state just before onclose is called");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-server-initiated-close.any.js
+++ b/websockets/Secure-Close-server-initiated-close.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Server initiated Close - Client sends back a CLOSE - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Server initiated Close - Client sends back a CLOSE - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("Create Secure WebSocket - Server initiated Close - Client sends back a CLOSE - Connection should be opened");
+var testClose = async_test("Create Secure WebSocket - Server initiated Close - Client sends back a CLOSE - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Close-server-initiated-close.any.js
+++ b/websockets/Secure-Close-server-initiated-close.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create Secure WebSocket - Server initiated Close - Client sends back a CLOSE - Connection should be opened");
-var testClose = async_test("Create Secure WebSocket - Server initiated Close - Client sends back a CLOSE - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create Secure WebSocket - Server initiated Close - Client sends back a CLOSE - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create Secure WebSocket - Server initiated Close - Client sends back a CLOSE - readyState should be in CLOSED state and wasClean is TRUE - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;

--- a/websockets/Secure-Send-65K-data.any.js
+++ b/websockets/Secure-Send-65K-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send  65K data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send 65K data on a Secure WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send 65K data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("Send  65K data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("Send 65K data on a Secure WebSocket - Message should be received");
+var testClose = async_test("Send 65K data on a Secure WebSocket - Connection should be closed");
 
 var data = "";
 var wsocket = CreateWebSocket(true, false, false);

--- a/websockets/Secure-Send-65K-data.any.js
+++ b/websockets/Secure-Send-65K-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send  65K data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("Send 65K data on a Secure WebSocket - Message should be received");
-var testClose = async_test("Send 65K data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send  65K data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send 65K data on a Secure WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send 65K data on a Secure WebSocket - Connection should be closed");
 
 var data = "";
 var wsocket = CreateWebSocket(true, false, false);

--- a/websockets/Secure-Send-binary-65K-arraybuffer.any.js
+++ b/websockets/Secure-Send-binary-65K-arraybuffer.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send 65K binary data on a Secure WebSocket - ArrayBuffer - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send 65K binary data on a Secure WebSocket - ArrayBuffer - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send 65K binary data on a Secure WebSocket - ArrayBuffer - Connection should be closed");
+var testOpen = async_test("Send 65K binary data on a Secure WebSocket - ArrayBuffer - Connection should be opened");
+var testMessage = async_test("Send 65K binary data on a Secure WebSocket - ArrayBuffer - Message should be received");
+var testClose = async_test("Send 65K binary data on a Secure WebSocket - ArrayBuffer - Connection should be closed");
 
 var data = "";
 var datasize = 65000;

--- a/websockets/Secure-Send-binary-65K-arraybuffer.any.js
+++ b/websockets/Secure-Send-binary-65K-arraybuffer.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send 65K binary data on a Secure WebSocket - ArrayBuffer - Connection should be opened");
-var testMessage = async_test("Send 65K binary data on a Secure WebSocket - ArrayBuffer - Message should be received");
-var testClose = async_test("Send 65K binary data on a Secure WebSocket - ArrayBuffer - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send 65K binary data on a Secure WebSocket - ArrayBuffer - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send 65K binary data on a Secure WebSocket - ArrayBuffer - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send 65K binary data on a Secure WebSocket - ArrayBuffer - Connection should be closed");
 
 var data = "";
 var datasize = 65000;

--- a/websockets/Secure-Send-binary-arraybuffer.any.js
+++ b/websockets/Secure-Send-binary-arraybuffer.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - ArrayBuffer - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - ArrayBuffer - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - ArrayBuffer - Connection should be closed");
+var testOpen = async_test("Send binary data on a Secure WebSocket - ArrayBuffer - Connection should be opened");
+var testMessage = async_test("Send binary data on a Secure WebSocket - ArrayBuffer - Message should be received");
+var testClose = async_test("Send binary data on a Secure WebSocket - ArrayBuffer - Connection should be closed");
 
 var data = "";
 var datasize = 15;

--- a/websockets/Secure-Send-binary-arraybuffer.any.js
+++ b/websockets/Secure-Send-binary-arraybuffer.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a Secure WebSocket - ArrayBuffer - Connection should be opened");
-var testMessage = async_test("Send binary data on a Secure WebSocket - ArrayBuffer - Message should be received");
-var testClose = async_test("Send binary data on a Secure WebSocket - ArrayBuffer - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - ArrayBuffer - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - ArrayBuffer - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - ArrayBuffer - Connection should be closed");
 
 var data = "";
 var datasize = 15;

--- a/websockets/Secure-Send-binary-arraybufferview-float32.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-float32.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float32Array - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float32Array - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float32Array - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Float32Array - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Float32Array - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Float32Array - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-float32.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-float32.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Float32Array - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Float32Array - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Float32Array - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float32Array - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float32Array - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float32Array - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-float64.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-float64.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float64Array - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float64Array - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float64Array - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Float64Array - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Float64Array - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Float64Array - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-float64.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-float64.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Float64Array - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Float64Array - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Float64Array - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float64Array - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float64Array - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Float64Array - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-int32.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-int32.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int32Array - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int32Array - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int32Array - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Int32Array - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Int32Array - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Int32Array - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-int32.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-int32.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Int32Array - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Int32Array - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Int32Array - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int32Array - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int32Array - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int32Array - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-uint16-offset-length.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-uint16-offset-length.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-uint16-offset-length.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-uint16-offset-length.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint16Array with offset and length - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-uint32-offset.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-uint32-offset.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-uint32-offset.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-uint32-offset.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint32Array with offset - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-uint8-offset-length.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-uint8-offset-length.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-uint8-offset-length.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-uint8-offset-length.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset and length - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-uint8-offset.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-uint8-offset.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-arraybufferview-uint8-offset.any.js
+++ b/websockets/Secure-Send-binary-arraybufferview-uint8-offset.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Uint8Array with offset - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Secure-Send-binary-blob.any.js
+++ b/websockets/Secure-Send-binary-blob.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - Blob - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - Blob - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - Blob - Connection should be closed");
+var testOpen = async_test("Send binary data on a Secure WebSocket - Blob - Connection should be opened");
+var testMessage = async_test("Send binary data on a Secure WebSocket - Blob - Message should be received");
+var testClose = async_test("Send binary data on a Secure WebSocket - Blob - Connection should be closed");
 
 var data = "";
 var datasize = 65000;

--- a/websockets/Secure-Send-binary-blob.any.js
+++ b/websockets/Secure-Send-binary-blob.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a Secure WebSocket - Blob - Connection should be opened");
-var testMessage = async_test("Send binary data on a Secure WebSocket - Blob - Message should be received");
-var testClose = async_test("Send binary data on a Secure WebSocket - Blob - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - Blob - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - Blob - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a Secure WebSocket - Blob - Connection should be closed");
 
 var data = "";
 var datasize = 65000;

--- a/websockets/Secure-Send-data.any.js
+++ b/websockets/Secure-Send-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send  data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send data on a Secure WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("Send  data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("Send data on a Secure WebSocket - Message should be received");
+var testClose = async_test("Send data on a Secure WebSocket - Connection should be closed");
 
 var data = "Message to send";
 var wsocket = CreateWebSocket(true, false, false);

--- a/websockets/Secure-Send-data.any.js
+++ b/websockets/Secure-Send-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send  data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("Send data on a Secure WebSocket - Message should be received");
-var testClose = async_test("Send data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send  data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send data on a Secure WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send data on a Secure WebSocket - Connection should be closed");
 
 var data = "Message to send";
 var wsocket = CreateWebSocket(true, false, false);

--- a/websockets/Secure-Send-null.any.js
+++ b/websockets/Secure-Send-null.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send null data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send null data on a Secure WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send null data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("Send null data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("Send null data on a Secure WebSocket - Message should be received");
+var testClose = async_test("Send null data on a Secure WebSocket - Connection should be closed");
 
 var data = null;
 var nullReturned = false;

--- a/websockets/Secure-Send-null.any.js
+++ b/websockets/Secure-Send-null.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send null data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("Send null data on a Secure WebSocket - Message should be received");
-var testClose = async_test("Send null data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send null data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send null data on a Secure WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send null data on a Secure WebSocket - Connection should be closed");
 
 var data = null;
 var nullReturned = false;

--- a/websockets/Secure-Send-paired-surrogates.any.js
+++ b/websockets/Secure-Send-paired-surrogates.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send paired surrogates data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send paired surrogates data on a Secure WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send paired surrogates data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("Send paired surrogates data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("Send paired surrogates data on a Secure WebSocket - Message should be received");
+var testClose = async_test("Send paired surrogates data on a Secure WebSocket - Connection should be closed");
 
 var data = "\uD801\uDC07";
 var wsocket = CreateWebSocket(true, false, false);

--- a/websockets/Secure-Send-paired-surrogates.any.js
+++ b/websockets/Secure-Send-paired-surrogates.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send paired surrogates data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("Send paired surrogates data on a Secure WebSocket - Message should be received");
-var testClose = async_test("Send paired surrogates data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send paired surrogates data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send paired surrogates data on a Secure WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send paired surrogates data on a Secure WebSocket - Connection should be closed");
 
 var data = "\uD801\uDC07";
 var wsocket = CreateWebSocket(true, false, false);

--- a/websockets/Secure-Send-unicode-data.any.js
+++ b/websockets/Secure-Send-unicode-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send  unicode data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send unicode data on a Secure WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send unicode data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("Send  unicode data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("Send unicode data on a Secure WebSocket - Message should be received");
+var testClose = async_test("Send unicode data on a Secure WebSocket - Connection should be closed");
 
 var data = "¥¥¥¥¥¥";
 var wsocket = CreateWebSocket(true, false, false);

--- a/websockets/Secure-Send-unicode-data.any.js
+++ b/websockets/Secure-Send-unicode-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send  unicode data on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("Send unicode data on a Secure WebSocket - Message should be received");
-var testClose = async_test("Send unicode data on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send  unicode data on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send unicode data on a Secure WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send unicode data on a Secure WebSocket - Connection should be closed");
 
 var data = "¥¥¥¥¥¥";
 var wsocket = CreateWebSocket(true, false, false);

--- a/websockets/Secure-Send-unpaired-surrogates.any.js
+++ b/websockets/Secure-Send-unpaired-surrogates.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send unpaired surrogates on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send unpaired surrogates on a Secure WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send unpaired surrogates on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("Send unpaired surrogates on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("Send unpaired surrogates on a Secure WebSocket - Message should be received");
+var testClose = async_test("Send unpaired surrogates on a Secure WebSocket - Connection should be closed");
 
 var data = "\uD807";
 var replacementChar = "\uFFFD";

--- a/websockets/Secure-Send-unpaired-surrogates.any.js
+++ b/websockets/Secure-Send-unpaired-surrogates.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send unpaired surrogates on a Secure WebSocket - Connection should be opened");
-var testMessage = async_test("Send unpaired surrogates on a Secure WebSocket - Message should be received");
-var testClose = async_test("Send unpaired surrogates on a Secure WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send unpaired surrogates on a Secure WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send unpaired surrogates on a Secure WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send unpaired surrogates on a Secure WebSocket - Connection should be closed");
 
 var data = "\uD807";
 var replacementChar = "\uFFFD";

--- a/websockets/Send-0byte-data.any.js
+++ b/websockets/Send-0byte-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send 0 byte data on a WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send 0 byte data on a WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send 0 byte data on a WebSocket - Connection should be closed");
+var testOpen = async_test("Send 0 byte data on a WebSocket - Connection should be opened");
+var testMessage = async_test("Send 0 byte data on a WebSocket - Message should be received");
+var testClose = async_test("Send 0 byte data on a WebSocket - Connection should be closed");
 
 var data = "";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/Send-0byte-data.any.js
+++ b/websockets/Send-0byte-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send 0 byte data on a WebSocket - Connection should be opened");
-var testMessage = async_test("Send 0 byte data on a WebSocket - Message should be received");
-var testClose = async_test("Send 0 byte data on a WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send 0 byte data on a WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send 0 byte data on a WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send 0 byte data on a WebSocket - Connection should be closed");
 
 var data = "";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/Send-65K-data.any.js
+++ b/websockets/Send-65K-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send 65K data on a WebSocket -  Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send 65K data on a WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send 65K data on a WebSocket - Connection should be closed");
+var testOpen = async_test("Send 65K data on a WebSocket -  Connection should be opened");
+var testMessage = async_test("Send 65K data on a WebSocket - Message should be received");
+var testClose = async_test("Send 65K data on a WebSocket - Connection should be closed");
 
 var data = "";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/Send-65K-data.any.js
+++ b/websockets/Send-65K-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send 65K data on a WebSocket -  Connection should be opened");
-var testMessage = async_test("Send 65K data on a WebSocket - Message should be received");
-var testClose = async_test("Send 65K data on a WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send 65K data on a WebSocket -  Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send 65K data on a WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send 65K data on a WebSocket - Connection should be closed");
 
 var data = "";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/Send-Unpaired-Surrogates.any.js
+++ b/websockets/Send-Unpaired-Surrogates.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send unpaired surrogates on a WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send unpaired surrogates on a WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send unpaired surrogates on a WebSocket - Connection should be closed");
+var testOpen = async_test("Send unpaired surrogates on a WebSocket - Connection should be opened");
+var testMessage = async_test("Send unpaired surrogates on a WebSocket - Message should be received");
+var testClose = async_test("Send unpaired surrogates on a WebSocket - Connection should be closed");
 
 var data = "\uD807";
 var replacementChar = "\uFFFD";

--- a/websockets/Send-Unpaired-Surrogates.any.js
+++ b/websockets/Send-Unpaired-Surrogates.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send unpaired surrogates on a WebSocket - Connection should be opened");
-var testMessage = async_test("Send unpaired surrogates on a WebSocket - Message should be received");
-var testClose = async_test("Send unpaired surrogates on a WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send unpaired surrogates on a WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send unpaired surrogates on a WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send unpaired surrogates on a WebSocket - Connection should be closed");
 
 var data = "\uD807";
 var replacementChar = "\uFFFD";

--- a/websockets/Send-before-open.any.js
+++ b/websockets/Send-before-open.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("INVALID_STATE_ERR", function() {
     wsocket.send("Message to send")
   });
-}, "W3C WebSocket API - Send data on a WebSocket before connection is opened - INVALID_STATE_ERR is returned")
+}, "Send data on a WebSocket before connection is opened - INVALID_STATE_ERR is returned")

--- a/websockets/Send-before-open.any.js
+++ b/websockets/Send-before-open.any.js
@@ -5,4 +5,4 @@ test(function() {
   assert_throws("INVALID_STATE_ERR", function() {
     wsocket.send("Message to send")
   });
-}, "Send data on a WebSocket before connection is opened - INVALID_STATE_ERR is returned")
+}, "W3C WebSocket API - Send data on a WebSocket before connection is opened - INVALID_STATE_ERR is returned")

--- a/websockets/Send-binary-65K-arraybuffer.any.js
+++ b/websockets/Send-binary-65K-arraybuffer.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send 65K binary data on a WebSocket - ArrayBuffer - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send 65K binary data on a WebSocket - ArrayBuffer - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send 65K binary data on a WebSocket - ArrayBuffer - Connection should be closed");
+var testOpen = async_test("Send 65K binary data on a WebSocket - ArrayBuffer - Connection should be opened");
+var testMessage = async_test("Send 65K binary data on a WebSocket - ArrayBuffer - Message should be received");
+var testClose = async_test("Send 65K binary data on a WebSocket - ArrayBuffer - Connection should be closed");
 
 var data = "";
 var datasize = 65000;

--- a/websockets/Send-binary-65K-arraybuffer.any.js
+++ b/websockets/Send-binary-65K-arraybuffer.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send 65K binary data on a WebSocket - ArrayBuffer - Connection should be opened");
-var testMessage = async_test("Send 65K binary data on a WebSocket - ArrayBuffer - Message should be received");
-var testClose = async_test("Send 65K binary data on a WebSocket - ArrayBuffer - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send 65K binary data on a WebSocket - ArrayBuffer - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send 65K binary data on a WebSocket - ArrayBuffer - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send 65K binary data on a WebSocket - ArrayBuffer - Connection should be closed");
 
 var data = "";
 var datasize = 65000;

--- a/websockets/Send-binary-arraybuffer.any.js
+++ b/websockets/Send-binary-arraybuffer.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBuffer - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBuffer - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBuffer - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBuffer - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBuffer - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBuffer - Connection should be closed");
 
 var data = "";
 var datasize = 15;

--- a/websockets/Send-binary-arraybuffer.any.js
+++ b/websockets/Send-binary-arraybuffer.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBuffer - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBuffer - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBuffer - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBuffer - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBuffer - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBuffer - Connection should be closed");
 
 var data = "";
 var datasize = 15;

--- a/websockets/Send-binary-arraybufferview-int16-offset.any.js
+++ b/websockets/Send-binary-arraybufferview-int16-offset.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Send-binary-arraybufferview-int16-offset.any.js
+++ b/websockets/Send-binary-arraybufferview-int16-offset.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int16Array with offset - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Send-binary-arraybufferview-int8.any.js
+++ b/websockets/Send-binary-arraybufferview-int8.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int8Array - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int8Array - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int8Array - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Int8Array - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Int8Array - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Int8Array - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Send-binary-arraybufferview-int8.any.js
+++ b/websockets/Send-binary-arraybufferview-int8.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - ArrayBufferView - Int8Array - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - ArrayBufferView - Int8Array - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - ArrayBufferView - Int8Array - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int8Array - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int8Array - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - ArrayBufferView - Int8Array - Connection should be closed");
 
 var data = "";
 var datasize = 8;

--- a/websockets/Send-binary-blob.any.js
+++ b/websockets/Send-binary-blob.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - Blob - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - Blob - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - Blob - Connection should be closed");
+var testOpen = async_test("Send binary data on a WebSocket - Blob - Connection should be opened");
+var testMessage = async_test("Send binary data on a WebSocket - Blob - Message should be received");
+var testClose = async_test("Send binary data on a WebSocket - Blob - Connection should be closed");
 
 var data = "";
 var datasize = 65000;

--- a/websockets/Send-binary-blob.any.js
+++ b/websockets/Send-binary-blob.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send binary data on a WebSocket - Blob - Connection should be opened");
-var testMessage = async_test("Send binary data on a WebSocket - Blob - Message should be received");
-var testClose = async_test("Send binary data on a WebSocket - Blob - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send binary data on a WebSocket - Blob - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send binary data on a WebSocket - Blob - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send binary data on a WebSocket - Blob - Connection should be closed");
 
 var data = "";
 var datasize = 65000;

--- a/websockets/Send-data.any.js
+++ b/websockets/Send-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send data on a WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send data on a WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send data on a WebSocket - Connection should be closed");
+var testOpen = async_test("Send data on a WebSocket - Connection should be opened");
+var testMessage = async_test("Send data on a WebSocket - Message should be received");
+var testClose = async_test("Send data on a WebSocket - Connection should be closed");
 
 var data = "Message to send";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/Send-data.any.js
+++ b/websockets/Send-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send data on a WebSocket - Connection should be opened");
-var testMessage = async_test("Send data on a WebSocket - Message should be received");
-var testClose = async_test("Send data on a WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send data on a WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send data on a WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send data on a WebSocket - Connection should be closed");
 
 var data = "Message to send";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/Send-data.worker.js
+++ b/websockets/Send-data.worker.js
@@ -16,6 +16,6 @@ async_test(function(t) {
             done();
     }), true);
 
-}, "W3C WebSocket API - Send data on a WebSocket in a Worker")
+}, "Send data on a WebSocket in a Worker")
 
 

--- a/websockets/Send-data.worker.js
+++ b/websockets/Send-data.worker.js
@@ -16,6 +16,6 @@ async_test(function(t) {
             done();
     }), true);
 
-}, "Send data on a WebSocket in a Worker")
+}, "W3C WebSocket API - Send data on a WebSocket in a Worker")
 
 

--- a/websockets/Send-null.any.js
+++ b/websockets/Send-null.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send null data on a WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send null data on a WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send null data on a WebSocket - Connection should be closed");
+var testOpen = async_test("Send null data on a WebSocket - Connection should be opened");
+var testMessage = async_test("Send null data on a WebSocket - Message should be received");
+var testClose = async_test("Send null data on a WebSocket - Connection should be closed");
 
 var data = null;
 var nullReturned = false;

--- a/websockets/Send-null.any.js
+++ b/websockets/Send-null.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send null data on a WebSocket - Connection should be opened");
-var testMessage = async_test("Send null data on a WebSocket - Message should be received");
-var testClose = async_test("Send null data on a WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send null data on a WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send null data on a WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send null data on a WebSocket - Connection should be closed");
 
 var data = null;
 var nullReturned = false;

--- a/websockets/Send-paired-surrogates.any.js
+++ b/websockets/Send-paired-surrogates.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send (paired surrogates) data on a WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send (paired surrogates) data on a WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send (paired surrogates) data on a WebSocket - Connection should be closed");
+var testOpen = async_test("Send (paired surrogates) data on a WebSocket - Connection should be opened");
+var testMessage = async_test("Send (paired surrogates) data on a WebSocket - Message should be received");
+var testClose = async_test("Send (paired surrogates) data on a WebSocket - Connection should be closed");
 
 var data = "\uD801\uDC07";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/Send-paired-surrogates.any.js
+++ b/websockets/Send-paired-surrogates.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send (paired surrogates) data on a WebSocket - Connection should be opened");
-var testMessage = async_test("Send (paired surrogates) data on a WebSocket - Message should be received");
-var testClose = async_test("Send (paired surrogates) data on a WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send (paired surrogates) data on a WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send (paired surrogates) data on a WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send (paired surrogates) data on a WebSocket - Connection should be closed");
 
 var data = "\uD801\uDC07";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/Send-unicode-data.any.js
+++ b/websockets/Send-unicode-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Send unicode data on a WebSocket - Connection should be opened");
-var testMessage = async_test("W3C WebSocket API - Send unicode data on a WebSocket - Message should be received");
-var testClose = async_test("W3C WebSocket API - Send unicode data on a WebSocket - Connection should be closed");
+var testOpen = async_test("Send unicode data on a WebSocket - Connection should be opened");
+var testMessage = async_test("Send unicode data on a WebSocket - Message should be received");
+var testClose = async_test("Send unicode data on a WebSocket - Connection should be closed");
 
 var data = "¥¥¥¥¥¥";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/Send-unicode-data.any.js
+++ b/websockets/Send-unicode-data.any.js
@@ -1,8 +1,8 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Send unicode data on a WebSocket - Connection should be opened");
-var testMessage = async_test("Send unicode data on a WebSocket - Message should be received");
-var testClose = async_test("Send unicode data on a WebSocket - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Send unicode data on a WebSocket - Connection should be opened");
+var testMessage = async_test("W3C WebSocket API - Send unicode data on a WebSocket - Message should be received");
+var testClose = async_test("W3C WebSocket API - Send unicode data on a WebSocket - Connection should be closed");
 
 var data = "¥¥¥¥¥¥";
 var wsocket = CreateWebSocket(false, false, false);

--- a/websockets/binaryType-wrong-value.any.js
+++ b/websockets/binaryType-wrong-value.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("W3C WebSocket API - Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be opened");
-var testClose = async_test("W3C WebSocket API - Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be closed");
+var testOpen = async_test("Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be opened");
+var testClose = async_test("Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 

--- a/websockets/binaryType-wrong-value.any.js
+++ b/websockets/binaryType-wrong-value.any.js
@@ -1,7 +1,7 @@
 // META: script=websocket.sub.js
 
-var testOpen = async_test("Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be opened");
-var testClose = async_test("Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be closed");
+var testOpen = async_test("W3C WebSocket API - Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be opened");
+var testClose = async_test("W3C WebSocket API - Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be closed");
 
 var wsocket = CreateWebSocket(true, false, false);
 

--- a/websockets/opening-handshake/003-sets-origin.worker.js
+++ b/websockets/opening-handshake/003-sets-origin.worker.js
@@ -14,5 +14,5 @@ async_test(function(t) {
     ws.close();
   })
   ws.onerror = ws.onclose = t.unreached_func();
-}, "W3C WebSocket API - origin set in a Worker");
+}, "origin set in a Worker");
 done();

--- a/websockets/opening-handshake/003-sets-origin.worker.js
+++ b/websockets/opening-handshake/003-sets-origin.worker.js
@@ -14,5 +14,5 @@ async_test(function(t) {
     ws.close();
   })
   ws.onerror = ws.onclose = t.unreached_func();
-}, "origin set in a Worker");
+}, "W3C WebSocket API - origin set in a Worker");
 done();


### PR DESCRIPTION
This prefix doesn't add any useful information, and isn't used in all
tests in this directory. Noticed because of the screen real estate it
takes up in a view like this:
https://wpt.fyi/results/websockets/Send-binary-65K-arraybuffer.any.html

In the directory, this command was run, on macOS:
git grep -lF 'W3C WebSocket API - ' | xargs sed -i '' 's/W3C WebSocket API - //g'