### PR TITLE
Add UCS-4 support check for Python in build-css-testsuites.sh

### DIFF
--- a/css/build-css-testsuites.sh
+++ b/css/build-css-testsuites.sh
@@ -35,6 +35,11 @@ main() {
             exit 1
         fi
 
+        if [ `$PYTHON -c 'import sys; print(sys.maxunicode)'` != "1114111" ]; then
+            echo "UCS-4 support for Python is required"
+            exit 1
+        fi
+
         virtualenv -p $PYTHON $VENV || { echo "Please ensure virtualenv is installed"; exit 2; }
     fi
 

--- a/css/build-css-testsuites.sh
+++ b/css/build-css-testsuites.sh
@@ -35,6 +35,7 @@ main() {
             exit 1
         fi
 
+        # The maximum Unicode code point is U+10FFFF = 1114111
         if [ `$PYTHON -c 'import sys; print(sys.maxunicode)'` != "1114111" ]; then
             echo "UCS-4 support for Python is required"
             exit 1


### PR DESCRIPTION
CSS test suite build system requires Python UCS-4 support.
Add this check in css/build-css-testsuites.sh.
Fix: #5504