### PR TITLE
Update docker image to Ubuntu 18.04

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -61,7 +61,7 @@ tasks:
               owner: ${event.pusher.email}
               source: ${event.repository.url}
             payload:
-              image: jugglinmike/web-platform-tests:0.21
+              image: harjgam/web-platform-tests:0.22
               maxRunTime: 7200
               artifacts:
                 public/results:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # No interactive frontend during docker build
 ENV DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
This is the latest LTS release, so it makes sense to test on it. Also it is a requirement
to get servo builds running in the docker image since 16.04 has a too-old gstreamer.