### PR TITLE
Remove ES6 construct from WebDriver element click center point tests

### DIFF
--- a/webdriver/tests/element_click/center_point.py
+++ b/webdriver/tests/element_click/center_point.py
@@ -51,7 +51,7 @@ def square(size):
         <script>
         window.clicks = [];
         let div = document.querySelector("div");
-        div.addEventListener("click", ({{clientX, clientY}}) => window.clicks.push([clientX, clientY]));
+        div.addEventListener("click", function(e) {{ window.clicks.push([e.clientX, e.clientY]) }});
         </script>
         """.format(size=size))
 


### PR DESCRIPTION
Older user agents (read: "Internet Explorer") do not support the
ES6 "fat arrow" construct. Changing the test event handler to the
older function-based syntax.