### PR TITLE
Unbreak resources tests

### DIFF
--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -4,6 +4,7 @@ import os
 import ssl
 
 import html5lib
+import py
 import pytest
 from selenium import webdriver
 from six import text_type
@@ -16,8 +17,10 @@ WPT_ROOT = os.path.normpath(os.path.join(HERE, '..', '..'))
 HARNESS = os.path.join(HERE, 'harness.html')
 TEST_TYPES = ('functional', 'unit')
 
+
 def pytest_addoption(parser):
     parser.addoption("--binary", action="store", default=None, help="path to browser binary")
+
 
 def pytest_collect_file(path, parent):
     if path.ext.lower() != '.html':
@@ -27,6 +30,7 @@ def pytest_collect_file(path, parent):
     test_type = os.path.relpath(str(path), HERE).split(os.path.sep)[1]
 
     return HTMLItem(str(path), test_type, parent)
+
 
 def pytest_configure(config):
     config.driver = webdriver.Firefox(firefox_binary=config.getoption("--binary"))
@@ -46,6 +50,7 @@ def pytest_configure(config):
     config.ssl_context = ssl._create_unverified_context()
     config.add_cleanup(config.server.stop)
 
+
 def resolve_uri(context, uri):
     if uri.startswith('/'):
         base = WPT_ROOT
@@ -55,6 +60,7 @@ def resolve_uri(context, uri):
         path = uri
 
     return os.path.exists(os.path.join(base, path))
+
 
 class HTMLItem(pytest.Item, pytest.Collector):
     def __init__(self, filename, test_type, parent):
@@ -116,7 +122,7 @@ class HTMLItem(pytest.Item, pytest.Collector):
         # This cannot use super(HTMLItem, self).__init__(..) because only the
         # Collector constructor takes the fspath argument.
         pytest.Item.__init__(self, name, parent)
-        pytest.Collector.__init__(self, name, parent, fspath=filename)
+        pytest.Collector.__init__(self, name, parent, fspath=py.path.local(filename))
 
 
     def reportinfo(self):


### PR DESCRIPTION
pytest appears to require that paths are passed in as LocalPath
objects from py.path rather than as strings.