### PR TITLE
Enable flake8 for py3 again

### DIFF
--- a/tools/py27-flake8.ini
+++ b/tools/py27-flake8.ini
@@ -1,0 +1,24 @@
+[flake8]
+select = E,W,F,N
+# E128: continuation line under-indented for visual indent
+# E129: visually indented line with same indent as next logical line
+# E226: missing whitespace around arithmetic operator
+# E231: missing whitespace after ‘,’, ‘;’, or ‘:’
+# E251: unexpected spaces around keyword / parameter equals
+# E265: block comment should start with ‘# ‘
+# E302: expected 2 blank lines, found 0
+# E303: too many blank lines (3)
+# E305: expected 2 blank lines after end of function or class
+# E402: module level import not at top of file
+# E731: do not assign a lambda expression, use a def
+# W601: .has_key() is deprecated, use ‘in’
+# N801: class names should use CapWords convention
+# N802: function name should be lowercase
+ignore = E128,E129,E226,E231,E251,E265,E302,E303,E305,E402,E731,W601,N801,N802
+exclude =
+    .tox,
+    pywebsocket,
+    third_party,
+    wptserve/docs/conf.py,
+    wptserve/tests/functional/docroot/invalid.py
+max-line-length = 141

--- a/tools/py36-flake8.ini
+++ b/tools/py36-flake8.ini
@@ -1,9 +1,7 @@
 [flake8]
-# flake8 config used in tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini
 select = E,W,F,N
 # E128: continuation line under-indented for visual indent
 # E129: visually indented line with same indent as next logical line
-# E221: multiple spaces before operator
 # E226: missing whitespace around arithmetic operator
 # E231: missing whitespace after ‘,’, ‘;’, or ‘:’
 # E251: unexpected spaces around keyword / parameter equals
@@ -12,16 +10,15 @@ select = E,W,F,N
 # E303: too many blank lines (3)
 # E305: expected 2 blank lines after end of function or class
 # E402: module level import not at top of file
-# E731: do not assign a lambda expression, use a def
-# E901: SyntaxError or IndentationError
-# W601: .has_key() is deprecated, use ‘in’
 # N801: class names should use CapWords convention
 # N802: function name should be lowercase
-ignore = E128,E129,E221,E226,E231,E251,E265,E302,E303,E305,E402,E731,E901,W601,N801,N802
+ignore = E128,E129,E226,E231,E251,E265,E302,E303,E305,E402,N801,N802
 exclude =
     .tox,
     pywebsocket,
     third_party,
+    wpt,
+    wptrunner,
     wptserve/docs/conf.py,
     wptserve/tests/functional/docroot/invalid.py
 max-line-length = 141

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,pypy,py27-flake8
+envlist = py27,py36,pypy,{py27,py36}-flake8
 skipsdist=True
 
 [testenv]
@@ -16,5 +16,9 @@ passenv =
   HYPOTHESIS_PROFILE
 
 [testenv:py27-flake8]
-deps = -r{toxinidir}/requirements_flake8.txt
-commands = flake8 --append-config={toxinidir}/flake8.ini {posargs}
+deps = -r requirements_flake8.txt
+commands = flake8 --append-config=py27-flake8.ini {posargs}
+
+[testenv:py36-flake8]
+deps = -r requirements_flake8.txt
+commands = flake8 --append-config=py36-flake8.ini {posargs}


### PR DESCRIPTION
This was accidentally dropped in https://github.com/web-platform-tests/wpt/pull/13865.

Splitting flake8.ini into two is a bit unfortunate, but after trimming
to just the errors and warnings that are hit, they differ a
bit. Unfortunately using `--append-config` twice doesn't work.