### PR TITLE
Remove reference loop from test clip-path-content-syling.svg.

### DIFF
--- a/css/css-masking/clip-path-svg-content/clip-path-content-syling.svg
+++ b/css/css-masking/clip-path-svg-content/clip-path-content-syling.svg
@@ -9,7 +9,7 @@
 	<desc class="assert">Style properties on content elements of clipPath
 	must be ignored. A green square should be visible.</desc>
 </g>
-<clipPath id="clip1" clip-path="url(#clip1)">
+<clipPath id="clip1">
 	<rect x="50" y="50" width="100" height="100" stroke="black" stroke-wdith="10" stroke-dasharray="10 10" fill="none"/>
 </clipPath>
 <rect width="200" height="200" fill="green" clip-path="url(#clip1)"/>

--- a/css/css-masking/clip-path-svg-content/clip-path-content-syling.svg
+++ b/css/css-masking/clip-path-svg-content/clip-path-content-syling.svg
@@ -10,7 +10,7 @@
 	must be ignored. A green square should be visible.</desc>
 </g>
 <clipPath id="clip1">
-	<rect x="50" y="50" width="100" height="100" stroke="black" stroke-wdith="10" stroke-dasharray="10 10" fill="none"/>
+	<rect x="50" y="50" width="100" height="100" stroke="black" stroke-width="10" stroke-dasharray="10 10" fill="none"/>
 </clipPath>
 <rect width="200" height="200" fill="green" clip-path="url(#clip1)"/>
 </svg>


### PR DESCRIPTION
This test currently has a reference loop (`clip1` is currently specified as being its own `clip-path`).

This is bogus and seems to be accidental -- `clip1` is also used lower down for the actual user-visible business of the test (and nothing about the test's naming or metadata/prose seem to suggest that it intended to exercise clip-path reference loops).

Let's remove the bogus reference loop.