### PR TITLE
Add URL parsing test for "ssh://example.com/foo/bar.git"

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -1433,6 +1433,22 @@
     "search": "",
     "hash": ""
   },
+  "# Based on https://felixfbecker.github.io/whatwg-url-custom-host-repro/",
+  {
+    "input": "ssh://example.com/foo/bar.git",
+    "base": "http://example.org/",
+    "href": "ssh://example.com/foo/bar.git",
+    "origin": "null",
+    "protocol": "ssh:",
+    "username": "",
+    "password": "",
+    "host": "example.com",
+    "hostname": "example.com",
+    "port": "",
+    "pathname": "/foo/bar.git",
+    "search": "",
+    "hash": ""
+  },
   "# Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/file.html",
   {
     "input": "file:c:\\foo\\bar.html",


### PR DESCRIPTION
Exercised in url-constructor.html and url/url-origin.html.

Points of disagreement:
 * `protocol` should be "ssh:" because it is simply the concatenation of
   scheme and ":": https://url.spec.whatwg.org/#dom-url-protocol. Set to
   "ssh" here: https://url.spec.whatwg.org/#scheme-state
 * `origin` should be "null" because the URL will be get an opaque
   origin in https://url.spec.whatwg.org/#concept-url-origin.
 * `host`, `hostname` and `pathname` require stepping through the parser
   to see why the result is what it is:
   https://url.spec.whatwg.org/#host-state
   https://url.spec.whatwg.org/#path-state

Based on https://felixfbecker.github.io/whatwg-url-custom-host-repro/
for https://github.com/webcompat/web-bugs/issues/19792.