### PR TITLE
[css-overscroll-behavior] Inheritance, initial

### DIFF
--- a/css/css-overscroll-behavior/META.yml
+++ b/css/css-overscroll-behavior/META.yml
@@ -1,0 +1,3 @@
+spec: https://drafts.csswg.org/css-overscroll-behavior/
+suggested_reviewers:
+  - majido

--- a/css/css-overscroll-behavior/inheritance.html
+++ b/css/css-overscroll-behavior/inheritance.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Overscroll Behavior properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-overscroll-behavior/#property-index">
+<meta name="assert" content="Properties inherit or not according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+assert_not_inherited('overscroll-behavior-x', 'auto', 'contain');
+assert_not_inherited('overscroll-behavior-y', 'auto', 'contain');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Properties inherit or not according to the spec.
Properties have initial values according to the spec.
https://drafts.csswg.org/css-overscroll-behavior/#property-index