### PR TITLE
Ensure that lone surrogates don't appear in wptreport json

### DIFF
--- a/tools/wptrunner/wptrunner/formatters.py
+++ b/tools/wptrunner/wptrunner/formatters.py
@@ -5,7 +5,7 @@ import sys
 from mozlog.structured.formatters.base import BaseFormatter
 
 
-LONE_SURROGATE_RE = re.compile(u"[\uD800-\uDFFFF]")
+LONE_SURROGATE_RE = re.compile(u"[\uD800-\uDFFF]")
 
 
 def surrogate_replacement_ucs4(match):

--- a/tools/wptrunner/wptrunner/formatters.py
+++ b/tools/wptrunner/wptrunner/formatters.py
@@ -1,6 +1,53 @@
 import json
+import re
+import sys
 
 from mozlog.structured.formatters.base import BaseFormatter
+
+
+LONE_SURROGATE_RE = re.compile(u"[\uD800-\uDFFFF]")
+
+
+def surrogate_replacement_ucs4(match):
+    return "U+" + hex(ord(match.group()))[2:]
+
+
+class SurrogateReplacementUcs2(object):
+    def __init__(self):
+        self.skip = False
+
+    def __call__(self, match):
+        char = match.group()
+
+        if self.skip:
+            self.skip = False
+            return char
+
+        is_low = 0xD800 <= ord(char) <= 0xDBFF
+
+        escape = True
+        if is_low:
+            next_idx = match.end()
+            if next_idx < len(match.string):
+                next_char = match.string[next_idx]
+                if 0xDC00 <= ord(next_char) <= 0xDFFF:
+                    escape = False
+
+        if not escape:
+            self.skip = True
+            return char
+
+        return "U+" + hex(ord(match.group()))[2:]
+
+
+if sys.maxunicode == 0x10FFFF:
+    surrogate_replacement = surrogate_replacement_ucs4
+else:
+    surrogate_replacement = SurrogateReplacementUcs2()
+
+
+def replace_lone_surrogate(data):
+    return LONE_SURROGATE_RE.subn(surrogate_replacement, data)[0]
 
 
 class WptreportFormatter(BaseFormatter):
@@ -40,7 +87,7 @@ class WptreportFormatter(BaseFormatter):
 
     def create_subtest(self, data):
         test = self.find_or_create_test(data)
-        subtest_name = data["subtest"]
+        subtest_name = replace_lone_surrogate(data["subtest"])
 
         subtest = {
             "name": subtest_name,
@@ -57,7 +104,7 @@ class WptreportFormatter(BaseFormatter):
         if "expected" in data:
             subtest["expected"] = data["expected"]
         if "message" in data:
-            subtest["message"] = data["message"]
+            subtest["message"] = replace_lone_surrogate(data["message"])
 
     def test_end(self, data):
         test = self.find_or_create_test(data)
@@ -67,7 +114,7 @@ class WptreportFormatter(BaseFormatter):
         if "expected" in data:
             test["expected"] = data["expected"]
         if "message" in data:
-            test["message"] = data["message"]
+            test["message"] = replace_lone_surrogate(data["message"])
 
     def assertion_count(self, data):
         test = self.find_or_create_test(data)

--- a/tools/wptrunner/wptrunner/tests/test_formatters.py
+++ b/tools/wptrunner/wptrunner/tests/test_formatters.py
@@ -4,10 +4,13 @@ import time
 from os.path import dirname, join
 from StringIO import StringIO
 
+import mock
+
 from mozlog import handlers, structuredlog
 
 sys.path.insert(0, join(dirname(__file__), "..", ".."))
 
+from wptrunner import formatters
 from wptrunner.formatters import WptreportFormatter
 
 
@@ -62,3 +65,73 @@ def test_wptreport_run_info_optional(capfd):
     output.seek(0)
     output_obj = json.load(output)
     assert "run_info" not in output_obj or output_obj["run_info"] == {}
+
+
+def test_wptreport_lone_surrogate(capfd):
+    output = StringIO()
+    logger = structuredlog.StructuredLogger("test_a")
+    logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
+
+    # output a bunch of stuff
+    logger.suite_start(["test-id-1"])  # no run_info arg!
+    logger.test_start("test-id-1")
+    logger.test_status("test-id-1",
+                       subtest=u"Name with surrogate\uD800",
+                       status="FAIL",
+                       message=u"\U0001F601 \uDE0A\uD83D")
+    logger.test_end("test-id-1",
+                    status="PASS",
+                    message=u"\uDE0A\uD83D \U0001F601")
+    logger.suite_end()
+
+    # check nothing got output to stdout/stderr
+    # (note that mozlog outputs exceptions during handling to stderr!)
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    # check the actual output of the formatter
+    output.seek(0)
+    output_obj = json.load(output)
+    test = output_obj["results"][0]
+    assert test["message"] == u"U+de0aU+d83d \U0001F601"
+    subtest = test["subtests"][0]
+    assert subtest["name"] == u"Name with surrogateU+d800"
+    assert subtest["message"] == u"\U0001F601 U+de0aU+d83d"
+
+
+def test_wptreport_lone_surrogate_ucs2(capfd):
+    # Since UCS4 is a superset of UCS2 we can meaningfully test the UCS2 code on a
+    # UCS4 build, but not the reverse. However UCS2 is harder to handle and UCS4 is
+    # the commonest (and sensible) configuration, so that's OK.
+    output = StringIO()
+    logger = structuredlog.StructuredLogger("test_a")
+    logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
+
+    with mock.patch.object(formatters, 'surrogate_replacement', formatters.SurrogateReplacementUcs2()):
+        # output a bunch of stuff
+        logger.suite_start(["test-id-1"])  # no run_info arg!
+        logger.test_start("test-id-1")
+        logger.test_status("test-id-1",
+                           subtest=u"Name with surrogate\uD800",
+                           status="FAIL",
+                           message=u"\U0001F601 \uDE0A\uD83D \uD83D\uDE0A")
+        logger.test_end("test-id-1",
+                        status="PASS",
+                        message=u"\uDE0A\uD83D \uD83D\uDE0A \U0001F601")
+        logger.suite_end()
+
+    # check nothing got output to stdout/stderr
+    # (note that mozlog outputs exceptions during handling to stderr!)
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    # check the actual output of the formatter
+    output.seek(0)
+    output_obj = json.load(output)
+    test = output_obj["results"][0]
+    assert test["message"] == u"U+de0aU+d83d \U0001f60a \U0001F601"
+    subtest = test["subtests"][0]
+    assert subtest["name"] == u"Name with surrogateU+d800"
+    assert subtest["message"] == u"\U0001F601 U+de0aU+d83d \U0001f60a"


### PR DESCRIPTION
Python will happily handle "string" data containing codepoints in the surrogate
range. In the JSON output these are always escaped and appear as \uD800 or
similar. That's pretty unfortunate for interop since other languages don't
necessarily support such codepoints not representing a character in the
unicode set in their normal string type. Although it's possible to clean this
up on import it seems more reasonable to ensure that our primary interchange
format is unicode-clean. Therefore this change starts escaping lone surrogates
using the U+ notation so that \uD800 becomed U+D800.

Because Python, this requires two implementations. In UCS4 Python we know that
only lone surrogates should appear in string data; characters outside the BMP
will be represented as a single internal character (*technically* this is
untrue since someone may manually create a string containing a sequence of
surrogates that happens to form a pair; we don't care about handling this
case other than as two unpaired surrogates that happen to be adjacent). In
UCS2 Python surrogates appear in the string data literally, so we need to
check each time we encounter one whether it's a low surrogate followed by
a high surrogate and not escape in that case.