### PR TITLE
[webdriver]: add checks for execute_script tests recognising promises

### DIFF
--- a/webdriver/tests/execute_script/promise.py
+++ b/webdriver/tests/execute_script/promise.py
@@ -1,0 +1,59 @@
+# META: timeout=long
+
+import pytest
+
+from tests.support.asserts import assert_dialog_handled, assert_error, assert_success
+
+
+def execute_script(session, script, args=None):
+    if args is None:
+        args = []
+    body = {"script": script, "args": args}
+
+    return session.transport.send(
+        "POST", "/session/{session_id}/execute/sync".format(
+            session_id=session.session_id),
+        body)
+
+
+def set_timeouts(session, timeouts):
+    return session.transport.send(
+        "POST", "session/{session_id}/timeouts".format(**vars(session)),
+        timeouts)
+
+
+def test_promise_resolve(session):
+    response = execute_script(session, """
+        return new Promise(
+            (resolve) => setTimeout(
+                () => resolve('foobar'),
+                1
+            )
+        );
+        """)
+    assert_success(response, "foobar")
+
+
+def test_promise_reject(session):
+    response = execute_script(session, """
+        return new Promise(
+            (resolve, reject) => setTimeout(
+                () => reject('some_error'),
+                1
+            )
+        );
+        """)
+    assert_error(response, "some_error")
+
+
+def test_promise_timeout(session):
+    response = set_timeouts(session, {"script": 100})
+    response = execute_script(session, """
+        return new Promise(
+            (resolve) => setTimeout(
+                () => resolve('timeout_error'),
+                200
+            )
+        );
+        """)
+    assert_error(response, "timeout_error")

--- a/webdriver/tests/execute_script/promise.py
+++ b/webdriver/tests/execute_script/promise.py
@@ -30,7 +30,7 @@ def test_promise_resolve_delayed(session):
             )
         );
         """)
-    assert_success(response, "foobar") 
+    assert_success(response, "foobar")
 
 
 def test_promise_all_resolve(session):
@@ -69,6 +69,7 @@ def test_promise_reject_delayed(session):
         """)
     assert_error(response, "javascript error")
 
+
 def test_promise_all_reject(session):
     response = execute_script(session, """
         return Promise.all([
@@ -78,9 +79,11 @@ def test_promise_all_reject(session):
         """)
     assert_error(response, "javascript error")
 
+
 def test_await_promise_reject(session):
     response = execute_script(session, """
         await Promise.reject(new Error('my error'));
+        return 'foo';
         """)
     assert_error(response, "javascript error")
 

--- a/webdriver/tests/execute_script/promise.py
+++ b/webdriver/tests/execute_script/promise.py
@@ -90,7 +90,7 @@ def test_promise_resolve_timeout(session):
     response = execute_script(session, """
         return new Promise(
             (resolve) => setTimeout(
-                () => resolve('success'),
+                () => resolve(),
                 1000
             )
         );

--- a/webdriver/tests/execute_script/promise.py
+++ b/webdriver/tests/execute_script/promise.py
@@ -33,12 +33,29 @@ def test_promise_resolve_delayed(session):
     assert_success(response, "foobar") 
 
 
+def test_promise_all_resolve(session):
+    response = execute_script(session, """
+        return Promise.all([
+            Promise.resolve(1),
+            Promise.resolve(2)
+        ]);
+        """)
+    assert_success(response, [1, 2])
+
+
+def test_await_promise_resolve(session):
+    response = execute_script(session, """
+        const res = await Promise.resolve('foobar');
+        return res;
+        """)
+    assert_success(response, "foobar")
+
+
 def test_promise_reject(session):
     response = execute_script(session, """
         return Promise.reject(new Error('my error'));
         """)
-    assert_error(response, "unknown error")
-    assert response.body["value"]["message"] == "Error: my error"
+    assert_error(response, "javascript error")
 
 
 def test_promise_reject_delayed(session):
@@ -50,8 +67,22 @@ def test_promise_reject_delayed(session):
             )
         );
         """)
-    assert_error(response, "unknown error")
-    assert response.body["value"]["message"] == "Error: my error" 
+    assert_error(response, "javascript error")
+
+def test_promise_all_reject(session):
+    response = execute_script(session, """
+        return Promise.all([
+            Promise.resolve(1),
+            Promise.reject(new Error('error'))
+        ]);
+        """)
+    assert_error(response, "javascript error")
+
+def test_await_promise_reject(session):
+    response = execute_script(session, """
+        await Promise.reject(new Error('my error'));
+        """)
+    assert_error(response, "javascript error")
 
 
 def test_promise_resolve_timeout(session):


### PR DESCRIPTION
I've been come across point 4, 5, 6 and 7 of the `[execute_script](https://w3c.github.io/webdriver/#execute-script)` recognising promises if returned as such and apparently Geckodriver does resolve/reject a promise properly but don't recognise script timeouts for it (see https://github.com/web-platform-tests/wpt/pull/13781#issuecomment-434319629). Chromedriver always returns with status code 200 and `value: {}`.

This is my first stab at this and would love to get initial feedback as it seems that drivers behave differently/inconsistent here which can be either a bug in the driver or in the protocol definition.