### PR TITLE
[ci] Filter GitHub pull request events

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -90,67 +90,71 @@ tasks:
                     --total-chunks=${chunk[2]};
     - $if: tasks_for == "github-pull-request"
       then:
-        $map: [{name: firefox, channel: nightly}, {name: chrome, channel: dev}]
-        each(browser):
-          $map:
-            - name: wpt-${browser.name}-${browser.channel}-stability
-              description: >-
-                Verify that all tests affected by a pull request are stable
-                when executed in ${browser.name}.
-              extra_args: '--verify'
-            - name: wpt-${browser.name}-${browser.channel}-results
-              description: >-
-                Collect results for all tests affected by a pull request in
-                ${browser.name}.
-              extra_args: '--no-fail-on-unexpected --log-wptreport=../artifacts/wpt_report.json'
-          each(operation):
-            taskId: {$eval: 'as_slugid(operation.name)'}
-            taskGroupId: {$eval: 'as_slugid("task group")'}
-            created: {$fromNow: ''}
-            deadline: {$fromNow: '24 hours'}
-            provisionerId: aws-provisioner-v1
-            workerType:
-              $if: event.repository.full_name == 'web-platform-tests/wpt'
-              then:
-                wpt-docker-worker
-              else:
-                github-worker
-            metadata:
-              name: ${operation.name}
-              description: ${operation.description}
-              owner: ${event.pull_request.user.login}@users.noreply.github.com
-              source: ${event.repository.url}
-            payload:
-              image: jugglinmike/web-platform-tests:0.21
-              maxRunTime: 7200
-              artifacts:
-                public/results:
-                  path: /home/test/artifacts
-                  type: directory
-              # Fetch the GitHub-provided merge commit (rather than the pull
-              # request branch) so that the tasks simulate the behavior of the
-              # submitted patch after it is merged. Using the merge commit also
-              # simplifies detection of modified files because the first parent
-              # of the merge commit can consistently be used to summarize the
-              # changes.
-              command:
-                - /bin/bash
-                - --login
-                - -c
-                - set -ex;
-                  ~/start.sh
-                    ${event.repository.clone_url}
-                    refs/pull/${event.number}/merge
-                    FETCH_HEAD
-                    ${browser.name}
-                    ${browser.channel};
-                  cd ~/web-platform-tests;
-                  result=0;
-                  ./tools/ci/taskcluster-run.py
-                    --commit-range HEAD^
-                    ${browser.name}
-                    --
-                    --channel=${browser.channel}
-                    ${operation.extra_args} || result=$?;
-                  echo $result > ../artifacts/run-return-code.txt;
-                  echo "Command exited with code $result (failures are allowed while this task is being vetted)."
+        # Taskcluster responds to a number of events issued by the GitHub API
+        # which should not trigger re-validation.
+        $if: event.action in ['opened', 'reopened', 'synchronize']
+        then:
+          $map: [{name: firefox, channel: nightly}, {name: chrome, channel: dev}]
+          each(browser):
+            $map:
+              - name: wpt-${browser.name}-${browser.channel}-stability
+                description: >-
+                  Verify that all tests affected by a pull request are stable
+                  when executed in ${browser.name}.
+                extra_args: '--verify'
+              - name: wpt-${browser.name}-${browser.channel}-results
+                description: >-
+                  Collect results for all tests affected by a pull request in
+                  ${browser.name}.
+                extra_args: '--no-fail-on-unexpected --log-wptreport=../artifacts/wpt_report.json'
+            each(operation):
+              taskId: {$eval: 'as_slugid(operation.name)'}
+              taskGroupId: {$eval: 'as_slugid("task group")'}
+              created: {$fromNow: ''}
+              deadline: {$fromNow: '24 hours'}
+              provisionerId: aws-provisioner-v1
+              workerType:
+                $if: event.repository.full_name == 'web-platform-tests/wpt'
+                then:
+                  wpt-docker-worker
+                else:
+                  github-worker
+              metadata:
+                name: ${operation.name}
+                description: ${operation.description}
+                owner: ${event.pull_request.user.login}@users.noreply.github.com
+                source: ${event.repository.url}
+              payload:
+                image: jugglinmike/web-platform-tests:0.21
+                maxRunTime: 7200
+                artifacts:
+                  public/results:
+                    path: /home/test/artifacts
+                    type: directory
+                # Fetch the GitHub-provided merge commit (rather than the pull
+                # request branch) so that the tasks simulate the behavior of the
+                # submitted patch after it is merged. Using the merge commit also
+                # simplifies detection of modified files because the first parent
+                # of the merge commit can consistently be used to summarize the
+                # changes.
+                command:
+                  - /bin/bash
+                  - --login
+                  - -c
+                  - set -ex;
+                    ~/start.sh
+                      ${event.repository.clone_url}
+                      refs/pull/${event.number}/merge
+                      FETCH_HEAD
+                      ${browser.name}
+                      ${browser.channel};
+                    cd ~/web-platform-tests;
+                    result=0;
+                    ./tools/ci/taskcluster-run.py
+                      --commit-range HEAD^
+                      ${browser.name}
+                      --
+                      --channel=${browser.channel}
+                      ${operation.extra_args} || result=$?;
+                    echo $result > ../artifacts/run-return-code.txt;
+                    echo "Command exited with code $result (failures are allowed while this task is being vetted)."


### PR DESCRIPTION
We've been validating pull requests on Taskcluster far more often than we need to. [This dummy pull request submitted to Bocoup's fork of WPT demonstrates the various events.](https://github.com/bocoup/wpt/pull/8 ) The GitHub UI only displays the latest status, so it's necessary to query the HTTP API to see the complete status history:

    $ curl --silent https://api.github.com/repos/bocoup/wpt/commits/e9dcdf611/statuses | \
      python -c 'import sys, json; print "\n".join(["{created_at} {description}".format(**x) for x in json.loads(sys.stdin.read())])'

<details>
  <summary>output</summary>

    2018-10-16T18:22:02Z TaskGroup: success
    2018-10-16T18:14:49Z The Travis CI build passed
    2018-10-16T18:14:09Z The Travis CI build passed
    2018-10-16T18:09:20Z The Travis CI build is in progress
    2018-10-16T18:08:51Z TaskGroup: success
    2018-10-16T18:08:51Z The Travis CI build is in progress
    2018-10-16T18:08:50Z The Travis CI build is in progress
    2018-10-16T18:08:50Z The Travis CI build is in progress
    2018-10-16T18:08:49Z The Travis CI build is in progress
    2018-10-16T18:08:49Z The Travis CI build is in progress
    2018-10-16T18:08:49Z The Travis CI build is in progress
    2018-10-16T18:08:48Z The Travis CI build is in progress
    2018-10-16T18:08:48Z The Travis CI build is in progress
    2018-10-16T18:08:48Z The Travis CI build is in progress
    2018-10-16T18:08:47Z The Travis CI build is in progress
    2018-10-16T18:08:46Z TaskGroup: Pending (for pull_request.reopened)
    2018-10-16T18:07:59Z TaskGroup: success
    2018-10-16T18:07:53Z TaskGroup: Pending (for pull_request.closed)
    2018-10-16T18:06:55Z TaskGroup: success
    2018-10-16T18:06:49Z TaskGroup: Pending (for pull_request.unassigned)
    2018-10-16T18:06:37Z TaskGroup: success
    2018-10-16T18:06:06Z TaskGroup: Pending (for pull_request.assigned)
    2018-10-16T18:05:25Z TaskGroup: success
    2018-10-16T18:04:56Z TaskGroup: Pending (for pull_request.review_request_removed)
    2018-10-16T18:04:03Z TaskGroup: success
    2018-10-16T18:03:56Z TaskGroup: Pending (for pull_request.review_requested)
    2018-10-16T18:02:06Z TaskGroup: success
    2018-10-16T18:01:55Z TaskGroup: Pending (for pull_request.edited)
    2018-10-16T18:01:51Z TaskGroup: Pending (for pull_request.edited)
    2018-10-16T18:01:07Z The Travis CI build passed

</details>

Validating commits in response to many of these events is inefficient. The response to the "closed" event is particularly concerning.  Many people (and all scripts) delete the base branch immediately after merging a pull request. The subsequent validation attempt cannot run in this state, so it always fails. Because the GitHub UI only displays the latest commit status, this gives a false impression of the status at the moment the patch was accepted (for a real-world example of this, see gh-13045).

[This dummy pull request demonstrates the behavior after this patch is applied.](https://github.com/bocoup/wpt/pull/10)

    $ curl --silent https://api.github.com/repos/bocoup/wpt/commits/03b1b7456a868d50adc/statuses | \
      python -c 'import sys, json; print "\n".join(["{created_at} {description}".format(**x) for x in json.loads(sys.stdin.read())])'

<details>
  <summary>output</summary>

    2018-10-16T20:30:36Z The Travis CI build passed
    2018-10-16T20:28:01Z The Travis CI build passed
    2018-10-16T20:26:25Z The Travis CI build could not complete due to an error
    2018-10-16T20:26:05Z TaskGroup: success
    2018-10-16T20:23:52Z The Travis CI build is in progress
    2018-10-16T20:23:51Z The Travis CI build is in progress
    2018-10-16T20:23:49Z The Travis CI build is in progress
    2018-10-16T20:23:48Z The Travis CI build is in progress
    2018-10-16T20:23:46Z The Travis CI build is in progress
    2018-10-16T20:23:45Z The Travis CI build is in progress
    2018-10-16T20:23:44Z The Travis CI build is in progress
    2018-10-16T20:23:43Z The Travis CI build is in progress
    2018-10-16T20:23:41Z The Travis CI build is in progress
    2018-10-16T20:23:40Z The Travis CI build is in progress
    2018-10-16T20:23:37Z TaskGroup: Pending (for pull_request.reopened)
    2018-10-16T20:22:55Z The Travis CI build is in progress
    2018-10-16T20:21:42Z TaskGroup: success
    2018-10-16T20:20:47Z The Travis CI build is in progress
    2018-10-16T20:20:46Z The Travis CI build is in progress
    2018-10-16T20:20:44Z The Travis CI build is in progress
    2018-10-16T20:20:43Z The Travis CI build is in progress
    2018-10-16T20:20:42Z The Travis CI build is in progress
    2018-10-16T20:20:41Z The Travis CI build is in progress
    2018-10-16T20:20:39Z The Travis CI build is in progress
    2018-10-16T20:20:36Z The Travis CI build is in progress
    2018-10-16T20:20:35Z The Travis CI build is in progress
    2018-10-16T20:20:33Z The Travis CI build is in progress
    2018-10-16T20:20:29Z TaskGroup: Pending (for pull_request.opened)

</details>

> The complete list of event "actions" emitted by GitHub (and recognized
> by Taskcluster) is [1]:
>
> > - assigned
> > - unassigned
> > - labeled
> > - unlabeled
> > - opened
> > - edited
> > - closed
> > - reopened
> > - synchronize
> > - review_requested
> > - review_request_removed
>
> Most of these have no bearing on the code under review, so they should
> not trigger validation.
>
> Do not validate commits in response to irrelevant events.
>
> [1] https://docs.taskcluster.net/docs/reference/integrations/taskcluster-github/references/events
