### PR TITLE
Ignore includers of untested mixins

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -305,7 +305,13 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
                 if (parsed[dep_type]) {
                     const inheriting = parsed[dep_type];
                     const inheritor = parsed.name || parsed.target;
-                    for (const dep of [inheriting, inheritor]) {
+                    const deps = [inheriting];
+                    // For A includes B, we can ignore A unless B is being tested.
+                    if (dep_type !== "includes"
+                        || (inheriting in this.members && !this.members[inheriting].untested)) {
+                        deps.push(inheritor);
+                    }
+                    for (const dep of deps) {
                         new_options.only.push(dep);
                         all_deps.add(dep);
                         follow_up.add(dep);
@@ -320,7 +326,7 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
                     next.forEach(process);
                 }
             }
-        });
+        }.bind(this));
     }.bind(this);
 
     for (let parsed of parsed_idls) {


### PR DESCRIPTION
Fix for #13598 

Specific example: `Window includes WindowOrWorkerGlobalScope`, as does `WorkerGlobalScope`, but we don't need to test `WorkerGlobalScope`.