### PR TITLE
Enable unified plan by default for Chrome Dev

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -264,6 +264,7 @@ class Chrome(BrowserSetup):
         if kwargs["browser_channel"] == "dev":
             logger.info("Automatically turning on experimental features for Chrome Dev")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
+            # TODO(foolip): remove after unified plan is enabled on Chrome stable
             kwargs["binary_args"].append("--enable-features=RTCUnifiedPlanByDefault")
 
         # Allow audio autoplay without a user gesture.

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -264,6 +264,7 @@ class Chrome(BrowserSetup):
         if kwargs["browser_channel"] == "dev":
             logger.info("Automatically turning on experimental features for Chrome Dev")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
+            kwargs["binary_args"].append("--enable-features=RTCUnifiedPlanByDefault")
 
         # Allow audio autoplay without a user gesture.
         kwargs["binary_args"].append("--autoplay-policy=no-user-gesture-required")


### PR DESCRIPTION
As documented in https://webrtc.org/web-apis/chrome/unified-plan/.

The plan is to enable this by default in Chrome 72, which is the current Chrome
Dev version. Enabling it now will make wpt.fyi more accurate reflect the likely
status of Chrome 72. (It's expected this will cause more tests to pass.)