### PR TITLE
[FileAPI] Remove reference to non-existent file

### DIFF
--- a/FileAPI/url/sandboxed-iframe.html
+++ b/FileAPI/url/sandboxed-iframe.html
@@ -11,8 +11,9 @@
 const iframe_scripts = [
   'resources/fetch-tests.js',
   'url-format.any.js',
+  'url-in-tags.window.js',
   'url-with-xhr.any.js',
-  'url-with-fetch.any.js'
+  'url-with-fetch.any.js',
 ];
 
 let html = '<!doctype html>\n<meta charset="utf-8">\n<body>\n';

--- a/FileAPI/url/sandboxed-iframe.html
+++ b/FileAPI/url/sandboxed-iframe.html
@@ -12,8 +12,7 @@ const iframe_scripts = [
   'resources/fetch-tests.js',
   'url-format.any.js',
   'url-with-xhr.any.js',
-  'url-with-fetch.any.js',
-  'url-with-tags.window.js',
+  'url-with-fetch.any.js'
 ];
 
 let html = '<!doctype html>\n<meta charset="utf-8">\n<body>\n';


### PR DESCRIPTION
The file `FileAPI/url/url-with-tags.window.js` is not currently present
in the repository nor was it present when the reference was introduced
[1]. Remove it to avoid triggering spurious request failures during test
execution.

[1] 9d8a1855092e90b2974453d6181c7f985170deba