### PR TITLE
Allow `test_driver.bless` to work when running manually

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -73,7 +73,11 @@
             return new Promise(function(resolve, reject) {
                     button.addEventListener("click", resolve);
 
-                    test_driver.click(button).catch(reject);
+                    test_driver.click(button).catch(reason => {
+                        if (navigator.webdriver) {
+                            reject(reason);
+                        }
+                    });
                 }).then(function() {
                     button.remove();
 


### PR DESCRIPTION
Tests using `test_driver.bless` now currently always fail when running
them manually, because the default `test_driver_internal.click`
rejects with "unimplemented".

Mute the rejection if the session isn't controlled by WebDriver, which
we check with `navigator.webdriver`.