### PR TITLE
Reduce text-sizing dependency & use clearer colors in reftest flex-flexitem-percentage-prescation.html

### DIFF
--- a/css/css-flexbox/flex-flexitem-percentage-prescation.html
+++ b/css/css-flexbox/flex-flexitem-percentage-prescation.html
@@ -6,18 +6,18 @@
 	<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-items">
 	<link rel="match" href="reference/flex-flexitem-percentage-prescation-ref.html">
 	<meta name="flags" content="" />
-	<meta name="assert" content="no blue color could be seen." />
+	<meta name="assert" content="no red color could be seen." />
     <style type="text/css">
     #test
     {
-        background: blue;
+        background: red;
         display: flex;
         height:300px;
         width:101px;
     }
     p {
         flex:1;
-        background:red;
+        background:olive;
         flex-direction:row;
         margin:0 0 0 0;
     }
@@ -25,8 +25,8 @@
 </head>
 <body>
 	<div id="test">
-        <p style="background:green;">damer</p>
-        <p>damer</p>
+        <p style="background:green;">d</p>
+        <p>d</p>
     </div>
 </body>
 </html>

--- a/css/css-flexbox/reference/flex-flexitem-percentage-prescation-ref.html
+++ b/css/css-flexbox/reference/flex-flexitem-percentage-prescation-ref.html
@@ -7,7 +7,7 @@
     <style>
     #test
     {
-        background: blue;
+        background: red;
         position:relative;
         height:300px;
         width:101px;
@@ -23,8 +23,8 @@
 <body>
 <div id="test">
 	<div id="test">
-        <p style="background:green;top:0px;height:300px;left:0px;height:300px;width:50.5px;">damer</p>
-        <p style="top:0px;left:50.5px;height:300px;background:Red;width:50.5px;">damer</p>
+        <p style="background:green;top:0px;height:300px;left:0px;height:300px;width:50.5px;">d</p>
+        <p style="top:0px;left:50.5px;height:300px;background:olive;width:50.5px;">d</p>
     </div>
 </div>
 </body>


### PR DESCRIPTION
This fixes #13626.

Making two changes to this test here:
 - Reducing the text inside the flex items (s/damer/d/) -- the text imposes an automatic minimum size on the flex item, and if that (somewhat arbitrary) minimum size happens to be larger than the hardcoded 101px/2=50.5px that the test allocates for each item, then the flex items will be a bit wider than the corresponding chunks in the reference case (which have no such automatic minimum size).  The test currently fails in Firefox on my system, for this reason.
 - Adjusting the colors to make it clearer. Until now, the testcase's expected rendering was "green + red should both be visible, and no blue should be visible".  Now, the testcase's expected rendering will be "green + olive should be visible, and no red should be visible."