### PR TITLE
webkitRelativePath preserves common ancestors

### DIFF
--- a/entries-api/file-webkitRelativePath-manual.html
+++ b/entries-api/file-webkitRelativePath-manual.html
@@ -23,9 +23,10 @@ promise_test(t => filesPromise.then(files => {
     (a, b) => a.name < b.name ? -1 : b.name < a.name ? 1 : 0);
   assert_equals(files[0].name, '1.txt');
   assert_equals(files[1].name, '2.txt');
-  assert_equals(files[0].webkitRelativePath, 'c/d/1.txt');
-  assert_equals(files[1].webkitRelativePath, 'c/d/2.txt');
-  assert_equals(files[2].webkitRelativePath, 'c/3.txt');
+  assert_equals(files[2].name, '3.txt');
+  assert_equals(files[0].webkitRelativePath, 'a/b/c/d/1.txt');
+  assert_equals(files[1].webkitRelativePath, 'a/b/c/d/2.txt');
+  assert_equals(files[2].webkitRelativePath, 'a/b/c/3.txt');
 
 }), 'webkitRelativePath is shortest common ancestor');
 


### PR DESCRIPTION
Drop requirement that webkitRelativePath only provides the shortest common ancestor, which matches behavior in Edge/Safari/Firefox, and soon Chrome.

Spec PR: https://github.com/WICG/entries-api/pull/27
Tracking issue: https://github.com/WICG/entries-api/issues/18