### PR TITLE
Add expectations for Safari in for infrastructure/ tests

### DIFF
--- a/infrastructure/metadata/infrastructure/assumptions/allowed-to-play.html.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/allowed-to-play.html.ini
@@ -1,0 +1,8 @@
+[allowed-to-play.html]
+  expected:
+    if product == "safari" or product == "safari_webdriver": ERROR # https://bugs.webkit.org/show_bug.cgi?id=190775
+
+
+  [<audio> autoplay]
+    expected:
+      if product == "safari" or product == "safari_webdriver": FAIL # https://bugs.webkit.org/show_bug.cgi?id=190775

--- a/infrastructure/metadata/infrastructure/assumptions/html-elements.html.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/html-elements.html.ini
@@ -1,0 +1,9 @@
+[html-elements.html]
+  [Compare CSS span definitions (only valid if pre-reqs pass)]
+    expected:
+      if product == "safari" or product == "safari_webdriver": FAIL # https://webkit.org/show_bug.cgi?id=187052
+
+
+  [Compare CSS div definitions (only valid if pre-reqs pass)]
+    expected:
+      if product == "safari" or product == "safari_webdriver": FAIL # https://webkit.org/show_bug.cgi?id=187052

--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -1,0 +1,4 @@
+[context.any.sharedworker.html]
+  [context]
+    expected:
+      if product == "safari" or product == "safari_webdriver": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850

--- a/infrastructure/metadata/infrastructure/server/order-of-metas.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/order-of-metas.any.js.ini
@@ -1,0 +1,4 @@
+[order-of-metas.any.sharedworker.html]
+  [foo]
+    expected:
+      if product == "safari" or product == "safari_webdriver": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850

--- a/infrastructure/metadata/infrastructure/server/secure-context.https.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/secure-context.https.any.js.ini
@@ -1,0 +1,4 @@
+[secure-context.https.any.sharedworker.html]
+  [secure-context]
+    expected:
+      if product == "safari" or product == "safari_webdriver": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850

--- a/infrastructure/metadata/infrastructure/server/title.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/title.any.js.ini
@@ -1,0 +1,4 @@
+[title.any.sharedworker.html]
+  [foobar]
+    expected:
+      if product == "safari" or product == "safari_webdriver": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850

--- a/infrastructure/metadata/infrastructure/testdriver/actions/elementPosition.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/elementPosition.html.ini
@@ -1,3 +1,3 @@
 [elementPosition.html]
   expected:
-    if product == "chrome": ERROR
+    if product == "chrome" or product == "safari" or product == "safari_webdriver": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/actions/elementTiming.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/elementTiming.html.ini
@@ -1,3 +1,3 @@
 [elementTiming.html]
   expected:
-    if product == "chrome": ERROR
+    if product == "chrome" or product == "safari" or product == "safari_webdriver": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
@@ -1,3 +1,3 @@
 [eventOrder.html]
   expected:
-    if product == "chrome": ERROR
+    if product == "chrome" or product == "safari" or product == "safari_webdriver": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiDevice.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiDevice.html.ini
@@ -1,3 +1,3 @@
 [multiDevice.html]
   expected:
-    if product == "chrome": ERROR
+    if product == "chrome" or product == "safari" or product == "safari_webdriver": ERROR


### PR DESCRIPTION
In preparation for running these tests in CI.

Verified locally with Safari Technology Preview 67:
```
export no_proxy='*'
./wpt run --metadata infrastructure/metadata/ --channel=preview safari infrastructure/
./wpt run --metadata infrastructure/metadata/ --channel=preview safari_webdriver infrastructure/
```

With Safari 12 there are still failures, but we'll not use that in CI.