### PR TITLE
Do not send old capabilities to ChromeDriver

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -37,8 +37,6 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
 
     capabilities = {
         "browserName": "chrome",
-        "platform": "ANY",
-        "version": "",
         "goog:chromeOptions": {
             "prefs": {
                 "profile": {


### PR DESCRIPTION
The configuration for Chrome currently sends 'platform' and 'version'
capabilities to ChromeDriver. These capabilities are non-standard and
unnecessary, and will cause errors when ChromeDriver becomes more
standard compliant.