### PR TITLE
Update replaceTrack after removeTrack tests

### DIFF
--- a/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html
@@ -86,7 +86,6 @@
   }, 'replaceTrack() rejects when the peer connection is closed.');
 
   promise_test(async t => {
-    const expectedException = 'InvalidModificationError';
     const caller = new RTCPeerConnection();
     t.add_cleanup(() => caller.close());
     const [tracks, streams] = await getUserMediaTracksAndStreams(2);
@@ -94,7 +93,19 @@
     caller.removeTrack(sender);
     await sender.replaceTrack(tracks[1]);
     assert_equals(sender.track, tracks[1], "Make sure track gets updated");
-  }, 'replaceTrack() rejects when invoked after removeTrack().');
+  }, 'replaceTrack() does not reject when invoked after removeTrack().');
+
+
+  promise_test(async t => {
+    const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
+    const [tracks, streams] = await getUserMediaTracksAndStreams(2);
+    const sender = caller.addTrack(tracks[0], streams[0]);
+    let p = sender.replaceTrack(tracks[1])
+    caller.removeTrack(sender);
+    await p;
+    assert_equals(sender.track, tracks[1], "Make sure track gets updated");
+  }, 'replaceTrack() does not reject after a subsequent removeTrack().');
 
   // TODO(hbos): Verify that replaceTrack() changes what media is received on
   // the remote end of two connected peer connections. For video tracks, this

--- a/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html
@@ -93,6 +93,7 @@
     const sender = caller.addTrack(tracks[0], streams[0]);
     caller.removeTrack(sender);
     await sender.replaceTrack(tracks[1]);
+    assert_equals(sender.track, tracks[1], "Make sure track gets updated");
   }, 'replaceTrack() rejects when invoked after removeTrack().');
 
   // TODO(hbos): Verify that replaceTrack() changes what media is received on

--- a/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html
@@ -85,57 +85,15 @@
     }));
   }, 'replaceTrack() rejects when the peer connection is closed.');
 
-  async_test(t => {
+  promise_test(async t => {
     const expectedException = 'InvalidModificationError';
     const caller = new RTCPeerConnection();
     t.add_cleanup(() => caller.close());
-    return getUserMediaTracksAndStreams(2)
-    .then(t.step_func(([tracks, streams]) => {
-      const sender = caller.addTrack(tracks[0], streams[0]);
-      caller.removeTrack(sender);
-      // replaceTrack() should fail because the sender should be inactive after
-      // removeTrack().
-      return sender.replaceTrack(tracks[1])
-      .then(t.step_func(() => {
-        assert_unreached('Expected replaceTrack() to be rejected with ' +
-                         expectedException + ' but the promise was resolved.');
-      }),
-      t.step_func(e => {
-        assert_equals(e.name, expectedException);
-        t.done();
-      }));
-    }))
-    .catch(t.step_func(reason => {
-      assert_unreached(reason);
-    }));
+    const [tracks, streams] = await getUserMediaTracksAndStreams(2);
+    const sender = caller.addTrack(tracks[0], streams[0]);
+    caller.removeTrack(sender);
+    await sender.replaceTrack(tracks[1]);
   }, 'replaceTrack() rejects when invoked after removeTrack().');
-
-  async_test(t => {
-    const expectedException = 'InvalidModificationError';
-    const caller = new RTCPeerConnection();
-    t.add_cleanup(() => caller.close());
-    return getUserMediaTracksAndStreams(2)
-    .then(t.step_func(([tracks, streams]) => {
-      const sender = caller.addTrack(tracks[0], streams[0]);
-      let p = sender.replaceTrack(tracks[1])
-      caller.removeTrack(sender);
-      // replaceTrack() should fail because it executes steps in parallel and
-      // queues a task to execute after removeTrack() has occurred. The sender
-      // should be inactive. If this can be racy, update or remove the test.
-      // https://github.com/w3c/webrtc-pc/issues/1728
-      return p.then(t.step_func(() => {
-        assert_unreached('Expected replaceTrack() to be rejected with ' +
-                         expectedException + ' but the promise was resolved.');
-      }),
-      t.step_func(e => {
-        assert_equals(e.name, expectedException);
-        t.done();
-      }));
-    }))
-    .catch(t.step_func(reason => {
-      assert_unreached(reason);
-    }));
-  }, 'replaceTrack() rejects after a subsequent removeTrack().');
 
   // TODO(hbos): Verify that replaceTrack() changes what media is received on
   // the remote end of two connected peer connections. For video tracks, this


### PR DESCRIPTION
All implementations seem to fail the test before modification.
As per my reading of the spec, replaceTrack does not check for inactive.