### PR TITLE
service workers: Add long timeout to matchall test

### DIFF
--- a/service-workers/service-worker/clients-matchall-order.https.html
+++ b/service-workers/service-worker/clients-matchall-order.https.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <title>Service Worker: Clients.matchAll ordering</title>
+<meta name=timeout content=long>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>


### PR DESCRIPTION
clients-matchall-order.https.html is a slow test because it does a lot of navigations.