### PR TITLE
[paint-timing] Avoid race condition

### DIFF
--- a/paint-timing/idlharness.window.js
+++ b/paint-timing/idlharness.window.js
@@ -19,6 +19,9 @@ idl_test(
         resolve();
       });
       observer.observe({ entryTypes: ['paint'] });
+
+      // Force the creation of a new "paint" entry
+      document.body.appendChild(document.createTextNode('content'));
     });
     const timeout = new Promise((_, reject) => {
       t.step_timeout(() => reject('Timed out waiting for paint event'), 3000);


### PR DESCRIPTION
Previously, this test implicitly relied on "paint" timing entries that
were created by the test harness. In some circumstances, the test may
execute after these entries have passed. Introduce an explicit document
modification that will reliably produce a new entry for the purpose of
WebIDL conformance testing.