### PR TITLE
[css-scrollbars] Inheritance, initial values

### DIFF
--- a/css/css-scrollbars/inheritance.html
+++ b/css/css-scrollbars/inheritance.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Scrollbars properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars/#property-index">
+<meta name="assert" content="Properties inherit according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+assert_inherited('scrollbar-color', 'auto', 'rgb(1, 2, 3) rgb(4, 5, 6)');
+assert_not_inherited('scrollbar-width', 'auto', 'thin');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Properties inherit or not according to the spec.
Properties have initial values according to the spec.
https://drafts.csswg.org/css-scrollbars/#property-index
