### PR TITLE
Add tests for `screenLeft` and `screenTop`

### DIFF
--- a/css/cssom-view/screenLeftTop.html
+++ b/css/cssom-view/screenLeftTop.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-window-screenleft">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-window-screentop">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_equals(typeof window.screenLeft, "number", "screenLeft type");
+  assert_equals(window.screenLeft, window.screenX, "alias of screenX");
+}, "screenLeft");
+
+test(() => {
+  assert_equals(typeof window.screenLeft, "number", "screenTop type");
+  assert_equals(window.screenLeft, window.screenX, "alias of screenY");
+}, "screenTop");
+</script>

--- a/css/cssom-view/screenLeftTop.html
+++ b/css/cssom-view/screenLeftTop.html
@@ -10,7 +10,7 @@ test(() => {
 }, "screenLeft");
 
 test(() => {
-  assert_equals(typeof window.screenLeft, "number", "screenTop type");
-  assert_equals(window.screenLeft, window.screenX, "alias of screenY");
+  assert_equals(typeof window.screenTop, "number", "screenTop type");
+  assert_equals(window.screenTop, window.screenY, "alias of screenY");
 }, "screenTop");
 </script>


### PR DESCRIPTION
Matches https://github.com/w3c/csswg-drafts/pull/2669.

Note that `screenX` and `screenY` themselves aren't tested at all:
https://github.com/web-platform-tests/wpt/issues/5471