### PR TITLE
[wptrunner] Convert data prior to transmission

### DIFF
--- a/tools/wptrunner/wptrunner/executors/testharness_webdriver_resume.js
+++ b/tools/wptrunner/wptrunner/executors/testharness_webdriver_resume.js
@@ -1,3 +1,21 @@
 var callback = arguments[arguments.length - 1];
-window.opener.testdriver_callback = callback;
+window.opener.testdriver_callback = function(results) {
+  /**
+   * The current window and its opener belong to the same domain, making it
+   * technically possible for data structures to be shared directly.
+   * Unfortunately, some browser/WebDriver implementations incorrectly
+   * serialize Arrays from foreign realms [1]. This issue does not extend to
+   * the behavior of `JSON.stringify` and `JSON.parse` in these
+   * implementations. Use that API to re-create the data structure in the local
+   * realm to avoid the problem in the non-conforming browsers.
+   *
+   * [1] This has been observed in Edge version 17 and/or the corresponding
+   *     release of Edgedriver
+   */
+  try {
+    results = JSON.parse(JSON.stringify(results));
+  } catch (error) {}
+
+  callback(results);
+};
 window.opener.process_next_event();


### PR DESCRIPTION
A recent improvement to wptrunner modified the way data structures are
transmitted from the browser to the WebDriver server [1]. One
consequence of this change is that the data structures are created in a
JavaScript realm which differs from the realm in which the "Execute
Script" WebDriver command is running. As of version 17, Microsoft Edge
does not correctly serialize cross-realm values, so referenced
improvement unintentionally precluded testing in that browser.

Serialize and deserialize the results data structure from the realm of
the WebDriver command to avoid this problem.

[1] https://github.com/web-platform-tests/wpt/pull/13419