### PR TITLE
Remove tests for supportedTypes from basic-card

### DIFF
--- a/payment-method-basic-card/empty-data-manual.https.html
+++ b/payment-method-basic-card/empty-data-manual.https.html
@@ -117,7 +117,7 @@ function runPromiseTest(button, data, expectedCard = visaCredit, expectedAddress
   </li>
   <li>
     <button onclick="runPromiseTest(this, { supportedNetworks: [] });">
-      Returns any card type on any network, because zero length supportedNetworks.
+      Returns a card on any network, because zero length supportedNetworks.
     </button>
   </li>
 </ol>

--- a/payment-method-basic-card/empty-data-manual.https.html
+++ b/payment-method-basic-card/empty-data-manual.https.html
@@ -77,7 +77,7 @@ function runPromiseTest(button, data, expectedCard = visaCredit, expectedAddress
   The test expects the following credit card.
 </p>
 <ol>
-  <li>Add credit card:
+  <li>Add card:
     <dl>
       <dt>Cardholder name:</dt>
       <dd>web platform test</dd>
@@ -112,22 +112,12 @@ function runPromiseTest(button, data, expectedCard = visaCredit, expectedAddress
 <ol>
   <li>
     <button onclick="runPromiseTest(this, {});">
-      When passed BasicCardRequest without members, allow the user to input of any credit card type.
-    </button>
-  </li>
-  <li>
-    <button onclick="runPromiseTest(this, { supportedNetworks: [], supportedTypes: [] });">
-      Returns any card type on any network, because zero length supportedNetworks and supportedTypes.
+      When passed BasicCardRequest without members, allow the user to input of any card type.
     </button>
   </li>
   <li>
     <button onclick="runPromiseTest(this, { supportedNetworks: [] });">
-      Returns any card type on any network, because supportedNetworks is missing and supportedTypes is empty.
-    </button>
-  </li>
-  <li>
-    <button onclick="runPromiseTest(this, { supportedTypes: [] });">
-      Returns any card type on any network missing supportedTypes, and empty supportedNetwork.
+      Returns any card type on any network, because zero length supportedNetworks.
     </button>
   </li>
 </ol>

--- a/payment-method-basic-card/empty-data-manual.https.html
+++ b/payment-method-basic-card/empty-data-manual.https.html
@@ -112,7 +112,7 @@ function runPromiseTest(button, data, expectedCard = visaCredit, expectedAddress
 <ol>
   <li>
     <button onclick="runPromiseTest(this, {});">
-      When passed BasicCardRequest without members, allow the user to input of any card type.
+      When passed BasicCardRequest without members, allow the user to input a card on any network.
     </button>
   </li>
   <li>

--- a/payment-method-basic-card/historical.https.html
+++ b/payment-method-basic-card/historical.https.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Historical Basic Card Changes</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+// https://github.com/w3c/payment-method-basic-card/pull/62
+test(() => {
+  try {
+    new PaymentRequest(
+      [
+        {
+          supportedMethods: "basic-card",
+          supportedTypes: [
+            "this was an enum value once - so this would have thrown",
+          ],
+        },
+      ],
+      { total: { label: "bar", amount: { currency: "BAZ", value: "0" } } }
+    );
+  } catch (err) {
+    assert_unreached("Unexpected error");
+  }
+}, "supportedTypes and BasicCardType enum were removed from the spec");
+</script>


### PR DESCRIPTION
Tests for: 
https://github.com/w3c/payment-method-basic-card/pull/62