### PR TITLE
Remove display of stats by default in webrtc/get-stats.html

### DIFF
--- a/webrtc/getstats.html
+++ b/webrtc/getstats.html
@@ -12,6 +12,7 @@ This test uses data only, and thus does not require fake media devices.
   <div id="log"></div>
   <h2>Retrieved stats info</h2>
   <pre>
+  <input type="button" onclick="showStats()" value="Show stats"></input>
   <div id="stats">
   </div>
   </pre>
@@ -21,7 +22,7 @@ This test uses data only, and thus does not require fake media devices.
   <script src="/resources/testharnessreport.js"></script>
   <script type="text/javascript">
   var test = async_test('Can get stats from a basic WebRTC call.');
-
+  var statsToShow;
   var gFirstConnection = null;
   var gSecondConnection = null;
 
@@ -56,13 +57,11 @@ This test uses data only, and thus does not require fake media devices.
     }
     gFirstConnection.getStats()
     .then(function(report) {
-      // Show the retrieved stats info
-      var showStats = document.getElementById('stats');
       let reportDictionary = {};
       for (let stats of report.values()) {
         reportDictionary[stats.id] = stats;
       }
-      showStats.innerHTML = JSON.stringify(reportDictionary, null, 2);
+      statsToShow = JSON.stringify(reportDictionary, null, 2);
       // Check the stats properties.
       assert_not_equals(report, null, 'No report');
       let sessionStat = getStatsRecordByType(report, 'peer-connection');
@@ -121,6 +120,13 @@ This test uses data only, and thus does not require fake media devices.
                        ' happened at step ' + atStep);
     }));
   });
+
+  function showStats() {
+    // Show the retrieved stats info
+    var showStats = document.getElementById('stats');
+    showStats.innerHTML = statsToShow;
+  }
+
 </script>
 
 </body>


### PR DESCRIPTION
Instead,  user needs to click on a button for that.
This allows having a consistent WebKitTestRunner output for this test.