### PR TITLE
Fix a typo in css/css-text/writing-system/ already fixed in ref

### DIFF
--- a/css/css-text/writing-system/writing-system-line-break-002.html
+++ b/css/css-text/writing-system/writing-system-line-break-002.html
@@ -17,6 +17,6 @@ div {
 }
 </style>
 
-<p>The test passes if the question mark in the phrase below is on alone on the second line.
+<p>The test passes if the question mark in the phrase below is alone on the second line.
 
 <div lang=en-Hrkt>ハロー、ハウアーユー？</div>


### PR DESCRIPTION
The typo in the ref was fixed in
https://github.com/web-platform-tests/wpt/pull/13430, but the test
itself was not updated. That's bad.