### PR TITLE
Remove ES6 object matching shorthand notation from WebDriver tests

### DIFF
--- a/webdriver/tests/support/helpers.py
+++ b/webdriver/tests/support/helpers.py
@@ -107,8 +107,8 @@ def clear_all_cookies(session):
 
 def document_dimensions(session):
     return tuple(session.execute_script("""
-        let {width, height} = document.documentElement.getBoundingClientRect();
-        return [width, height];
+        let rect = document.documentElement.getBoundingClientRect();
+        return [rect.width, rect.height];
         """))
 
 
@@ -122,13 +122,13 @@ def document_hidden(session):
 def element_rect(session, element):
     return session.execute_script("""
         let element = arguments[0];
-        let {height, left, top, width} = element.getBoundingClientRect();
+        let rect = element.getBoundingClientRect();
 
         return {
-            x: left + window.pageXOffset,
-            y: top + window.pageYOffset,
-            width: width,
-            height: height,
+            x: rect.left + window.pageXOffset,
+            y: rect.top + window.pageYOffset,
+            width: rect.width,
+            height: rect.height,
         };
         """, args=(element,))
 

--- a/webdriver/tests/take_element_screenshot/__init__.py
+++ b/webdriver/tests/take_element_screenshot/__init__.py
@@ -1,6 +1,6 @@
 def element_rect(session, element):
     return session.execute_script("""
-        let {devicePixelRatio} = window;
+        let devicePixelRatio = window.devicePixelRatio;
         let rect = arguments[0].getBoundingClientRect();
 
         return {

--- a/webdriver/tests/take_screenshot/__init__.py
+++ b/webdriver/tests/take_screenshot/__init__.py
@@ -1,6 +1,6 @@
 def document_dimensions(session):
     return tuple(session.execute_script("""
-        let {devicePixelRatio} = window;
-        let {width, height} = document.documentElement.getBoundingClientRect();
-        return [Math.floor(width * devicePixelRatio), Math.floor(height * devicePixelRatio)];
+        let devicePixelRatio = window.devicePixelRatio;
+        let rect = document.documentElement.getBoundingClientRect();
+        return [Math.floor(rect.width * devicePixelRatio), Math.floor(rect.height * devicePixelRatio)];
         """))


### PR DESCRIPTION
This change is to allow older user agents that do not support ES6
constructs to run the WebDriver tests.