### PR TITLE
grid-template-areas serialization

### DIFF
--- a/css/css-grid/parsing/grid-template-areas-valid.html
+++ b/css/css-grid/parsing/grid-template-areas-valid.html
@@ -21,7 +21,7 @@ test_valid_value("grid-template-areas", '"first second" "third ." "1st 2nd" "3rd
 
 // Firefox preserves specific whitespace and full stop sequences.
 // Other browsers consolidate to ' ' and '.'
-test_valid_value("grid-template-areas", '"  a  \t  b  "', '"a b"'); // Fails in Firefox
+test_valid_value("grid-template-areas", '"  a  \t  b  "', ['"a b"', '"  a  \\9   b  "']);
 test_valid_value("grid-template-areas", '"c\td"', ['"c d"', '"c\\9 d"']);
 test_valid_value("grid-template-areas", '"first ..."', ['"first ."', '"first ..."']);
 </script>


### PR DESCRIPTION
The test now captures the serialization used by all 4 main browsers.

Firefox preserves whitespace, serializing tab character as baskslash
nine space.
https://drafts.csswg.org/cssom/#escape-a-character-as-code-point

Other browsers are collapsing whitespace to a single space.