### PR TITLE
Fix a test with missing period after <strong>no red</strong>

### DIFF
--- a/css/CSS2/borders/border-top-width-003.xht
+++ b/css/CSS2/borders/border-top-width-003.xht
@@ -25,7 +25,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is a wide and thin horizontal black line and <strong>no red</strong></p>
+        <p>Test passes if there is a wide and thin horizontal black line and <strong>no red</strong>.</p>
         <div id="wrapper">
             <div id="test"></div>
         </div>

--- a/css/CSS2/selectors/default-attribute-selector-005.xht
+++ b/css/CSS2/selectors/default-attribute-selector-005.xht
@@ -22,7 +22,7 @@
 
  <body>
 
-  <p>Test passes if there is a green stripe and <strong>no red</strong></p>
+  <p>Test passes if there is a green stripe and <strong>no red</strong>.</p>
 
   <p><a>&nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
   &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;</a></p>

--- a/css/CSS2/selectors/default-attribute-selector-006.xht
+++ b/css/CSS2/selectors/default-attribute-selector-006.xht
@@ -22,7 +22,7 @@
 
  <body>
 
-  <p>Test passes if there is a green bar across the page and <strong>no red</strong></p>
+  <p>Test passes if there is a green bar across the page and <strong>no red</strong>.</p>
 
   <form action="">
    <p>&nbsp;</p>

--- a/css/CSS2/selectors/default-attribute-selector-007.xht
+++ b/css/CSS2/selectors/default-attribute-selector-007.xht
@@ -29,7 +29,7 @@
 
  <body>
 
-  <p>Test passes if there is a green square and <strong>no red</strong></p>
+  <p>Test passes if there is a green square and <strong>no red</strong>.</p>
 
   <form action="">
    <p><input></input></p>

--- a/css/CSS2/selectors/default-attribute-selector-008.xht
+++ b/css/CSS2/selectors/default-attribute-selector-008.xht
@@ -29,7 +29,7 @@
 
  <body>
 
-  <p>Test passes if there is a green square and <strong>no red</strong></p>
+  <p>Test passes if there is a green square and <strong>no red</strong>.</p>
 
   <form action="">
    <p><button>&nbsp;</button></p>


### PR DESCRIPTION
That test is border-top-width-003.xht, discovered here:
https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml#logurl=https://taskcluster-artifacts.net/U6OIGr7ZTjurDYjy_KgyCg/0/public/results/log_tbpl.log

default-attribute-selector-*.xht are visual tests, but change them
anyway for consistency with other tests to avoid confusion if anyone
tries to convert them to reftests.