### PR TITLE
Avoid the use of `readlink -f` in shell scripts

### DIFF
--- a/css/build-css-testsuites.sh
+++ b/css/build-css-testsuites.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/..)
+WPT_ROOT=$(cd $(dirname "$0")/.. && pwd -P)
 cd $WPT_ROOT
 
 main() {

--- a/css/build-css-testsuites.sh
+++ b/css/build-css-testsuites.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/..
 cd $WPT_ROOT
 
 main() {

--- a/tools/ci/ci_built_diff.sh
+++ b/tools/ci/ci_built_diff.sh
@@ -1,6 +1,7 @@
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 main() {

--- a/tools/ci/ci_built_diff.sh
+++ b/tools/ci/ci_built_diff.sh
@@ -1,7 +1,6 @@
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 main() {

--- a/tools/ci/ci_lint.sh
+++ b/tools/ci/ci_lint.sh
@@ -1,7 +1,6 @@
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 mkdir -p ~/meta

--- a/tools/ci/ci_lint.sh
+++ b/tools/ci/ci_lint.sh
@@ -1,6 +1,7 @@
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 mkdir -p ~/meta

--- a/tools/ci/ci_manifest.sh
+++ b/tools/ci/ci_manifest.sh
@@ -1,7 +1,6 @@
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 mkdir -p ~/meta

--- a/tools/ci/ci_manifest.sh
+++ b/tools/ci/ci_manifest.sh
@@ -1,6 +1,7 @@
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 mkdir -p ~/meta

--- a/tools/ci/ci_resources_unittest.sh
+++ b/tools/ci/ci_resources_unittest.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 source tools/ci/lib.sh

--- a/tools/ci/ci_resources_unittest.sh
+++ b/tools/ci/ci_resources_unittest.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 source tools/ci/lib.sh

--- a/tools/ci/ci_stability.sh
+++ b/tools/ci/ci_stability.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 source tools/ci/lib.sh

--- a/tools/ci/ci_stability.sh
+++ b/tools/ci/ci_stability.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 source tools/ci/lib.sh

--- a/tools/ci/ci_tools_unittest.sh
+++ b/tools/ci/ci_tools_unittest.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 run_applicable_tox () {

--- a/tools/ci/ci_tools_unittest.sh
+++ b/tools/ci/ci_tools_unittest.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 run_applicable_tox () {

--- a/tools/ci/ci_wpt.sh
+++ b/tools/ci/ci_wpt.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 source tools/ci/lib.sh

--- a/tools/ci/ci_wpt.sh
+++ b/tools/ci/ci_wpt.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 source tools/ci/lib.sh

--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 source tools/ci/lib.sh

--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 source tools/ci/lib.sh

--- a/tools/ci/install.sh
+++ b/tools/ci/install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 if [[ $RUN_JOB -eq 1 ]]; then

--- a/tools/ci/install.sh
+++ b/tools/ci/install.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 if [[ $RUN_JOB -eq 1 ]]; then

--- a/tools/ci/run.sh
+++ b/tools/ci/run.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
 cd $WPT_ROOT
 
 if [[ $RUN_JOB -eq 1 ]]; then

--- a/tools/ci/run.sh
+++ b/tools/ci/run.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -ex
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+WPT_ROOT=$(cd $(dirname "$0")/../.. && pwd -P)
 cd $WPT_ROOT
 
 if [[ $RUN_JOB -eq 1 ]]; then


### PR DESCRIPTION
This doesn't work on macOS. Replacement taken from:
https://serverfault.com/a/406371

Fixes #7452