### PR TITLE
webrtc: rename DTLSTransport.transport to .iceTransport

### DIFF
--- a/webrtc/RTCIceTransport.html
+++ b/webrtc/RTCIceTransport.html
@@ -58,7 +58,7 @@
     assert_true(dtlsTransport instanceof RTCDtlsTransport,
       'Expect sctp.transport to be an RTCDtlsTransport');
 
-    const iceTransport = dtlsTransport.transport;
+    const iceTransport = dtlsTransport.iceTransport;
     assert_true(iceTransport instanceof RTCIceTransport,
       'Expect dtlsTransport.transport to be an RTCIceTransport');
 

--- a/webrtc/RTCPeerConnection-connectionState.html
+++ b/webrtc/RTCPeerConnection-connectionState.html
@@ -34,7 +34,7 @@
 
     5.5.  RTCDtlsTransport Interface
       interface RTCDtlsTransport {
-        readonly attribute RTCIceTransport       transport;
+        readonly attribute RTCIceTransport       iceTransport;
         readonly attribute RTCDtlsTransportState state;
         ...
       };
@@ -121,7 +121,7 @@
         assert_equals(dtlsTransport.state, 'connected',
           'Expect DTLS transport to be in connected state');
 
-        const iceTransport = dtlsTransport.transport
+        const iceTransport = dtlsTransport.iceTransport
         assert_true(iceTransport.state ===  'connected' ||
           iceTransport.state === 'completed',
           'Expect ICE transport to be in connected or completed state');

--- a/webrtc/idlharness.https.window.js
+++ b/webrtc/idlharness.https.window.js
@@ -67,7 +67,9 @@ function asyncInitTransports() {
       'Expect sctpTransport.transport to be instance of RTCDtlsTransport');
     idlTestObjects.dtlsTransport = dtlsTransport;
 
-    const iceTransport = dtlsTransport.transport;
+    const iceTransport = dtlsTransport.iceTransport;
+    assert_true(iceTransport instanceof RTCIceTransport,
+      'Expect sctpTransport.transport to be instance of RTCDtlsTransport');
     idlTestObjects.iceTransport = iceTransport;
   });
 }


### PR DESCRIPTION
test for https://github.com/w3c/webrtc-pc/pull/2017