### PR TITLE
[svg] circle radius 0 disables rendering

### DIFF
--- a/svg/shapes/circle-01-ref.svg
+++ b/svg/shapes/circle-01-ref.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+</svg>

--- a/svg/shapes/circle-01.svg
+++ b/svg/shapes/circle-01.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#CircleElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="circle-01-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="r 0 disables rendering."/>
+  </metadata>
+  <circle cx="50" cy="50" r="0" fill="red" stroke="red" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-09.svg
+++ b/svg/shapes/ellipse-09.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="ellipse-04-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="rx or ry 0 disables rendering."/>
+  </metadata>
+  <ellipse cx="30" cy="50" rx="0" ry="10" fill="red" stroke="red" stroke-width="5"/>
+  <ellipse cx="50" cy="50" rx="10" ry="0" fill="red" stroke="red" stroke-width="5"/>
+  <ellipse cx="70" cy="50" rx="0" ry="0" fill="red" stroke="red" stroke-width="5"/>
+</svg>

--- a/svg/shapes/rect-05-ref.svg
+++ b/svg/shapes/rect-05-ref.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+</svg>

--- a/svg/shapes/rect-05.svg
+++ b/svg/shapes/rect-05.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="http://www.w3.org/TR/SVG2/shapes.html#RectElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="rect-05-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="width or height 0 disables rendering."/>
+  </metadata>
+  <rect x="30" y="50" width="0" height="10" fill="red" stroke="red" stroke-width="4"/>
+  <rect x="50" y="50" width="10" height="0" fill="red" stroke="red" stroke-width="4"/>
+  <rect x="70" y="50" width="0" height="0" fill="red" stroke="red" stroke-width="4"/>
+</svg>


### PR DESCRIPTION
A value of 0 for circle r, ellipse rx/ry, rect width/height
disables rendering.

https://www.w3.org/TR/SVG2/shapes.html#CircleElement
https://www.w3.org/TR/SVG2/shapes.html#EllipseElement
https://www.w3.org/TR/SVG2/shapes.html#RectElement