### PR TITLE
[wptserve] Include server scheme in logging output

### DIFF
--- a/tools/wptserve/wptserve/router.py
+++ b/tools/wptserve/wptserve/router.py
@@ -92,12 +92,13 @@ class Router(object):
     :param routes: Initial routes to add; a list of three item tuples
                    (method, path_pattern, handler_function), defined
                    as for register()
+    :param logger: An instance of the standard library logging API
     """
 
-    def __init__(self, doc_root, routes):
+    def __init__(self, doc_root, routes, logger=None):
         self.doc_root = doc_root
         self.routes = []
-        self.logger = get_logger()
+        self.logger = logger or get_logger()
         for route in reversed(routes):
             self.register(*route)
 


### PR DESCRIPTION
Because multiple server processes are started in parallel, requests logs
for each are interleaved in the parent process. Previously, they shared
the same configuration, so it was not possible to differentiate entries
added by each server process.

Use "child" loggers with names derived from the server scheme so that
each logging entry describes the server from which it originated.

---

Example output (starting the server, requesting http://web-platform.test:8000, then requesting https://web-platform.test:8443):

    [...]

    INFO:web-platform-tests.https:Starting server on web-platform.test:8443
    DEBUG:web-platform-tests.http:GET /
    DEBUG:web-platform-tests.http:Found handler FileHandler
    DEBUG:web-platform-tests.http:200 GET / (None) 0
    DEBUG:web-platform-tests.https:GET /
    DEBUG:web-platform-tests.https:Found handler FileHandler
    DEBUG:web-platform-tests.https:200 GET / (None) 0

[In `master` today, the use of a single logger is clearly intentional](https://github.com/web-platform-tests/wpt/blob/64fed9375cb182a7109797f034a741977af95485/tools/wptserve/wptserve/logger.py). I don't understand the motivation, so I can't tell if introducing so-called "child" loggers is somehow undesirable.

The structure of the code suggests that some consumers might be supplying custom implementations of the `RequestRewriter` and `Router` classes. My preference is to avoid optional parameters when possible, but I've used them here in the interest of maintaining compatibility with those users.