### PR TITLE
SVG Painting: property parsing

### DIFF
--- a/svg/painting/parsing/color-interpolation-invalid.svg
+++ b/svg/painting/parsing/color-interpolation-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing color-interpolation with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty"/>
+    <h:meta name="assert" content="color-interpolation supports only the grammar 'auto | sRGB | linearRGB'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("color-interpolation", "none");
+test_invalid_value("color-interpolation", "auto srgb");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/color-interpolation-valid.svg
+++ b/svg/painting/parsing/color-interpolation-valid.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing color-interpolation with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty"/>
+    <h:meta name="assert" content="color-interpolation supports the full grammar 'auto | sRGB | linearRGB'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("color-interpolation", "auto");
+test_valid_value("color-interpolation", "srgb");
+test_valid_value("color-interpolation", "linearrgb");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/color-rendering-invalid.svg
+++ b/svg/painting/parsing/color-rendering-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing color-rendering with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorRenderingProperty"/>
+    <h:meta name="assert" content="color-rendering supports only the grammar 'auto | optimizeSpeed | optimizeQuality'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("color-rendering", "optimizelegibility");
+test_invalid_value("color-rendering", "auto optimizespeed");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/color-rendering-valid.svg
+++ b/svg/painting/parsing/color-rendering-valid.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing color-rendering with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorRenderingProperty"/>
+    <h:meta name="assert" content="color-rendering supports the full grammar 'auto | optimizeSpeed | optimizeQuality'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("color-rendering", "auto");
+test_valid_value("color-rendering", "optimizespeed");
+test_valid_value("color-rendering", "optimizequality");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/fill-invalid.svg
+++ b/svg/painting/parsing/fill-invalid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing fill with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillProperty"/>
+    <h:meta name="assert" content="fill supports only the paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("fill", "auto");
+test_invalid_value("fill", "none red");
+test_invalid_value("fill", 'none url("https://example.com/")');
+test_invalid_value("fill", 'red url("https://example.com/")');
+test_invalid_value("fill", 'url("https://example.com/") none red');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/fill-opacity-invalid.svg
+++ b/svg/painting/parsing/fill-opacity-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing fill-opacity with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty"/>
+    <h:meta name="assert" content="fill-opacity supports only the grammar 'alpha-value'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("fill-opacity", "1.");
+test_invalid_value("fill-opacity", "2 3");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/fill-opacity-valid.svg
+++ b/svg/painting/parsing/fill-opacity-valid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing fill-opacity with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty"/>
+    <h:meta name="assert" content="fill-opacity supports the full grammar 'alpha-value'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("fill-opacity", "-1");
+test_valid_value("fill-opacity", "0.5");
+test_valid_value("fill-opacity", "3");
+test_valid_value("fill-opacity", "-100%");
+test_valid_value("fill-opacity", "50%");
+test_valid_value("fill-opacity", "300%");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/fill-rule-invalid.svg
+++ b/svg/painting/parsing/fill-rule-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing fill-rule with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty"/>
+    <h:meta name="assert" content="fill-rule supports only the grammar 'nonzero | evenodd'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("fill-rule", "auto");
+test_invalid_value("fill-rule", "nonzero evenodd");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/fill-rule-valid.svg
+++ b/svg/painting/parsing/fill-rule-valid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing fill-rule with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty"/>
+    <h:meta name="assert" content="fill-rule supports the full grammar 'nonzero | evenodd'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("fill-rule", "nonzero");
+test_valid_value("fill-rule", "evenodd");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/fill-valid.svg
+++ b/svg/painting/parsing/fill-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing fill with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillProperty"/>
+    <h:meta name="assert" content="fill supports the full paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("fill", "none");
+test_valid_value("fill", "context-fill");
+test_valid_value("fill", "context-stroke");
+test_valid_value("fill", "rgb(12, 34, 56)");
+
+test_valid_value("fill", 'url("https://example.com/")');
+test_valid_value("fill", 'url("https://example.com/") none');
+test_valid_value("fill", 'url("https://example.com/") rgb(12, 34, 56)');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/image-rendering-invalid.svg
+++ b/svg/painting/parsing/image-rendering-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing image-rendering with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ImageRenderingProperty"/>
+    <h:meta name="assert" content="image-rendering supports only the grammar 'auto | optimizeQuality | optimizeSpeed'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("image-rendering", "optimizelegibility");
+test_invalid_value("image-rendering", "auto optimizequality");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/image-rendering-valid.svg
+++ b/svg/painting/parsing/image-rendering-valid.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing image-rendering with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ImageRenderingProperty"/>
+    <h:meta name="assert" content="image-rendering supports the full grammar 'auto | optimizeQuality | optimizeSpeed'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("image-rendering", "auto");
+test_valid_value("image-rendering", "optimizequality");
+test_valid_value("image-rendering", "optimizespeed");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/marker-end-invalid.svg
+++ b/svg/painting/parsing/marker-end-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing marker-end with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty"/>
+    <h:meta name="assert" content="marker-end supports only the paint grammar 'none | marker-ref'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("marker-end", "auto");
+test_invalid_value("marker-end", 'none url("https://example.com/")');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/marker-end-valid.svg
+++ b/svg/painting/parsing/marker-end-valid.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing marker-end with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty"/>
+    <h:meta name="assert" content="marker-end supports the full paint grammar 'none | marker-ref'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("marker-end", "none");
+
+test_valid_value("marker-end", 'url("https://example.com/")');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/marker-mid-invalid.svg
+++ b/svg/painting/parsing/marker-mid-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing marker-mid with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty"/>
+    <h:meta name="assert" content="marker-mid supports only the paint grammar 'none | marker-ref'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("marker-mid", "auto");
+test_invalid_value("marker-mid", 'none url("https://example.com/")');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/marker-mid-valid.svg
+++ b/svg/painting/parsing/marker-mid-valid.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing marker-mid with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty"/>
+    <h:meta name="assert" content="marker-mid supports the full paint grammar 'none | marker-ref'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("marker-mid", "none");
+
+test_valid_value("marker-mid", 'url("https://example.com/")');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/marker-start-invalid.svg
+++ b/svg/painting/parsing/marker-start-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing marker-start with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty"/>
+    <h:meta name="assert" content="marker-start supports only the paint grammar 'none | marker-ref'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("marker-start", "auto");
+test_invalid_value("marker-start", 'none url("https://example.com/")');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/marker-start-valid.svg
+++ b/svg/painting/parsing/marker-start-valid.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing marker-start with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty"/>
+    <h:meta name="assert" content="marker-start supports the full paint grammar 'none | marker-ref'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("marker-start", "none");
+
+test_valid_value("marker-start", 'url("https://example.com/")');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/paint-order-invalid.svg
+++ b/svg/painting/parsing/paint-order-invalid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing paint-order with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty"/>
+    <h:meta name="assert" content="paint-order supports only the grammar 'normal | [ fill || stroke || markers ]'."/>
+    <h:meta name="assert" content="paint-order uses the shortest serialization."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("paint-order", "normal stroke");
+test_invalid_value("paint-order", "fill fill");
+test_invalid_value("paint-order", "markers normal");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/paint-order-valid.svg
+++ b/svg/painting/parsing/paint-order-valid.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing paint-order with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty"/>
+    <h:meta name="assert" content="paint-order supports the full grammar 'normal | [ fill || stroke || markers ]'."/>
+    <h:meta name="assert" content="paint-order uses the shortest serialization."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("paint-order", "normal");
+
+test_valid_value("paint-order", "fill");
+test_valid_value("paint-order", "stroke");
+test_valid_value("paint-order", "markers");
+
+test_valid_value("paint-order", "fill stroke", "fill");
+test_valid_value("paint-order", "fill markers");
+test_valid_value("paint-order", "stroke fill", "stroke");
+test_valid_value("paint-order", "stroke markers");
+test_valid_value("paint-order", "markers fill", "markers");
+test_valid_value("paint-order", "markers stroke");
+
+test_valid_value("paint-order", "fill stroke markers", "fill");
+test_valid_value("paint-order", "fill markers stroke", "fill markers");
+test_valid_value("paint-order", "stroke fill markers", "stroke");
+test_valid_value("paint-order", "stroke markers fill", "stroke markers");
+test_valid_value("paint-order", "markers fill stroke", "markers");
+test_valid_value("paint-order", "markers stroke fill", "markers stroke");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/shape-rendering-invalid.svg
+++ b/svg/painting/parsing/shape-rendering-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing shape-rendering with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"/>
+    <h:meta name="assert" content="shape-rendering supports only the grammar 'auto | optimizeSpeed | crispEdges | geometricPrecision'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("shape-rendering", "optimizelegibility");
+test_invalid_value("shape-rendering", "auto optimizespeed");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/shape-rendering-valid.svg
+++ b/svg/painting/parsing/shape-rendering-valid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing shape-rendering with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"/>
+    <h:meta name="assert" content="shape-rendering supports the full grammar 'auto | optimizeSpeed | crispEdges | geometricPrecision'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("shape-rendering", "auto");
+test_valid_value("shape-rendering", "optimizespeed");
+test_valid_value("shape-rendering", "crispedges");
+test_valid_value("shape-rendering", "geometricprecision");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-dasharray-invalid.svg
+++ b/svg/painting/parsing/stroke-dasharray-invalid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-dasharray with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty"/>
+    <h:meta name="assert" content="stroke-dasharray supports only the grammar 'none | dasharray'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("stroke-dasharray", "auto");
+test_invalid_value("stroke-dasharray", "none 10px");
+test_invalid_value("stroke-dasharray", "20px / 30px");
+test_invalid_value("stroke-dasharray", "-40px");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-dasharray-valid.svg
+++ b/svg/painting/parsing/stroke-dasharray-valid.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-dasharray with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty"/>
+    <h:meta name="assert" content="stroke-dasharray supports the full grammar 'none | dasharray'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("stroke-dasharray", "none");
+
+// dasharray = [ length-percentage | number ]#*
+test_valid_value("stroke-dasharray", "10px");
+test_valid_value("stroke-dasharray", "20%");
+test_valid_value("stroke-dasharray", "calc(2em + 3ex)");
+
+test_valid_value("stroke-dasharray", "10px, 20%, 30px");
+test_valid_value("stroke-dasharray", "0, 5", ["0, 5", "0px, 5px"]); // Edge/Safari serialize numbers as lengths.
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-dashoffset-invalid.svg
+++ b/svg/painting/parsing/stroke-dashoffset-invalid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-dashoffset with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
+    <h:meta name="assert" content="stroke-dashoffset supports only the grammar 'length-percentage'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("stroke-dashoffset", "auto");
+test_invalid_value("stroke-dashoffset", "-10.px");
+test_invalid_value("stroke-dashoffset", "30deg");
+test_invalid_value("stroke-dashoffset", "40px 50%");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-dashoffset-valid.svg
+++ b/svg/painting/parsing/stroke-dashoffset-valid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-dashoffset with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
+    <h:meta name="assert" content="stroke-dashoffset supports the full grammar 'length-percentage'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("stroke-dashoffset", "0");
+test_valid_value("stroke-dashoffset", "10px");
+test_valid_value("stroke-dashoffset", "-20%");
+test_valid_value("stroke-dashoffset", "30");
+test_valid_value("stroke-dashoffset", "calc(2em + 3ex)");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-invalid.svg
+++ b/svg/painting/parsing/stroke-invalid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty"/>
+    <h:meta name="assert" content="stroke supports only the paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("stroke", "auto");
+test_invalid_value("stroke", "none red");
+test_invalid_value("stroke", 'none url("https://example.com/")');
+test_invalid_value("stroke", 'red url("https://example.com/")');
+test_invalid_value("stroke", 'url("https://example.com/") none red');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-linecap-invalid.svg
+++ b/svg/painting/parsing/stroke-linecap-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-linecap with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty"/>
+    <h:meta name="assert" content="stroke-linecap supports only the grammar 'butt | round | square'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("stroke-linecap", "auto");
+test_invalid_value("stroke-linecap", "butt round");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-linecap-valid.svg
+++ b/svg/painting/parsing/stroke-linecap-valid.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-linecap with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty"/>
+    <h:meta name="assert" content="stroke-linecap supports the full grammar 'butt | round | square'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("stroke-linecap", "butt");
+test_valid_value("stroke-linecap", "round");
+test_valid_value("stroke-linecap", "square");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-linejoin-invalid.svg
+++ b/svg/painting/parsing/stroke-linejoin-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-linejoin with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty"/>
+    <h:meta name="assert" content="stroke-linejoin supports only the grammar 'miter | miter-clip | round | bevel | arcs'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("stroke-linejoin", "auto");
+test_invalid_value("stroke-linejoin", "round bevel");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-linejoin-valid.svg
+++ b/svg/painting/parsing/stroke-linejoin-valid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-linejoin with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty"/>
+    <h:meta name="assert" content="stroke-linejoin supports the full grammar 'miter | miter-clip | round | bevel | arcs'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("stroke-linejoin", "miter");
+test_valid_value("stroke-linejoin", "miter-clip");
+test_valid_value("stroke-linejoin", "round");
+test_valid_value("stroke-linejoin", "bevel");
+test_valid_value("stroke-linejoin", "arcs");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-miterlimit-invalid.svg
+++ b/svg/painting/parsing/stroke-miterlimit-invalid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-miterlimit with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
+    <h:meta name="assert" content="stroke-miterlimit supports only the grammar 'number'"/>
+    <h:meta name="assert" content="A negative value for stroke-miterlimit must be treated as an illegal value."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("stroke-miterlimit", "1.");
+test_invalid_value("stroke-miterlimit", "2 3");
+test_invalid_value("stroke-miterlimit", "-4");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-miterlimit-valid.svg
+++ b/svg/painting/parsing/stroke-miterlimit-valid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-miterlimit with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
+    <h:meta name="assert" content="stroke-miterlimit supports the full grammar 'number'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("stroke-miterlimit", "0");
+test_valid_value("stroke-miterlimit", "0.5");
+test_valid_value("stroke-miterlimit", "1");
+test_valid_value("stroke-miterlimit", "7.5");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-opacity-invalid.svg
+++ b/svg/painting/parsing/stroke-opacity-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-opacity with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty"/>
+    <h:meta name="assert" content="stroke-opacity supports only the grammar 'alpha-value'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("stroke-opacity", "1.");
+test_invalid_value("stroke-opacity", "2 3");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-opacity-valid.svg
+++ b/svg/painting/parsing/stroke-opacity-valid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-opacity with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty"/>
+    <h:meta name="assert" content="stroke-opacity supports the full grammar 'alpha-value'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("stroke-opacity", "-1");
+test_valid_value("stroke-opacity", "0.5");
+test_valid_value("stroke-opacity", "3");
+test_valid_value("stroke-opacity", "-100%");
+test_valid_value("stroke-opacity", "50%");
+test_valid_value("stroke-opacity", "300%");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-valid.svg
+++ b/svg/painting/parsing/stroke-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty"/>
+    <h:meta name="assert" content="stroke supports the full paint grammar 'none | color | url [none | color]? | context-fill | context-stroke'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("stroke", "none");
+test_valid_value("stroke", "context-fill");
+test_valid_value("stroke", "context-stroke");
+test_valid_value("stroke", "rgb(12, 34, 56)");
+
+test_valid_value("stroke", 'url("https://example.com/")');
+test_valid_value("stroke", 'url("https://example.com/") none');
+test_valid_value("stroke", 'url("https://example.com/") rgb(12, 34, 56)');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/text-rendering-invalid.svg
+++ b/svg/painting/parsing/text-rendering-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing text-rendering with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty"/>
+    <h:meta name="assert" content="text-rendering supports only the grammar 'auto | optimizeSpeed | optimizeLegibility | geometricPrecision'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("text-rendering", "crispedges");
+test_invalid_value("text-rendering", "auto optimizespeed");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/text-rendering-valid.svg
+++ b/svg/painting/parsing/text-rendering-valid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing text-rendering with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty"/>
+    <h:meta name="assert" content="text-rendering supports the full grammar 'auto | optimizeSpeed | optimizeLegibility | geometricPrecision'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("text-rendering", "auto");
+test_valid_value("text-rendering", "optimizespeed");
+test_valid_value("text-rendering", "optimizelegibility");
+test_valid_value("text-rendering", "geometricprecision");
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
Test that properties support the full grammar.
https://svgwg.org/svg2-draft/painting.html

The tests highlight a number of spec and implementation issues:-

Spec issues:

Blink/Edge/Firefox/Safari do not accept percentage fill-opacity/stroke-opacity
https://github.com/w3c/svgwg/issues/403#issuecomment-439600770

Browsers do not accept stroke-linejoin 'miter-clip' or 'arcs'
https://github.com/w3c/svgwg/issues/592

Browsers accept numeric stroke-dashoffset and stroke-width
https://github.com/w3c/svgwg/issues/534

Browser bugs:

Blink image-rendering does not accept 'optimizespeed' or 'optimizequality'
https://bugs.chromium.org/p/chromium/issues/detail?id=901669

Firefox rejects stroke-miterlimit less than 1
https://bugzilla.mozilla.org/show_bug.cgi?id=1508028

Edge serializes fill/stroke url() without quoting the url string.
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/16900961/

Edge accepts misformed numbers fill-opacity: 1.; stroke-miterlimit: 1.; stroke-opacity: 1.;
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19656838/

Edge accepts negative stroke-dasharray
Edge does not accept calc in stroke-dasharray
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19656979/

Edge accepts negative stroke-width values
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19656907/

Safari accepts negative stroke-width
https://bugs.webkit.org/show_bug.cgi?id=191804

Safari serializes color-interpolation, color-rendering, image-rendering, shape-rendering, text-rendering in mixed case
https://bugs.webkit.org/show_bug.cgi?id=190685

Edge serializes paint-order 'normal' as 'fill', unlike other browsers.

Firefox does not use shortest paint-order serialization, instead it uses 2 keywords when 1 would suffice

Browsers yet to implement properties:

Firefox does not support color-rendering

Edge does not support color-interpolation/color-rendering/image-rendering/shape-rendering/text-rendering
Note: When implementing, the keywords should serialize in lower case.
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19328562/

Browsers yet to implement keywords:

Blink/Edge/Safari do not accept fill/stroke 'context-fill' or 'context-stroke'
Firefox does support the keywords: https://jsfiddle.net/ericwilligers/8bhyafe1/