### PR TITLE
Setup logging earlier in the wpt run startup.

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -282,7 +282,7 @@ class Firefox(Browser):
 
             url = self.get_profile_bundle_url(version, channel)
 
-            print("Installing test prefs from %s" % url)
+            logger.info("Installing test prefs from %s" % url)
             try:
                 extract_dir = tempfile.mkdtemp()
                 unzip(get(url).raw, dest=extract_dir)
@@ -294,7 +294,7 @@ class Firefox(Browser):
             finally:
                 shutil.rmtree(extract_dir)
         else:
-            print("Using cached test prefs from %s" % dest)
+            logger.info("Using cached test prefs from %s" % dest)
 
         return dest
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -197,7 +197,7 @@ Install Firefox or use --binary to set the binary path""")
                 logger.info("""Can't find certutil, certificates will not be checked.
 Consider installing certutil via your OS package manager or directly.""")
             else:
-                print("Using certutil %s" % certutil)
+                logger.info("Using certutil %s" % certutil)
 
             kwargs["certutil_binary"] = certutil
 
@@ -208,15 +208,15 @@ Consider installing certutil via your OS package manager or directly.""")
                 install = self.prompt_install("geckodriver")
 
                 if install:
-                    print("Downloading geckodriver")
+                    logger.info("Downloading geckodriver")
                     webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path)
             else:
-                print("Using webdriver binary %s" % webdriver_binary)
+                logger.info("Using webdriver binary %s" % webdriver_binary)
 
             if webdriver_binary:
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
-                print("Unable to find or install geckodriver, skipping wdspec tests")
+                logger.info("Unable to find or install geckodriver, skipping wdspec tests")
                 kwargs["test_types"].remove("wdspec")
 
         if kwargs["prefs_root"] is None:
@@ -253,10 +253,10 @@ class Chrome(BrowserSetup):
                 install = self.prompt_install("chromedriver")
 
                 if install:
-                    print("Downloading chromedriver")
+                    logger.info("Downloading chromedriver")
                     webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path)
             else:
-                print("Using webdriver binary %s" % webdriver_binary)
+                logger.info("Using webdriver binary %s" % webdriver_binary)
 
             if webdriver_binary:
                 kwargs["webdriver_binary"] = webdriver_binary
@@ -287,10 +287,10 @@ class ChromeAndroid(BrowserSetup):
                 install = self.prompt_install("chromedriver")
 
                 if install:
-                    print("Downloading chromedriver")
+                    logger.info("Downloading chromedriver")
                     webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path)
             else:
-                print("Using webdriver binary %s" % webdriver_binary)
+                logger.info("Using webdriver binary %s" % webdriver_binary)
 
             if webdriver_binary:
                 kwargs["webdriver_binary"] = webdriver_binary
@@ -310,10 +310,10 @@ class Opera(BrowserSetup):
                 install = self.prompt_install("operadriver")
 
                 if install:
-                    print("Downloading operadriver")
+                    logger.info("Downloading operadriver")
                     webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path)
             else:
-                print("Using webdriver binary %s" % webdriver_binary)
+                logger.info("Using webdriver binary %s" % webdriver_binary)
 
             if webdriver_binary:
                 kwargs["webdriver_binary"] = webdriver_binary
@@ -454,17 +454,11 @@ product_setup = {
 }
 
 
-def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
-    from wptrunner import wptrunner, wptcommandline
+def setup_logging(kwargs):
     import mozlog
+    from wptrunner import wptrunner
 
     global logger
-
-    kwargs = utils.Kwargs(kwargs.iteritems())
-
-    product_parts = kwargs["product"].split(":")
-    kwargs["product"] = product_parts[0]
-    sub_product = product_parts[1:]
 
     # Use the grouped formatter by default where mozlog 3.9+ is installed
     if hasattr(mozlog.formatters, "GroupingFormatter"):
@@ -473,6 +467,16 @@ def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
         default_formatter = "mach"
     wptrunner.setup_logging(kwargs, {default_formatter: sys.stdout})
     logger = wptrunner.logger
+
+
+def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
+    from wptrunner import wptcommandline
+
+    kwargs = utils.Kwargs(kwargs.iteritems())
+
+    product_parts = kwargs["product"].split(":")
+    kwargs["product"] = product_parts[0]
+    sub_product = product_parts[1:]
 
     check_environ(kwargs["product"])
     args_general(kwargs)
@@ -516,6 +520,8 @@ def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
 
 
 def run(venv, **kwargs):
+    setup_logging(kwargs)
+
     # Remove arguments that aren't passed to wptrunner
     prompt = kwargs.pop("prompt", True)
     install_browser = kwargs.pop("install_browser", False)

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -39,6 +39,11 @@ def venv():
     shutil.rmtree(venv.path)
 
 
+@pytest.fixture(scope="module")
+def logger():
+    run.setup_logging({})
+
+
 @pytest.mark.parametrize("platform", ["Windows", "Linux", "Darwin"])
 def test_check_environ_fail(platform):
     m_open = mock.mock_open(read_data=b"")
@@ -53,7 +58,7 @@ def test_check_environ_fail(platform):
 
 
 @pytest.mark.parametrize("product", product_list)
-def test_setup_wptrunner(venv, product):
+def test_setup_wptrunner(venv, logger, product):
     parser = run.create_parser()
     kwargs = vars(parser.parse_args(["--channel=nightly", product]))
     kwargs["prompt"] = False

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -15,15 +15,13 @@ from mozlog import structured
 manifest = None
 manifest_update = None
 download_from_github = None
-manifest_log = None
 
 def do_delayed_imports():
     # This relies on an already loaded module having set the sys.path correctly :(
-    global manifest, manifest_update, download_from_github, manifest_log
+    global manifest, manifest_update, download_from_github
     from manifest import manifest
     from manifest import update as manifest_update
     from manifest.download import download_from_github
-    from manifest import log as manifest_log
 
 
 class TestChunker(object):
@@ -406,7 +404,6 @@ class ManifestLoader(object):
     def update_manifest(self, manifest_path, tests_path, url_base="/",
                         recreate=False, download=False):
         self.logger.info("Updating test manifest %s" % manifest_path)
-        manifest_log.setup()
 
         json_data = None
         if download:


### PR DESCRIPTION
Curerntly we wait until we're setting up wptrunner kwargs to create the logger.
But that's pretty silly; we should set up the logger first thing and then use it
consistently to log during the setup phase.