### PR TITLE
SVG Text Parsing

### DIFF
--- a/svg/text/parsing/inline-size-invalid.svg
+++ b/svg/text/parsing/inline-size-invalid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing inline-size with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#InlineSizeProperty"/>
+    <h:link rel="help" href="https://drafts.csswg.org/css-logical/#dimension-properties"/>
+    <h:meta name="assert" content="inline-size supports only the grammar 'auto | length-percentage'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("inline-size", "none");
+test_invalid_value("inline-size", "-10px");
+test_invalid_value("inline-size", "20");
+test_invalid_value("inline-size", "30deg");
+test_invalid_value("inline-size", "40px 50%");
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/inline-size-valid.svg
+++ b/svg/text/parsing/inline-size-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing inline-size with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#InlineSizeProperty"/>
+    <h:link rel="help" href="https://drafts.csswg.org/css-logical/#dimension-properties"/>
+    <h:meta name="assert" content="inline-size supports the full grammar 'auto | length-percentage'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("inline-size", "auto");
+
+test_valid_value("inline-size", "0", "0px");
+test_valid_value("inline-size", "10px");
+test_valid_value("inline-size", "20%");
+test_valid_value("inline-size", "calc(2em + 3ex)");
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/shape-inside-invalid.svg
+++ b/svg/text/parsing/shape-inside-invalid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing shape-inside with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#ShapeInsideProperty"/>
+    <h:meta name="assert" content="shape-inside supports only the grammar 'auto | [ basic-shape | uri ]+'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("shape-inside", "none");
+test_invalid_value("shape-inside", "auto circle(10px at 20px -30px)");
+test_invalid_value("shape-inside", 'url("https://example.com/") auto');
+
+test_invalid_value("shape-inside", "inset(25%)");
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/shape-inside-valid.svg
+++ b/svg/text/parsing/shape-inside-valid.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing shape-inside with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#ShapeInsideProperty"/>
+    <h:meta name="assert" content="shape-inside supports the full grammar 'auto | [ basic-shape | uri ]+'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("shape-inside", "auto");
+
+test_valid_value("shape-inside", "circle(10px at 20px -30px)");
+test_valid_value("shape-inside", "ellipse(10px 20px at -30px 40px)");
+test_valid_value("shape-inside", "polygon(10px 20px, -30px 40px, 50px 60px)");
+
+test_valid_value("shape-inside", 'url("https://example.com/")');
+
+test_valid_value("shape-inside", 'circle(10px at 20px -30px) url("https://example.com/") ellipse(10px 20px at -30px 40px)');
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/shape-margin-invalid.svg
+++ b/svg/text/parsing/shape-margin-invalid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing shape-margin with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#ShapeMarginProperty"/>
+    <h:meta name="assert" content="shape-margin supports only the grammar 'length-percentage'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("shape-margin", "auto");
+test_invalid_value("shape-margin", "-10px");
+test_invalid_value("shape-margin", "20");
+test_invalid_value("shape-margin", "30deg");
+test_invalid_value("shape-margin", "40px 50%");
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/shape-margin-valid.svg
+++ b/svg/text/parsing/shape-margin-valid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing shape-margin with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#ShapeMarginProperty"/>
+    <h:meta name="assert" content="shape-margin supports the full grammar 'length-percentage'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("shape-margin", "0", "0px");
+test_valid_value("shape-margin", "10px");
+test_valid_value("shape-margin", "20%");
+test_valid_value("shape-margin", "calc(2em + 3ex)");
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/shape-subtract-invalid.svg
+++ b/svg/text/parsing/shape-subtract-invalid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing shape-subtract with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextShapeSubtract"/>
+    <h:meta name="assert" content="shape-subtract supports only the grammar 'auto | [ basic-shape | uri ]+'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("shape-subtract", "none");
+test_invalid_value("shape-subtract", "auto circle(10px at 20px -30px)");
+test_invalid_value("shape-subtract", 'url("https://example.com/") auto');
+
+test_invalid_value("shape-subtract", "inset(25%)");
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/shape-subtract-valid.svg
+++ b/svg/text/parsing/shape-subtract-valid.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing shape-subtract with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextShapeSubtract"/>
+    <h:meta name="assert" content="shape-subtract supports the full grammar 'auto | [ basic-shape | uri ]+'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("shape-subtract", "auto");
+
+test_valid_value("shape-subtract", "circle(10px at 20px -30px)");
+test_valid_value("shape-subtract", "ellipse(10px 20px at -30px 40px)");
+test_valid_value("shape-subtract", "polygon(10px 20px, -30px 40px, 50px 60px)");
+
+test_valid_value("shape-subtract", 'url("https://example.com/")');
+
+test_valid_value("shape-subtract", 'circle(10px at 20px -30px) url("https://example.com/") ellipse(10px 20px at -30px 40px)');
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/text-anchor-invalid.svg
+++ b/svg/text/parsing/text-anchor-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing text-anchor with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty"/>
+    <h:meta name="assert" content="text-anchor supports only the grammar 'start | middle | end'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("text-anchor", "auto");
+test_invalid_value("text-anchor", "start middle");
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/text-anchor-valid.svg
+++ b/svg/text/parsing/text-anchor-valid.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing text-anchor with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty"/>
+    <h:meta name="assert" content="text-anchor supports the full grammar 'start | middle | end'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("text-anchor", "start");
+test_valid_value("text-anchor", "middle");
+test_valid_value("text-anchor", "end");
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/text-decoration-fill-invalid.svg
+++ b/svg/text/parsing/text-decoration-fill-invalid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing text-decoration-fill with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextDecorationFillProperty"/>
+    <h:meta name="assert" content="text-decoration-fill supports only the paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("text-decoration-fill", "auto");
+test_invalid_value("text-decoration-fill", "none red");
+test_invalid_value("text-decoration-fill", 'none url("https://example.com/")');
+test_invalid_value("text-decoration-fill", 'red url("https://example.com/")');
+test_invalid_value("text-decoration-fill", 'url("https://example.com/") none red');
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/text-decoration-fill-valid.svg
+++ b/svg/text/parsing/text-decoration-fill-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing text-decoration-fill with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextDecorationFillProperty"/>
+    <h:meta name="assert" content="text-decoration-fill supports the full paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("text-decoration-fill", "none");
+test_valid_value("text-decoration-fill", "context-fill");
+test_valid_value("text-decoration-fill", "context-stroke");
+test_valid_value("text-decoration-fill", "rgb(12, 34, 56)");
+
+test_valid_value("text-decoration-fill", 'url("https://example.com/")');
+test_valid_value("text-decoration-fill", 'url("https://example.com/") none');
+test_valid_value("text-decoration-fill", 'url("https://example.com/") rgb(12, 34, 56)');
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/text-decoration-stroke-invalid.svg
+++ b/svg/text/parsing/text-decoration-stroke-invalid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing text-decoration-stroke with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextDecorationStrokeProperty"/>
+    <h:meta name="assert" content="text-decoration-stroke supports only the paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("text-decoration-stroke", "auto");
+test_invalid_value("text-decoration-stroke", "none red");
+test_invalid_value("text-decoration-stroke", 'none url("https://example.com/")');
+test_invalid_value("text-decoration-stroke", 'red url("https://example.com/")');
+test_invalid_value("text-decoration-stroke", 'url("https://example.com/") none red');
+
+  ]]></script>
+</svg>

--- a/svg/text/parsing/text-decoration-stroke-valid.svg
+++ b/svg/text/parsing/text-decoration-stroke-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: parsing text-decoration-stroke with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextDecorationStrokeProperty"/>
+    <h:meta name="assert" content="text-decoration-stroke supports the full paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("text-decoration-stroke", "none");
+test_valid_value("text-decoration-stroke", "context-fill");
+test_valid_value("text-decoration-stroke", "context-stroke");
+test_valid_value("text-decoration-stroke", "rgb(12, 34, 56)");
+
+test_valid_value("text-decoration-stroke", 'url("https://example.com/")');
+test_valid_value("text-decoration-stroke", 'url("https://example.com/") none');
+test_valid_value("text-decoration-stroke", 'url("https://example.com/") rgb(12, 34, 56)');
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
Test that properties support the full grammar in
https://svgwg.org/svg2-draft/text.html

Blink/Firefox/Edge/Safari do not support
- shape-inside
- shape-subtract
- text-decoration-fill
- text-decoration-stroke

Safari/Edge do not support
- inline-size

Edge does not support
- shape-margin