### PR TITLE
Indent `manager_group` method calls to within the `with` scope

### DIFF
--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -275,8 +275,8 @@ def run_tests(config, test_paths, product, **kwargs):
                             logger.critical("Main thread got signal")
                             manager_group.stop()
                             raise
-                    test_count += manager_group.test_count()
-                    unexpected_count += manager_group.unexpected_count()
+                        test_count += manager_group.test_count()
+                        unexpected_count += manager_group.unexpected_count()
 
                 test_total += test_count
                 unexpected_total += unexpected_count


### PR DESCRIPTION
While variable binding `manager_group` does survive after the `with`
statement, that will be after `__exit__` has been called. That still
works, but there's no reason for the reader to wonder if there's a
difference, whether indentation is intentional.