### PR TITLE
[ci] Complete Docker image update

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -125,7 +125,7 @@ tasks:
                 owner: ${event.pull_request.user.login}@users.noreply.github.com
                 source: ${event.repository.url}
               payload:
-                image: jugglinmike/web-platform-tests:0.21
+                image: harjgam/web-platform-tests:0.22
                 maxRunTime: 7200
                 artifacts:
                   public/results:


### PR DESCRIPTION
A recent patch updated the Docker image used by Taskcluster when
building the project's `master` branch [1]. Update the corresponding
configuration for tasks triggered by pull requests. This improves parity
between the two processes, and because the new image is based on a more
recent LTS release of Ubuntu, it reduces the likelihood of errors due to
outdated system dependencies.

[1] https://github.com/web-platform-tests/wpt/pull/13676