### PR TITLE
[Resource Timing] Test XO redirection sandwich with and without TAO

### DIFF
--- a/common/get-host-info.sub.js
+++ b/common/get-host-info.sub.js
@@ -3,9 +3,12 @@ function get_host_info() {
   var HTTP_PORT = '{{ports[http][0]}}';
   var HTTP_PORT2 = '{{ports[http][1]}}';
   var HTTPS_PORT = '{{ports[https][0]}}';
+  var PROTOCOL = window.location.protocol;
+  var IS_HTTPS = (PROTOCOL == "https:");
   var HTTP_PORT_ELIDED = HTTP_PORT == "80" ? "" : (":" + HTTP_PORT);
   var HTTP_PORT2_ELIDED = HTTP_PORT2 == "80" ? "" : (":" + HTTP_PORT2);
   var HTTPS_PORT_ELIDED = HTTPS_PORT == "443" ? "" : (":" + HTTPS_PORT);
+  var PORT_ELIDED = IS_HTTPS ? HTTPS_PORT_ELIDED : HTTP_PORT_ELIDED;
   var ORIGINAL_HOST = '{{host}}';
   var REMOTE_HOST = (ORIGINAL_HOST === 'localhost') ? '127.0.0.1' : ('www1.' + ORIGINAL_HOST);
   var OTHER_HOST = '{{domains[www2]}}';
@@ -18,10 +21,12 @@ function get_host_info() {
     ORIGINAL_HOST: ORIGINAL_HOST,
     REMOTE_HOST: REMOTE_HOST,
 
+    ORIGIN: PROTOCOL + "//" + ORIGINAL_HOST + PORT_ELIDED,
     HTTP_ORIGIN: 'http://' + ORIGINAL_HOST + HTTP_PORT_ELIDED,
     HTTPS_ORIGIN: 'https://' + ORIGINAL_HOST + HTTPS_PORT_ELIDED,
     HTTPS_ORIGIN_WITH_CREDS: 'https://foo:bar@' + ORIGINAL_HOST + HTTPS_PORT_ELIDED,
     HTTP_ORIGIN_WITH_DIFFERENT_PORT: 'http://' + ORIGINAL_HOST + HTTP_PORT2_ELIDED,
+    REMOTE_ORIGIN: PROTOCOL + "//" + REMOTE_HOST + PORT_ELIDED,
     HTTP_REMOTE_ORIGIN: 'http://' + REMOTE_HOST + HTTP_PORT_ELIDED,
     HTTP_NOTSAMESITE_ORIGIN: 'http://' + NOTSAMESITE_HOST + HTTP_PORT_ELIDED,
     HTTP_REMOTE_ORIGIN_WITH_DIFFERENT_PORT: 'http://' + REMOTE_HOST + HTTP_PORT2_ELIDED,

--- a/resource-timing/crossorigin-sandwich-TAO.sub.html
+++ b/resource-timing/crossorigin-sandwich-TAO.sub.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8" />
 <title>This test validates resource timing information for a same-origin=>cross-origin=>same-origin redirect chain with Timing-Allow-Origin.</title>
-<link rel="author" title="Intel" href="http://www.intel.com/" />
 <link rel="help" href="http://www.w3.org/TR/resource-timing/#performanceresourcetiming"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -19,8 +18,7 @@
 
     function onload_test()
     {
-        const context = new PerformanceContext(performance);
-        const entries = context.getEntriesByName(document.getElementById('frameContext').src, 'resource');
+        const entries = performance.getEntriesByName(document.getElementById('frameContext').src, 'resource');
         test_equals(entries.length, 1, 'There should be one entry.');
         const entry = entries[0];
 

--- a/resource-timing/crossorigin-sandwich-TAO.sub.html
+++ b/resource-timing/crossorigin-sandwich-TAO.sub.html
@@ -7,14 +7,15 @@
 <link rel="help" href="http://www.w3.org/TR/resource-timing/#performanceresourcetiming"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="resources/webperftestharness.js"></script>
 <script src="resources/webperftestharnessextension.js"></script>
 
 <script>
     setup({explicit_done: true});
     test_namespace('getEntriesByName');
-    const pageOrigin = "{{host}}:{{ports[http][0]}}"
-    const crossOrigin = "{{domains[www]}}:{{ports[http][0]}}"
+    const pageOrigin = get_host_info()['ORIGIN'];
+    const crossOrigin = get_host_info()['REMOTE_ORIGIN'];
 
     function onload_test()
     {
@@ -35,10 +36,10 @@
 <body>
 <iframe id="frameContext" src="" style="width: 250px; height: 250px;"></iframe>
 <script>
-    let destUrl = 'http://' + pageOrigin + '/resource-timing/resources/multi_redirect.py?';
-    destUrl += 'page_origin=' + 'http://' + pageOrigin;
+    let destUrl = pageOrigin + '/resource-timing/resources/multi_redirect.py?';
+    destUrl += 'page_origin=' + pageOrigin;
     destUrl += '&timing_allow=1';
-    destUrl += '&cross_origin=' + 'http://' + crossOrigin;
+    destUrl += '&cross_origin=' + crossOrigin;
     const frameContext = document.getElementById('frameContext');
     frameContext.onload = onload_test;
     frameContext.src = destUrl;

--- a/resource-timing/crossorigin-sandwich-TAO.sub.html
+++ b/resource-timing/crossorigin-sandwich-TAO.sub.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>This test validates resource timing information for a same-origin=>cross-origin=>same-origin redirect chain with Timing-Allow-Origin.</title>
+<link rel="author" title="Intel" href="http://www.intel.com/" />
+<link rel="help" href="http://www.w3.org/TR/resource-timing/#performanceresourcetiming"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/webperftestharness.js"></script>
+<script src="resources/webperftestharnessextension.js"></script>
+
+<script>
+    setup({explicit_done: true});
+    test_namespace('getEntriesByName');
+    const pageOrigin = "{{host}}:{{ports[http][0]}}"
+    const crossOrigin = "{{domains[www]}}:{{ports[http][0]}}"
+
+    function onload_test()
+    {
+        const context = new PerformanceContext(performance);
+        const entries = context.getEntriesByName(document.getElementById('frameContext').src, 'resource');
+        test_equals(entries.length, 1, 'There should be one entry.');
+        const entry = entries[0];
+
+        test_greater_than(entry.redirectStart, 0, 'redirectStart > 0 in cross-origin redirect with Timing-Allow-Origin.');
+        test_greater_than(entry.redirectEnd, 0, 'redirectEnd > 0 in cross-origin redirect with Timing-Allow-Origin.');
+        test_greater_than(entry.fetchStart, 0, 'fetchStart > 0 in cross-origin redirect.');
+        test_greater_than(entry.fetchStart, entry.startTime, 'startTime < fetchStart in cross-origin redirect with Timing-Allow-Origin.');
+        done();
+    }
+</script>
+
+</head>
+<body>
+<iframe id="frameContext" src="" style="width: 250px; height: 250px;"></iframe>
+<script>
+    let destUrl = 'http://' + pageOrigin + '/resource-timing/resources/multi_redirect.py?';
+    destUrl += 'page_origin=' + 'http://' + pageOrigin;
+    destUrl += '&timing_allow=1';
+    destUrl += '&cross_origin=' + 'http://' + crossOrigin;
+    const frameContext = document.getElementById('frameContext');
+    frameContext.onload = onload_test;
+    frameContext.src = destUrl;
+</script>
+</body>
+</html>

--- a/resource-timing/crossorigin-sandwich-no-TAO.sub.html
+++ b/resource-timing/crossorigin-sandwich-no-TAO.sub.html
@@ -2,8 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8" />
-<title>This test validates resource timing information for a same-origin=>cross-origin=>same-origin redirect chain with Timing-Allow-Origin.</title>
-<link rel="author" title="Intel" href="http://www.intel.com/" />
+<title>This test validates resource timing information for a same-origin=>cross-origin=>same-origin redirect chain without Timing-Allow-Origin.</title>
 <link rel="help" href="http://www.w3.org/TR/resource-timing/#performanceresourcetiming"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -19,8 +18,7 @@
 
     function onload_test()
     {
-        const context = new PerformanceContext(performance);
-        const entries = context.getEntriesByName(document.getElementById('frameContext').src, 'resource');
+        const entries = performance.getEntriesByName(document.getElementById('frameContext').src, 'resource');
         test_equals(entries.length, 1, 'There should be one entry.');
         const entry = entries[0];
 

--- a/resource-timing/crossorigin-sandwich-no-TAO.sub.html
+++ b/resource-timing/crossorigin-sandwich-no-TAO.sub.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>This test validates resource timing information for a same-origin=>cross-origin=>same-origin redirect chain with Timing-Allow-Origin.</title>
+<link rel="author" title="Intel" href="http://www.intel.com/" />
+<link rel="help" href="http://www.w3.org/TR/resource-timing/#performanceresourcetiming"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/webperftestharness.js"></script>
+<script src="resources/webperftestharnessextension.js"></script>
+
+<script>
+    setup({explicit_done: true});
+    test_namespace('getEntriesByName');
+    const pageOrigin = "{{host}}:{{ports[http][0]}}"
+    const crossOrigin = "{{domains[www]}}:{{ports[http][0]}}"
+
+    function onload_test()
+    {
+        const context = new PerformanceContext(performance);
+        const entries = context.getEntriesByName(document.getElementById('frameContext').src, 'resource');
+        test_equals(entries.length, 1, 'There should be one entry.');
+        const entry = entries[0];
+
+        test_equals(entry.redirectStart, 0, 'redirectStart == 0 in cross-origin redirect with no Timing-Allow-Origin.');
+        test_equals(entry.redirectEnd, 0, 'redirectEnd == 0 in cross-origin redirect with no Timing-Allow-Origin.');
+        test_greater_than(entry.fetchStart, 0, 'fetchStart > 0 in cross-origin redirect.');
+        test_equals(entry.fetchStart, entry.startTime, 'startTime == fetchStart in cross-origin redirect with no Timing-Allow-Origin.');
+        done();
+    }
+</script>
+
+</head>
+<body>
+<iframe id="frameContext" src="" style="width: 250px; height: 250px;"></iframe>
+<script>
+    let destUrl = 'http://' + pageOrigin + '/resource-timing/resources/multi_redirect.py?';
+    destUrl += 'page_origin=' + 'http://' + pageOrigin;
+    destUrl += '&cross_origin=' + 'http://' + crossOrigin;
+    const frameContext = document.getElementById('frameContext');
+    frameContext.onload = onload_test;
+    frameContext.src = destUrl;
+</script>
+</body>
+</html>

--- a/resource-timing/crossorigin-sandwich-no-TAO.sub.html
+++ b/resource-timing/crossorigin-sandwich-no-TAO.sub.html
@@ -7,14 +7,15 @@
 <link rel="help" href="http://www.w3.org/TR/resource-timing/#performanceresourcetiming"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="resources/webperftestharness.js"></script>
 <script src="resources/webperftestharnessextension.js"></script>
 
 <script>
     setup({explicit_done: true});
     test_namespace('getEntriesByName');
-    const pageOrigin = "{{host}}:{{ports[http][0]}}"
-    const crossOrigin = "{{domains[www]}}:{{ports[http][0]}}"
+    const pageOrigin = get_host_info()['ORIGIN'];
+    const crossOrigin = get_host_info()['REMOTE_ORIGIN'];
 
     function onload_test()
     {
@@ -35,9 +36,9 @@
 <body>
 <iframe id="frameContext" src="" style="width: 250px; height: 250px;"></iframe>
 <script>
-    let destUrl = 'http://' + pageOrigin + '/resource-timing/resources/multi_redirect.py?';
-    destUrl += 'page_origin=' + 'http://' + pageOrigin;
-    destUrl += '&cross_origin=' + 'http://' + crossOrigin;
+    let destUrl = pageOrigin + '/resource-timing/resources/multi_redirect.py?';
+    destUrl += 'page_origin=' + pageOrigin;
+    destUrl += '&cross_origin=' + crossOrigin;
     const frameContext = document.getElementById('frameContext');
     frameContext.onload = onload_test;
     frameContext.src = destUrl;

--- a/resource-timing/resources/multi_redirect.py
+++ b/resource-timing/resources/multi_redirect.py
@@ -21,7 +21,7 @@ def main(request, response):
         timing_allow = request.GET.first("timing_allow")
 
     redirect_url_path = "/resource-timing/resources/multi_redirect.py?"
-    redirect_url_path+= "page_origin=" + page_origin
+    redirect_url_path += "page_origin=" + page_origin
     redirect_url_path += "&cross_origin=" + cross_origin
     redirect_url_path += "&timing_allow=" + timing_allow
     redirect_url_path += "&step="

--- a/resource-timing/resources/multi_redirect.py
+++ b/resource-timing/resources/multi_redirect.py
@@ -13,27 +13,31 @@ def main(request, response):
         except ValueError:
             pass
 
+    origin = request.url_parts.scheme + "://" + request.url_parts.hostname + ":" + str(request.url_parts.port)
     page_origin = request.GET.first("page_origin")
     cross_origin = request.GET.first("cross_origin")
     timing_allow = "0"
     if "timing_allow" in request.GET:
         timing_allow = request.GET.first("timing_allow")
 
-    redirect_url = "/resource-timing/resources/multi_redirect.py?"
-    redirect_url += "page_origin=" + page_origin
-    redirect_url += "&cross_origin=" + cross_origin
-    redirect_url += "&timing_allow=" + timing_allow
-    redirect_url += "&step="
+    redirect_url_path = "/resource-timing/resources/multi_redirect.py?"
+    redirect_url_path+= "page_origin=" + page_origin
+    redirect_url_path += "&cross_origin=" + cross_origin
+    redirect_url_path += "&timing_allow=" + timing_allow
+    redirect_url_path += "&step="
 
     if step == 1:
-        redirect_url = cross_origin + redirect_url + "2"
-        if timing_allow != "0":
+        # On the first request, redirect to a cross origin URL
+        redirect_url = cross_origin + redirect_url_path + "2"
+        if timing_allow != "0" and origin != page_origin:
             response.headers.set("timing-allow-origin", page_origin)
     elif step == 2:
-        redirect_url = page_origin + redirect_url + "3"
+        # On the second request, redirect to a same origin URL
+        redirect_url = page_origin + redirect_url_path + "3"
         if timing_allow != "0":
             response.headers.set("timing-allow-origin", page_origin)
     else:
+        # On the third request, redirect to a static response
         redirect_url = page_origin + "/resource-timing/resources/blank_page_green.htm"
 
     response.status = 302


### PR DESCRIPTION
Add a test to make sure that a Same-Origin=>Cross-Origin=>Same-origin redirection chain is not exposing timing information unless Timing-Allow-Origin is set.

Partially fixes https://github.com/w3c/resource-timing/issues/152