### PR TITLE
[Payment Request] Include both valid and invalid Apple Pay payment methods in payment-request-canmakepayment-method.https.html.

### DIFF
--- a/payment-request/payment-request-canmakepayment-method.https.html
+++ b/payment-request/payment-request-canmakepayment-method.https.html
@@ -10,6 +10,13 @@
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const applePay = Object.freeze({
   supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 1,
+    merchantIdentifier: "wpt",
+    merchantCapabilities: ["supportsCredit"],
+    supportedNetworks: ["visa"],
+    countryCode: "US",
+  },
 });
 const defaultMethods = Object.freeze([basicCard, applePay]);
 const defaultDetails = Object.freeze({
@@ -25,6 +32,7 @@ const defaultDetails = Object.freeze({
 const unsupportedMethods = [
   { supportedMethods: "this-is-not-supported" },
   { supportedMethods: "https://not.supported" },
+  { supportedMethods: "https://apple.com/apple-pay" },
 ];
 
 promise_test(async t => {


### PR DESCRIPTION
Apple Pay has a number of required fields in its payment method data. If these fields are missing,
PaymentRequest.canMakePayment() will resolve to false.

Updated defaultMethods to include a valid Apple Pay payment method. Updated unsupportedMethods to include an invalid Apple Pay payment method.