### PR TITLE
[docs] Deprecate `async_test`

### DIFF
--- a/docs/_writing-tests/testharness-api.md
+++ b/docs/_writing-tests/testharness-api.md
@@ -66,7 +66,7 @@ The function passed in is run in the `test()` call.
 test. Currently it is only used to provide test-specific
 metadata, as described in the [metadata](#metadata) section below.
 
-## Asynchronous Tests ##
+## **DEPRECATED** Asynchronous Tests ##
 
 Testing asynchronous features is somewhat more complex since the result of
 a test may depend on one or more events or other callbacks. The API provided
@@ -152,6 +152,11 @@ document.documentElement.addEventListener("DOMContentLoaded",
 
 Keep in mind that other tests could start executing before an Asynchronous
 Test is finished.
+
+This is deprecated because the `step`-based API introduces overhead which is
+difficult to maintain. New asynchronous tests should be defined using
+`promise_test` instead (see also the `EventWatcher` interface for succinctly
+testing evented APIs with promises).
 
 ## Promise Tests ##
 


### PR DESCRIPTION
This may be a little too aggressive. [We know that test contributors dislike the `step`-based API of `async_test`](http://lists.w3.org/Archives/Public/public-test-infra/2018JulSep/0011.html), but [using `promise_test` for a callback-driven API carries it's own overhead](http://lists.w3.org/Archives/Public/public-test-infra/2018OctDec/0000.html). The web platform may not be sufficiently Promise-based to make `promise_test` an ergonomic default. There may also be other reasons to keep `async_test` around (e.g. cases where parallel testing is a hard requirement). A pull request seemed like the best way to prompt the discussion.