### PR TITLE
Small adjustment to document.write TrustedTypes test.

### DIFF
--- a/trusted-types/Document-write.tentative.html
+++ b/trusted-types/Document-write.tentative.html
@@ -4,10 +4,11 @@
 <script src="support/helper.sub.js"></script>
 <body>
 <script>
+  // TrustedHTML assignments do not throw.
   test(t => {
     let p = createHTML_policy(window, 1);
     let html = p.createHTML(INPUTS.HTML);
     document.write(html);
-    assert_equals(document.body.innerText, RESULTS.HTML);
-  }, "document.write with html assigned via policy (successful URL transformation).");
+    assert_true(document.body.innerText.indexOf(RESULTS.HTML) !== -1);
+  }, "document.write with html assigned via policy (successful transformation).");
 </script>

--- a/trusted-types/block-string-assignment-to-Document-write.tentative.html
+++ b/trusted-types/block-string-assignment-to-Document-write.tentative.html
@@ -9,14 +9,6 @@
 </head>
 <body>
 <script>
-  // TrustedURL assignments do not throw.
-  test(t => {
-    let p = createHTML_policy(window, 1);
-    let html = p.createHTML(INPUTS.HTML);
-    document.write(html);
-    assert_equals(document.body.innerText, RESULTS.HTML);
-  }, "document.write with html assigned via policy (successful URL transformation).");
-
   // String assignments throw.
   test(t => {
     assert_throws(new TypeError(), _ => {


### PR DESCRIPTION
WindowTestEnvironment writes to the DOM, breaking the test when viewed in the browser.
Also removed a duplicate test.