### PR TITLE
[testharness.js] Honor test config in workers

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -311,6 +311,7 @@ SET TIMEOUT: resources/test/tests/functional/add_cleanup_async_rejection.html
 SET TIMEOUT: resources/test/tests/functional/add_cleanup_async_rejection_after_load.html
 SET TIMEOUT: resources/test/tests/functional/api-tests-1.html
 SET TIMEOUT: resources/test/tests/functional/worker.js
+SET TIMEOUT: resources/test/tests/functional/worker-uncaught-allow.js
 SET TIMEOUT: resources/test/tests/unit/exceptional-cases.html
 SET TIMEOUT: resources/testharness.js
 

--- a/resources/test/tests/functional/worker-dedicated-uncaught-allow.html
+++ b/resources/test/tests/functional/worker-dedicated-uncaught-allow.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
+<title>Dedicated Worker Tests - Allowed Uncaught Exception</title>
+<script src="../../variants.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<h1>Dedicated Web Worker Tests - Allowed Uncaught Exception</h1>
+<p>Demonstrates running <tt>testharness</tt> based tests inside a dedicated web worker.
+<p>The test harness is expected to pass despite an uncaught exception in a worker because that worker is configured to allow uncaught exceptions.</p>
+<div id="log"></div>
+
+<script>
+test(function(t) {
+        assert_true("Worker" in self, "Browser should support Workers");
+    },
+    "Browser supports Workers");
+
+fetch_tests_from_worker(new Worker("worker-uncaught-allow.js"));
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [
+    {
+      "status_string": "PASS",
+      "name": "Browser supports Workers",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "onerror event is triggered",
+      "properties": {},
+      "message": null
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>

--- a/resources/test/tests/functional/worker-uncaught-allow.js
+++ b/resources/test/tests/functional/worker-uncaught-allow.js
@@ -1,0 +1,17 @@
+importScripts("/resources/testharness.js");
+
+setup({allow_uncaught_exception:true});
+
+async_test(function(t) {
+  onerror = function() {
+    // Further delay the test's completion to ensure that the worker's
+    // `onerror` handler does not influence results in the parent context.
+    setTimeout(function() {
+      t.done();
+    }, 0);
+  };
+
+  setTimeout(function() {
+    throw new Error("This error is expected.");
+  }, 0);
+}, 'onerror event is triggered');

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1904,7 +1904,9 @@ policies and contribution forms [3].
      */
     function RemoteContext(remote, message_target, message_filter) {
         this.running = true;
+        this.started = false;
         this.tests = new Array();
+        this.early_exception = null;
 
         var this_obj = this;
         // If remote context is cross origin assigning to onerror is not
@@ -1943,6 +1945,21 @@ policies and contribution forms [3].
     }
 
     RemoteContext.prototype.remote_error = function(error) {
+        if (error.preventDefault) {
+            error.preventDefault();
+        }
+
+        // Defer interpretation of errors until the testing protocol has
+        // started and the remote test's `allow_uncaught_exception` property
+        // is available.
+        if (!this.started) {
+            this.early_exception = error;
+        } else if (!this.allow_uncaught_exception) {
+            this.report_uncaught(error);
+        }
+    };
+
+    RemoteContext.prototype.report_uncaught = function(error) {
         var message = error.message || String(error);
         var filename = (error.filename ? " " + error.filename: "");
         // FIXME: Display remote error states separately from main document
@@ -1950,9 +1967,14 @@ policies and contribution forms [3].
         tests.set_status(tests.status.ERROR,
                          "Error in remote" + filename + ": " + message,
                          error.stack);
+    };
 
-        if (error.preventDefault) {
-            error.preventDefault();
+    RemoteContext.prototype.start = function(data) {
+        this.started = true;
+        this.allow_uncaught_exception = data.properties.allow_uncaught_exception;
+
+        if (this.early_exception && !this.allow_uncaught_exception) {
+            this.report_uncaught(this.early_exception);
         }
     };
 
@@ -2002,6 +2024,7 @@ policies and contribution forms [3].
     };
 
     RemoteContext.prototype.message_handlers = {
+        start: RemoteContext.prototype.start,
         test_state: RemoteContext.prototype.test_state,
         result: RemoteContext.prototype.test_done,
         complete: RemoteContext.prototype.remote_done


### PR DESCRIPTION
Ensure that uncaught exceptions originating from workers do not
influence harness status when the `allow_uncaught_exception` setting has
been enabled.

This is intended to resolve gh-14041.