### PR TITLE
disable Firefox WebRTC ICE logging to reduce log size

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -230,6 +230,11 @@ Consider installing certutil via your OS package manager or directly.""")
             kwargs["headless"] = True
             logger.info("Running in headless mode, pass --no-headless to disable")
 
+        # Turn off Firefox WebRTC ICE logging on WPT (turned on by mozrunner)
+        os.unsetenv('R_LOG_LEVEL')
+        os.unsetenv('R_LOG_DESTINATION')
+        os.unsetenv('R_LOG_VERBOSE')
+
         # Allow WebRTC tests to call getUserMedia.
         kwargs["extra_prefs"].append("media.navigator.streams.fake=true")
 


### PR DESCRIPTION
Multiple WebRTC WPT tests appear to be not stable when testing Firefox. When trying to look at them you don't see the actual test failure, because even the raw log is truncated at 3MB. These logs are full of ICE and signaling logs. But since all WPT WebRTC simply connect one browser instance to itself over loopback they are highly unlikely to encounter ICE problems.

So the idea here is to turn off the ICE logging, which is inherited from using mozrunner, when executing on WPT, so that the 3MB logs hopefully are hopefully no longer get truncated.