### PR TITLE
location.pathname should return "blank" when there is no browsing con…

### DIFF
--- a/html/browsers/history/the-location-interface/no-browsing-context.window.js
+++ b/html/browsers/history/the-location-interface/no-browsing-context.window.js
@@ -42,7 +42,7 @@ function bcLessLocation() {
   },
   {
     "property": "pathname",
-    "expected": "",
+    "expected": "blank",
     "values": ["/", "x"]
   },
   {


### PR DESCRIPTION
…text

The pathname of "about:blank" is "blank", not "".