### PR TITLE
Add some missing window properties

### DIFF
--- a/html/browsers/the-window-object/window-properties.https.html
+++ b/html/browsers/the-window-object/window-properties.https.html
@@ -54,6 +54,7 @@ var replaceableAttributes = [
   "parent",
   "external",
   "length",
+  "origin",
 
   // CSSOM-View
   "screen",
@@ -63,6 +64,8 @@ var replaceableAttributes = [
   "pageYOffset",
   "innerWidth",
   "innerHeight",
+  "screenLeft",
+  "screenTop",
   "screenX",
   "screenY",
   "outerWidth",
@@ -92,6 +95,12 @@ var methods = [
   "setInterval",
   "clearInterval",
 
+  // Microtask queuing
+  "queueMicrotask",
+
+  // ImageBitmap
+  "createImageBitmap",
+
   // HTML Editing APIs
   "getSelection",
 
@@ -100,6 +109,10 @@ var methods = [
 
   // CSSOM-View
   "matchMedia",
+  "moveBy",
+  "moveTo",
+  "resizeBy",
+  "resizeTo",
   "scroll",
   "scrollTo",
   "scrollBy"


### PR DESCRIPTION
This test is meant to include all properties specified on `window`, but some from the [WindowOrWorkerGlobalScope mixin](https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope) and [CSSOM View](https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface) are missing.

The added tests all pass in Chrome Canary and Safari TP, while Firefox Nightly fails one due to a missing `queueMicrotask()`-implementation.