### PR TITLE
Replace direct use of offerToReceiveAudio by generateAudioReceiveOnlyOffer

### DIFF
--- a/webrtc/RTCConfiguration-rtcpMuxPolicy.html
+++ b/webrtc/RTCConfiguration-rtcpMuxPolicy.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="RTCConfiguration-helper.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
 <script>
   'use strict';
 
@@ -188,8 +189,8 @@
     const pc = new RTCPeerConnection({rtcpMuxPolicy: 'require'});
     t.add_cleanup(() => pc.close());
 
-    await pc.createOffer({offerToReceiveAudio: true})
-      .then(offer => pc.setLocalDescription(offer));
+    const offer = await generateAudioReceiveOnlyOffer(pc);
+    await pc.setLocalDescription(offer);
     return promise_rejects(t, 'InvalidAccessError', pc.setRemoteDescription({type: 'answer', sdp}));
   }, 'setRemoteDescription throws InvalidAccessError when called with an answer without rtcp-mux and rtcpMuxPolicy is set to require');
 </script>

--- a/webrtc/RTCPeerConnection-iceGatheringState.html
+++ b/webrtc/RTCPeerConnection-iceGatheringState.html
@@ -11,8 +11,9 @@
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
-  // exchangeIceCandidates
   // doSignalingHandshake
+  // exchangeIceCandidates
+  // generateAudioReceiveOnlyOffer
 
   /*
     4.3.2.  Interface Definition
@@ -72,7 +73,7 @@
 
     pc.addEventListener('icegatheringstatechange', onIceGatheringStateChange);
 
-    pc.createOffer({ offerToReceiveAudio: true })
+    generateAudioReceiveOnlyOffer(pc)
     .then(offer => pc.setLocalDescription(offer))
     .then(err => t.step_func(err =>
       assert_unreached(`Unhandled rejection ${err.name}: ${err.message}`)));

--- a/webrtc/RTCPeerConnection-onnegotiationneeded.html
+++ b/webrtc/RTCPeerConnection-onnegotiationneeded.html
@@ -12,6 +12,7 @@
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
   //   generateAnswer
+  //   generateAudioReceiveOnlyOffer
   //   test_never_resolve
 
   // Listen to the negotiationneeded event on a peer connection
@@ -165,7 +166,7 @@
     const pc = new RTCPeerConnection();
     const negotiated = awaitNegotiation(pc);
 
-    return pc.createOffer({ offerToReceiveAudio: true })
+    return generateAudioReceiveOnlyOffer(pc)
     .then(offer => pc.setLocalDescription(offer))
     .then(() => negotiated)
     .then(({nextPromise}) => {
@@ -190,7 +191,7 @@
 
     return assert_first_promise_fulfill_after_second(
       awaitNegotiation(pc),
-      pc.createOffer({ offerToReceiveAudio: true })
+      generateAudioReceiveOnlyOffer(pc)
       .then(offer =>
         pc.setLocalDescription(offer)
         .then(() => {

--- a/webrtc/RTCPeerConnection-setLocalDescription-rollback.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-rollback.html
@@ -12,6 +12,7 @@
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
   //   assert_session_desc_similar
+  //   generateAudioReceiveOnlyOffer
 
   /*
     4.3.2.  Interface Definition
@@ -105,7 +106,7 @@
   promise_test(t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    return pc.createOffer({ offerToReceiveAudio: true })
+    return generateAudioReceiveOnlyOffer(pc)
     .then(offer =>
       pc.setRemoteDescription(offer)
       .then(() => pc.createAnswer()))

--- a/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
@@ -12,6 +12,7 @@
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
   //   assert_session_desc_similar()
+  //   generateAudioReceiveOnlyOffer
 
   /*
     4.3.2.  Interface Definition
@@ -115,7 +116,7 @@
     .then(offer1 => {
       return pc1.setLocalDescription(offer1)
        .then(()=> {
-        return pc1.createOffer({ offerToReceiveAudio: true })
+        return generateAudioReceiveOnlyOffer(pc1)
         .then(offer2 => {
           assert_session_desc_not_similar(offer1, offer2);
 

--- a/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html
@@ -11,8 +11,9 @@
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
-  //   generateDataChannelOffer
   //   assert_session_desc_similar
+  //   generateAudioReceiveOnlyOffer
+  //   generateDataChannelOffer
 
   /*
     4.3.2.  Interface Definition
@@ -105,7 +106,7 @@
   promise_test(t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    return pc.createOffer({ offerToReceiveAudio: true })
+    return generateAudioReceiveOnlyOffer(pc)
     .then(offer => pc.setRemoteDescription(offer))
     .then(() => pc.setRemoteDescription({
       type: 'rollback',


### PR DESCRIPTION
This allows to use non legacy APIs by default if supported.