### PR TITLE
[css-backgrounds] Initial values and inheritance

### DIFF
--- a/css/css-backgrounds/inheritance.html
+++ b/css/css-backgrounds/inheritance.html
@@ -12,24 +12,25 @@
 </head>
 <body>
 <div id="reference"></div>
+<!-- container and target are used by the functions in inheritance-testcommon.js -->
 <div id="container">
   <div id="target"></div>
 </div>
 <style>
   #reference {
-    column-rule-style: dotted; /* Avoid column-rule-width computed style 0 */
+    column-rule-style: dotted; /* Avoid column-rule-width computed style 0px */
     column-rule-width: medium;
   }
   #container {
-    border-style: solid;
+    border-style: solid; /* Avoid border-*-width computed style 0px */
   }
   #target {
-    border-style: solid;
+    border-style: solid; /* Avoid border-*-width computed style 0px */
   }
 </style>
 <script>
 const transparentColor = 'rgba(0, 0, 0, 0)'; // https://www.w3.org/TR/css-color-3/#transparent
-const mediumWidth = getComputedStyle(reference).columnRuleWidth; // e.g. 3px
+const mediumWidth = getComputedStyle(document.getElementById('reference')).columnRuleWidth; // e.g. 3px
 const currentColor = 'rgb(2, 3, 4)';
 container.style.color = currentColor;
 

--- a/css/css-backgrounds/inheritance.html
+++ b/css/css-backgrounds/inheritance.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Backgrounds and Borders properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#property-index">
+<meta name="assert" content="Properties inherit or not according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="reference"></div>
+<div id="container">
+  <div id="target"></div>
+</div>
+<style>
+  #reference {
+    column-rule-style: dotted; /* Avoid column-rule-width computed style 0 */
+    column-rule-width: medium;
+  }
+  #container {
+    border-style: solid;
+  }
+  #target {
+    border-style: solid;
+  }
+</style>
+<script>
+const transparentColor = 'rgba(0, 0, 0, 0)'; // https://www.w3.org/TR/css-color-3/#transparent
+const mediumWidth = getComputedStyle(reference).columnRuleWidth; // e.g. 3px
+const currentColor = 'rgb(2, 3, 4)';
+container.style.color = currentColor;
+
+
+// assert_not_inherited accepts: property name, expected initial value, another value the property supports.
+assert_not_inherited('background-attachment', 'scroll', 'fixed');
+assert_not_inherited('background-clip', 'border-box', 'padding-box');
+assert_not_inherited('background-color', transparentColor, 'rgb(42, 53, 64)');
+assert_not_inherited('background-image', 'none', 'url("https://example.com/")');
+assert_not_inherited('background-origin', 'padding-box', 'content-box');
+assert_not_inherited('background-position', '0% 0%', '10px 20px');
+assert_not_inherited('background-repeat', 'repeat', 'space round');
+assert_not_inherited('background-size', 'auto', 'contain');
+
+assert_not_inherited('border-bottom-color', currentColor, 'rgb(42, 53, 64)');
+assert_not_inherited('border-bottom-left-radius', '0px', '5px 7%');
+assert_not_inherited('border-bottom-right-radius', '0px', '5px 7%');
+assert_not_inherited('border-bottom-style', 'none', 'dashed');
+assert_not_inherited('border-bottom-width', mediumWidth, '10px');
+
+assert_not_inherited('border-image-outset', '0', '1px 2px 3px 4px');
+assert_not_inherited('border-image-repeat', 'stretch', 'repeat round');
+assert_not_inherited('border-image-slice', '100%', '1% 2% 3% 4% fill');
+assert_not_inherited('border-image-source', 'none', 'url("https://example.com/")');
+assert_not_inherited('border-image-width', '1', '1px 2px 3px 4px');
+
+assert_not_inherited('border-left-color', currentColor, 'rgb(42, 53, 64)');
+assert_not_inherited('border-left-style', 'none', 'dashed');
+assert_not_inherited('border-left-width', mediumWidth, '10px');
+
+assert_not_inherited('border-right-color', currentColor, 'rgb(42, 53, 64)');
+assert_not_inherited('border-right-style', 'none', 'dashed');
+assert_not_inherited('border-right-width', mediumWidth, '10px');
+
+assert_not_inherited('border-top-color', currentColor, 'rgb(42, 53, 64)');
+assert_not_inherited('border-top-left-radius', '0px', '5px 7%');
+assert_not_inherited('border-top-right-radius', '0px', '5px 7%');
+assert_not_inherited('border-top-style', 'none', 'dashed');
+assert_not_inherited('border-top-width', mediumWidth, '10px');
+
+assert_not_inherited('box-shadow', 'none', 'rgb(42, 53, 64) 1px 2px 3px 4px');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Test that CSS Backgrounds and Borders properties have the initial
values given in the spec. None of the properties inherit.

https://drafts.csswg.org/css-backgrounds/

Identified bugs:

repeated keywords in initial value
~https://bugzilla.mozilla.org/show_bug.cgi?id=1501261~

border-image initial values
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19381805/

box-shadow serialization order
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19381950/

border-image-outset initial value
https://bugs.chromium.org/p/chromium/issues/detail?id=898203