### PR TITLE
Make it possible to run webdriver-based Servo from wpt tool

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -711,7 +711,7 @@ class Servo(Browser):
     def version(self, binary):
         """Retrieve the release version of the installed browser."""
         output = call(binary, "--version")
-        m = re.search(r"[0-9\.]+( [a-z]+)?$", output.strip())
+        m = re.search(r"Servo ([0-9\.]+-[a-f0-9]+)?(-dirty)?$", output.strip())
         if m:
             return m.group(0)
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -716,6 +716,10 @@ class Servo(Browser):
             return m.group(0)
 
 
+class ServoWebDriver(Servo):
+    product = "servodriver"
+
+
 class Sauce(Browser):
     """Sauce-specific interface."""
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -414,6 +414,11 @@ class Servo(BrowserSetup):
             kwargs["binary"] = binary
 
 
+class ServoWebDriver(Servo):
+    name = "servodriver"
+    browser_cls = browser.ServoWebDriver
+
+
 class WebKit(BrowserSetup):
     name = "webkit"
     browser_cls = browser.WebKit
@@ -436,7 +441,7 @@ product_setup = {
     "safari": Safari,
     "safari_webdriver": SafariWebDriver,
     "servo": Servo,
-    "servodriver": Servo,
+    "servodriver": ServoWebDriver,
     "sauce": Sauce,
     "opera": Opera,
     "webkit": WebKit,

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -4,7 +4,7 @@ import tempfile
 
 from mozprocess import ProcessHandler
 
-from serve.serve import make_hosts_file
+from tools.serve.serve import make_hosts_file
 
 from .base import Browser, require_arg, get_free_port, browser_command, ExecutorBrowser
 from ..executors import executor_kwargs as base_executor_kwargs


### PR DESCRIPTION
These are changes that were required when I was experimenting with running webdriver-enabled Servo from the `wpt` tool instead of Servo's custom automation.