### PR TITLE
In affected tests logic, don't do `git diff` using a `A..B` range

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -336,7 +336,7 @@ def get_parser_affected():
 def get_revish(**kwargs):
     revish = kwargs["revish"]
     if kwargs["revish"] is None:
-        revish = "%s..HEAD" % branch_point()
+        revish = branch_point()
     return revish
 
 


### PR DESCRIPTION
"%s..HEAD" will result in something like `git diff abcd1234..HEAD`
being called, and this is the same as `git diff abcd1234 HEAD`, which
in turn is the same as `git diff abcd1234`.

Also, while `git rev-parse` can parse `A..B`, it doesn't refer to
*one* revision, so isn't appropriate to call a revish.