### PR TITLE
Remove timeout in async_test for IndexedDB tests

### DIFF
--- a/IndexedDB/idbcursor_advance_index2.htm
+++ b/IndexedDB/idbcursor_advance_index2.htm
@@ -10,7 +10,7 @@
 <script>
 
     var db,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       records = [ { pKey: "primaryKey_0", iKey: "indexKey_0" },
                   { pKey: "primaryKey_1", iKey: "indexKey_1" } ];
 

--- a/IndexedDB/idbcursor_advance_index3.htm
+++ b/IndexedDB/idbcursor_advance_index3.htm
@@ -10,7 +10,7 @@
 <script type="text/javascript">
 
     var db,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       records = [ { pKey: "primaryKey_0", iKey: "indexKey_0" },
                   { pKey: "primaryKey_1", iKey: "indexKey_1" } ];
 

--- a/IndexedDB/idbcursor_advance_index5.htm
+++ b/IndexedDB/idbcursor_advance_index5.htm
@@ -11,7 +11,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       records = [ { pKey: "primaryKey_0",   iKey: "indexKey_0" },
                   { pKey: "primaryKey_1",   iKey: "indexKey_1" },
                   { pKey: "primaryKey_1-2", iKey: "indexKey_1" } ],

--- a/IndexedDB/idbcursor_continue_index5.htm
+++ b/IndexedDB/idbcursor_continue_index5.htm
@@ -11,7 +11,7 @@
 <script>
 
     var db,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       records = [ { pKey: "primaryKey_0",   iKey: "indexKey_0" },
                   { pKey: "primaryKey_1",   iKey: "indexKey_1" },
                   { pKey: "primaryKey_1-2", iKey: "indexKey_1" },

--- a/IndexedDB/idbcursor_continue_index6.htm
+++ b/IndexedDB/idbcursor_continue_index6.htm
@@ -11,7 +11,7 @@
 <script>
 
     var db,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       records = [ { pKey: "primaryKey_0",   iKey: "indexKey_0" },
                   { pKey: "primaryKey_1",   iKey: "indexKey_1" },
                   { pKey: "primaryKey_1-2", iKey: "indexKey_1" },

--- a/IndexedDB/idbcursor_continue_invalid.htm
+++ b/IndexedDB/idbcursor_continue_invalid.htm
@@ -8,7 +8,7 @@
 <script>
 
     var db,
-      t = async_test(document.title, {timeout: 10000});
+      t = async_test(document.title);
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbcursor_iterating.htm
+++ b/IndexedDB/idbcursor_iterating.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title, {timeout: 10000});
+      t = async_test(document.title);
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbcursor_iterating_index.htm
+++ b/IndexedDB/idbcursor_iterating_index.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       records = [ { pKey: "primaryKey_0", obj: { iKey: "iKey_0" }},
                   { pKey: "primaryKey_1", obj: { iKey: "iKey_1" }},
                   { pKey: "primaryKey_2", obj: { iKey: "iKey_2" }} ],

--- a/IndexedDB/idbcursor_iterating_index2.htm
+++ b/IndexedDB/idbcursor_iterating_index2.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       records = [ { pKey: "primaryKey_0", obj: { iKey: "iKey_0" }},
                   { pKey: "primaryKey_2", obj: { iKey: "iKey_2" }} ],
 

--- a/IndexedDB/idbcursor_iterating_objectstore.htm
+++ b/IndexedDB/idbcursor_iterating_objectstore.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       records = [ { pKey: "primaryKey_0" },
                   { pKey: "primaryKey_1" },
                   { pKey: "primaryKey_2" } ],

--- a/IndexedDB/idbcursor_iterating_objectstore2.htm
+++ b/IndexedDB/idbcursor_iterating_objectstore2.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       records = [ { pKey: "primaryKey_0" },
                   { pKey: "primaryKey_2" } ],
       expected_records = [ { pKey: "primaryKey_0" },

--- a/IndexedDB/idbcursor_update_objectstore4.htm
+++ b/IndexedDB/idbcursor_update_objectstore4.htm
@@ -8,7 +8,7 @@
 <script>
 
     var db,
-      t = async_test(document.title, {timeout: 10000})
+      t = async_test(document.title)
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbdatabase_createObjectStore10-1000ends.htm
+++ b/IndexedDB/idbdatabase_createObjectStore10-1000ends.htm
@@ -7,7 +7,7 @@
 
 <script>
 var db,
-    t = async_test(document.title, {timeout: 600000}),
+    t = async_test(document.title),
     open_rq = createdb(t)
 
 open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbdatabase_createObjectStore7.htm
+++ b/IndexedDB/idbdatabase_createObjectStore7.htm
@@ -7,7 +7,7 @@
 
 <script>
 
-var t = async_test(document.title, {timeout: 10000}),
+var t = async_test(document.title),
     open_rq = createdb(t)
 
 open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbdatabase_deleteObjectStore4-not_reused.htm
+++ b/IndexedDB/idbdatabase_deleteObjectStore4-not_reused.htm
@@ -8,7 +8,7 @@
 
 <script>
 
-var t = async_test(document.title, {timeout: 10000}),
+var t = async_test(document.title),
     keys = [],
     open_rq = createdb(t)
 

--- a/IndexedDB/idbdatabase_transaction4.htm
+++ b/IndexedDB/idbdatabase_transaction4.htm
@@ -7,7 +7,7 @@
 
 <script>
     var db,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       open_rq = createdb(t);
 
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbfactory_deleteDatabase3.htm
+++ b/IndexedDB/idbfactory_deleteDatabase3.htm
@@ -9,7 +9,7 @@
 
 <script>
     var db
-    var open_rq = createdb(async_test(document.title, {timeout: 10000}), undefined, 9)
+    var open_rq = createdb(async_test(document.title), undefined, 9)
 
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result

--- a/IndexedDB/idbfactory_open10.htm
+++ b/IndexedDB/idbfactory_open10.htm
@@ -7,7 +7,7 @@
 
 <script>
     var db, db2;
-    var open_rq = createdb(async_test(document.title, {timeout: 10000}), undefined, 9);
+    var open_rq = createdb(async_test(document.title), undefined, 9);
 
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;

--- a/IndexedDB/idbfactory_open11.htm
+++ b/IndexedDB/idbfactory_open11.htm
@@ -8,7 +8,7 @@
 <script>
     var db;
     var count_done = 0;
-    var open_rq = createdb(async_test(document.title, {timeout: 10000}));
+    var open_rq = createdb(async_test(document.title));
 
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;

--- a/IndexedDB/idbfactory_open12.htm
+++ b/IndexedDB/idbfactory_open12.htm
@@ -7,7 +7,7 @@
 
 <script>
     var db;
-    var open_rq = createdb(async_test(document.title, {timeout: 10000}), undefined, 9);
+    var open_rq = createdb(async_test(document.title), undefined, 9);
     var open2_t = async_test(document.title + " - second upgrade");
 
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbindex-multientry-arraykeypath.htm
+++ b/IndexedDB/idbindex-multientry-arraykeypath.htm
@@ -9,7 +9,7 @@
 <script src="support.js"></script>
 
 <script>
-    createdb(async_test(document.title, {timeout: 10000})).onupgradeneeded = function(e) {
+    createdb(async_test(document.title)).onupgradeneeded = function(e) {
         var store = e.target.result.createObjectStore("store");
 
         assert_throws('InvalidAccessError', function() {

--- a/IndexedDB/idbindex-multientry-big.htm
+++ b/IndexedDB/idbindex-multientry-big.htm
@@ -10,8 +10,8 @@
 
 <script>
     var db,
-        t_add = async_test("Adding one item with 1000 multiEntry keys", { timeout: 10000 }),
-        t_get = async_test("Getting the one item by 1000 indeced keys ", { timeout: 10000 });
+        t_add = async_test("Adding one item with 1000 multiEntry keys"),
+        t_get = async_test("Getting the one item by 1000 indeced keys ");
 
     var open_rq = createdb(t_add);
     var obj = { test: 'yo', idxkeys: [] };

--- a/IndexedDB/idbindex-multientry.htm
+++ b/IndexedDB/idbindex-multientry.htm
@@ -12,7 +12,7 @@
     var db,
         expected_keys = [1, 2, 2, 3, 3];
 
-    var open_rq = createdb(async_test(document.title, {timeout: 10000}))
+    var open_rq = createdb(async_test(document.title))
 
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;

--- a/IndexedDB/idbindex_indexNames.htm
+++ b/IndexedDB/idbindex_indexNames.htm
@@ -8,7 +8,7 @@
 
 <script>
     var db,
-      t = async_test(document.title, {timeout: 10000});
+      t = async_test(document.title);
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex3-usable-right-away.htm
+++ b/IndexedDB/idbobjectstore_createIndex3-usable-right-away.htm
@@ -9,7 +9,7 @@
 
 <script>
     var db, aborted,
-      t = async_test(document.title, {timeout:19000})
+      t = async_test(document.title)
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex4-deleteIndex-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex4-deleteIndex-event_order.htm
@@ -9,7 +9,7 @@
 <script>
     var db,
       events = [],
-      t = async_test(document.title, {timeout: 10000})
+      t = async_test(document.title)
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex5-emptykeypath.htm
+++ b/IndexedDB/idbobjectstore_createIndex5-emptykeypath.htm
@@ -8,7 +8,7 @@
 
 <script>
     var db, aborted,
-      t = async_test(document.title, {timeout: 10000})
+      t = async_test(document.title)
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex6-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex6-event_order.htm
@@ -16,7 +16,7 @@
 
     var db,
       events = [],
-      t = async_test(document.title, {timeout: 10000})
+      t = async_test(document.title)
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex7-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex7-event_order.htm
@@ -18,7 +18,7 @@
 
     var db,
       events = [],
-      t = async_test(document.title, {timeout: 10000})
+      t = async_test(document.title)
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex8-valid_keys.htm
+++ b/IndexedDB/idbobjectstore_createIndex8-valid_keys.htm
@@ -9,7 +9,7 @@
 
 <script>
     var db,
-      t = async_test(document.title, {timeout:19000}),
+      t = async_test(document.title),
       now = new Date(),
       mar18 = new Date(1111111111111),
       ar = ["Yay", 2, -Infinity],

--- a/IndexedDB/idbobjectstore_deleted.htm
+++ b/IndexedDB/idbobjectstore_deleted.htm
@@ -11,7 +11,7 @@
 <script>
     var db,
       add_success = false,
-      t = async_test(document.title, {timeout: 10000})
+      t = async_test(document.title)
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbtransaction-oncomplete.htm
+++ b/IndexedDB/idbtransaction-oncomplete.htm
@@ -7,7 +7,7 @@
 
 <script>
     var db, store,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       open_rq = createdb(t),
       stages = [];
 

--- a/IndexedDB/idbtransaction_abort.htm
+++ b/IndexedDB/idbtransaction_abort.htm
@@ -8,7 +8,7 @@
 
 <script>
     var db, aborted,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       record = { indexedProperty: "bar" };
 
     var open_rq = createdb(t);

--- a/IndexedDB/idbversionchangeevent.htm
+++ b/IndexedDB/idbversionchangeevent.htm
@@ -13,7 +13,7 @@
 <script>
 
     var db,
-        t = async_test(document.title, {timeout: 10000});
+        t = async_test(document.title);
 
     t.step(function() {
         var openrq = indexedDB.open('db', 3);

--- a/IndexedDB/keygenerator-constrainterror.htm
+++ b/IndexedDB/keygenerator-constrainterror.htm
@@ -9,7 +9,7 @@
 <script>
 
     var db,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       objects = [1, null, {id: 2}, null, 2.00001, 5, null, {id: 6} ],
       expected = [1, 2, 2.00001, 3, 5, 6],
       errors = 0;

--- a/IndexedDB/keygenerator-overflow.htm
+++ b/IndexedDB/keygenerator-overflow.htm
@@ -11,7 +11,7 @@
 <script>
 
     var db,
-      t = async_test(document.title, {timeout: 10000}),
+      t = async_test(document.title),
       overflow_error_fired = false,
       objects =  [9007199254740991, null, "error", 2, "error" ],
       expected_keys = [2, 9007199254740991, 9007199254740992];

--- a/IndexedDB/keyorder.htm
+++ b/IndexedDB/keyorder.htm
@@ -22,7 +22,7 @@
 
     function keysort(desc, unsorted, expected) {
         var db,
-            t = async_test("Database readback sort - " + desc, { timeout: 10000 }),
+            t = async_test("Database readback sort - " + desc),
             store_name = 'store-' + Date.now() + Math.random();
 
         // The database test

--- a/IndexedDB/keypath_maxsize.htm
+++ b/IndexedDB/keypath_maxsize.htm
@@ -11,7 +11,7 @@
 <script>
     function keypath(keypath, objects, expected_keys, desc) {
         var db,
-            t = async_test(document.title + " - " + (desc ? desc : keypath), { timeout: 10000 }),
+            t = async_test(document.title + " - " + (desc ? desc : keypath)),
             open_rq = createdb(t);
 
         open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/request_bubble-and-capture.htm
+++ b/IndexedDB/request_bubble-and-capture.htm
@@ -9,7 +9,7 @@
 <script>
     var events = [];
 
-    var open_rq = createdb(async_test(document.title, {timeout: 10000}));
+    var open_rq = createdb(async_test(document.title));
     open_rq.onupgradeneeded = function(e) {
         var db = e.target.result;
         var txn = e.target.transaction;

--- a/IndexedDB/transaction-lifetime-blocked.htm
+++ b/IndexedDB/transaction-lifetime-blocked.htm
@@ -11,7 +11,7 @@
 
     var db, db_got_versionchange, db2,
         events = [],
-        t = async_test(document.title, {timeout: 10000});
+        t = async_test(document.title);
 
     t.step(function() {
         var openrq = indexedDB.open('db', 3);

--- a/IndexedDB/transaction-lifetime.htm
+++ b/IndexedDB/transaction-lifetime.htm
@@ -11,7 +11,7 @@
 
     var db, db_got_versionchange, db2,
         events = [],
-        t = async_test(document.title, {timeout: 10000});
+        t = async_test(document.title);
 
     t.step(function() {
         var openrq = indexedDB.open('db', 3);

--- a/IndexedDB/transaction-requestqueue.htm
+++ b/IndexedDB/transaction-requestqueue.htm
@@ -8,7 +8,7 @@
 
 <script>
 
-var db, t = async_test(document.title, {timeout: 10000}),
+var db, t = async_test(document.title),
     keys = { txn: [], txn2: [] },
     open_rq = createdb(t)
 

--- a/IndexedDB/transaction_bubble-and-capture.htm
+++ b/IndexedDB/transaction_bubble-and-capture.htm
@@ -9,7 +9,7 @@
 <script>
     var events = [];
 
-    var open_rq = createdb(async_test(document.title, {timeout: 10000}));
+    var open_rq = createdb(async_test(document.title));
     open_rq.onupgradeneeded = function(e) {
         var db = e.target.result;
         var txn = e.target.transaction;

--- a/IndexedDB/writer-starvation.htm
+++ b/IndexedDB/writer-starvation.htm
@@ -12,7 +12,7 @@
     var write_request_count = 0, write_success_count = 0;
     var RQ_COUNT = 25;
 
-    var open_rq = createdb(async_test(undefined, {timeout: 20000}));
+    var open_rq = createdb(async_test(undefined));
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;
         db.createObjectStore("s")


### PR DESCRIPTION
Remove all the timeout parameters in async_test for IndexedDB tests.
Affected tests: 44, Pass: 44, Failed: 0
Related: #11120