### PR TITLE
Cross origin workers should fail to fetch

### DIFF
--- a/workers/Worker_cross_origin_security_err.htm
+++ b/workers/Worker_cross_origin_security_err.htm
@@ -11,7 +11,7 @@ async_test(function(t) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
-    assert_throws("SecurityError", () => {throw e}, "DOMExceptions thrown on cross-origin worker construction must be SecurityErrors");
+    assert_throws("SecurityError", () => {throw e}, "DOMExceptions thrown on cross-origin Worker construction must be SecurityErrors");
     t.done();
   }
 }, "Cross-origin classic workers should fail to fetch");
@@ -23,7 +23,7 @@ async_test(function(t) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
-    assert_throws("SecurityError", () => {throw e}, "DOMExceptions thrown on cross-origin module worker construction must be SecurityErrors");
+    assert_throws("SecurityError", () => {throw e}, "DOMExceptions thrown on cross-origin module Worker construction must be SecurityErrors");
     t.done();
   }
 }, "Cross-origin module workers should fail to fetch");

--- a/workers/Worker_cross_origin_security_err.htm
+++ b/workers/Worker_cross_origin_security_err.htm
@@ -11,6 +11,7 @@ async_test(function(t) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
+    assert_throws("SecurityError", () => {throw e}, "DOMExceptions thrown on cross-origin worker construction must be SecurityErrors");
     t.done();
   }
 }, "Cross-origin classic workers should fail to fetch");
@@ -22,6 +23,7 @@ async_test(function(t) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
+    assert_throws("SecurityError", () => {throw e}, "DOMExceptions thrown on cross-origin module worker construction must be SecurityErrors");
     t.done();
   }
 }, "Cross-origin module workers should fail to fetch");

--- a/workers/Worker_cross_origin_security_err.htm
+++ b/workers/Worker_cross_origin_security_err.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title> Worker cross-origin URL </title>
+<title>Worker cross-origin URL</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
@@ -11,7 +11,18 @@ async_test(function(t) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
-    t.step_func_done(function(e) { assert_true(true); });
+    assert_unreached("Constructing a cross-origin worker should not synchronously fail. Its error event should be fired instead.");
   }
-});
+}, "Cross-origin classic workers should fail to fetch");
+
+async_test(function(t) {
+  try {
+    var w = new Worker("ftp://example.org/support/WorkerBasic.js", {type: "module"});
+    w.onerror = t.step_func_done(function(e) {
+      assert_true(e instanceof Event);
+    });
+  } catch (e) {
+    assert_unreached("Constructing a cross-origin module worker should not synchronously fail. Its error even should be fired instead.");
+  }
+}, "Cross-origin module workers should fail to fetch");
 </script>

--- a/workers/Worker_cross_origin_security_err.htm
+++ b/workers/Worker_cross_origin_security_err.htm
@@ -11,7 +11,7 @@ async_test(function(t) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
-    assert_unreached("Constructing a cross-origin worker should not synchronously fail. Its error event should be fired instead.");
+    t.done();
   }
 }, "Cross-origin classic workers should fail to fetch");
 
@@ -22,7 +22,7 @@ async_test(function(t) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
-    assert_unreached("Constructing a cross-origin module worker should not synchronously fail. Its error even should be fired instead.");
+    t.done();
   }
 }, "Cross-origin module workers should fail to fetch");
 </script>

--- a/workers/constructors/SharedWorker/same-origin.html
+++ b/workers/constructors/SharedWorker/same-origin.html
@@ -19,7 +19,7 @@ function testSharedWorkerHelper(t, script) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
-    t.step_func_done(function(e) { assert_true(true); });
+    t.done();
   }
 }
 

--- a/workers/constructors/SharedWorker/same-origin.html
+++ b/workers/constructors/SharedWorker/same-origin.html
@@ -3,7 +3,7 @@
 -->
 <!doctype html>
 <title>same-origin checks</title>
-<link rel=help href="http://www.whatwg.org/html/#dom-sharedworker">
+<link rel=help href="https://html.spec.whatwg.org/multipage/workers.html#dom-sharedworker">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
@@ -19,6 +19,7 @@ function testSharedWorkerHelper(t, script) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
+    assert_throws("SecurityError", () => {throw e}, "DOMExceptions thrown on cross-origin SharedWorker construction must be SecurityErrors");
     t.done();
   }
 }

--- a/workers/constructors/Worker/same-origin.html
+++ b/workers/constructors/Worker/same-origin.html
@@ -17,7 +17,7 @@ function testSharedWorkerHelper(t, script) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
-    t.step_func_done(function(e) { assert_true(true); });
+    t.done();
   }
 }
 

--- a/workers/constructors/Worker/same-origin.html
+++ b/workers/constructors/Worker/same-origin.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset=utf-8>
 <title>same-origin checks; the script is in a script element</title>
-<link rel=help href="http://www.whatwg.org/html/#dom-worker">
+<link rel=help href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
@@ -10,13 +10,14 @@
 // not propogate to the window before the tests finish
 setup({allow_uncaught_exception: true});
 
-function testSharedWorkerHelper(t, script) {
+function testWorkerHelper(t, script) {
   try {
-    var worker = new SharedWorker(script, '');
+    var worker = new Worker(script);
     worker.onerror = t.step_func_done(function(e) {
       assert_true(e instanceof Event);
     });
   } catch (e) {
+    assert_throws("SecurityError", () => {throw e}, "DOMExceptions thrown on cross-origin Worker construction must be SecurityErrors");
     t.done();
   }
 }
@@ -33,31 +34,31 @@ async_test(function() {
 }, "data_url");
 
 async_test(function(t) {
-  testSharedWorkerHelper(t, 'about:blank');
+  testWorkerHelper(t, 'about:blank');
 }, "about_blank");
 
 async_test(function(t) {
-  testSharedWorkerHelper(t, 'http://www.example.invalid/');
+  testWorkerHelper(t, 'http://www.example.invalid/');
 }, "example_invalid");
 
 async_test(function(t) {
-  testSharedWorkerHelper(t, location.protocol+'//'+location.hostname+':81/');
+  testWorkerHelper(t, location.protocol+'//'+location.hostname+':81/');
 }, "port_81");
 
 async_test(function(t) {
-  testSharedWorkerHelper(t, 'https://'+location.hostname+':80/');
+  testWorkerHelper(t, 'https://'+location.hostname+':80/');
 }, "https_port_80");
 
 async_test(function(t) {
-  testSharedWorkerHelper(t, 'https://'+location.hostname+':8000/');
+  testWorkerHelper(t, 'https://'+location.hostname+':8000/');
 }, "https_port_8000");
 
 async_test(function(t) {
-  testSharedWorkerHelper(t, 'http://'+location.hostname+':8012/');
+  testWorkerHelper(t, 'http://'+location.hostname+':8012/');
 }, "http_post_8012");
 
 async_test(function(t) {
-  testSharedWorkerHelper(t,'javascript:""');
+  testWorkerHelper(t,'javascript:""');
 }, "javascript_url");
 
 </script>


### PR DESCRIPTION
/cc @domenic @bzbarsky @nhiroki 

Tackle low-hanging fruit in https://github.com/web-platform-tests/wpt/issues/13426.

Prior to this PR, testing that cross-origin workers fail was pretty [grim](https://wpt.fyi/results/workers/Worker_cross_origin_security_err.htm?aligned&label=stable), in that the test basically broke for everyone but Firefox, who seems to be the only conforming implementation here.

It is true that cross-origin workers fail to fetch in all or most implementations, but it seems that every failure is some synchronous security error, as opposed to letting the Fetch naturally result in a failure, and going through the normal means of firing ["an event named error"](https://html.spec.whatwg.org/multipage/workers.html#worker-processing-model:event-error).

This PR fixes the test for non-Firefox-like impls, and extends it to include module workers. I guess I should follow-up with vendors though, to see if they'd be willing to remove their immediate-erroring behavior in favor of letting Fetch naturally fail the request. Is it possible that vendors see cross-origin workers as a big enough security concern such that it's too big a risk to Fetch the doomed request, lest it somehow slip through the cracks and got sent? I just think its odd that a lot of impls are immediately failing cross-origin worker construction, when the spec does never mentions this. Here's where we do it [in Chrome](https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/workers/abstract_worker.cc?sq=package:chromium&g=0&l=52).