### PR TITLE
Fix #13699: css-shapes parsing-utils.js doesn't restore fonts properly

### DIFF
--- a/css/css-shapes/shape-outside/values/support/parsing-utils.js
+++ b/css/css-shapes/shape-outside/values/support/parsing-utils.js
@@ -458,15 +458,18 @@ function setupFonts(func) {
             savedValues[key] = document.body.style.getPropertyValue(key);
             document.body.style.setProperty(key, value);
         });
-        func.apply(this, arguments);
-        each(fontProperties, function (key, value) {
-            if (value) {
-                document.body.style.setProperty(key, value);
-            }
-            else {
-                document.body.style.removeProperty(key);
-            }
-        });
+        try {
+            func.apply(this, arguments);
+        } finally {
+            each(savedValues, function (key, value) {
+                if (value) {
+                    document.body.style.setProperty(key, value);
+                }
+                else {
+                    document.body.style.removeProperty(key);
+                }
+            });
+        }
     };
 }
 


### PR DESCRIPTION
Fixes #13699.