### PR TITLE
Modulepreload crossorigin attribute testing

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/credentials.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/credentials.sub.html
@@ -2,11 +2,8 @@
 <meta charset="utf-8">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
 
-<script type="text/javascript">
-host_info = get_host_info();
-
+<script>
 document.cookie = 'same=1';
 
 const setCookiePromise = fetch(

--- a/preload/modulepreload.html
+++ b/preload/modulepreload.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <body>
 <script>
+host_info = get_host_info();
 
 function verifyNumberOfDownloads(url, number) {
     var numDownloads = 0;
@@ -47,6 +49,116 @@ promise_test(function(t) {
         verifyNumberOfDownloads('resources/dummy.js', 1);
     });
 }, 'link rel=modulepreload');
+
+/**
+ * Begin tests to ensure crossorigin value behaves the same on
+ * link rel=modulepreload as it does script elements.
+ */
+promise_test(function(t) {
+    document.cookie = 'same=1';
+    var link = document.createElement('link');
+    link.rel = 'modulepreload';
+    link.crossorigin = 'anonymous';
+    link.href = 'resources/dummy.js?sameOriginAnonymous';
+    return attachAndWaitForLoad(link).then(() => {
+        verifyNumberOfDownloads('resources/dummy.js?sameOriginAnonymous', 1);
+
+        // Verify that <script> doesn't fetch the module again.
+        var script = document.createElement('script');
+        script.type = 'module';
+        script.crossorigin = 'anonymous';
+        script.src = 'resources/dummy.js?sameOriginAnonymous';
+        return attachAndWaitForLoad(script);
+    }).then(() => {
+        verifyNumberOfDownloads('resources/dummy.js?sameOriginAnonymous', 1);
+    });
+}, 'same-origin link rel=modulepreload crossorigin=anonymous');
+
+promise_test(function(t) {
+    var link = document.createElement('link');
+    link.rel = 'modulepreload';
+    link.crossorigin = 'use-credentials';
+    link.href = 'resources/dummy.js?sameOriginUseCredentials';
+    return attachAndWaitForLoad(link).then(() => {
+        verifyNumberOfDownloads('resources/dummy.js?sameOriginUseCredentials', 1);
+
+        // Verify that <script> doesn't fetch the module again.
+        var script = document.createElement('script');
+        script.type = 'module';
+        script.crossorigin = 'use-credentials';
+        script.src = 'resources/dummy.js?sameOriginUseCredentials';
+        return attachAndWaitForLoad(script);
+    }).then(() => {
+        verifyNumberOfDownloads('resources/dummy.js?sameOriginUseCredentials', 1);
+    });
+}, 'same-origin link rel=modulepreload crossorigin=use-credentials');
+
+promise_test(function(t) {
+    const setCookiePromise = fetch(
+        `${host_info.HTTP_REMOTE_ORIGIN}/cookies/resources/set-cookie.py?name=cross&path=/preload/`,
+        {
+          mode: 'no-cors',
+          credentials: 'include',
+        });
+
+    return setCookiePromise.then(() => {
+        var link = document.createElement('link');
+        link.rel = 'modulepreload';
+        link.href = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`;
+        return attachAndWaitForLoad(link);
+    }).then(() => {
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`, 1);
+
+        // Verify that <script> doesn't fetch the module again.
+        var script = document.createElement('script');
+        script.type = 'module';
+        script.src = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`;
+        return attachAndWaitForLoad(script);
+    }).then(() => {
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginNone`, 1);
+    });
+}, 'cross-origin link rel=modulepreload');
+
+promise_test(function(t) {
+    var link = document.createElement('link');
+    link.rel = 'modulepreload';
+    link.crossorigin = 'anonymous';
+    link.href = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`;
+    return attachAndWaitForLoad(link).then(() => {
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`, 1);
+
+        // Verify that <script> doesn't fetch the module again.
+        var script = document.createElement('script');
+        script.type = 'module';
+        script.crossorigin = 'anonymous';
+        script.src = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`;
+        return attachAndWaitForLoad(script);
+    }).then(() => {
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginAnonymous`, 1);
+    });
+}, 'cross-origin link rel=modulepreload crossorigin=anonymous');
+
+promise_test(function(t) {
+    var link = document.createElement('link');
+    link.rel = 'modulepreload';
+    link.crossorigin = 'use-credentials';
+    link.href = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`;
+    return attachAndWaitForLoad(link).then(() => {
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`, 1);
+
+        // Verify that <script> doesn't fetch the module again.
+        var script = document.createElement('script');
+        script.type = 'module';
+        script.crossorigin = 'use-credentials';
+        script.src = `${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`;
+        return attachAndWaitForLoad(script);
+    }).then(() => {
+        verifyNumberOfDownloads(`${host_info.HTTP_REMOTE_ORIGIN}/preload/resources/cross-origin-module.py?crossOriginUseCredentials`, 1);
+    });
+}, 'cross-origin link rel=modulepreload crossorigin=use-credentials');
+/**
+ * End link rel=modulepreload crossorigin attribute tests.
+ */
 
 promise_test(function(t) {
     var link = document.createElement('link');

--- a/preload/resources/cross-origin-module.py
+++ b/preload/resources/cross-origin-module.py
@@ -1,0 +1,9 @@
+def main(request, response):
+    headers = [
+        ("Content-Type", "text/javascript"),
+        ("Access-Control-Allow-Origin", request.headers.get("Origin")),
+        ("Timing-Allow-Origin", request.headers.get("Origin")),
+        ("Access-Control-Allow-Credentials", "true")
+    ]
+
+    return headers, "// Cross-origin module, nothing to see here"


### PR DESCRIPTION
Another piece of https://github.com/web-platform-tests/wpt/issues/13426. This PR tests that preloads made by the following:

 - same-origin modulepreload & script no crossorigin attribute (already tested)
 - same-origin modulepreload & script crossorigin anonymous
 - same-origin modulepreload & script crossorigin use-credentials
 - cross-origin modulepreload & script no crossorigin attribute
 - cross-origin modulepreload & script crossorigin anonymous
 - cross-origin modulepreload & script crossorigin use-credentials

only trigger one request each. This ensures the default credentials/crossorigin attribute behavior is uniform between `<script>` and `<link>`.