### PR TITLE
Call the tools/wpt/ tests simply "tests" (not "unittests")

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
       os: linux
       python: "3.6"
       env: JOB=tools_unittest TOXENV=py36 HYPOTHESIS_PROFILE=ci SCRIPT=tools/ci/ci_tools_unittest.sh
-    - name: "tools/wpt/ unittests"
+    - name: "tools/wpt/ tests"
       if: type = pull_request
       os: linux
       python: "2.7"


### PR DESCRIPTION
The job name is wpt_integration, and tools/ci/ci_wpt.sh both writes
/etc/hosts and installs Chrome, so these are integration tests. But just
call them tests, like for resources/ and infrastructure/.