### PR TITLE
[css-animations] computed value for animation-name

### DIFF
--- a/css/css-animations/parsing/animation-name-computed.html
+++ b/css/css-animations/parsing/animation-name-computed.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: getComputedValue().animationName</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-name">
+<meta name="assert" content="animation-name computes to lists containing identifier, string or none.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("animation-name", 'NONE', 'none');
+
+test_computed_value("animation-name", 'foo');
+test_computed_value("animation-name", 'Both');
+test_computed_value("animation-name", 'ease-in');
+test_computed_value("animation-name", 'infinite');
+test_computed_value("animation-name", 'paused');
+test_computed_value("animation-name", 'first, second, third');
+
+test_computed_value("animation-name", '"string"');
+test_computed_value("animation-name", '"multi word string"');
+test_computed_value("animation-name", '"initial"');
+test_computed_value("animation-name", '"---\\22---"', '\"---\\\"---\"');
+
+test_computed_value("animation-name", '"initial", "None", None, Last', '"initial", "None", none, Last');
+</script>
+</body>
+</html>

--- a/css/css-animations/parsing/animation-name-valid.html
+++ b/css/css-animations/parsing/animation-name-valid.html
@@ -24,6 +24,8 @@ test_valid_value("animation-name", '"string"');
 test_valid_value("animation-name", '"multi word string"');
 test_valid_value("animation-name", '"initial"');
 test_valid_value("animation-name", '"---\\22---"', '\"---\\\"---\"');
+
+test_valid_value("animation-name", '"initial", "None", None, Last', '"initial", "None", none, Last');
 </script>
 </body>
 </html>


### PR DESCRIPTION
Firefox accepts string in animation-name but currently does not use
strings in the computed value:

Unlike the specified value serialization tests
https://wpt.fyi/results/css/css-animations/parsing/animation-name-valid.html ,
these computed value tests currently fail in Firefox:

Fail	Property animation-name value '"string"' computes to '"string"'	assert_equals: expected "\"string\"" but got "string"
Fail	Property animation-name value '"multi word string"' computes to '"multi word string"'	assert_equals: expected "\"multi word string\"" but got "multi\\ word\ string"
Fail	Property animation-name value '"initial"' computes to '"initial"'	assert_equals: expected "\"initial\"" but got "initial"
Fail	Property animation-name value '"---\22---"' computes to '"---\"---"'	assert_equals: expected "\"---\\\"---\"" but got "---\\\"---"
Fail	Property animation-name value '"initial", "None", None, Last' computes to '"initial", "None", none, Last'	assert_equals: expected "\"initial\", \"None\", none, Last" but got "initial, None, none, Last"

For example, the computed value "initial, None, none, Last" currently returned by Firefox does not round trip.