### PR TITLE
[Azure Pipelines] Run pytest tests (and publish results) on macOS

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -4,6 +4,7 @@
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/multiple-phases
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/index
 #
 # In addition to this configuration file, the "Build pull requests from forks
 # of this repository" setting must also be enabled in the Azure DevOps project:
@@ -50,3 +51,43 @@ jobs:
     displayName: 'Run tests (Firefox Nightly)'
   - script: no_proxy='*' ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --channel=preview safari_webdriver infrastructure/
     displayName: 'Run tests (Safari Technology Preview)'
+
+- job: tools_unittest_macOS
+  displayName: 'tools/ unittests (macOS)'
+  dependsOn: root
+  condition: dependencies.root.outputs['test_jobs.tools_unittest']
+  pool:
+    vmImage: 'macOS-10.13'
+  steps:
+  - template: tools/ci/azure/checkout.yml
+  - template: tools/ci/azure/tox_pytest.yml
+    parameters:
+      directory: tools/
+      toxenv: py27
+
+- job: wptrunner_unittest_macOS
+  displayName: 'tools/wptrunner/ unittests (macOS)'
+  dependsOn: root
+  condition: dependencies.root.outputs['test_jobs.wptrunner_unittest']
+  pool:
+    vmImage: 'macOS-10.13'
+  steps:
+  - template: tools/ci/azure/checkout.yml
+  - template: tools/ci/azure/tox_pytest.yml
+    parameters:
+      directory: tools/wptrunner/
+
+- job: wpt_integration_macOS
+  displayName: 'tools/wpt/ tests (macOS)'
+  dependsOn: root
+  condition: dependencies.root.outputs['test_jobs.wpt_integration']
+  pool:
+    vmImage: 'macOS-10.13'
+  steps:
+  # full checkout required
+  - template: tools/ci/azure/install_chrome.yml
+  - template: tools/ci/azure/install_firefox.yml
+  - template: tools/ci/azure/update_hosts.yml
+  - template: tools/ci/azure/tox_pytest.yml
+    parameters:
+      directory: tools/wpt/

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,6 +1,8 @@
 # This is the configuration file for Azure Pipelines, used to run tests on
 # macOS. Documentation to help understand this setup:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/multiple-phases
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables
 #
 # In addition to this configuration file, the "Build pull requests from forks
@@ -10,76 +12,41 @@
 trigger: none # disable builds for branches
 
 jobs:
-- job: macOS
-
+- job: root
+  displayName: './wpt test-jobs'
   pool:
-    vmImage: 'macOS-10.13'
-
+    vmImage: 'ubuntu-16.04'
   steps:
-  - checkout: self
-    fetchDepth: 50
-    submodules: false
-
+  - template: tools/ci/azure/checkout.yml
   - script: |
-      echo "Test jobs:"
       ./wpt test-jobs | while read job; do
         echo "$job"
-        echo "##vso[task.setvariable variable=run_$job]true";
+        echo "##vso[task.setvariable variable=$job;isOutput=true]true";
       done
-    displayName: 'List test jobs'
+    name: test_jobs
+    displayName: 'Run ./wpt test-jobs'
 
-  - script: |
-      sudo easy_install pip
-      sudo pip install -U virtualenv
-    displayName: 'Install Python packages'
-    condition: variables.run_wptrunner_infrastructure
-
-  # Installig Ahem in /Library/Fonts instead of using --install-fonts is a
-  # workaround for https://github.com/web-platform-tests/wpt/issues/13803.
-  - script: sudo cp fonts/Ahem.ttf /Library/Fonts
-    displayName: 'Install Ahem font'
-    condition: variables.run_wptrunner_infrastructure
-
-  - script: |
-      # https://github.com/web-platform-tests/results-collection/blob/master/src/scripts/trust-root-ca.sh
-      sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain tools/certs/cacert.pem
-    displayName: 'Install web-platform.test certificate'
-    condition: variables.run_wptrunner_infrastructure
-
-  - script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install Homebrew/homebrew-cask-versions/google-chrome-dev
-    displayName: 'Install Chrome Dev'
-    condition: variables.run_wptrunner_infrastructure
-
-  - script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install Homebrew/homebrew-cask-versions/firefox-nightly
-    displayName: 'Install Firefox Nightly'
-    condition: variables.run_wptrunner_infrastructure
-
-  - script: |
-      # Pin to STP 67, as SafariDriver isn't working in 68:
-      # https://github.com/web-platform-tests/wpt/issues/13800
-      HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/23fae0a88868911913c2ee7d527c89164b6d5720/Casks/safari-technology-preview.rb
-      # https://web-platform-tests.org/running-tests/safari.html
-      sudo "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable
-      defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
-    displayName: 'Install Safari Technology Preview'
-    condition: variables.run_wptrunner_infrastructure
-
-  - script: ./wpt make-hosts-file | sudo tee -a /etc/hosts
-    displayName: 'Update /etc/hosts'
-    condition: variables.run_wptrunner_infrastructure
-
-  - script: ./wpt manifest
-    displayName: 'Update manifest'
-    condition: variables.run_wptrunner_infrastructure
-
+- job: infrastructure_macOS
+  displayName: 'infrastructure/ tests (macOS)'
+  dependsOn: root
+  condition: dependencies.root.outputs['test_jobs.wptrunner_infrastructure']
+  pool:
+    vmImage: 'macOS-10.13'
+  steps:
+  - template: tools/ci/azure/checkout.yml
+  - template: tools/ci/azure/pip_install.yml
+    parameters:
+      packages: virtualenv
+  - template: tools/ci/azure/install_fonts.yml
+  - template: tools/ci/azure/install_certs.yml
+  - template: tools/ci/azure/install_chrome.yml
+  - template: tools/ci/azure/install_firefox.yml
+  - template: tools/ci/azure/install_safari.yml
+  - template: tools/ci/azure/update_hosts.yml
+  - template: tools/ci/azure/update_manifest.yml
   - script: no_proxy='*' ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --channel=dev chrome infrastructure/
-    displayName: 'Run infrastructure/ tests (Chrome Dev)'
-    condition: variables.run_wptrunner_infrastructure
-
+    displayName: 'Run tests (Chrome Dev)'
   - script: no_proxy='*' ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --channel=nightly firefox infrastructure/
-    displayName: 'Run infrastructure/ tests (Firefox Nightly)'
-    condition: variables.run_wptrunner_infrastructure
-
+    displayName: 'Run tests (Firefox Nightly)'
   - script: no_proxy='*' ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --channel=preview safari_webdriver infrastructure/
-    displayName: 'Run infrastructure/ tests (Safari Technology Preview)'
-    condition: variables.run_wptrunner_infrastructure
+    displayName: 'Run tests (Safari Technology Preview)'

--- a/tools/ci/azure/README.md
+++ b/tools/ci/azure/README.md
@@ -1,0 +1,2 @@
+These are step templates for Azure Pipelines, used in `.azure-pipelines.yml`
+in the root of the repository.

--- a/tools/ci/azure/checkout.yml
+++ b/tools/ci/azure/checkout.yml
@@ -1,0 +1,4 @@
+steps:
+- checkout: self
+  fetchDepth: 50
+  submodules: false

--- a/tools/ci/azure/install_certs.yml
+++ b/tools/ci/azure/install_certs.yml
@@ -1,0 +1,5 @@
+steps:
+- script: |
+    # https://github.com/web-platform-tests/results-collection/blob/master/src/scripts/trust-root-ca.sh
+    sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain tools/certs/cacert.pem
+  displayName: 'Install web-platform.test certificate'

--- a/tools/ci/azure/install_chrome.yml
+++ b/tools/ci/azure/install_chrome.yml
@@ -1,0 +1,3 @@
+steps:
+- script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install Homebrew/homebrew-cask-versions/google-chrome-dev
+  displayName: 'Install Chrome Dev'

--- a/tools/ci/azure/install_firefox.yml
+++ b/tools/ci/azure/install_firefox.yml
@@ -1,0 +1,3 @@
+steps:
+- script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install Homebrew/homebrew-cask-versions/firefox-nightly
+  displayName: 'Install Firefox Nightly'

--- a/tools/ci/azure/install_fonts.yml
+++ b/tools/ci/azure/install_fonts.yml
@@ -1,0 +1,5 @@
+steps:
+# Installig Ahem in /Library/Fonts instead of using --install-fonts is a
+# workaround for https://github.com/web-platform-tests/wpt/issues/13803.
+- script: sudo cp fonts/Ahem.ttf /Library/Fonts
+  displayName: 'Install Ahem font'

--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -1,0 +1,9 @@
+steps:
+- script: |
+    # Pin to STP 67, as SafariDriver isn't working in 68:
+    # https://github.com/web-platform-tests/wpt/issues/13800
+    HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/23fae0a88868911913c2ee7d527c89164b6d5720/Casks/safari-technology-preview.rb
+    # https://web-platform-tests.org/running-tests/safari.html
+    sudo "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable
+    defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
+  displayName: 'Install Safari Technology Preview'

--- a/tools/ci/azure/pip_install.yml
+++ b/tools/ci/azure/pip_install.yml
@@ -1,0 +1,12 @@
+parameters:
+  packages: ''
+
+steps:
+- script: |
+    sudo easy_install pip
+    # `sudo pip install` is not used because some packages (e.g. tox) depend on
+    # system packages (e.g. setuptools) which cannot be upgraded due to System
+    # Integrity Protection, see https://stackoverflow.com/a/33004920.
+    pip install --user ${{ parameters.packages }}
+    echo "##vso[task.prependpath]$HOME/Library/Python/2.7/bin"
+  displayName: 'Install Python packages'

--- a/tools/ci/azure/tox_pytest.yml
+++ b/tools/ci/azure/tox_pytest.yml
@@ -1,0 +1,18 @@
+parameters:
+  directory: ''
+  toxenv: 'ALL'
+
+steps:
+- template: pip_install.yml
+  parameters:
+    packages: tox
+
+- script: tox -c ${{ parameters.directory }} -e ${{ parameters.toxenv }} -- --junitxml=results.xml
+  displayName: 'Run tests'
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: '${{ parameters.directory }}/results.xml'
+    testRunTitle: '${{ parameters.directory }}'
+  displayName: 'Publish results'
+  condition: succeededOrFailed()

--- a/tools/ci/azure/update_hosts.yml
+++ b/tools/ci/azure/update_hosts.yml
@@ -1,0 +1,3 @@
+steps:
+- script: ./wpt make-hosts-file | sudo tee -a /etc/hosts
+  displayName: 'Update /etc/hosts'

--- a/tools/ci/azure/update_manifest.yml
+++ b/tools/ci/azure/update_manifest.yml
@@ -1,0 +1,3 @@
+steps:
+- script: ./wpt manifest
+  displayName: 'Update manifest'


### PR DESCRIPTION
Two changes in this PR:

The decision job running in a Linux VM will decide whether or not jobs
running on other OSes start at all. Most templates are now only used
once, but most ought to be reused when running affected tests.

And run pytest tests and public results using this nifty task:
https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results