### PR TITLE
Check for AudioContext to enable generating audio tracks with it

### DIFF
--- a/webrtc/RTCPeerConnection-helper.js
+++ b/webrtc/RTCPeerConnection-helper.js
@@ -358,7 +358,7 @@ const trackFactories = {
    */
   canCreate(requested) {
     const supported = {
-      audio: !!window.MediaStreamAudioDestinationNode,
+      audio: !!window.AudioContext && !!window.MediaStreamAudioDestinationNode,
       video: !!HTMLCanvasElement.prototype.captureStream
     };
 


### PR DESCRIPTION
WebKit exposes webkitAudioContext which is slightly different from AudioContext.
For WebRTC tests, it is simpler to rely on getUserMedia tests with mock active.