### PR TITLE
Perform safe addIceCandidate together with signaling handshake

### DIFF
--- a/webrtc/RTCDTMFSender-helper.js
+++ b/webrtc/RTCDTMFSender-helper.js
@@ -8,7 +8,7 @@
 
 // The following helper functions are called from RTCPeerConnection-helper.js:
 //   getTrackFromUserMedia
-//   doSignalingHandshake
+//   doSignalingAndCandidateHandshake
 
 // Create a RTCDTMFSender using getUserMedia()
 // Connect the PeerConnection to another PC and wait until it is
@@ -25,8 +25,7 @@ function createDtmfSender(pc = new RTCPeerConnection()) {
     // on whether sending should be possible before negotiation.
     const pc2 = new RTCPeerConnection();
     Object.defineProperty(pc, 'otherPc', { value: pc2 });
-    exchangeIceCandidates(pc, pc2);
-    return doSignalingHandshake(pc, pc2);
+    return doSignalingAndCandidateHandshake(pc, pc2);
   }).then(() => {
     if (!('canInsertDTMF' in dtmfSender)) {
       return Promise.resolve();

--- a/webrtc/RTCDtlsTransport-getRemoteCertificates.html
+++ b/webrtc/RTCDtlsTransport-getRemoteCertificates.html
@@ -8,8 +8,7 @@
   'use strict';
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
-  //   exchangeIceCandidates
-  //   doSignalingHandshake
+  //   doSignalingAndCandidateHandshake
 
   /*
     5.5.  RTCDtlsTransport Interface
@@ -43,9 +42,8 @@
     t.add_cleanup(() => pc2.close());
 
     pc1.createDataChannel('test');
-    exchangeIceCandidates(pc1, pc2);
 
-    doSignalingHandshake(pc1, pc2)
+    doSignalingAndCandidateHandshake(pc1, pc2)
     .then(t.step_func(() => {
       // pc.sctp is set when set*Description(answer) is called
       const sctpTransport1 = pc1.sctp;

--- a/webrtc/RTCPeerConnection-connectionState.html
+++ b/webrtc/RTCPeerConnection-connectionState.html
@@ -10,8 +10,7 @@
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.htm
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
-  // exchangeIceCandidates
-  // doSignalingHandshake
+  // doSignalingAndCandidateHandshake
 
   /*
     4.3.2.  Interface Definition
@@ -133,8 +132,7 @@
 
     pc1.addEventListener('connectionstatechange', onConnectionStateChange);
 
-    exchangeIceCandidates(pc1, pc2);
-    doSignalingHandshake(pc1, pc2);
+    doSignalingAndCandidateHandshake(pc1, pc2);
   }, 'connection with one data channel should eventually have connected connection state');
 
   async_test(t => {
@@ -165,9 +163,8 @@
 
     pc1.addEventListener('connectionstatechange', onConnectionStateChange);
 
-    exchangeIceCandidates(pc1, pc2);
-    doSignalingHandshake(pc1, pc2);
-  }, 'connection with one data channel should eventually have transports in connected state');
+    doSignalingAndCandidateHandshake(pc1, pc2);
+  }, 'connection with one data channel should eventually have connected connection state');
 
   /*
     TODO

--- a/webrtc/RTCPeerConnection-getStats.https.html
+++ b/webrtc/RTCPeerConnection-getStats.https.html
@@ -21,8 +21,7 @@
   //   assert_stats_report_has_stats
 
   // The following helper function is called from RTCPeerConnection-helper.js
-  //   exchangeIceCandidates
-  //   doSignalingHandshake
+  //   doSignalingAndCandidateHandshake
 
   /*
     8.2.  getStats
@@ -331,9 +330,7 @@
         }
       }));
 
-
-      exchangeIceCandidates(pc1, pc2);
-      doSignalingHandshake(pc1, pc2);
+      return doSignalingAndCandidateHandshake(pc1, pc2);
     }))
     .catch(t.step_func(err => {
       assert_unreached(`test failed with error: ${err}`);

--- a/webrtc/RTCPeerConnection-iceConnectionState.html
+++ b/webrtc/RTCPeerConnection-iceConnectionState.html
@@ -11,8 +11,7 @@
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
-  // exchangeIceCandidates
-  // doSignalingHandshake
+  // doSignalingAndCandidateHandshake
 
   /*
     4.3.2.  Interface Definition
@@ -105,8 +104,8 @@
   async_test(t => {
     const pc1 = new RTCPeerConnection();
     t.add_cleanup(() => pc1.close());
-    const pc2 = new RTCPeerConnection();
 
+    const pc2 = new RTCPeerConnection();
     t.add_cleanup(() => pc2.close());
 
     const onIceConnectionStateChange = t.step_func(() => {
@@ -139,8 +138,8 @@
 
     pc1.addEventListener('iceconnectionstatechange', onIceConnectionStateChange);
 
-    exchangeIceCandidates(pc1, pc2);
-    doSignalingHandshake(pc1, pc2);
+    doSignalingAndCandidateHandshake(pc1, pc2)
+    .catch(t.unreached_func('handshake error'));
   }, 'connection with one data channel should eventually have connected connection state');
 
   /*

--- a/webrtc/RTCPeerConnection-iceGatheringState.html
+++ b/webrtc/RTCPeerConnection-iceGatheringState.html
@@ -11,8 +11,8 @@
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
-  // doSignalingHandshake
-  // exchangeIceCandidates
+
+  // doSignalingAndCandidateHandshake
   // generateAudioReceiveOnlyOffer
 
   /*
@@ -134,8 +134,8 @@
     // when icegatheringstatechange event is fired.
     pc2.addEventListener('icegatheringstatechange', onIceGatheringStateChange);
 
-    exchangeIceCandidates(pc1, pc2);
-    doSignalingHandshake(pc1, pc2);
+    doSignalingAndCandidateHandshake(pc1, pc2)
+    .catch(t.unreached_func('handshake error'));
   }, 'connection with one data channel should eventually have connected connection state');
 
   /*

--- a/webrtc/RTCPeerConnection-ondatachannel.html
+++ b/webrtc/RTCPeerConnection-ondatachannel.html
@@ -11,8 +11,7 @@
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
-  // exchangeIceCandidates
-  // doSignalingHandshake
+  // doSignalingAndCandidateHandshake
 
   /*
     6.2.  RTCDataChannel
@@ -70,8 +69,9 @@
     localPc.createDataChannel('test');
 
     remotePc.addEventListener('datachannel', onDataChannel);
-    exchangeIceCandidates(localPc, remotePc);
-    doSignalingHandshake(localPc, remotePc);
+
+    doSignalingAndCandidateHandshake(localPc, remotePc)
+    .catch(t.unreached_func('handshake error'));
   }, 'datachannel event should fire when new data channel is announced to the remote peer');
 
   /*
@@ -134,8 +134,9 @@
     assert_equals(localChannel.priority, 'high');
 
     remotePc.addEventListener('datachannel', onDataChannel);
-    exchangeIceCandidates(localPc, remotePc);
-    doSignalingHandshake(localPc, remotePc);
+
+    doSignalingAndCandidateHandshake(localPc, remotePc)
+    .catch(t.unreached_func('handshake error'));
   }, 'Data channel created on remote peer should match the same configuration as local peer');
 
   /*
@@ -162,8 +163,9 @@
     });
 
     remotePc.addEventListener('datachannel', onDataChannel);
-    exchangeIceCandidates(localPc, remotePc);
-    doSignalingHandshake(localPc, remotePc);
+
+    doSignalingAndCandidateHandshake(localPc, remotePc)
+    .catch(t.unreached_func('handshake error'));
 
     t.step_timeout(t.step_func_done(), 200);
   }, 'Data channel created with negotiated set to true should not fire datachannel event on remote peer');

--- a/webrtc/RTCPeerConnection-track-stats.https.html
+++ b/webrtc/RTCPeerConnection-track-stats.https.html
@@ -402,8 +402,7 @@
     let [tracks, streams] = await getUserMediaTracksAndStreams(2);
     let sender = caller.addTrack(tracks[0], streams[0]);
     callee.addTrack(tracks[1], streams[1]);
-    exchangeIceCandidates(caller, callee);
-    await doSignalingHandshake(caller, callee);
+    await doSignalingAndCandidateHandshake(caller, callee);
     await onIceConnectionStateCompleted(caller);
     let receiver = caller.getReceivers()[0];
 
@@ -450,8 +449,7 @@
     let [tracks, streams] = await getUserMediaTracksAndStreams(2);
     let sender = caller.addTrack(tracks[0], streams[0]);
     callee.addTrack(tracks[1], streams[1]);
-    exchangeIceCandidates(caller, callee);
-    await doSignalingHandshake(caller, callee);
+    await doSignalingAndCandidateHandshake(caller, callee);
     await onIceConnectionStateCompleted(caller);
     let receiver = caller.getReceivers()[0];
 
@@ -498,8 +496,7 @@
     let [tracks, streams] = await getUserMediaTracksAndStreams(2);
     let sender = caller.addTrack(tracks[0], streams[0]);
     callee.addTrack(tracks[1], streams[1]);
-    exchangeIceCandidates(caller, callee);
-    await doSignalingHandshake(caller, callee);
+    await doSignalingAndCandidateHandshake(caller, callee);
     await onIceConnectionStateCompleted(caller);
 
     // Wait until RTCP has arrived so that it can not arrive between
@@ -529,8 +526,7 @@
     let [tracks, streams] = await getUserMediaTracksAndStreams(2);
     let sender = caller.addTrack(tracks[0], streams[0]);
     callee.addTrack(tracks[1], streams[1]);
-    exchangeIceCandidates(caller, callee);
-    await doSignalingHandshake(caller, callee);
+    await doSignalingAndCandidateHandshake(caller, callee);
     await onIceConnectionStateCompleted(caller);
     let receiver = caller.getReceivers()[0];
 

--- a/webrtc/RTCRtpReceiver-getContributingSources.https.html
+++ b/webrtc/RTCRtpReceiver-getContributingSources.https.html
@@ -12,8 +12,7 @@
 
   // The following helper function is called from RTCPeerConnection-helper.js
   //   getTrackFromUserMedia
-  //   exchangeIceCandidates
-  //   doSignalingHandshake
+  //   doSignalingAndCandidateHandshake
 
   /*
     5.3.  RTCRtpReceiver Interface
@@ -58,8 +57,7 @@
     return getTrackFromUserMedia('audio')
     .then(([track, mediaStream]) => {
       pc1.addTrack(track, mediaStream);
-      exchangeIceCandidates(pc1, pc2);
-      return doSignalingHandshake(pc1, pc2);
+      return doSignalingAndCandidateHandshake(pc1, pc2);
     })
     .then(() => ontrackPromise)
     .then(receiver => {

--- a/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html
+++ b/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html
@@ -45,8 +45,7 @@
     return getTrackFromUserMedia('audio')
     .then(([track, mediaStream]) => {
       pc1.addTrack(track, mediaStream);
-      exchangeIceCandidates(pc1, pc2);
-      return doSignalingHandshake(pc1, pc2);
+      return doSignalingAndCandidateHandshake(pc1, pc2);
     })
     .then(() => ontrackPromise)
     .then(receiver => {


### PR DESCRIPTION
Fixes #12028.

Note that not all usage of `exchangeIceCandidates()` is replaced. The remaining should be fixed in another PR.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
