### PR TITLE
Remove unused method `ManagerGroup.is_alive()`

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -818,10 +818,6 @@ class ManagerGroup(object):
             self.pool.add(manager)
         self.wait()
 
-    def is_alive(self):
-        """Boolean indicating whether any manager in the group is still alive"""
-        return any(manager.is_alive() for manager in self.pool)
-
     def wait(self):
         """Wait for all the managers in the group to finish"""
         for item in self.pool:


### PR DESCRIPTION
It's not used internally, and the only `ManagerGroup` instance is
created at `with ManagerGroup(...) as manager_group` in wptrunner.py,
and the method is also not called there.