### PR TITLE
Add tests for element/attribute name selectors in HTML

### DIFF
--- a/html/semantics/selectors/case-sensitivity-of-selectors/attr-name-selectors.html
+++ b/html/semantics/selectors/case-sensitivity-of-selectors/attr-name-selectors.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<meta charset=utf8>
+<title>CSS attribute name selector case-sensitivity</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+const xhtmlns = "http://www.w3.org/1999/xhtml";
+const svgns = "http://www.w3.org/2000/svg";
+const fakens = "http://example.com/i.made.this.up";
+
+const xhtml_doc = document.implementation.createDocument(xhtmlns, "html", null);
+const svg_doc = document.implementation.createDocument(svgns, "svg", null);
+
+function pretty_print_name(ns, ln) {
+  if (ns === xhtmlns)
+    return "xhtml:" + ln;
+  if (ns === svgns)
+    return "svg:" + ln;
+  if (ns === fakens)
+    return "fakens:" + ln;
+
+  return ns + ":" + ln;
+}
+
+function format_element(el) {
+  return pretty_print_name(el.namespaceURI, el.localName);
+}
+
+function get_strings(s) {
+  switch(s) {
+  case "lower":
+    return ["a", "tspan", "madeupelement", "a\u0301"];
+  case "upper":
+    return ["A", "TSPAN", "MADEUPELEMENT", "A\u0301"];
+  case "lower-nonascii":
+    return ["\u00e5", "\u00e9"];
+  case "upper-nonascii":
+    return ["\u00c5", "\u00c9"];
+  }
+}
+
+function get_test_pair(local, selector) {
+  let locals = get_strings(local);
+  let selectors = get_strings(selector);
+
+  let rv = [];
+  for (let i = 0; i < locals.length; i++)
+    rv.push([locals[i], selectors[i]]);
+
+  return rv;
+}
+
+for (let [doc, isHTML] of [[document, true], [xhtml_doc, false], [svg_doc, false]]) {
+  let doc_name = format_element(doc.documentElement) + " (" + (isHTML ? "HTML" : "XML") + ")";
+
+  let tests = [
+    {
+      local: "lower",
+      selector: "lower",
+      matches: true,
+    },
+    {
+      local: "lower",
+      selector: "upper",
+      matches: false,
+      matchesHTML: true,
+    },
+    {
+      local: "upper",
+      selector: "lower",
+      matches: false,
+    },
+    {
+      local: "upper",
+      selector: "upper",
+      matches: true,
+      matchesHTML: false,
+    },
+    {
+      local: "lower-nonascii",
+      selector: "lower-nonascii",
+      matches: true,
+    },
+    {
+      local: "lower-nonascii",
+      selector: "upper-nonascii",
+      matches: false,
+    },
+    {
+      local: "upper-nonascii",
+      selector: "lower-nonascii",
+      matches: false,
+    },
+    {
+      local: "upper-nonascii",
+      selector: "upper-nonascii",
+      matches: true,
+    },
+  ];
+
+  for (let t of tests) {
+    for (let element_ns of [null, xhtmlns, svgns, fakens]) {
+      for (let ns of [null, xhtmlns, svgns, fakens]) {
+        for (let [local, attr_selector] of get_test_pair(t.local, t.selector)) {
+          selector = "span[" + attr_selector + "]";
+          test(function() {
+            let el = doc.createElementNS(element_ns, "span");
+            doc.documentElement.appendChild(el);
+            this.add_cleanup(function() { el.remove(); });
+            el.setAttributeNS(ns, local, "foobar");
+            let expect_match;
+            if (ns !== null)
+              expect_match = false;
+            else if (element_ns === xhtmlns)
+              expect_match = (isHTML && "matchesHTML" in t ? t.matchesHTML : t.matches);
+            else
+              expect_match = attr_selector === local;
+            assert_equals(doc.querySelector(selector), expect_match ? el : null);
+          }, "match " + selector + " with " + pretty_print_name(ns, local) + " attribute on " + pretty_print_name(element_ns, "span") + " element in " + doc_name);
+        }
+      }
+    }
+  }
+}
+</script>

--- a/html/semantics/selectors/case-sensitivity-of-selectors/element-selectors.html
+++ b/html/semantics/selectors/case-sensitivity-of-selectors/element-selectors.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<meta charset=utf8>
+<title>CSS element selector case-sensitivity</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+const xhtmlns = "http://www.w3.org/1999/xhtml";
+const svgns = "http://www.w3.org/2000/svg";
+const fakens = "http://example.com/i.made.this.up";
+
+const xhtml_doc = document.implementation.createDocument(xhtmlns, "html", null);
+const svg_doc = document.implementation.createDocument(svgns, "svg", null);
+
+function pretty_print_name(ns, ln) {
+  if (ns === xhtmlns)
+    return "xhtml:" + ln;
+  if (ns === svgns)
+    return "svg:" + ln;
+  if (ns === fakens)
+    return "fakens:" + ln;
+
+  return ns + ":" + ln;
+}
+
+function format_element(el) {
+  return pretty_print_name(el.namespaceURI, el.localName);
+}
+
+function get_strings(s) {
+  switch(s) {
+  case "lower":
+    return ["a", "tspan", "madeupelement", "a\u0301"];
+  case "upper":
+    return ["A", "TSPAN", "MADEUPELEMENT", "A\u0301"];
+  case "lower-nonascii":
+    return ["\u00e5", "\u00e9"];
+  case "upper-nonascii":
+    return ["\u00c5", "\u00c9"];
+  }
+}
+
+function get_test_pair(local, selector) {
+  let locals = get_strings(local);
+  let selectors = get_strings(selector);
+
+  let rv = [];
+  for (let i = 0; i < locals.length; i++)
+    rv.push([locals[i], selectors[i]]);
+
+  return rv;
+}
+
+for (let [doc, isHTML] of [[document, true], [xhtml_doc, false], [svg_doc, false]]) {
+  let doc_name = format_element(doc.documentElement) + " (" + (isHTML ? "HTML" : "XML") + ")";
+
+  let tests = [
+    {
+      local: "lower",
+      selector: "lower",
+      matches: true,
+    },
+    {
+      local: "lower",
+      selector: "upper",
+      matches: false,
+      matchesHTML: true,
+    },
+    {
+      local: "upper",
+      selector: "lower",
+      matches: false,
+    },
+    {
+      local: "upper",
+      selector: "upper",
+      matches: true,
+      matchesHTML: false,
+    },
+    {
+      local: "lower-nonascii",
+      selector: "lower-nonascii",
+      matches: true,
+    },
+    {
+      local: "lower-nonascii",
+      selector: "upper-nonascii",
+      matches: false,
+    },
+    {
+      local: "upper-nonascii",
+      selector: "lower-nonascii",
+      matches: false,
+    },
+    {
+      local: "upper-nonascii",
+      selector: "upper-nonascii",
+      matches: true,
+    },
+  ];
+
+  for (let t of tests) {
+    for (let ns of [null, xhtmlns, svgns, fakens]) {
+      for (let [local, selector] of get_test_pair(t.local, t.selector)) {
+        test(function() {
+          let el = doc.createElementNS(ns, local);
+          doc.documentElement.appendChild(el);
+          this.add_cleanup(function() { el.remove(); });
+          let expect_match = (isHTML && ns === xhtmlns && "matchesHTML" in t ? t.matchesHTML : t.matches);
+          assert_equals(doc.querySelector(selector), expect_match ? el : null);
+        }, "match " + selector + " with " + pretty_print_name(ns, local) + " in " + doc_name);
+      }
+    }
+  }
+}
+</script>

--- a/html/semantics/selectors/case-sensitivity-of-selectors/selector-namespace-prefix.html
+++ b/html/semantics/selectors/case-sensitivity-of-selectors/selector-namespace-prefix.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<title>Test whether namespace prefixes are lowercased</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<style>
+@namespace xhtml "http://www.w3.org/1999/xhtml";
+
+xhtml|span {
+    color: rgb(0, 128, 128);
+}
+
+XHTML|span {
+    color: rgb(255, 165, 0);
+}
+
+[xhtml|data-foo] {
+    color: rgb(255, 255, 0);
+}
+
+[XHTML|data-foo] {
+    color: rgb(128, 0, 128);
+}
+</style>
+<span></span>
+<div></div>
+<script>
+test(function() {
+  let span = document.querySelector("span");
+  let cs = window.getComputedStyle(span);
+  assert_equals(cs.color, "rgb(0, 128, 128)");
+}, "element selector");
+
+test(function() {
+  let div = document.querySelector("div");
+  div.setAttributeNS("http://www.w3.org/1999/xhtml", "data-foo", "bar");
+  let cs = window.getComputedStyle(div);
+  assert_equals(cs.color, "rgb(255, 255, 0)");
+}, "attribute selector");
+</script>

--- a/html/semantics/selectors/case-sensitivity-of-selectors/selector-namespace-prefix.html
+++ b/html/semantics/selectors/case-sensitivity-of-selectors/selector-namespace-prefix.html
@@ -15,6 +15,16 @@ XHTML|span {
 </style>
 <span></span>
 <div></div>
+<!--
+
+This is specifically testing whether the namespace prefix gets lowercased when
+comparing element type selectors on HTML elements in HTML documents.
+
+i.e., whether the entire CSS qualified name is lowercased, or whether it's just
+the local part (see element-selectors.html for tests about case-sensitivity of
+the local part)
+
+-->
 <script>
 test(function() {
   let span = document.querySelector("span");

--- a/html/semantics/selectors/case-sensitivity-of-selectors/selector-namespace-prefix.html
+++ b/html/semantics/selectors/case-sensitivity-of-selectors/selector-namespace-prefix.html
@@ -12,14 +12,6 @@ xhtml|span {
 XHTML|span {
     color: rgb(255, 165, 0);
 }
-
-[xhtml|data-foo] {
-    color: rgb(255, 255, 0);
-}
-
-[XHTML|data-foo] {
-    color: rgb(128, 0, 128);
-}
 </style>
 <span></span>
 <div></div>
@@ -29,11 +21,4 @@ test(function() {
   let cs = window.getComputedStyle(span);
   assert_equals(cs.color, "rgb(0, 128, 128)");
 }, "element selector");
-
-test(function() {
-  let div = document.querySelector("div");
-  div.setAttributeNS("http://www.w3.org/1999/xhtml", "data-foo", "bar");
-  let cs = window.getComputedStyle(div);
-  assert_equals(cs.color, "rgb(255, 255, 0)");
-}, "attribute selector");
 </script>


### PR DESCRIPTION
Inspired by https://github.com/whatwg/html/issues/3372. This tests the current spec.