### PR TITLE
 Make logging on taskcluster more space efficient

### DIFF
--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -31,10 +31,12 @@ def find_wptreport(args):
     return parser.parse_known_args(args)[0].log_wptreport
 
 
-def gzip_file(filename):
+def gzip_file(filename, delete_original=True):
     with open(filename, 'rb') as f_in:
         with gzip.open('%s.gz' % filename, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
+    if delete_original:
+        os.unlink(filename)
 
 
 def main(product, commit_range, wpt_args):
@@ -67,9 +69,8 @@ def main(product, commit_range, wpt_args):
         logger.info("Running all tests")
 
     wpt_args += [
-        "--log-tbpl=../artifacts/log_tbpl.log",
         "--log-tbpl-level=info",
-        "--log-mach=-",
+        "--log-tbpl=-",
         "-y",
         "--no-pause",
         "--no-restart-on-unexpected",


### PR DESCRIPTION
This fixes two issues

 * Remove the uncompressed wptreport artifact after creating a
   compressed one.

 * Use the tbpl format as the stdout logger.

Originally we didn't upload tbpl-format logs at all since they include
screenshot information and can be large. However this was
accidentially enabled when TaskCluster checks for PRs were introduced,
and the screenshots are useful. However the logs are rather large and
uncompressed. Explicitly compressing them like we do for
wptreport.json doesn't work well with the reftest analyzer since it
expects an uncompressed log url. However the logs written to stdout
are automatically compressed and served with the appropriate headers,
so using tbpl logging there gives us both the screenshots and also
more efficient storage. The tradeoff is that these logs are more
verbose than the mach logs (and don't include e.g. a summary) so
there's more to wade through reading the logs.