### PR TITLE
webkit: add support for the WPE port

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -35,12 +35,13 @@ def capabilities_for_port(server_config, **kwargs):
     if port_name in ["gtk", "wpe"]:
         port_key_map = {"gtk": "webkitgtk"}
         browser_options_port = port_key_map.get(port_name, port_name)
+        browser_options_key = "%s:browserOptions" % browser_options_port
 
         return {
             "browserName": "MiniBrowser",
             "browserVersion": "2.20",
             "platformName": "ANY",
-            "{}:browserOptions".format(browser_options_port): {
+            browser_options_key: {
                 "binary": kwargs["binary"],
                 "args": kwargs.get("binary_args", []),
                 "certificates": [

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -31,22 +31,21 @@ def browser_kwargs(test_type, run_info_data, config, **kwargs):
 
 
 def capabilities_for_port(server_config, **kwargs):
-    if kwargs["webkit_port"] == "gtk":
-        capabilities = {
+    port_name = kwargs["webkit_port"]
+    if port_name in ["gtk", "wpe"]:
+        port_key_map = {"gtk": "webkitgtk"}
+        browser_options_port = port_key_map.get(port_name, port_name)
+
+        return {
             "browserName": "MiniBrowser",
             "browserVersion": "2.20",
             "platformName": "ANY",
-            "webkitgtk:browserOptions": {
+            "{}:browserOptions".format(browser_options_port): {
                 "binary": kwargs["binary"],
                 "args": kwargs.get("binary_args", []),
                 "certificates": [
                     {"host": server_config["browser_host"],
-                     "certificateFile": kwargs["host_cert_path"]}
-                ]
-            }
-        }
-
-        return capabilities
+                     "certificateFile": kwargs["host_cert_path"]}]}}
 
     return {}
 


### PR DESCRIPTION
WPE port is closely related to the GTK port, using the same WebDriver
implementation as well as similar testing-purpose browser application.
Much of the capabilities dictionary construction can thus be the same.