### PR TITLE
[css-multicol] Initial values and inheritance

### DIFF
--- a/css/css-multicol/inheritance.html
+++ b/css/css-multicol/inheritance.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Multi-column Layout properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#property-index">
+<meta name="assert" content="Properties not not inherit.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="reference"></div>
+<div id="container">
+  <div id="target"></div>
+</div>
+<style>
+  #reference {
+    border-style: dotted; /* Avoid border-top-width computed style 0 */
+    border-top-width: medium;
+  }
+  #container {
+    color: rgba(42, 53, 64, 0.75);
+    column-rule-style: dotted; /* Avoid column-rule-width computed style 0 */
+  }
+  #target {
+    column-rule-style: dotted;
+  }
+</style>
+<script>
+const mediumWidth = getComputedStyle(reference).borderTopWidth; // e.g. 3px
+reference.style.display = 'none';
+
+assert_not_inherited('column-count', 'auto', '2');
+assert_not_inherited('column-fill', 'balance', 'auto');
+assert_not_inherited('column-gap', 'normal', '10px');
+assert_not_inherited('column-rule-color', 'rgba(42, 53, 64, 0.75)', 'rgba(2, 3, 5, 0.5)');
+assert_not_inherited('column-rule-style', 'none', 'dashed');
+assert_not_inherited('column-rule-width', mediumWidth, '10px');
+assert_not_inherited('column-span', 'none', 'all');
+assert_not_inherited('column-width', 'auto', '10px');
+</script>
+</body>
+</html>

--- a/css/css-multicol/inheritance.html
+++ b/css/css-multicol/inheritance.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>Inheritance of CSS Multi-column Layout properties</title>
 <link rel="help" href="https://drafts.csswg.org/css-multicol/#property-index">
-<meta name="assert" content="Properties not not inherit.">
+<meta name="assert" content="Properties should not inherit.">
 <meta name="assert" content="Properties have initial values according to the spec.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/support/inheritance-testcommon.js
+++ b/css/support/inheritance-testcommon.js
@@ -10,6 +10,14 @@ function assert_initial(property, initial) {
   }, 'Property ' + property + ' has initial value ' + initial);
 }
 
+/**
+ * Create tests that a CSS property inherits and has the given initial value.
+ *
+ * @param {string} property  The name of the CSS property being tested.
+ * @param {string} initial   The computed value for 'initial'.
+ * @param {string} other     An arbitrary value for the property that round
+ *                           trips and is distinct from the initial value.
+ */
 function assert_inherited(property, initial, other) {
   assert_initial(property, initial);
 
@@ -33,6 +41,15 @@ function assert_inherited(property, initial, other) {
   }, 'Property ' + property + ' inherits');
 }
 
+/**
+ * Create tests that a CSS property does not inherit, and that it has the
+ * given initial value.
+ *
+ * @param {string} property  The name of the CSS property being tested.
+ * @param {string} initial   The computed value for 'initial'.
+ * @param {string} other     An arbitrary value for the property that round
+ *                           trips and is distinct from the initial value.
+ */
 function assert_not_inherited(property, initial, other) {
   assert_initial(property, initial);
 


### PR DESCRIPTION
Test that CSS Multi-column Layout properties have the initial values
given in the spec. None of the properties inherit.

https://drafts.csswg.org/css-multicol/#property-index

Identified bugs:
- https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19367855/
- https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19367975/
- https://bugs.webkit.org/show_bug.cgi?id=190702
