### PR TITLE
Fix typo in RTCRtpReceiver-getParameters.html

### DIFF
--- a/webrtc/RTCRtpReceiver-getParameters.html
+++ b/webrtc/RTCRtpReceiver-getParameters.html
@@ -36,7 +36,7 @@
   test(t => {
     const pc = new RTCPeerConnection();
     const { receiver } = pc.addTransceiver('audio');
-    const param = pc.getParameters();
+    const param = receiver.getParameters();
     validateReceiverRtpParameters(param);
   });
 </script>


### PR DESCRIPTION
RTCPeerConnection does not have a `getParameters` method.