### PR TITLE
[cookies] Add test for default path calculation

### DIFF
--- a/cookies/http-state/resources/cookie-http-state-template.js
+++ b/cookies/http-state/resources/cookie-http-state-template.js
@@ -86,6 +86,13 @@ CookieManager.prototype.resetCookies = () => {
     expireCookie(cookies_to_delete[i].replace(/=.*$/, ""),
                  /*expiry_date=*/null,
                  /*path=*/'/');
+    // Some browsers incorrectly include the final "forward slash" character
+    // when calculating the default path. The expected behavior for default
+    // path calculation is verified elsewhere; this utility accommodates the
+    // non-standard behavior in order to improve the focus of the test suite.
+    expireCookie(cookies_to_delete[i].replace(/=.*$/, ""),
+                 /*expiry_date=*/null,
+                 /*path=*/getLocalResourcesPath() + "/");
   }
 }
 

--- a/cookies/path/default.html
+++ b/cookies/path/default.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset=utf-8>
+  <title>Test for default cookie path</title>
+  <meta name=help href="http://tools.ietf.org/html/rfc6265#section-5.1.4">
+
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id=log></div>
+
+<script>
+var body = document.getElementsByTagName('body')[0];
+var createIframe = function (src, done) {
+  var iframe = document.createElement('iframe');
+  iframe.src = src;
+  body.appendChild(iframe);
+  iframe.onload = function () {
+    done(iframe);
+  };
+};
+
+async_test(function (t) {
+  var iframe;
+  var verify = t.step_func(function () {
+    assert_true(
+      !!iframe.contentWindow.isCookieSet('cookies-path-default'),
+      'cookie can be retrieved from expected path'
+    );
+
+    // The default-path of this cookie must contain, "the characters of the
+    // uri-path from the first character up to, but not including, the
+    // right-most %x2F ("/")."
+    iframe.contentWindow.expireCookie(
+      'cookies-path-default', '/cookies/resources'
+    );
+
+    // As of 2018-11-21, some UAs were observed to include the right-most %x2F
+    // character in violation of RFC6265.
+    t.add_cleanup(function () {
+      iframe.contentWindow.expireCookie(
+        'cookies-path-default', '/cookies/resources/'
+      );
+    });
+
+    assert_false(
+      !!iframe.contentWindow.isCookieSet('cookies-path-default'),
+      'cookie can be referenced using the expected path'
+    );
+
+    t.done();
+  });
+
+  createIframe('/cookies/resources/echo-cookie.html', t.step_func(function (_iframe) {
+    iframe = _iframe;
+
+    createIframe('/cookies/resources/set.py?cookies-path-default=1', verify);
+  }));
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
@mikewest This is the cause of many of [the failures reported by wpt.fyi for `cookies/http-state` in Firefox](https://wpt.fyi/results/cookies/http-state?sha=e340f910d3&labels=taskcluster,firefox), but it's difficult to understand the problem in those terms.

browser    | status
-----------|-------
Chrome 70  | :heavy_check_mark:
Edge 15    | :x:
Firefox 63 | :x:
IE 11      | :x:
Safari 12  | :heavy_check_mark: