### PR TITLE
Remove timeout in async_test for mediacapture-streams tests

### DIFF
--- a/mediacapture-streams/GUM-deny.https.html
+++ b/mediacapture-streams/GUM-deny.https.html
@@ -16,7 +16,7 @@
   <script src=/resources/testharness.js></script>
   <script src=/resources/testharnessreport.js></script>
   <script>
-    var t = async_test("Tests that the error callback is triggered when permission is denied", {timeout:10000});
+    var t = async_test("Tests that the error callback is triggered when permission is denied");
     t.step(function() {
       navigator.mediaDevices.getUserMedia({video: true})
         .then(t.step_func(function (stream) {

--- a/mediacapture-streams/GUM-impossible-constraint.https.html
+++ b/mediacapture-streams/GUM-impossible-constraint.https.html
@@ -16,7 +16,7 @@ constraint (width &gt;=1G) in getUserMedia works</p>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that setting an impossible constraint in getUserMedia fails", {timeout:10000});
+var t = async_test("Tests that setting an impossible constraint in getUserMedia fails");
 t.step(function() {
   // Note - integer conversion is weird for +inf and numbers > 2^32, so we
   // use a number less than 2^32 for testing.

--- a/mediacapture-streams/GUM-optional-constraint.https.html
+++ b/mediacapture-streams/GUM-optional-constraint.https.html
@@ -15,7 +15,7 @@ getUserMedia is handled as optional</p>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that setting an optional constraint in getUserMedia is handled as optional", {timeout:10000});
+var t = async_test("Tests that setting an optional constraint in getUserMedia is handled as optional");
 t.step(function() {
   navigator.mediaDevices.getUserMedia({video: {advanced: [{width: {min:1024, max: 800}}]}})
     .then(t.step_func(function (stream) {

--- a/mediacapture-streams/GUM-trivial-constraint.https.html
+++ b/mediacapture-streams/GUM-trivial-constraint.https.html
@@ -15,7 +15,7 @@ constraint (width &gt;=0) in getUserMedia works</p>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that setting a trivial mandatory constraint in getUserMedia works", {timeout:10000});
+var t = async_test("Tests that setting a trivial mandatory constraint in getUserMedia works");
 t.step(function() {
   navigator.mediaDevices.getUserMedia({video: {width: {min:0}}})
     .then(t.step_func(function (stream) {

--- a/mediacapture-streams/MediaStream-add-audio-track.https.html
+++ b/mediacapture-streams/MediaStream-add-audio-track.https.html
@@ -15,7 +15,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that adding a track to a MediaStream works as expected", {timeout: 20000}); // longer timeout since requires double user interaction
+var t = async_test("Tests that adding a track to a MediaStream works as expected"); // longer timeout since requires double user interaction
 t.step(function () {
   var audio, video;
 

--- a/mediacapture-streams/MediaStream-add-audio-track.https.html
+++ b/mediacapture-streams/MediaStream-add-audio-track.https.html
@@ -15,7 +15,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that adding a track to a MediaStream works as expected"); // longer timeout since requires double user interaction
+var t = async_test("Tests that adding a track to a MediaStream works as expected");
 t.step(function () {
   var audio, video;
 

--- a/mediacapture-streams/MediaStream-audio-only.https.html
+++ b/mediacapture-streams/MediaStream-audio-only.https.html
@@ -17,7 +17,7 @@ the success callback in getUserMedia has exactly one audio track.</p>
 <script src=/resources/testharnessreport.js></script>
 <script>
 var astream;
-var t = async_test("Tests that a MediaStream with exactly one audio track is returned", {timeout: 10000});
+var t = async_test("Tests that a MediaStream with exactly one audio track is returned");
 t.step(function() {
   navigator.mediaDevices.getUserMedia({audio:true}).then(t.step_func(function (stream) {
     astream = stream;

--- a/mediacapture-streams/MediaStream-finished-add.https.html
+++ b/mediacapture-streams/MediaStream-finished-add.https.html
@@ -17,7 +17,7 @@ MediaStream is allowed.</p>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that adding a track to an inactive MediaStream is allowed", {timeout:20000});
+var t = async_test("Tests that adding a track to an inactive MediaStream is allowed");
 t.step(function () {
   var audio, video;
 

--- a/mediacapture-streams/MediaStream-gettrackid.https.html
+++ b/mediacapture-streams/MediaStream-gettrackid.https.html
@@ -14,7 +14,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that MediaStream.getTrackById works as expected", {timeout: 10000});
+var t = async_test("Tests that MediaStream.getTrackById works as expected");
 t.step(function () {
   navigator.mediaDevices.getUserMedia({video: true})
       .then(t.step_func(gotVideo), t.step_func(function (error) {

--- a/mediacapture-streams/MediaStream-idl.https.html
+++ b/mediacapture-streams/MediaStream-idl.https.html
@@ -20,7 +20,7 @@ follows the algorithm set in the spec.</p>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-let t = async_test("Tests that a MediaStream constructor follows the algorithm set in the spec", {timeout: 10000});
+let t = async_test("Tests that a MediaStream constructor follows the algorithm set in the spec");
 t.step(() => {
   navigator.mediaDevices.getUserMedia({video: true, audio:true})
     .then(t.step_func(stream => {

--- a/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-audio-is-silence.https.html
+++ b/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-audio-is-silence.https.html
@@ -18,7 +18,7 @@ Web Audio API</a>.</p>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that a disabled audio track in a MediaStream is rendered as silence", {timeout: 200000});
+var t = async_test("Tests that a disabled audio track in a MediaStream is rendered as silence");
 var aud = document.getElementById("aud");
 t.step(function() {
   navigator.mediaDevices.getUserMedia({audio: true}).then(t.step_func(function (stream) {

--- a/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-video-is-black.https.html
+++ b/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-video-is-black.https.html
@@ -19,7 +19,7 @@ MediaStream is rendered as blackness.</p>
 <script>
 var vid = document.getElementById("vid");
 var cv = document.createElement("canvas");
-var t = async_test("Tests that a disabled video track in a MediaStream is rendered as blackness", {timeout: 10000});
+var t = async_test("Tests that a disabled video track in a MediaStream is rendered as blackness");
 t.step(function() {
   navigator.mediaDevices.getUserMedia({video: true})
     .then(t.step_func(function (stream) {

--- a/mediacapture-streams/MediaStreamTrack-end-manual.https.html
+++ b/mediacapture-streams/MediaStreamTrack-end-manual.https.html
@@ -17,7 +17,7 @@ correctly set into inactive state when permission is revoked.</p>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that the video MediaStreamTrack objects are properly ended on permission revocation", {timeout: 20000}); // longer timeout since requires user interaction
+var t = async_test("Tests that the video MediaStreamTrack objects are properly ended on permission revocation"); // longer timeout since requires user interaction
 t.step(function () {
   navigator.mediaDevices.getUserMedia({audio: true,video: true}).then(t.step_func(function (stream) {
     var vidTrack = stream.getVideoTracks()[0];

--- a/mediacapture-streams/MediaStreamTrack-end-manual.https.html
+++ b/mediacapture-streams/MediaStreamTrack-end-manual.https.html
@@ -17,7 +17,7 @@ correctly set into inactive state when permission is revoked.</p>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that the video MediaStreamTrack objects are properly ended on permission revocation"); // longer timeout since requires user interaction
+var t = async_test("Tests that the video MediaStreamTrack objects are properly ended on permission revocation");
 t.step(function () {
   navigator.mediaDevices.getUserMedia({audio: true,video: true}).then(t.step_func(function (stream) {
     var vidTrack = stream.getVideoTracks()[0];

--- a/mediacapture-streams/MediaStreamTrack-id.https.html
+++ b/mediacapture-streams/MediaStreamTrack-id.https.html
@@ -14,7 +14,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
-var t = async_test("Tests that distinct mediastream tracks have distinct ids ", {timeout: 10000});
+var t = async_test("Tests that distinct mediastream tracks have distinct ids ");
 t.step(function () {
   navigator.mediaDevices.getUserMedia({video: true, audio: true})
     .then(t.step_func(gotStream), t.step_func(function(error) {t.assert_unreached("Access to audio and video stream is granted");}));


### PR DESCRIPTION
Remove all the timeout in `async_test` for mediacapture-streams tests.
Affected tests: 12
Before: Pass: 10, Failed: 2
After: Pass: 10, Failed: 2
Related: #11120