### PR TITLE
Remove timeout in async_test for html tests

### DIFF
--- a/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_2.html
+++ b/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_2.html
@@ -6,7 +6,7 @@
 <pre id="step_log"></pre>
 <iframe id="test"></iframe>
 <script>
-var t = async_test(undefined);
+var t = async_test();
 var f = document.getElementById("test");
 var l = document.getElementById("step_log");
 

--- a/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_2.html
+++ b/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_2.html
@@ -6,7 +6,7 @@
 <pre id="step_log"></pre>
 <iframe id="test"></iframe>
 <script>
-var t = async_test(undefined, {timeout:10000});
+var t = async_test(undefined);
 var f = document.getElementById("test");
 var l = document.getElementById("step_log");
 

--- a/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_3.html
+++ b/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_3.html
@@ -6,7 +6,7 @@
 <pre id="step_log"></pre>
 <iframe id="test"></iframe>
 <script>
-var t = async_test(undefined);
+var t = async_test();
 var f = document.getElementById("test");
 var l = document.getElementById("step_log");
 

--- a/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_3.html
+++ b/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_3.html
@@ -6,7 +6,7 @@
 <pre id="step_log"></pre>
 <iframe id="test"></iframe>
 <script>
-var t = async_test(undefined, {timeout:10000});
+var t = async_test(undefined);
 var f = document.getElementById("test");
 var l = document.getElementById("step_log");
 

--- a/html/browsers/browsing-the-web/navigating-across-documents/010.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/010.html
@@ -7,7 +7,7 @@
 <form target="test" action="javascript:(function() {var x = new XMLHttpRequest(); x.open('GET', 'blank.html?pipe=trickle(d2)', false); x.send(); document.write('<script>parent.postMessage(&quot;write&quot;, &quot;*&quot;)</script>'); return '<script>parent.postMessage(&quot;click&quot;, &quot;*&quot;)</script>'})()"></form>
 <a target="test" onclick="document.forms[0].submit()" href="href.html">Test</a>
 <script>
-var t = async_test(undefined, {timeout:4000});
+var t = async_test(undefined);
 t.step(function() {document.getElementsByTagName("a")[0].click()});
 onmessage = t.step_func(
   function(e) {

--- a/html/browsers/browsing-the-web/navigating-across-documents/010.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/010.html
@@ -7,7 +7,7 @@
 <form target="test" action="javascript:(function() {var x = new XMLHttpRequest(); x.open('GET', 'blank.html?pipe=trickle(d2)', false); x.send(); document.write('<script>parent.postMessage(&quot;write&quot;, &quot;*&quot;)</script>'); return '<script>parent.postMessage(&quot;click&quot;, &quot;*&quot;)</script>'})()"></form>
 <a target="test" onclick="document.forms[0].submit()" href="href.html">Test</a>
 <script>
-var t = async_test(undefined);
+var t = async_test();
 t.step(function() {document.getElementsByTagName("a")[0].click()});
 onmessage = t.step_func(
   function(e) {

--- a/html/browsers/browsing-the-web/navigating-across-documents/012.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/012.html
@@ -10,7 +10,7 @@
      javascript url involved here, unlike what the title claims! -->
 <a target="test" onclick="javascript:(function() {var x = new XMLHttpRequest(); x.open('GET', 'blank.html?pipe=trickle(d2)', false); x.send(); document.write('write<script>parent.postMessage(&quot;write&quot;, &quot;*&quot;)</script>'); return '<script>parent.postMessage(&quot;click&quot;, &quot;*&quot;)</script>'})()" href="href.html">Test</a>
 <script>
-var t = async_test(undefined);
+var t = async_test();
 t.step(function() {document.getElementsByTagName("a")[0].click()});
 onmessage = t.step_func(
   function(e) {

--- a/html/browsers/browsing-the-web/navigating-across-documents/012.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/012.html
@@ -10,7 +10,7 @@
      javascript url involved here, unlike what the title claims! -->
 <a target="test" onclick="javascript:(function() {var x = new XMLHttpRequest(); x.open('GET', 'blank.html?pipe=trickle(d2)', false); x.send(); document.write('write<script>parent.postMessage(&quot;write&quot;, &quot;*&quot;)</script>'); return '<script>parent.postMessage(&quot;click&quot;, &quot;*&quot;)</script>'})()" href="href.html">Test</a>
 <script>
-var t = async_test(undefined, {timeout:4000});
+var t = async_test(undefined);
 t.step(function() {document.getElementsByTagName("a")[0].click()});
 onmessage = t.step_func(
   function(e) {

--- a/html/browsers/browsing-the-web/navigating-across-documents/013.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/013.html
@@ -6,7 +6,7 @@
 <iframe id="test" name="test"></iframe>
 <a target="test" href="javascript:parent.events.push('javascript');">Test</a>
 <script>
-var t = async_test(undefined, {timeout:4000});
+var t = async_test(undefined);
 var events = [];
 t.step(function() {
   document.getElementsByTagName("a")[0].click();

--- a/html/browsers/browsing-the-web/navigating-across-documents/013.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/013.html
@@ -6,7 +6,7 @@
 <iframe id="test" name="test"></iframe>
 <a target="test" href="javascript:parent.events.push('javascript');">Test</a>
 <script>
-var t = async_test(undefined);
+var t = async_test();
 var events = [];
 t.step(function() {
   document.getElementsByTagName("a")[0].click();

--- a/html/browsers/browsing-the-web/navigating-across-documents/014.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/014.html
@@ -7,7 +7,7 @@
 <form target="test" action="javascript:parent.events.push('submit');"></form>
 <a target="test" onclick="document.forms[0].submit()">Test</a>
 <script>
-var t = async_test(undefined);
+var t = async_test();
 var events = [];
 t.step(function() {
   document.getElementsByTagName("a")[0].click();

--- a/html/browsers/browsing-the-web/navigating-across-documents/014.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/014.html
@@ -7,7 +7,7 @@
 <form target="test" action="javascript:parent.events.push('submit');"></form>
 <a target="test" onclick="document.forms[0].submit()">Test</a>
 <script>
-var t = async_test(undefined, {timeout:4000});
+var t = async_test(undefined);
 var events = [];
 t.step(function() {
   document.getElementsByTagName("a")[0].click();

--- a/html/browsers/browsing-the-web/navigating-across-documents/015.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/015.html
@@ -6,7 +6,7 @@
 <iframe id="test" name="test"></iframe>
 <a target="test" onclick="parent.events.push('click');" href="javascript:parent.events.push('href')">Test</a>
 <script>
-var t = async_test(undefined);
+var t = async_test();
 var events = [];
 t.step(function() {
   document.getElementsByTagName("a")[0].click();

--- a/html/browsers/browsing-the-web/navigating-across-documents/015.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/015.html
@@ -6,7 +6,7 @@
 <iframe id="test" name="test"></iframe>
 <a target="test" onclick="parent.events.push('click');" href="javascript:parent.events.push('href')">Test</a>
 <script>
-var t = async_test(undefined, {timeout:4000});
+var t = async_test(undefined);
 var events = [];
 t.step(function() {
   document.getElementsByTagName("a")[0].click();

--- a/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-query-fragment-components.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-query-fragment-components.html
@@ -13,7 +13,7 @@ var c = null;
 <iframe id="c" src='javascript:"%252525 ? %252525 # %252525"'></iframe>
 
 <script>
-var t = async_test("iframes with javascript src", {timeout:1000});
+var t = async_test("iframes with javascript src");
 function check(id, expected) {
   assert_equals(
     document.getElementById(id).contentDocument.body.textContent,

--- a/html/browsers/history/the-history-interface/history_back_1.html
+++ b/html/browsers/history/the-history-interface/history_back_1.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/history_back_1.html
+++ b/html/browsers/history/the-history-interface/history_back_1.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/history_forward_1.html
+++ b/html/browsers/history/the-history-interface/history_forward_1.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/history_forward_1.html
+++ b/html/browsers/history/the-history-interface/history_forward_1.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/history_go_no_argument.html
+++ b/html/browsers/history/the-history-interface/history_go_no_argument.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   gone = false;
   pages = []

--- a/html/browsers/history/the-history-interface/history_go_no_argument.html
+++ b/html/browsers/history/the-history-interface/history_go_no_argument.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   gone = false;
   pages = []

--- a/html/browsers/history/the-history-interface/history_go_to_uri.html
+++ b/html/browsers/history/the-history-interface/history_go_to_uri.html
@@ -7,7 +7,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   gone = false;
   pages = []

--- a/html/browsers/history/the-history-interface/history_go_to_uri.html
+++ b/html/browsers/history/the-history-interface/history_go_to_uri.html
@@ -7,7 +7,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   gone = false;
   pages = []

--- a/html/browsers/history/the-history-interface/history_go_undefined.html
+++ b/html/browsers/history/the-history-interface/history_go_undefined.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/history_go_undefined.html
+++ b/html/browsers/history/the-history-interface/history_go_undefined.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/history_go_zero.html
+++ b/html/browsers/history/the-history-interface/history_go_zero.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   gone = false;
   pages = []

--- a/html/browsers/history/the-history-interface/history_go_zero.html
+++ b/html/browsers/history/the-history-interface/history_go_zero.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   gone = false;
   pages = []

--- a/html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_1-manual.html
+++ b/html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_1-manual.html
@@ -5,7 +5,7 @@
 <div id="log"></div>
 <script>
   setup({timeout:3600000});
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_1-manual.html
+++ b/html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_1-manual.html
@@ -5,7 +5,7 @@
 <div id="log"></div>
 <script>
   setup({timeout:3600000});
-  var t = async_test(undefined, {timeout:3600000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_2-manual.html
+++ b/html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_2-manual.html
@@ -5,7 +5,7 @@
 <div id="log"></div>
 <script>
   setup({timeout:3600000});
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_2-manual.html
+++ b/html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_2-manual.html
@@ -5,7 +5,7 @@
 <div id="log"></div>
 <script>
   setup({timeout:3600000});
-  var t = async_test(undefined, {timeout:3600000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/non-automated/traverse_the_session_history_unload_prompt_1-manual.html
+++ b/html/browsers/history/the-history-interface/non-automated/traverse_the_session_history_unload_prompt_1-manual.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/non-automated/traverse_the_session_history_unload_prompt_1-manual.html
+++ b/html/browsers/history/the-history-interface/non-automated/traverse_the_session_history_unload_prompt_1-manual.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/traverse_the_history_3.html
+++ b/html/browsers/history/the-history-interface/traverse_the_history_3.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/traverse_the_history_3.html
+++ b/html/browsers/history/the-history-interface/traverse_the_history_3.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/traverse_the_history_4.html
+++ b/html/browsers/history/the-history-interface/traverse_the_history_4.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/traverse_the_history_4.html
+++ b/html/browsers/history/the-history-interface/traverse_the_history_4.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/traverse_the_history_5.html
+++ b/html/browsers/history/the-history-interface/traverse_the_history_5.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/traverse_the_history_5.html
+++ b/html/browsers/history/the-history-interface/traverse_the_history_5.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/traverse_the_history_unload_1.html
+++ b/html/browsers/history/the-history-interface/traverse_the_history_unload_1.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:5000});
+  var t = async_test(undefined);
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-history-interface/traverse_the_history_unload_1.html
+++ b/html/browsers/history/the-history-interface/traverse_the_history_unload_1.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
   started = false;
   pages = []
   timer = null;

--- a/html/browsers/history/the-location-interface/non-automated/manual_click_assign_during_load-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/manual_click_assign_during_load-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined, {timeout:3600000});
+var t = async_test(undefined);
 var win = window.open("manual_click_assign_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/non-automated/manual_click_assign_during_load-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/manual_click_assign_during_load-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined);
+var t = async_test();
 var win = window.open("manual_click_assign_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/non-automated/manual_click_location_replace_during_load-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/manual_click_location_replace_during_load-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined, {timeout:3600000});
+var t = async_test(undefined);
 var win = window.open("manual_click_location_replace_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/non-automated/manual_click_location_replace_during_load-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/manual_click_location_replace_during_load-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined);
+var t = async_test();
 var win = window.open("manual_click_location_replace_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/non-automated/manual_click_replace_during_load-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/manual_click_replace_during_load-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined);
+var t = async_test();
 var win = window.open("manual_click_replace_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/non-automated/manual_click_replace_during_load-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/manual_click_replace_during_load-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined, {timeout:3600000});
+var t = async_test(undefined);
 var win = window.open("manual_click_replace_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/non-automated/manual_form_submit_assign_during_load-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/manual_form_submit_assign_during_load-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined, {timeout:3600000});
+var t = async_test(undefined);
 var win = window.open("manual_form_submit_assign_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/non-automated/manual_form_submit_assign_during_load-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/manual_form_submit_assign_during_load-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined);
+var t = async_test();
 var win = window.open("manual_form_submit_assign_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/non-automated/reload_in_resize-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/reload_in_resize-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000})
-var t = async_test(undefined, {timeout:3600000});
+var t = async_test(undefined);
 var load_count = 0;
 var resized = false;
 var win = window.open("reload_in_resize-1.html")

--- a/html/browsers/history/the-location-interface/non-automated/reload_in_resize-manual.html
+++ b/html/browsers/history/the-location-interface/non-automated/reload_in_resize-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000})
-var t = async_test(undefined);
+var t = async_test();
 var load_count = 0;
 var resized = false;
 var win = window.open("reload_in_resize-1.html")

--- a/html/browsers/history/the-location-interface/scripted_click_assign_during_load.html
+++ b/html/browsers/history/the-location-interface/scripted_click_assign_during_load.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined, {timeout:3600000});
+var t = async_test(undefined);
 var win = window.open("scripted_click_assign_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/scripted_click_assign_during_load.html
+++ b/html/browsers/history/the-location-interface/scripted_click_assign_during_load.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined);
+var t = async_test();
 var win = window.open("scripted_click_assign_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load.html
+++ b/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined);
+var t = async_test();
 var win = window.open("scripted_form_submit_assign_during_load-1.html");
 
 var history_length;

--- a/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load.html
+++ b/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000});
-var t = async_test(undefined, {timeout:3600000});
+var t = async_test(undefined);
 var win = window.open("scripted_form_submit_assign_during_load-1.html");
 
 var history_length;

--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_script_defer.html
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_script_defer.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-var t = async_test(undefined, {timeout:4000});
+var t = async_test(undefined);
 t.step(function() {
   var w = window.open("close_script_defer-1.html");
   w.document.open()

--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_script_defer.html
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_script_defer.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-var t = async_test(undefined);
+var t = async_test();
 t.step(function() {
   var w = window.open("close_script_defer-1.html");
   w.document.open()

--- a/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_3.html
+++ b/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/discard_iframe_history_3.html
@@ -4,6 +4,6 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-var t = async_test(undefined);
+var t = async_test();
 var w = window.open("discard_iframe_history_3-1.html");
 </script>

--- a/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/non-automated/discard_iframe_history_1-manual.html
+++ b/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/non-automated/discard_iframe_history_1-manual.html
@@ -5,6 +5,6 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000})
-var t = async_test(undefined, {timeout:3600000});
+var t = async_test(undefined);
 var w = window.open("discard_iframe_history_1-1.html");
 </script>

--- a/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/non-automated/discard_iframe_history_1-manual.html
+++ b/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/non-automated/discard_iframe_history_1-manual.html
@@ -5,6 +5,6 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000})
-var t = async_test(undefined);
+var t = async_test();
 var w = window.open("discard_iframe_history_1-1.html");
 </script>

--- a/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/non-automated/discard_iframe_history_2-manual.html
+++ b/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/non-automated/discard_iframe_history_2-manual.html
@@ -5,6 +5,6 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000})
-var t = async_test(undefined, {timeout:3600000});
+var t = async_test(undefined);
 var w = window.open("discard_iframe_history_2-1.html");
 </script>

--- a/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/non-automated/discard_iframe_history_2-manual.html
+++ b/html/browsers/the-window-object/garbage-collection-and-browsing-contexts/non-automated/discard_iframe_history_2-manual.html
@@ -5,6 +5,6 @@
 <div id="log"></div>
 <script>
 setup({timeout:3600000})
-var t = async_test(undefined);
+var t = async_test();
 var w = window.open("discard_iframe_history_2-1.html");
 </script>

--- a/html/interaction/focus/focus-01.html
+++ b/html/interaction/focus/focus-01.html
@@ -21,7 +21,7 @@ var t1 = async_test("The keydown event must be targeted at the input element"),
 setup(function () {
   testEle = document.getElementById("test");
   testEle.focus();
-}, {timeout: 10000});
+});
 
 document.onkeydown = t1.step_func_done(function(evt){
   assert_equals(evt.target, testEle, "The keydown events must be targeted at the input element.");

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html
@@ -31,7 +31,7 @@ var i = 0,
 
 setup(function () {
   document.body.focus();
-}, {timeout: 20000});
+});
 
 
 

--- a/html/semantics/embedded-content/media-elements/event_canplay.html
+++ b/html/semantics/embedded-content/media-elements/event_canplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger canplay event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger canplay event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("canplay", t.step_func(function() {
@@ -26,7 +26,7 @@ test(function() {
 }, "audio events - canplay");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger canplay event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger canplay event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("canplay", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/event_canplay_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_canplay_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function () {
-  var t = async_test("setting src attribute on non-autoplay audio should trigger canplay event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay audio should trigger canplay event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("canplay", t.step_func_done(), false);
@@ -23,7 +23,7 @@ test(function () {
 }, "audio events - canplay");
 
 test(function () {
-  var t = async_test("setting src attribute on non-autoplay video should trigger canplay event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay video should trigger canplay event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("canplay", t.step_func_done(), false);

--- a/html/semantics/embedded-content/media-elements/event_canplaythrough.html
+++ b/html/semantics/embedded-content/media-elements/event_canplaythrough.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger canplaythrough event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger canplaythrough event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("canplaythrough", t.step_func(function() {
@@ -26,7 +26,7 @@ test(function() {
 }, "audio events - canplaythrough");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger canplaythrough event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger canplaythrough event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("canplaythrough", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/event_canplaythrough_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_canplaythrough_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay audio should trigger canplaythrough event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay audio should trigger canplaythrough event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("canplaythrough", t.step_func_done(), false);
@@ -23,7 +23,7 @@ test(function() {
 }, "audio events - canplaythrough");
 
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay video should trigger canplaythrough event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay video should trigger canplaythrough event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("canplaythrough", t.step_func_done(), false);

--- a/html/semantics/embedded-content/media-elements/event_loadeddata.html
+++ b/html/semantics/embedded-content/media-elements/event_loadeddata.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger loadeddata event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger loadeddata event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("loadeddata", t.step_func(function() {
@@ -26,7 +26,7 @@ test(function() {
 }, "audio events - loadeddata");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger loadeddata event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger loadeddata event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("loadeddata", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/event_loadeddata_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_loadeddata_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay audio should trigger loadeddata event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay audio should trigger loadeddata event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("loadeddata", t.step_func_done(), false);
@@ -23,7 +23,7 @@ test(function() {
 }, "audio events - loadeddata");
 
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay video should trigger loadeddata event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay video should trigger loadeddata event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("loadeddata", t.step_func_done(), false);

--- a/html/semantics/embedded-content/media-elements/event_loadedmetadata.html
+++ b/html/semantics/embedded-content/media-elements/event_loadedmetadata.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger loadedmetadata event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger loadedmetadata event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("loadedmetadata", t.step_func(function() {
@@ -26,7 +26,7 @@ test(function() {
 }, "audio events - loadedmetadata");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger loadedmetadata event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger loadedmetadata event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("loadedmetadata", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/event_loadedmetadata_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_loadedmetadata_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay audio should trigger loadedmetadata event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay audio should trigger loadedmetadata event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("loadedmetadata", t.step_func_done(), false);
@@ -23,7 +23,7 @@ test(function() {
 }, "audio events - loadedmetadata");
 
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay video should trigger loadedmetadata event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay video should trigger loadedmetadata event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("loadedmetadata", t.step_func_done(), false);

--- a/html/semantics/embedded-content/media-elements/event_loadstart.html
+++ b/html/semantics/embedded-content/media-elements/event_loadstart.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger loadstart event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger loadstart event");
   var a = document.getElementById("a");
   a.addEventListener("loadstart", function() {
     t.done();
@@ -25,7 +25,7 @@ test(function() {
 }, "audio events - loadstart");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger loadstart event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger loadstart event");
   var v = document.getElementById("v");
   v.addEventListener("loadstart", function() {
     t.done();

--- a/html/semantics/embedded-content/media-elements/event_loadstart_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_loadstart_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay audio should trigger loadstart event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay audio should trigger loadstart event");
   var a = document.getElementById("a");
   a.addEventListener("loadstart", function() {
     t.done();
@@ -24,7 +24,7 @@ test(function() {
 }, "audio events - loadstart");
 
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay video should trigger loadstart event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay video should trigger loadstart event");
   var v = document.getElementById("v");
   v.addEventListener("loadstart", function() {
     t.done();

--- a/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html
+++ b/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger canplay then canplaythrough event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger canplay then canplaythrough event");
   var a = document.getElementById("a");
   var found_canplay = false;
   a.addEventListener("error", t.unreached_func());
@@ -31,7 +31,7 @@ test(function() {
 }, "audio events - canplay, then canplaythrough");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger canplay then canplaythrough event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger canplay then canplaythrough event");
   var v = document.getElementById("v");
   var found_canplay = false;
   v.addEventListener("error", t.unreached_func());

--- a/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html
+++ b/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger canplay then playing event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger canplay then playing event");
   var a = document.getElementById("a");
   var found_canplay = false;
   a.addEventListener("error", t.unreached_func());
@@ -31,7 +31,7 @@ test(function() {
 }, "audio events - canplay, then playing");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger canplay then playing event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger canplay then playing event");
   var v = document.getElementById("v");
   var found_canplay = false;
   v.addEventListener("error", t.unreached_func());

--- a/html/semantics/embedded-content/media-elements/event_order_loadedmetadata_loadeddata.html
+++ b/html/semantics/embedded-content/media-elements/event_order_loadedmetadata_loadeddata.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger loadedmetadata then loadeddata event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger loadedmetadata then loadeddata event");
   var a = document.getElementById("a");
   var found_loadedmetadata = false;
   a.addEventListener("error", t.unreached_func());
@@ -31,7 +31,7 @@ test(function() {
 }, "audio events - loadedmetadata, then loadeddata");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger loadedmetadata then loadeddata event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger loadedmetadata then loadeddata event");
   var v = document.getElementById("v");
   var found_loadedmetadata = false;
   v.addEventListener("error", t.unreached_func());

--- a/html/semantics/embedded-content/media-elements/event_order_loadstart_progress.html
+++ b/html/semantics/embedded-content/media-elements/event_order_loadstart_progress.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger loadstart then progress event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger loadstart then progress event");
   var a = document.getElementById("a");
   var found_loadstart = false;
   a.addEventListener("error", t.unreached_func());
@@ -31,7 +31,7 @@ test(function() {
 }, "audio events - loadstart, then progress");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger loadstart then progress event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger loadstart then progress event");
   var v = document.getElementById("v");
   var found_loadstart = false;
   v.addEventListener("error", t.unreached_func());

--- a/html/semantics/embedded-content/media-elements/event_pause.html
+++ b/html/semantics/embedded-content/media-elements/event_pause.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("calling pause() on autoplay audio should trigger pause event", {timeout:5000});
+  var t = async_test("calling pause() on autoplay audio should trigger pause event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("pause", t.step_func_done(), false);
@@ -26,7 +26,7 @@ test(function() {
 }, "audio events - pause");
 
 test(function() {
-  var t = async_test("calling pause() on autoplay video should trigger pause event", {timeout:5000});
+  var t = async_test("calling pause() on autoplay video should trigger pause event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("pause", t.step_func_done(), false);

--- a/html/semantics/embedded-content/media-elements/event_pause_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_pause_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 promise_test(function(t) {
-  var async_t = async_test("calling play() then pause() on non-autoplay audio should trigger pause event", {timeout:5000});
+  var async_t = async_test("calling play() then pause() on non-autoplay audio should trigger pause event");
   var a = document.getElementById("a");
   a.addEventListener("pause", function() {
     async_t.done();
@@ -27,7 +27,7 @@ promise_test(function(t) {
 }, "audio events - pause");
 
 promise_test(function(t) {
-  var async_t = async_test("calling play() then pause() on non-autoplay video should trigger pause event", {timeout:5000});
+  var async_t = async_test("calling play() then pause() on non-autoplay video should trigger pause event");
   var v = document.getElementById("v");
   v.addEventListener("pause", function() {
     async_t.done();

--- a/html/semantics/embedded-content/media-elements/event_play.html
+++ b/html/semantics/embedded-content/media-elements/event_play.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger play event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger play event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("play", t.step_func(function() {
@@ -26,7 +26,7 @@ test(function() {
 }, "audio events - play");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger play event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger play event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("play", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/event_play_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_play_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 promise_test(function(t) {
-  var async_t = async_test("calling play() on audio should trigger play event", {timeout:5000});
+  var async_t = async_test("calling play() on audio should trigger play event");
   var a = document.getElementById("a");
   a.addEventListener("play", async_t.step_func(function() {
     a.pause();
@@ -26,7 +26,7 @@ promise_test(function(t) {
 }, "audio events - play");
 
 promise_test(function(t) {
-  var async_t = async_test("calling play() on video should trigger play event", {timeout:5000});
+  var async_t = async_test("calling play() on video should trigger play event");
   var v = document.getElementById("v");
   v.addEventListener("play", async_t.step_func(function() {
     v.pause();

--- a/html/semantics/embedded-content/media-elements/event_playing.html
+++ b/html/semantics/embedded-content/media-elements/event_playing.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger playing event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger playing event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("playing", t.step_func(function() {
@@ -26,7 +26,7 @@ test(function() {
 }, "audio events - playing");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger playing event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger playing event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("playing", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/event_playing_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_playing_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("calling play() on audio should trigger playing event", {timeout:5000});
+  var t = async_test("calling play() on audio should trigger playing event");
   var a = document.getElementById("a");
   a.addEventListener("playing", function() {
     t.done();
@@ -26,7 +26,7 @@ test(function() {
 }, "audio events - playing");
 
 test(function() {
-  var t = async_test("calling play() on video should trigger playing event", {timeout:5000});
+  var t = async_test("calling play() on video should trigger playing event");
   var v = document.getElementById("v");
   v.addEventListener("playing", function() {
     t.done();

--- a/html/semantics/embedded-content/media-elements/event_progress.html
+++ b/html/semantics/embedded-content/media-elements/event_progress.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on autoplay audio should trigger progress event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay audio should trigger progress event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("progress", t.step_func(function() {
@@ -26,7 +26,7 @@ test(function() {
 }, "audio events - progress");
 
 test(function() {
-  var t = async_test("setting src attribute on autoplay video should trigger progress event", {timeout:5000});
+  var t = async_test("setting src attribute on autoplay video should trigger progress event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("progress", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay audio should trigger progress event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay audio should trigger progress event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("progress", t.step_func_done(), false);
@@ -23,7 +23,7 @@ test(function() {
 }, "audio events - progress");
 
 test(function() {
-  var t = async_test("setting src attribute on non-autoplay video should trigger progress event", {timeout:5000});
+  var t = async_test("setting src attribute on non-autoplay video should trigger progress event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("progress", t.step_func_done(), false);

--- a/html/semantics/embedded-content/media-elements/event_timeupdate.html
+++ b/html/semantics/embedded-content/media-elements/event_timeupdate.html
@@ -14,7 +14,7 @@
   </video>
   <div id="log"></div>
   <script>
-var ta = async_test("setting src attribute on a sufficiently long autoplay audio should trigger timeupdate event", {timeout:5000});
+var ta = async_test("setting src attribute on a sufficiently long autoplay audio should trigger timeupdate event");
 var a = document.getElementById("a");
 a.addEventListener("timeupdate", function() {
   ta.done();
@@ -22,7 +22,7 @@ a.addEventListener("timeupdate", function() {
 }, false);
 a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 
-var tv = async_test("setting src attribute on a sufficiently long autoplay video should trigger timeupdate event", {timeout:5000});
+var tv = async_test("setting src attribute on a sufficiently long autoplay video should trigger timeupdate event");
 var v = document.getElementById("v");
 v.addEventListener("timeupdate", function() {
   tv.done();

--- a/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("calling play() on a sufficiently long audio should trigger timeupdate event", {timeout:5000});
+  var t = async_test("calling play() on a sufficiently long audio should trigger timeupdate event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("timeupdate", t.step_func(function() {
@@ -27,7 +27,7 @@ test(function() {
 }, "audio events - timeupdate");
 
 test(function() {
-  var t = async_test("calling play() on a sufficiently long video should trigger timeupdate event", {timeout:5000});
+  var t = async_test("calling play() on a sufficiently long video should trigger timeupdate event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("timeupdate", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrack/activeCues.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrack/activeCues.html
@@ -18,7 +18,7 @@ setup(function(){
     document.body.appendChild(video);
     if (!t1)
         throw new Error('t1 was undefined')
-}, {timeout:25000});
+});
 function smoke_test() {
   assert_true('HTMLTrackElement' in window, 'track not supported');
 }
@@ -56,9 +56,9 @@ test(function(){
 }, document.title+', different modes');
 
 // ok now let's load in a video
-var test1 = async_test(document.title+', video loading', {timeout:20000});
-var test2 = async_test(document.title+', video playing', {timeout:20000});
-var test3 = async_test(document.title+', adding cue during playback', {timeout:20000});
+var test1 = async_test(document.title+', video loading');
+var test2 = async_test(document.title+', video playing');
+var test3 = async_test(document.title+', adding cue during playback');
 test1.step(smoke_test);
 test2.step(smoke_test);
 test3.step(smoke_test);

--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrack/addCue.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrack/addCue.html
@@ -7,7 +7,7 @@
 setup(function(){
     window.video = document.createElement('video');
     document.body.appendChild(video);
-}, {timeout:5000});
+});
 test(function() {
     var t1 = video.addTextTrack('subtitles');
     var t2 = video.addTextTrack('subtitles');

--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrack/removeCue.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrack/removeCue.html
@@ -7,7 +7,7 @@
 setup(function(){
     window.video = document.createElement('video');
     document.body.appendChild(video);
-}, {timeout:5000});
+});
 test(function() {
     var t1 = video.addTextTrack('subtitles');
     var t2 = video.addTextTrack('subtitles');

--- a/html/semantics/embedded-content/media-elements/networkState_during_loadstart.html
+++ b/html/semantics/embedded-content/media-elements/networkState_during_loadstart.html
@@ -14,7 +14,7 @@
   </video>
   <div id="log"></div>
   <script>
-var ta = async_test("audioElement.networkState should be NETWORK_LOADING during loadstart event", {timeout:5000});
+var ta = async_test("audioElement.networkState should be NETWORK_LOADING during loadstart event");
 var a = document.getElementById("a");
 a.addEventListener("loadstart", function() {
   ta.step(function() {
@@ -26,7 +26,7 @@ a.addEventListener("loadstart", function() {
 }, false);
 a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 
-var tv = async_test("videoElement.networkState should be NETWORK_LOADING during loadstart event", {timeout:5000});
+var tv = async_test("videoElement.networkState should be NETWORK_LOADING during loadstart event");
 var v = document.getElementById("v");
 v.addEventListener("loadstart", function() {
   tv.step(function() {

--- a/html/semantics/embedded-content/media-elements/networkState_during_progress.html
+++ b/html/semantics/embedded-content/media-elements/networkState_during_progress.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var ta = async_test("audioElement.networkState should be NETWORK_LOADING during progress event", {timeout:5000});
+  var ta = async_test("audioElement.networkState should be NETWORK_LOADING during progress event");
   var a = document.getElementById("a");
   a.addEventListener("error", ta.unreached_func());
   a.addEventListener("progress", ta.step_func(function() {
@@ -27,7 +27,7 @@ test(function() {
 }, "audio events - networkState during progress");
 
 test(function() {
-  var tv = async_test("videoElement.networkState should be NETWORK_LOADING during progress event", {timeout:5000});
+  var tv = async_test("videoElement.networkState should be NETWORK_LOADING during progress event");
   var v = document.getElementById("v");
   v.addEventListener("error", tv.unreached_func());
   v.addEventListener("progress", tv.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/paused_false_during_play.html
+++ b/html/semantics/embedded-content/media-elements/paused_false_during_play.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("audio.paused should be false during play event", {timeout:5000});
+  var t = async_test("audio.paused should be false during play event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("play", t.step_func(function() {
@@ -27,7 +27,7 @@ test(function() {
 }, "audio events - paused property");
 
 test(function() {
-  var t = async_test("video.paused should be false during play event", {timeout:5000});
+  var t = async_test("video.paused should be false during play event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("play", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/paused_true_during_pause.html
+++ b/html/semantics/embedded-content/media-elements/paused_true_during_pause.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("audio.paused should be true during pause event", {timeout:5000});
+  var t = async_test("audio.paused should be true during pause event");
   var a = document.getElementById("a");
   a.addEventListener("pause", function() {
     t.step(function() {
@@ -30,7 +30,7 @@ test(function() {
 }, "audio events - paused property");
 
 test(function() {
-  var t = async_test("video.paused should be true during pause event", {timeout:5000});
+  var t = async_test("video.paused should be true during pause event");
   var v = document.getElementById("v");
   v.addEventListener("pause", function() {
     t.step(function() {

--- a/html/semantics/embedded-content/media-elements/readyState_during_canplay.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_canplay.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("audio.readyState should be >= HAVE_FUTURE_DATA during canplay event", {timeout:5000});
+  var t = async_test("audio.readyState should be >= HAVE_FUTURE_DATA during canplay event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("canplay", t.step_func(function() {
@@ -27,7 +27,7 @@ test(function() {
 }, "audio events - readyState property during canplay");
 
 test(function() {
-  var t = async_test("video.readyState should be >= HAVE_FUTURE_DATA during canplay event", {timeout:5000});
+  var t = async_test("video.readyState should be >= HAVE_FUTURE_DATA during canplay event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("canplay", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("audio.readyState should be HAVE_ENOUGH_DATA during canplaythrough event", {timeout:5000});
+  var t = async_test("audio.readyState should be HAVE_ENOUGH_DATA during canplaythrough event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("canplaythrough", t.step_func(function() {
@@ -27,7 +27,7 @@ test(function() {
 }, "audio events - readyState property during canplaythrough");
 
 test(function() {
-  var t = async_test("video.readyState should be HAVE_ENOUGH_DATA during canplaythrough event", {timeout:5000});
+  var t = async_test("video.readyState should be HAVE_ENOUGH_DATA during canplaythrough event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("canplaythrough", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/readyState_during_loadeddata.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_loadeddata.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("audio.readyState should be >= HAVE_CURRENT_DATA during loadeddata event", {timeout:5000});
+  var t = async_test("audio.readyState should be >= HAVE_CURRENT_DATA during loadeddata event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("loadeddata", t.step_func(function() {
@@ -27,7 +27,7 @@ test(function() {
 }, "audio events - readyState property during loadeddata");
 
 test(function() {
-  var t = async_test("video.readyState should be >= HAVE_CURRENT_DATA during loadeddata event", {timeout:5000});
+  var t = async_test("video.readyState should be >= HAVE_CURRENT_DATA during loadeddata event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("loadeddata", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/readyState_during_loadedmetadata.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_loadedmetadata.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("audio.readyState should be >= HAVE_METADATA during loadedmetadata event", {timeout:5000});
+  var t = async_test("audio.readyState should be >= HAVE_METADATA during loadedmetadata event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("loadedmetadata", t.step_func(function() {
@@ -27,7 +27,7 @@ test(function() {
 }, "audio events - readyState property during loadedmetadata");
 
 test(function() {
-  var t = async_test("video.readyState should be >= HAVE_METADATA during loadedmetadata event", {timeout:5000});
+  var t = async_test("video.readyState should be >= HAVE_METADATA during loadedmetadata event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("loadedmetadata", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/readyState_during_playing.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_playing.html
@@ -15,7 +15,7 @@
   <div id="log"></div>
   <script>
 test(function() {
-  var t = async_test("audio.readyState should be >= HAVE_FUTURE_DATA during playing event", {timeout:5000});
+  var t = async_test("audio.readyState should be >= HAVE_FUTURE_DATA during playing event");
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
   a.addEventListener("playing", t.step_func(function() {
@@ -27,7 +27,7 @@ test(function() {
 }, "audio events - readyState property during playing");
 
 test(function() {
-  var t = async_test("video.readyState should be >= HAVE_FUTURE_DATA during playing event", {timeout:5000});
+  var t = async_test("video.readyState should be >= HAVE_FUTURE_DATA during playing event");
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
   v.addEventListener("playing", t.step_func(function() {

--- a/html/semantics/embedded-content/media-elements/track/track-element/cors/support/common.js
+++ b/html/semantics/embedded-content/media-elements/track/track-element/cors/support/common.js
@@ -12,7 +12,7 @@ setup(function(){
 }, {timeout:10000, explicit_done:true});
 
 onload = function() {
-    (async_test(document.title, {timeout:10000})).step(function() {
+    (async_test(document.title)).step(function() {
         // fail early if track isn't supported
         assert_true('HTMLTrackElement' in window, 'track not supported');
         window.corsMode = document.title.match(/^track CORS: (No CORS|Anonymous|Use Credentials)/)[1];

--- a/html/semantics/scripting-1/the-script-element/execution-timing/078.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/078.html
@@ -15,7 +15,7 @@
         }
         return testlib.addScript(contents, props, head, false);
     }
-    var t = async_test(undefined, { timeout: 10000 })
+    var t = async_test(undefined)
 
     function test() {
         document.getElementById("log").textContent = "Please wait..."

--- a/html/semantics/scripting-1/the-script-element/execution-timing/078.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/078.html
@@ -15,7 +15,7 @@
         }
         return testlib.addScript(contents, props, head, false);
     }
-    var t = async_test(undefined)
+    var t = async_test()
 
     function test() {
         document.getElementById("log").textContent = "Please wait..."

--- a/html/semantics/scripting-1/the-script-element/execution-timing/081.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/081.html
@@ -10,7 +10,7 @@
   <div id="log">FAILED (This TC requires JavaScript enabled)</div>
   <div></div>
   <script>
-  var t = async_test(undefined)
+  var t = async_test()
   log('inline script #1');
   testlib.addScript('', { src:'scripts/include-1.js?pipe=trickle(d1)&'+Math.random() }, document.getElementsByTagName('head')[0], false );
   log('end script #1');

--- a/html/semantics/scripting-1/the-script-element/execution-timing/081.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/081.html
@@ -10,7 +10,7 @@
   <div id="log">FAILED (This TC requires JavaScript enabled)</div>
   <div></div>
   <script>
-  var t = async_test(undefined, {timeout:5000})
+  var t = async_test(undefined)
   log('inline script #1');
   testlib.addScript('', { src:'scripts/include-1.js?pipe=trickle(d1)&'+Math.random() }, document.getElementsByTagName('head')[0], false );
   log('end script #1');

--- a/html/semantics/scripting-1/the-script-element/execution-timing/082.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/082.html
@@ -22,7 +22,7 @@
   </script>
   <script type="text/javascript">
   log('inline script #2');
-  var t = async_test(undefined)
+  var t = async_test()
 
   function test() {
     assert_array_equals(eventOrder, ['inline script #1', 'end script #1', 'inline script #2', 'external script #1', 'load on include-1.js', 'external script #7', 'load on include-7.js', 'external script #2', 'load on include-2.js']);

--- a/html/semantics/scripting-1/the-script-element/execution-timing/082.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/082.html
@@ -22,7 +22,7 @@
   </script>
   <script type="text/javascript">
   log('inline script #2');
-  var t = async_test(undefined, {timeout:10000})
+  var t = async_test(undefined)
 
   function test() {
     assert_array_equals(eventOrder, ['inline script #1', 'end script #1', 'inline script #2', 'external script #1', 'load on include-1.js', 'external script #7', 'load on include-7.js', 'external script #2', 'load on include-2.js']);

--- a/html/semantics/scripting-1/the-script-element/execution-timing/091.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/091.html
@@ -10,7 +10,7 @@
         <div id="log">FAILED (This TC requires JavaScript enabled)</div>
 
         <script>
-          var t = async_test(undefined, {timeout:4000});
+          var t = async_test(undefined);
 
           sources = ["scripts/include-1.js?pipe=trickle(d2)", "scripts/include-2.js?pipe=trickle(d1)"];
           sources.forEach(function(x) {

--- a/html/semantics/scripting-1/the-script-element/execution-timing/091.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/091.html
@@ -10,7 +10,7 @@
         <div id="log">FAILED (This TC requires JavaScript enabled)</div>
 
         <script>
-          var t = async_test(undefined);
+          var t = async_test();
 
           sources = ["scripts/include-1.js?pipe=trickle(d2)", "scripts/include-2.js?pipe=trickle(d1)"];
           sources.forEach(function(x) {

--- a/html/semantics/scripting-1/the-script-element/execution-timing/092.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/092.html
@@ -10,7 +10,7 @@
         <div id="log">FAILED (This TC requires JavaScript enabled)</div>
 
         <script>
-          var t = async_test(undefined, {timeout:3500});
+          var t = async_test(undefined);
 
           var script = document.createElement("script");
           script.src = "scripts/include-2.js?pipe=trickle(d2)";

--- a/html/semantics/scripting-1/the-script-element/execution-timing/092.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/092.html
@@ -10,7 +10,7 @@
         <div id="log">FAILED (This TC requires JavaScript enabled)</div>
 
         <script>
-          var t = async_test(undefined);
+          var t = async_test();
 
           var script = document.createElement("script");
           script.src = "scripts/include-2.js?pipe=trickle(d2)";

--- a/html/semantics/scripting-1/the-script-element/execution-timing/094.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/094.html
@@ -11,7 +11,7 @@
         <iframe id="myFrame"></iframe>
 
         <script>
-          var t = async_test(undefined);
+          var t = async_test();
           onload = t.step_func(function() {
             var doc = document.getElementById("myFrame").contentDocument;
             var win = document.getElementById("myFrame").contentWindow;

--- a/html/semantics/scripting-1/the-script-element/execution-timing/094.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/094.html
@@ -11,7 +11,7 @@
         <iframe id="myFrame"></iframe>
 
         <script>
-          var t = async_test(undefined, {timeout:3500});
+          var t = async_test(undefined);
           onload = t.step_func(function() {
             var doc = document.getElementById("myFrame").contentDocument;
             var win = document.getElementById("myFrame").contentWindow;

--- a/html/semantics/scripting-1/the-script-element/execution-timing/095.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/095.html
@@ -10,7 +10,7 @@
         <div id="log">FAILED (This TC requires JavaScript enabled)</div>
 
         <script>
-          var t = async_test(undefined);
+          var t = async_test();
           function test() {
             t.step(function() {
               assert_array_equals(eventOrder, ['external script #8', 'external script #9']);

--- a/html/semantics/scripting-1/the-script-element/execution-timing/095.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/095.html
@@ -10,7 +10,7 @@
         <div id="log">FAILED (This TC requires JavaScript enabled)</div>
 
         <script>
-          var t = async_test(undefined, {timeout:3500});
+          var t = async_test(undefined);
           function test() {
             t.step(function() {
               assert_array_equals(eventOrder, ['external script #8', 'external script #9']);

--- a/html/semantics/scripting-1/the-script-element/execution-timing/097.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/097.html
@@ -15,7 +15,7 @@
         </script>
         <script>
           log("inline script #2");
-          var t = async_test(undefined, {timeout:3500});
+          var t = async_test(undefined);
 
           addEventListener("DOMContentLoaded", t.step_func(function() {assert_array_equals(eventOrder, ["inline script #1", "inline script #2"])}), false);
 

--- a/html/semantics/scripting-1/the-script-element/execution-timing/097.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/097.html
@@ -15,7 +15,7 @@
         </script>
         <script>
           log("inline script #2");
-          var t = async_test(undefined);
+          var t = async_test();
 
           addEventListener("DOMContentLoaded", t.step_func(function() {assert_array_equals(eventOrder, ["inline script #1", "inline script #2"])}), false);
 

--- a/html/semantics/scripting-1/the-script-element/execution-timing/122.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/122.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <script id="test" type="text/plain" src="scripts/include-1.js?pipe=trickle(d1)"></script>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/122.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/122.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:4000});
+  var t = async_test(undefined);
 </script>
 <script id="test" type="text/plain" src="scripts/include-1.js?pipe=trickle(d1)"></script>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/123.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/123.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <script id="test" type="text/plain" src="scripts/include-2.js?pipe=trickle(d1)"></script>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/123.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/123.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:4000});
+  var t = async_test(undefined);
 </script>
 <script id="test" type="text/plain" src="scripts/include-2.js?pipe=trickle(d1)"></script>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/125.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/125.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <script id="test" type="text/plain" src="scripts/include-1.js?pipe=trickle(d1)"></script>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/125.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/125.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:4000});
+  var t = async_test(undefined);
 </script>
 <script id="test" type="text/plain" src="scripts/include-1.js?pipe=trickle(d1)"></script>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/126.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/126.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:4000});
+  var t = async_test(undefined);
 </script>
 <script id="test" type="text/plain" src="scripts/include-2.js"></script>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/126.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/126.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <script id="test" type="text/plain" src="scripts/include-2.js"></script>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/136.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/136.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/136.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/136.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/137.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/137.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script xlink:href="">

--- a/html/semantics/scripting-1/the-script-element/execution-timing/137.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/137.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script xlink:href="">

--- a/html/semantics/scripting-1/the-script-element/execution-timing/138.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/138.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/138.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/138.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/139.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/139.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/139.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/139.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/140.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/140.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script xlink:href="scripts/include-1.js">

--- a/html/semantics/scripting-1/the-script-element/execution-timing/140.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/140.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script xlink:href="scripts/include-1.js">

--- a/html/semantics/scripting-1/the-script-element/execution-timing/141.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/141.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/141.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/141.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/142.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/142.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/142.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/142.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/143.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/143.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/143.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/143.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/144.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/144.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script type="text/plain">

--- a/html/semantics/scripting-1/the-script-element/execution-timing/144.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/144.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script type="text/plain">

--- a/html/semantics/scripting-1/the-script-element/execution-timing/145.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/145.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined);
+  var t = async_test();
 </script>
 <svg>
 <script></script>

--- a/html/semantics/scripting-1/the-script-element/execution-timing/145.html
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/145.html
@@ -7,7 +7,7 @@
 </head>
 <div id="log"></div>
 <script>
-  var t = async_test(undefined, {timeout:3000});
+  var t = async_test(undefined);
 </script>
 <svg>
 <script></script>


### PR DESCRIPTION
Remove all the timeout in `async_test` for html tests.
Affected tests: 125
Before: Pass: 64, Failed: 61
After:  Pass: 64, Failed: 61
Related: #11120