### PR TITLE
[wptserve] Eliminate race condition

### DIFF
--- a/tools/wptserve/tests/test_stash.py
+++ b/tools/wptserve/tests/test_stash.py
@@ -68,7 +68,7 @@ def test_delayed_lock(add_cleanup):
 
     queue = multiprocessing.Queue()
 
-    def handle_lock_request():
+    def mutex_lock_request():
         """This request handler allows the caller to delay execution of a
         thread which has requested a proxied representation of the `lock`
         property, simulating a "slow" interprocess communication channel."""
@@ -78,7 +78,7 @@ def test_delayed_lock(add_cleanup):
         return threading.Lock()
 
     SlowLock.register("get_dict", callable=lambda: {})
-    SlowLock.register("Lock", callable=handle_lock_request)
+    SlowLock.register("Lock", callable=mutex_lock_request)
 
     slowlock = SlowLock(("localhost", 4543), b"some key")
     slowlock.start()
@@ -106,7 +106,7 @@ def test_delayed_dict(add_cleanup):
 
     # This request handler allows the caller to delay execution of a thread
     # which has requested a proxied representation of the "get_dict" property.
-    def handle_dict_request():
+    def mutex_dict_request():
         """This request handler allows the caller to delay execution of a
         thread which has requested a proxied representation of the `get_dict`
         property, simulating a "slow" interprocess communication channel."""
@@ -114,7 +114,7 @@ def test_delayed_dict(add_cleanup):
         response_lock.acquire()
         return {}
 
-    SlowDict.register("get_dict", callable=handle_dict_request)
+    SlowDict.register("get_dict", callable=mutex_dict_request)
     SlowDict.register("Lock", callable=lambda: threading.Lock())
 
     slowdict = SlowDict(("localhost", 4543), b"some key")

--- a/tools/wptserve/tests/test_stash.py
+++ b/tools/wptserve/tests/test_stash.py
@@ -19,8 +19,8 @@ def add_cleanup():
         fn()
 
 def test_delayed_lock(add_cleanup):
-    '''Ensure that delays in proxied Lock retrieval do not interfere with
-    initialization in parallel threads.'''
+    """Ensure that delays in proxied Lock retrieval do not interfere with
+    initialization in parallel threads."""
 
     class SlowLock(BaseManager):
         pass
@@ -38,13 +38,13 @@ def test_delayed_lock(add_cleanup):
     SlowLock.register("get_dict", callable=lambda: {})
     SlowLock.register("Lock", callable=handle_lock_request)
 
-    slowlock = SlowLock(('localhost', 4543), 'some key')
+    slowlock = SlowLock(("localhost", 4543), b"some key")
     slowlock.start()
     add_cleanup(lambda: slowlock.shutdown())
 
     def run(process_queue, request_lock, response_lock):
         def target(thread_queue):
-            stash = Stash('/', ('localhost', 4543), 'some key')
+            stash = Stash("/", ("localhost", 4543), b"some key")
             thread_queue.put(stash.lock is None)
 
         thread_queue = multiprocessing.Queue()
@@ -72,11 +72,11 @@ def test_delayed_lock(add_cleanup):
     add_cleanup(lambda: parallel.terminate())
 
     assert [queue.get(), queue.get()] == [False, False], (
-        'both instances had valid locks')
+        "both instances had valid locks")
 
 def test_delayed_dict(add_cleanup):
-    '''Ensure that delays in proxied `dict` retrieval do not interfere with
-    initialization in parallel threads.'''
+    """Ensure that delays in proxied `dict` retrieval do not interfere with
+    initialization in parallel threads."""
 
     class SlowDict(BaseManager):
         pass
@@ -94,13 +94,13 @@ def test_delayed_dict(add_cleanup):
     SlowDict.register("get_dict", callable=handle_dict_request)
     SlowDict.register("Lock", callable=lambda: threading.Lock())
 
-    slowdict = SlowDict(('localhost', 4543), 'some key')
+    slowdict = SlowDict(("localhost", 4543), b"some key")
     slowdict.start()
     add_cleanup(lambda: slowdict.shutdown())
 
     def run(process_queue, request_lock, response_lock):
         def target(thread_queue):
-            stash = Stash('/', ('localhost', 4543), 'some key')
+            stash = Stash("/", ("localhost", 4543), b"some key")
             thread_queue.put(stash.lock is None)
 
         thread_queue = multiprocessing.Queue()
@@ -128,4 +128,4 @@ def test_delayed_dict(add_cleanup):
     add_cleanup(lambda: parallel.terminate())
 
     assert [queue.get(), queue.get()] == [False, False], (
-        'both instances had valid locks')
+        "both instances had valid locks")

--- a/tools/wptserve/tests/test_stash.py
+++ b/tools/wptserve/tests/test_stash.py
@@ -18,6 +18,44 @@ def add_cleanup():
     for fn in fns:
         fn()
 
+def run(process_queue, request_lock, response_lock):
+    """Create two Stash instances in parallel threads. Use the provided locks
+    to ensure the first thread is actively establishing an interprocess
+    communication channel at the moment the second thread executes."""
+
+    def target(thread_queue):
+        stash = Stash("/", ("localhost", 4543), b"some key")
+
+        # The `lock` property of the Stash instance should always be set
+        # immediately following initialization. These values are asserted in
+        # the active test.
+        thread_queue.put(stash.lock is None)
+
+    thread_queue = multiprocessing.Queue()
+    first = threading.Thread(target=target, args=(thread_queue,))
+    second = threading.Thread(target=target, args=(thread_queue,))
+
+    request_lock.acquire()
+    response_lock.acquire()
+    first.start()
+
+    request_lock.acquire()
+
+    # At this moment, the `first` thread is waiting for a proxied object.
+    # Create a second thread in order to inspect the behavior of the Stash
+    # constructor at this moment.
+
+    second.start()
+
+    # Allow the `first` thread to proceed
+
+    response_lock.release()
+
+    # Wait for both threads to complete and report their stateto the test
+    process_queue.put(thread_queue.get())
+    process_queue.put(thread_queue.get())
+
+
 def test_delayed_lock(add_cleanup):
     """Ensure that delays in proxied Lock retrieval do not interfere with
     initialization in parallel threads."""
@@ -31,6 +69,10 @@ def test_delayed_lock(add_cleanup):
     queue = multiprocessing.Queue()
 
     def handle_lock_request():
+        """This request handler allows the caller to delay execution of a
+        thread which has requested a proxied representation of the `lock`
+        property, simulating a "slow" interprocess communication channel."""
+
         request_lock.release()
         response_lock.acquire()
         return threading.Lock()
@@ -41,30 +83,6 @@ def test_delayed_lock(add_cleanup):
     slowlock = SlowLock(("localhost", 4543), b"some key")
     slowlock.start()
     add_cleanup(lambda: slowlock.shutdown())
-
-    def run(process_queue, request_lock, response_lock):
-        def target(thread_queue):
-            stash = Stash("/", ("localhost", 4543), b"some key")
-            thread_queue.put(stash.lock is None)
-
-        thread_queue = multiprocessing.Queue()
-        first = threading.Thread(target=target, args=(thread_queue,))
-        second = threading.Thread(target=target, args=(thread_queue,))
-
-        request_lock.acquire()
-        response_lock.acquire()
-        first.start()
-
-        request_lock.acquire()
-        # First is now waiting for Lock
-
-        second.start()
-
-        # Allow the first to proceed
-        response_lock.release()
-
-        process_queue.put(thread_queue.get())
-        process_queue.put(thread_queue.get())
 
     parallel = multiprocessing.Process(target=run,
                                        args=(queue, request_lock, response_lock))
@@ -86,7 +104,12 @@ def test_delayed_dict(add_cleanup):
 
     queue = multiprocessing.Queue()
 
+    # This request handler allows the caller to delay execution of a thread
+    # which has requested a proxied representation of the "get_dict" property.
     def handle_dict_request():
+        """This request handler allows the caller to delay execution of a
+        thread which has requested a proxied representation of the `get_dict`
+        property, simulating a "slow" interprocess communication channel."""
         request_lock.release()
         response_lock.acquire()
         return {}
@@ -97,30 +120,6 @@ def test_delayed_dict(add_cleanup):
     slowdict = SlowDict(("localhost", 4543), b"some key")
     slowdict.start()
     add_cleanup(lambda: slowdict.shutdown())
-
-    def run(process_queue, request_lock, response_lock):
-        def target(thread_queue):
-            stash = Stash("/", ("localhost", 4543), b"some key")
-            thread_queue.put(stash.lock is None)
-
-        thread_queue = multiprocessing.Queue()
-        first = threading.Thread(target=target, args=(thread_queue,))
-        second = threading.Thread(target=target, args=(thread_queue,))
-
-        request_lock.acquire()
-        response_lock.acquire()
-        first.start()
-
-        request_lock.acquire()
-        # First is now waiting for Lock
-
-        second.start()
-
-        # Allow the first to proceed
-        response_lock.release()
-
-        process_queue.put(thread_queue.get())
-        process_queue.put(thread_queue.get())
 
     parallel = multiprocessing.Process(target=run,
                                        args=(queue, request_lock, response_lock))

--- a/tools/wptserve/tests/test_stash.py
+++ b/tools/wptserve/tests/test_stash.py
@@ -1,0 +1,131 @@
+import threading
+import multiprocessing
+from multiprocessing.managers import BaseManager
+
+import pytest
+
+Stash = pytest.importorskip("wptserve.stash").Stash
+
+@pytest.fixture()
+def add_cleanup():
+    fns = []
+
+    def add(fn):
+        fns.append(fn)
+
+    yield add
+
+    for fn in fns:
+        fn()
+
+def test_delayed_lock(add_cleanup):
+    '''Ensure that delays in proxied Lock retrieval do not interfere with
+    initialization in parallel threads.'''
+
+    class SlowLock(BaseManager):
+        pass
+
+    request_lock = multiprocessing.Lock()
+    response_lock = multiprocessing.Lock()
+
+    queue = multiprocessing.Queue()
+
+    def handle_lock_request():
+        request_lock.release()
+        response_lock.acquire()
+        return threading.Lock()
+
+    SlowLock.register("get_dict", callable=lambda: {})
+    SlowLock.register("Lock", callable=handle_lock_request)
+
+    slowlock = SlowLock(('localhost', 4543), 'some key')
+    slowlock.start()
+    add_cleanup(lambda: slowlock.shutdown())
+
+    def run(process_queue, request_lock, response_lock):
+        def target(thread_queue):
+            stash = Stash('/', ('localhost', 4543), 'some key')
+            thread_queue.put(stash.lock is None)
+
+        thread_queue = multiprocessing.Queue()
+        first = threading.Thread(target=target, args=(thread_queue,))
+        second = threading.Thread(target=target, args=(thread_queue,))
+
+        request_lock.acquire()
+        response_lock.acquire()
+        first.start()
+
+        request_lock.acquire()
+        # First is now waiting for Lock
+
+        second.start()
+
+        # Allow the first to proceed
+        response_lock.release()
+
+        process_queue.put(thread_queue.get())
+        process_queue.put(thread_queue.get())
+
+    parallel = multiprocessing.Process(target=run,
+                                       args=(queue, request_lock, response_lock))
+    parallel.start()
+    add_cleanup(lambda: parallel.terminate())
+
+    assert [queue.get(), queue.get()] == [False, False], (
+        'both instances had valid locks')
+
+def test_delayed_dict(add_cleanup):
+    '''Ensure that delays in proxied `dict` retrieval do not interfere with
+    initialization in parallel threads.'''
+
+    class SlowDict(BaseManager):
+        pass
+
+    request_lock = multiprocessing.Lock()
+    response_lock = multiprocessing.Lock()
+
+    queue = multiprocessing.Queue()
+
+    def handle_dict_request():
+        request_lock.release()
+        response_lock.acquire()
+        return {}
+
+    SlowDict.register("get_dict", callable=handle_dict_request)
+    SlowDict.register("Lock", callable=lambda: threading.Lock())
+
+    slowdict = SlowDict(('localhost', 4543), 'some key')
+    slowdict.start()
+    add_cleanup(lambda: slowdict.shutdown())
+
+    def run(process_queue, request_lock, response_lock):
+        def target(thread_queue):
+            stash = Stash('/', ('localhost', 4543), 'some key')
+            thread_queue.put(stash.lock is None)
+
+        thread_queue = multiprocessing.Queue()
+        first = threading.Thread(target=target, args=(thread_queue,))
+        second = threading.Thread(target=target, args=(thread_queue,))
+
+        request_lock.acquire()
+        response_lock.acquire()
+        first.start()
+
+        request_lock.acquire()
+        # First is now waiting for Lock
+
+        second.start()
+
+        # Allow the first to proceed
+        response_lock.release()
+
+        process_queue.put(thread_queue.get())
+        process_queue.put(thread_queue.get())
+
+    parallel = multiprocessing.Process(target=run,
+                                       args=(queue, request_lock, response_lock))
+    parallel.start()
+    add_cleanup(lambda: parallel.terminate())
+
+    assert [queue.get(), queue.get()] == [False, False], (
+        'both instances had valid locks')

--- a/tools/wptserve/wptserve/stash.py
+++ b/tools/wptserve/wptserve/stash.py
@@ -104,6 +104,7 @@ class Stash(object):
 
     _proxy = None
     lock = None
+    _initializing = threading.Lock()
 
     def __init__(self, default_path, address=None, authkey=None):
         self.default_path = default_path
@@ -115,7 +116,16 @@ class Stash(object):
             Stash._proxy = {}
             Stash.lock = threading.Lock()
 
-        if Stash._proxy is None:
+        # Initializing the proxy involves connecting to the remote process and
+        # retrieving two proxied objects. This process is not inherently
+        # atomic, so a lock must be used to make it so. Atomicity ensures that
+        # only one thread attempts to initialize the connection and that any
+        # threads running in parallel correctly wait for initialization to be
+        # fully complete.
+        with Stash._initializing:
+            if Stash.lock:
+                return
+
             manager = ClientDictManager(address, authkey)
             manager.connect()
             Stash._proxy = manager.get_dict()


### PR DESCRIPTION
This race condition was expressed during testing sessions where the
first test to use the Stash feature issued did so with multiple requests
made in parallel.

---

The tests are brittle, but given the conditions we need to model, brittleness seems unavoidable.

The server code hasn't changed recently, so it's a little surprising that a race condition should suddenly become an issue [in Taskcluster](https://github.com/web-platform-tests/wpt/issues/13989) and [in the results-collection project](https://github.com/web-platform-tests/results-collection/issues/625).  Reviewing the status for each commit in `master` shows that [this intermittent error first surfaced on November 5](https://github.com/web-platform-tests/wpt/commits/master?after=7c568fdbd98ccdb92152c14521d3cc8c729a45a2+74).  Guy Fawkes is the obvious suspect, but the trail's gone cold. I turned to more technical explanations.

[The most recent Chromedriver release is version 2.43](https://chromedriver.storage.googleapis.com/index.html), and [that was published on October 16](https://chromedriver.storage.googleapis.com/2.43/notes.txt), ruling out a regression there. Chrome itself may have regressed, but I'm not set up to do any sort of bisecting, so I'm proceeding under the assumption that this is an issue in WPT.

A small incongruity between the Buildbot and Taskcluster setup is useful here.  Each system experiences the issue on a different "chunk" of WPT, but they define the segments in different terms. Buildbot uses 20 "chunks" containing tests of all types (failing on number 3) while Taskcluster uses 15 "chunks" for the testharness.js tests (failing on 13). We can narrow the set of suspect files by using the union of the following two lists:

    ./wpt run --list-tests --this-chunk 3 --total-chunks 20 chrome
    ./wpt run --list-tests --this-chunk 13 --total chunks 15 --test-type testdriver -- chrome

That returns 187 test files to consider. Feeding those files into `git log` shows that only one of them changed on that day:

    $ cat both.txt | xargs git log --after=2018-11-04 --before=2018-11-06 --oneline --
    7e66d13 Ensure eval flag is properly transfered to context from CSPRO

[`content-security-policy/script-src/eval-allowed-in-report-only-mode-and-sends-report.html` doesn't appear to be doing anything invalid.](https://github.com/web-platform-tests/wpt/blob/89188af97522b15cfe7ab6cc1c9cdb58007f0967/content-security-policy/script-src/eval-allowed-in-report-only-mode-and-sends-report.html) It does make parallel requests to a Stash-enabled endpoint, though (via [`checkReport.sub.js`](https://github.com/web-platform-tests/wpt/blob/89188af97522b15cfe7ab6cc1c9cdb58007f0967/content-security-policy/support/checkReport.sub.js)). The race condition fixed by this patch would only be expressed when the first test to use Stash did so via two parallel requests; my guess is that's uncommon but became true on November 5.