### PR TITLE
[css-exclusions] Inheritance, initial values

### DIFF
--- a/css/css-exclusions/inheritance.html
+++ b/css/css-exclusions/inheritance.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Exclusions properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-exclusions/#property-index">
+<meta name="assert" content="Properties do not inherit.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+assert_not_inherited('wrap-flow', 'auto', 'both');
+assert_not_inherited('wrap-through', 'wrap', 'none');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Properties inherit or not according to the spec.
Properties have initial values according to the spec.
https://drafts.csswg.org/css-exclusions/#property-index