### PR TITLE
Fix handling of about:blank in lint.

### DIFF
--- a/infrastructure/assumptions/blank.html
+++ b/infrastructure/assumptions/blank.html
@@ -1,0 +1,2 @@
+<title>Blank Document</title>
+<link rel=match href="about:blank">

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -458,10 +458,15 @@ def check_parsed(repo_root, path, f):
     if source_file.type == "visual" and not source_file.name_is_visual:
         errors.append(("CONTENT-VISUAL", "Visual test whose filename doesn't end in '-visual'", path, None))
 
+    about_blank_parts = urlsplit("about:blank")
     for reftest_node in source_file.reftest_nodes:
         href = reftest_node.attrib.get("href", "").strip(space_chars)
         parts = urlsplit(href)
-        if (parts.scheme or parts.netloc) and parts != urlsplit("about:blank"):
+
+        if parts == about_blank_parts:
+            continue
+
+        if (parts.scheme or parts.netloc):
             errors.append(("ABSOLUTE-URL-REF",
                      "Reference test with a reference file specified via an absolute URL: '%s'" % href, path, None))
             continue


### PR DESCRIPTION
about:blank should be unconditionally allowed as a reference. Also add
an infrastructure test that actually uses this to ensure it keeps working.