### PR TITLE
Add iterable checking for response content

### DIFF
--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -193,6 +193,17 @@ class TestFunctionHandler(TestUsingServer):
         assert "Content-Length" not in resp.info()
         assert resp.read() == b""
 
+    def test_non_iterable_content(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.content = 1234
+            return response
+
+        route = ("GET", "/non_iterable_rv", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1])
+        self.assertEqual(500, resp.getcode())
+
 
 @pytest.mark.xfail((3,) <= sys.version_info < (3, 6), reason="wptserve only works on Py2")
 class TestJSONHandler(TestUsingServer):

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, Iterable
 from datetime import datetime, timedelta
 from six.moves.http_cookies import BaseCookie, Morsel
 import json
@@ -183,6 +183,9 @@ class Response(object):
         True, the entire content of the file will be returned as a string facilitating
         non-streaming operations like template substitution.
         """
+        if not isinstance(self.content, Iterable) and not hasattr(self.content, "read"):
+            raise TypeError("Response content must be an iterable or file-like object!")
+
         if isinstance(self.content, binary_type):
             yield self.content
         elif isinstance(self.content, text_type):

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, Iterable
+from collections import OrderedDict
 from datetime import datetime, timedelta
 from six.moves.http_cookies import BaseCookie, Morsel
 import json
@@ -94,6 +94,15 @@ class Response(object):
         else:
             self._status = (int(value), None)
 
+    def can_iter_content(self):
+        try:
+            iter(self.content)
+            return True
+        except TypeError:
+            if hasattr(self.content, "read"):
+                return True
+            return False
+
     def set_cookie(self, name, value, path="/", domain=None, max_age=None,
                    expires=None, secure=False, httponly=False, comment=None):
         """Set a cookie to be sent with a Set-Cookie header in the
@@ -183,9 +192,6 @@ class Response(object):
         True, the entire content of the file will be returned as a string facilitating
         non-streaming operations like template substitution.
         """
-        if not isinstance(self.content, Iterable) and not hasattr(self.content, "read"):
-            raise TypeError("Response content must be an iterable or file-like object!")
-
         if isinstance(self.content, binary_type):
             yield self.content
         elif isinstance(self.content, text_type):

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -268,13 +268,12 @@ class BaseWebTestRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 response.set_error(e.code, e.message)
             except Exception as e:
                 self.respond_with_error(response, e)
-        self.logger.debug("%i %s %s (%s) %i" % (response.status[0],
-                                                request.method,
-                                                request.request_path,
-                                                request.headers.get('Referer'),
-                                                request.raw_input.length))
 
         if not response.writer.content_written:
+            if not response.can_iter_content():
+                self.respond_with_error(response,
+                    "Response content is not iterable!")
+
             response.write()
 
         # If a python handler has been used, the old ones won't send a END_STR data frame, so this
@@ -282,6 +281,11 @@ class BaseWebTestRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         if isinstance(response, H2Response) and not response.writer.stream_ended:
             response.writer.end_stream()
 
+        self.logger.debug("%i %s %s (%s) %i" % (response.status[0],
+                                                request.method,
+                                                request.request_path,
+                                                request.headers.get('Referer'),
+                                                request.raw_input.length))
         # If we want to remove this in the future, a solution is needed for
         # scripts that produce a non-string iterable of content, since these
         # can't set a Content-Length header. A notable example of this kind of


### PR DESCRIPTION
We need check if the response content is iterable before we iterable
over it. Otherwise, it might cause the server hanging. See #8368