### PR TITLE
webrtc: add test for legacy default stream

### DIFF
--- a/webrtc/RTCPeerConnection-setRemoteDescription-nomsid.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-nomsid.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCPeerConnection.prototype.setRemoteDescription - legacy streams without a=msid lines</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+'use strict';
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  //   addEventListenerPromise
+
+const FINGERPRINT_SHA256 = '00:00:00:00:00:00:00:00:00:00:00:00:00' +
+    ':00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00';
+const ICEUFRAG = 'someufrag';
+const ICEPWD = 'somelongpwdwithenoughrandomness';
+const SDP_BOILERPLATE = 'v=0\r\n' +
+    'o=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+    's=-\r\n' +
+    't=0 0\r\n';
+const MINIMAL_AUDIO_MLINE =
+    'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
+    'c=IN IP4 0.0.0.0\r\n' +
+    'a=rtcp:9 IN IP4 0.0.0.0\r\n' +
+    'a=ice-ufrag:' + ICEUFRAG + '\r\n' +
+    'a=ice-pwd:' + ICEPWD + '\r\n' +
+    'a=fingerprint:sha-256 ' + FINGERPRINT_SHA256 + '\r\n' +
+    'a=setup:actpass\r\n' +
+    'a=mid:0\r\n' +
+    'a=sendrecv\r\n' +
+    'a=rtcp-mux\r\n' +
+    'a=rtcp-rsize\r\n' +
+    'a=rtpmap:111 opus/48000/2\r\n';
+
+  promise_test(async t => {
+    const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
+    const ontrackPromise = addEventListenerPromise(t, pc, 'track', e => {
+      assert_equals(e.streams.length, 1);
+    });
+    await pc.setRemoteDescription({type: 'offer', sdp: SDP_BOILERPLATE + MINIMAL_AUDIO_MLINE});
+    await ontrackPromise;
+
+  }, 'setRemoteDescription with an SDP without a=msid lines triggers ontrack with a default stream.');
+
+</script>

--- a/webrtc/RTCPeerConnection-setRemoteDescription-nomsid.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-nomsid.html
@@ -3,11 +3,8 @@
 <title>RTCPeerConnection.prototype.setRemoteDescription - legacy streams without a=msid lines</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="RTCPeerConnection-helper.js"></script>
 <script>
 'use strict';
-  // The following helper functions are called from RTCPeerConnection-helper.js:
-  //   addEventListenerPromise
 
 const FINGERPRINT_SHA256 = '00:00:00:00:00:00:00:00:00:00:00:00:00' +
     ':00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00';
@@ -35,12 +32,9 @@ const MINIMAL_AUDIO_MLINE =
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
 
-    const ontrackPromise = addEventListenerPromise(t, pc, 'track', e => {
-      assert_equals(e.streams.length, 1);
-    });
+    const haveOntrack = new Promise(r => pc.ontrack = r);
     await pc.setRemoteDescription({type: 'offer', sdp: SDP_BOILERPLATE + MINIMAL_AUDIO_MLINE});
-    await ontrackPromise;
-
+    assert_equals((await haveOntrack).streams.length, 1);
   }, 'setRemoteDescription with an SDP without a=msid lines triggers ontrack with a default stream.');
 
 </script>


### PR DESCRIPTION
adds a test covering the legacy behaviour of dealing
with SDP not containing a a=msid lines.

See also
https://github.com/rtcweb-wg/jsep/issues/856
https://github.com/w3c/webrtc-pc/issues/2027

SDP bits stem from [here](https://github.com/otalk/rtcpeerconnection-shim/blob/master/test/rtcpeerconnection.js) which I wrote so this should be ok in terms of license. Might make sense to use them elsewhere but there are surprisingly few attempts to make assertions about SDP here.

@jan-ivar I emulated the style from you, can you take a look?
@henbos how do you want to deal with this breaking in unified-plan mode?
@alvestrand do you happen to have a nice video sdp with both H264 and VP8? Then we could also assert that both tracks are in the same stream. I tried duplicating the audio m-line but that fails in Chrome without unified-plan.