### PR TITLE
Remove support for supportedTypes in Payment Request

### DIFF
--- a/payment-request/payment-request-constructor.https.html
+++ b/payment-request/payment-request-constructor.https.html
@@ -283,9 +283,6 @@ test(() => {
       [
         {
           supportedMethods: "https://wpt.fyi/payment-request",
-          data: {
-            supportedTypes: ["debit"],
-          },
         },
       ],
       {


### PR DESCRIPTION
Tests for https://github.com/w3c/payment-method-basic-card/pull/62