### PR TITLE
[wpt] Refactor internal function for clarity

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -264,8 +264,8 @@ def affected_testfiles(files_changed, skip_tests, manifest_path=None):
                 for interface in interfaces_changed_names:
                     regex = '[\'"]' + interface + '(\\.idl)?[\'"]'
                     if re.search(regex, file_contents):
-                        affected_testfiles.add(test_full_path)
-                        break
+                        return True
+        return False
 
     for root, dirs, fnames in os.walk(wpt_root):
         # Walk top_level_subdir looking for test files containing either the


### PR DESCRIPTION
The `affected_by_interfaces` function is used for flow control in the
following `if` condition:

    if rel_path in file_contents or repo_path in file_contents or affected_by_interfaces(file_contents):
        affected_testfiles.add(test_full_path)

This usage suggests that the function should return a boolean value
indicating whether the provided file contents are "affected." However,
it was previously implemented to interact with the `affected_testfiles`
set directly and return `None` in all cases.

Refactor the implementation to adhere to the functional style implied by
the call site.