### PR TITLE
[wptrunner] Improve errors from Selenium

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -266,7 +266,7 @@ class SeleniumRun(object):
             if message:
                 message += "\n"
             message += traceback.format_exc(e)
-            self.result = False, ("INTERNAL-ERROR", e)
+            self.result = False, ("INTERNAL-ERROR", message)
         finally:
             self.result_flag.set()
 


### PR DESCRIPTION
The `message` computed by the Selenium executor was mistakenly unused,
and in its place, a Python exception object was used to communicate
information on the failure. The string representation of Exceptions is
generally terse and less helpful during debugging. Replace with the
intended value which includes a complete stack trace and the name of the
exception's class.

---

Prior to this patch, Python exception which were raised during Selenium-mediated testing would be reported without context. This made debugging difficult, particularly for `KeyError`s, (as in https://github.com/web-platform-tests/results-collection/issues/563):

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 1 checks (1 tests)
    Expected results: 0
    Unexpected results: 1
      test: 1 (1 error)
    
    Unexpected Results
    ------------------
    ERROR /dom/events/CustomEvent.html - 1

With this patch applied, the reported message includes a stack trace and the name of the exception's class:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 1 checks (1 tests)
    Expected results: 0
    Unexpected results: 1
      test: 1 (1 error)
    
    Unexpected Results
    ------------------
    ERROR /dom/events/CustomEvent.html - 1
    Traceback (most recent call last):
      File "/home/mike/projects/bocoup/google-wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorselenium.py", line 259, in _run
        self.result = True, self.func(self.protocol, self.url, self.timeout)
      File "/home/mike/projects/bocoup/google-wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorselenium.py", line 333, in do_testharness
        done, rv = handler(result)
      File "/home/mike/projects/bocoup/google-wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/base.py", line 534, in __call__
        self.logger.debug("Got async callback: %s" % result[1])
    KeyError: 1