### PR TITLE
webkit: provide port name as run info

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -71,7 +71,7 @@ def env_options():
 
 
 def run_info_extras(**kwargs):
-    return {"wk_port": kwargs["webkit_port"]}
+    return {"webkit_port": kwargs["webkit_port"]}
 
 
 class WebKitBrowser(Browser):

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -15,7 +15,8 @@ __wptrunner__ = {"product": "webkit",
                               "wdspec": "WebKitDriverWdspecExecutor"},
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",
-                 "env_options": "env_options"}
+                 "env_options": "env_options",
+                 "run_info_extras": "run_info_extras"}
 
 
 def check_args(**kwargs):
@@ -67,6 +68,10 @@ def env_extras(**kwargs):
 
 def env_options():
     return {}
+
+
+def run_info_extras(**kwargs):
+    return {"wk_port": kwargs["webkit_port"]}
 
 
 class WebKitBrowser(Browser):


### PR DESCRIPTION
For the WebKit product, include the port name inside the run info, under the
'wk_port' key. This will come in handy when disabling tests in metadata files
for specific ports.