### PR TITLE
Remove unused `channel` argument in `Firefox.version`

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -367,9 +367,8 @@ class Firefox(Browser):
 
         return path
 
-    def version(self, binary=None, channel=None):
+    def version(self, binary=None):
         """Retrieve the release version of the installed browser."""
-        binary = binary or self.find_binary(channel)
         version_string = call(binary, "--version").strip()
         m = re.match(r"Mozilla Firefox (.*)", version_string)
         if not m:


### PR DESCRIPTION
The only call site is in at the end of `setup_wptrunner` (run.py) where
no `channel` argument is passed. At that point, `setup_kwargs` has
already been called, which guarantees that `kwargs["binary"]` is set, so
even the fallback `self.find_binary(channel)` (where `channel` would be
`None`) is dead code.