### PR TITLE
Remove timout in async_test for websockets tests

### DIFF
--- a/websockets/binary/002.html
+++ b/websockets/binary/002.html
@@ -23,5 +23,5 @@ async_test(function(t){
     t.done();
   });
 
-}, null);
+});
 </script>

--- a/websockets/binary/002.html
+++ b/websockets/binary/002.html
@@ -23,5 +23,5 @@ async_test(function(t){
     t.done();
   });
 
-}, null, {timeout:20000});
+}, null);
 </script>

--- a/websockets/binary/004.html
+++ b/websockets/binary/004.html
@@ -22,5 +22,5 @@ async_test(function(t){
     t.done();
   })
 
-}, null);
+});
 </script>

--- a/websockets/binary/004.html
+++ b/websockets/binary/004.html
@@ -22,5 +22,5 @@ async_test(function(t){
     t.done();
   })
 
-}, null, {timeout:20000});
+}, null);
 </script>

--- a/websockets/constructor/013.html
+++ b/websockets/constructor/013.html
@@ -36,6 +36,6 @@ async_test(function(t) {
     }, ws[i]);
     ws[i].onerror = t.step_func(function() {assert_unreached()});
   }
-}, null, {timeout:25000});
+}, null);
 </script>
 

--- a/websockets/constructor/013.html
+++ b/websockets/constructor/013.html
@@ -36,6 +36,6 @@ async_test(function(t) {
     }, ws[i]);
     ws[i].onerror = t.step_func(function() {assert_unreached()});
   }
-}, null);
+});
 </script>
 

--- a/websockets/cookies/003.html
+++ b/websockets/cookies/003.html
@@ -29,5 +29,5 @@ var t = async_test(function(t) {
     ws.onerror = ws.onclose = t.step_func(function(e) {assert_unreached(e.type)});
   });
   document.body.appendChild(iframe);
-}, null, {timeout:9900});
+}, null);
 </script>

--- a/websockets/cookies/003.html
+++ b/websockets/cookies/003.html
@@ -29,5 +29,5 @@ var t = async_test(function(t) {
     ws.onerror = ws.onclose = t.step_func(function(e) {assert_unreached(e.type)});
   });
   document.body.appendChild(iframe);
-}, null);
+});
 </script>

--- a/websockets/cookies/004.html
+++ b/websockets/cookies/004.html
@@ -27,5 +27,5 @@ var t = async_test(function(t) {
   });
   ws.onerror = ws.onclose = t.step_func(function(e) {assert_unreached(e.type)});
   document.body.appendChild(iframe);
-}, null)
+});
 </script>

--- a/websockets/cookies/004.html
+++ b/websockets/cookies/004.html
@@ -27,5 +27,5 @@ var t = async_test(function(t) {
   });
   ws.onerror = ws.onclose = t.step_func(function(e) {assert_unreached(e.type)});
   document.body.appendChild(iframe);
-}, null, {timeout:9900})
+}, null)
 </script>

--- a/websockets/cookies/007.html
+++ b/websockets/cookies/007.html
@@ -31,5 +31,5 @@ async_test(function(t) {
   if (new RegExp('ws_test_'+cookie_id+'=test').test(document.cookie)) {
     assert_unreached('cookie was set during script execution');
   }
-}, null);
+});
 </script>

--- a/websockets/cookies/007.html
+++ b/websockets/cookies/007.html
@@ -31,5 +31,5 @@ async_test(function(t) {
   if (new RegExp('ws_test_'+cookie_id+'=test').test(document.cookie)) {
     assert_unreached('cookie was set during script execution');
   }
-}, null, {timeout:12000});
+}, null);
 </script>

--- a/websockets/extended-payload-length.html
+++ b/websockets/extended-payload-length.html
@@ -20,7 +20,7 @@ async_test(function(t){
         assert_equals(e.data, data);
         t.done();
     });
-}, "Application data is 125 byte which means any 'Extended payload length' field isn't used at all.", {timeout:20000});
+}, "Application data is 125 byte which means any 'Extended payload length' field isn't used at all.");
 
 async_test(function(t){
     var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo');
@@ -34,7 +34,7 @@ async_test(function(t){
         assert_equals(e.data, data);
         t.done();
     });
-}, "Application data is 126 byte which starts to use the 16 bit 'Extended payload length' field.", {timeout:20000});
+}, "Application data is 126 byte which starts to use the 16 bit 'Extended payload length' field.");
 
 async_test(function(t){
     var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo');
@@ -48,7 +48,7 @@ async_test(function(t){
         assert_equals(e.data, data);
         t.done();
     });
-}, "Application data is 0xFFFF byte which means the upper bound of the 16 bit 'Extended payload length' field.", {timeout:20000});
+}, "Application data is 0xFFFF byte which means the upper bound of the 16 bit 'Extended payload length' field.");
 
 async_test(function(t){
     var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo');
@@ -62,6 +62,6 @@ async_test(function(t){
         assert_equals(e.data, data);
         t.done();
     });
-}, "Application data is (0xFFFF + 1) byte which starts to use the 64 bit 'Extended payload length' field", {timeout:20000});
+}, "Application data is (0xFFFF + 1) byte which starts to use the 64 bit 'Extended payload length' field");
 
 </script>

--- a/websockets/interfaces/CloseEvent/clean-close.html
+++ b/websockets/interfaces/CloseEvent/clean-close.html
@@ -19,5 +19,5 @@ async_test(function(t) {
     assert_equals(e.wasClean,true);
     t.done();
   });
-}, null, {timeout:2000});
+}, null);
 </script>

--- a/websockets/interfaces/CloseEvent/clean-close.html
+++ b/websockets/interfaces/CloseEvent/clean-close.html
@@ -19,5 +19,5 @@ async_test(function(t) {
     assert_equals(e.wasClean,true);
     t.done();
   });
-}, null);
+});
 </script>

--- a/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-large.html
+++ b/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-large.html
@@ -23,5 +23,5 @@ async_test(function(t) {
     assert_equals(e.data, data);
     t.done();
   })
-}, null);
+});
 </script>

--- a/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-large.html
+++ b/websockets/interfaces/WebSocket/bufferedAmount/bufferedAmount-large.html
@@ -23,5 +23,5 @@ async_test(function(t) {
     assert_equals(e.data, data);
     t.done();
   })
-}, null, {timeout:20000});
+}, null);
 </script>

--- a/websockets/interfaces/WebSocket/close/close-basic.html
+++ b/websockets/interfaces/WebSocket/close/close-basic.html
@@ -22,5 +22,5 @@ async_test(function(t) {
   });
   ws.close();
   assert_equals(ws.readyState, ws.CLOSING);
-}, undefined);
+});
 </script>

--- a/websockets/interfaces/WebSocket/close/close-basic.html
+++ b/websockets/interfaces/WebSocket/close/close-basic.html
@@ -22,5 +22,5 @@ async_test(function(t) {
   });
   ws.close();
   assert_equals(ws.readyState, ws.CLOSING);
-}, undefined, {timeout:9900});
+}, undefined);
 </script>

--- a/websockets/interfaces/WebSocket/close/close-connecting.html
+++ b/websockets/interfaces/WebSocket/close/close-connecting.html
@@ -21,5 +21,5 @@ async_test(function(t) {
     });
   }, 1000);
   ws.onopen = ws.onclose = t.unreached_func();
-}, undefined);
+});
 </script>

--- a/websockets/interfaces/WebSocket/close/close-connecting.html
+++ b/websockets/interfaces/WebSocket/close/close-connecting.html
@@ -21,5 +21,5 @@ async_test(function(t) {
     });
   }, 1000);
   ws.onopen = ws.onclose = t.unreached_func();
-}, undefined, {timeout:12000});
+}, undefined);
 </script>

--- a/websockets/interfaces/WebSocket/close/close-nested.html
+++ b/websockets/interfaces/WebSocket/close/close-nested.html
@@ -24,5 +24,5 @@ async_test(function(t) {
   });
   ws.close();
   assert_equals(ws.readyState, ws.CLOSING);
-}, undefined);
+});
 </script>

--- a/websockets/interfaces/WebSocket/close/close-nested.html
+++ b/websockets/interfaces/WebSocket/close/close-nested.html
@@ -24,5 +24,5 @@ async_test(function(t) {
   });
   ws.close();
   assert_equals(ws.readyState, ws.CLOSING);
-}, undefined, {timeout:9900});
+}, undefined);
 </script>

--- a/websockets/interfaces/WebSocket/events/003.html
+++ b/websockets/interfaces/WebSocket/events/003.html
@@ -17,5 +17,5 @@ async_test(function(t) {
   var ev = document.createEvent('UIEvents');
   ev.initUIEvent('open', false, false, window, 5);
   ws.dispatchEvent(ev);
-}, null, {timeout:2000});
+}, null);
 </script>

--- a/websockets/interfaces/WebSocket/events/003.html
+++ b/websockets/interfaces/WebSocket/events/003.html
@@ -17,5 +17,5 @@ async_test(function(t) {
   var ev = document.createEvent('UIEvents');
   ev.initUIEvent('open', false, false, window, 5);
   ws.dispatchEvent(ev);
-}, null);
+});
 </script>

--- a/websockets/interfaces/WebSocket/events/007.html
+++ b/websockets/interfaces/WebSocket/events/007.html
@@ -17,5 +17,5 @@ async_test(function(t) {
   var ev = document.createEvent('UIEvents');
   ev.initUIEvent('message', false, false, window, 5);
   ws.dispatchEvent(ev);
-}, null, {timeout:2000});
+}, null);
 </script>

--- a/websockets/interfaces/WebSocket/events/007.html
+++ b/websockets/interfaces/WebSocket/events/007.html
@@ -17,5 +17,5 @@ async_test(function(t) {
   var ev = document.createEvent('UIEvents');
   ev.initUIEvent('message', false, false, window, 5);
   ws.dispatchEvent(ev);
-}, null);
+});
 </script>

--- a/websockets/interfaces/WebSocket/events/009.html
+++ b/websockets/interfaces/WebSocket/events/009.html
@@ -17,5 +17,5 @@ async_test(function(t) {
   var ev = document.createEvent('UIEvents');
   ev.initUIEvent('close', false, false, window, 5);
   ws.dispatchEvent(ev);
-}, null);
+});
 </script>

--- a/websockets/interfaces/WebSocket/events/009.html
+++ b/websockets/interfaces/WebSocket/events/009.html
@@ -17,5 +17,5 @@ async_test(function(t) {
   var ev = document.createEvent('UIEvents');
   ev.initUIEvent('close', false, false, window, 5);
   ws.dispatchEvent(ev);
-}, null, {timeout:2000});
+}, null);
 </script>

--- a/websockets/keeping-connection-open/001.html
+++ b/websockets/keeping-connection-open/001.html
@@ -24,5 +24,5 @@ async_test(function(t) {
       });
     }, 20000);
   })
-}, null, {timeout:30000});
+}, null);
 </script>

--- a/websockets/keeping-connection-open/001.html
+++ b/websockets/keeping-connection-open/001.html
@@ -24,5 +24,5 @@ async_test(function(t) {
       });
     }, 20000);
   })
-}, null);
+});
 </script>

--- a/websockets/opening-handshake/001.html
+++ b/websockets/opening-handshake/001.html
@@ -15,5 +15,5 @@ async_test(function(t) {
     t.step_timeout(() => t.done(), 50);
   });
    ws.onmessage = ws.onopen = t.unreached_func();
-}, null);
+});
 </script>

--- a/websockets/opening-handshake/001.html
+++ b/websockets/opening-handshake/001.html
@@ -15,5 +15,5 @@ async_test(function(t) {
     t.step_timeout(() => t.done(), 50);
   });
    ws.onmessage = ws.onopen = t.unreached_func();
-}, null, {timeout:9900});
+}, null);
 </script>

--- a/websockets/opening-handshake/002.html
+++ b/websockets/opening-handshake/002.html
@@ -19,5 +19,5 @@ async_test(function(t) {
     ws.close();
   });
   ws.onerror = ws.onmessage = ws.onclose = t.unreached_func();
-}, null, {timeout:9900});
+}, null);
 </script>

--- a/websockets/opening-handshake/002.html
+++ b/websockets/opening-handshake/002.html
@@ -19,5 +19,5 @@ async_test(function(t) {
     ws.close();
   });
   ws.onerror = ws.onmessage = ws.onclose = t.unreached_func();
-}, null);
+});
 </script>

--- a/websockets/unload-a-document/002.html
+++ b/websockets/unload-a-document/002.html
@@ -10,7 +10,7 @@
 <p>Test requires popup blocker disabled</p>
 <div id=log></div>
 <script>
-var t = async_test(null, {timeout:15000});
+var t = async_test(null);
 var w;
 var uuid;
 t.step(function() {

--- a/websockets/unload-a-document/002.html
+++ b/websockets/unload-a-document/002.html
@@ -10,7 +10,7 @@
 <p>Test requires popup blocker disabled</p>
 <div id=log></div>
 <script>
-var t = async_test(null);
+var t = async_test();
 var w;
 var uuid;
 t.step(function() {

--- a/websockets/unload-a-document/004.html
+++ b/websockets/unload-a-document/004.html
@@ -7,7 +7,7 @@
 <div id=log></div>
 <script>
 var uuid;
-var t = async_test(null)
+var t = async_test();
 t.step(function() {uuid = token()});
 var navigate = t.step_func(function() {
   document.getElementsByTagName("iframe")[0].src = 'data:text/html,<body onload="history.back()">';

--- a/websockets/unload-a-document/004.html
+++ b/websockets/unload-a-document/004.html
@@ -7,7 +7,7 @@
 <div id=log></div>
 <script>
 var uuid;
-var t = async_test(null, {timeout:15000})
+var t = async_test(null)
 t.step(function() {uuid = token()});
 var navigate = t.step_func(function() {
   document.getElementsByTagName("iframe")[0].src = 'data:text/html,<body onload="history.back()">';

--- a/websockets/unload-a-document/005.html
+++ b/websockets/unload-a-document/005.html
@@ -10,7 +10,7 @@
 <p>Test requires popup blocker disabled</p>
 <div id=log></div>
 <script>
-var t = async_test(null);
+var t = async_test();
 t.step(function() {
   var w = window.open("005-1.html");
   add_result_callback(function() {

--- a/websockets/unload-a-document/005.html
+++ b/websockets/unload-a-document/005.html
@@ -10,7 +10,7 @@
 <p>Test requires popup blocker disabled</p>
 <div id=log></div>
 <script>
-var t = async_test(null, {timeout:15000});
+var t = async_test(null);
 t.step(function() {
   var w = window.open("005-1.html");
   add_result_callback(function() {


### PR DESCRIPTION
Remove all the timeout in async_test for websockets tests.
Affected tests: 21
Before: Pass: 6, Failed: 15
After: Pass: 6, Failed: 15
Related: #11120