### PR TITLE
Consolidate the flake8 setup into tools/tox.ini and config files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ matrix:
         apt:
           packages:
             - libnss3-tools
-      env: JOB=wpt_integration TOXENV=py27,py27-flake8 SCRIPT=tools/ci/ci_wpt.sh
+      env: JOB=wpt_integration TOXENV=py27 SCRIPT=tools/ci/ci_wpt.sh
     - name: "resources/ tests"
       if: type = pull_request
       os: linux

--- a/tools/flake8.ini
+++ b/tools/flake8.ini
@@ -18,4 +18,10 @@ select = E,W,F,N
 # N801: class names should use CapWords convention
 # N802: function name should be lowercase
 ignore = E128,E129,E221,E226,E231,E251,E265,E302,E303,E305,E402,E731,E901,W601,N801,N802
+exclude =
+    .tox,
+    pywebsocket,
+    third_party,
+    wptserve/docs/conf.py,
+    wptserve/tests/functional/docroot/invalid.py
 max-line-length = 141

--- a/tools/requirements_flake8.txt
+++ b/tools/requirements_flake8.txt
@@ -1,0 +1,4 @@
+flake8==3.5.0
+pycodestyle==2.3.1
+pyflakes==1.6.0
+pep8-naming==0.4.1

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -1,26 +1,21 @@
 [tox]
-envlist = py27,py36,pypy
+envlist = py27,py36,pypy,py27-flake8
 skipsdist=True
 
 [testenv]
-# flake8 versions should be kept in sync across tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini
 deps =
-  flake8==3.5.0
-  pycodestyle==2.3.1
-  pyflakes==1.6.0
-  pep8-naming==0.4.1
   pytest
   pytest-cov
   mock
   hypothesis
   pytest-catchlog
+  -r{toxinidir}/requirements_flake8.txt
 
-commands =
-  pytest --cov {posargs}
-  flake8 --append-config=flake8.ini
+commands = pytest --cov {posargs}
 
 passenv =
   HYPOTHESIS_PROFILE
 
-[flake8]
-exclude = .tox,html5lib,third_party,pywebsocket,six,_venv,webencodings,wptserve/docs,wptserve/tests/functional/docroot/,wpt,wptrunner
+[testenv:py27-flake8]
+deps = -r{toxinidir}/requirements_flake8.txt
+commands = flake8 --append-config={toxinidir}/flake8.ini {posargs}

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -9,7 +9,6 @@ deps =
   mock
   hypothesis
   pytest-catchlog
-  -r{toxinidir}/requirements_flake8.txt
 
 commands = pytest --cov {posargs}
 

--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py27-flake8
+envlist = py27
 skipsdist=True
 
 [testenv]
@@ -14,14 +14,3 @@ deps =
 
 commands =
   pytest --cov {posargs}
-
-[testenv:py27-flake8]
-# flake8 versions should be kept in sync across tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini
-deps =
-     flake8==3.5.0
-     pycodestyle==2.3.1
-     pyflakes==1.6.0
-     pep8-naming==0.4.1
-
-commands =
-     flake8 --append-config=../flake8.ini {posargs}

--- a/tools/wptrunner/tox.ini
+++ b/tools/wptrunner/tox.ini
@@ -2,7 +2,7 @@
 xfail_strict=true
 
 [tox]
-envlist = {py27}-{base,chrome,edge,firefox,ie,opera,safari,sauce,servo},py27-flake8
+envlist = py27-{base,chrome,edge,firefox,ie,opera,safari,sauce,servo}
 
 [testenv]
 deps =
@@ -23,14 +23,3 @@ deps =
 commands = pytest {posargs:--cov}
 
 setenv = CURRENT_TOX_ENV = {envname}
-
-[testenv:py27-flake8]
-# flake8 versions should be kept in sync across tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini
-deps =
-     flake8==3.5.0
-     pycodestyle==2.3.1
-     pyflakes==1.6.0
-     pep8-naming==0.4.1
-
-commands =
-     flake8 --append-config=../flake8.ini


### PR DESCRIPTION
flake8 is still run as part of the "tools/ unittests (Python 2)" job in
Travis, because `run_applicable_tox` in tools/ci/ci_tools_unittest.sh
will turn `TOXENV=py27` into `TOXENV=py27,py27-flake8`.

Splitting flake8 into a separate job entirely is left for later.