### PR TITLE
SVG Painting: computed property values

### DIFF
--- a/svg/painting/parsing/color-interpolation-computed.svg
+++ b/svg/painting/parsing/color-interpolation-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().colorInterpolation</title>
+  <title>SVG Painting: getComputedValue().colorInterpolation</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty"/>
     <h:meta name="assert" content="color-interpolation computed value is as specified."/>

--- a/svg/painting/parsing/color-interpolation-computed.svg
+++ b/svg/painting/parsing/color-interpolation-computed.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().colorInterpolation</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty"/>
+    <h:meta name="assert" content="color-interpolation computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("color-interpolation", "auto");
+test_computed_value("color-interpolation", "srgb");
+test_computed_value("color-interpolation", "linearrgb");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/color-rendering-computed.svg
+++ b/svg/painting/parsing/color-rendering-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().colorRendering</title>
+  <title>SVG Painting: getComputedValue().colorRendering</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorRenderingProperty"/>
     <h:meta name="assert" content="color-rendering computed value is as specified."/>

--- a/svg/painting/parsing/color-rendering-computed.svg
+++ b/svg/painting/parsing/color-rendering-computed.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().colorRendering</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ColorRenderingProperty"/>
+    <h:meta name="assert" content="color-rendering computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("color-rendering", "auto");
+test_computed_value("color-rendering", "optimizespeed");
+test_computed_value("color-rendering", "optimizequality");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/fill-computed.svg
+++ b/svg/painting/parsing/fill-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().fill</title>
+  <title>SVG Painting: getComputedValue().fill</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillProperty"/>
     <h:meta name="assert" content="fill computed value is as specified, with url values absolute."/>
@@ -26,7 +26,8 @@ test(() => {
   const target = document.getElementById('target');
   target.style['fill'] = 'url("a.b#c")';
   const result = getComputedStyle(target)['fill'];
-  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+  const resolved = new URL("a.b#c", document.URL).href;
+  assert_equals(result, 'url("' + resolved + '")');
 }, 'url values are made absolute');
 
   ]]></script>

--- a/svg/painting/parsing/fill-computed.svg
+++ b/svg/painting/parsing/fill-computed.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().fill</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillProperty"/>
+    <h:meta name="assert" content="fill computed value is as specified, with url values absolute."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("fill", "none");
+test_computed_value("fill", "rgb(12, 34, 56)");
+
+test_computed_value("fill", 'url("https://example.com/")');
+test_computed_value("fill", 'url("https://example.com/") none');
+test_computed_value("fill", 'url("https://example.com/") rgb(12, 34, 56)');
+
+// context-fill and context-stroke are not yet supported by browsers.
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style['fill'] = 'url("a.b#c")';
+  const result = getComputedStyle(target)['fill'];
+  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+}, 'url values are made absolute');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/fill-opacity-computed.svg
+++ b/svg/painting/parsing/fill-opacity-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().fillOpacity</title>
+  <title>SVG Painting: getComputedValue().fillOpacity</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillOpacity"/>
     <h:meta name="assert" content="fill-opacity computed value is clamped to the range [0,1]."/>

--- a/svg/painting/parsing/fill-rule-computed.svg
+++ b/svg/painting/parsing/fill-rule-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().fillRule</title>
+  <title>SVG Painting: getComputedValue().fillRule</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty"/>
     <h:meta name="assert" content="fill-rule computed value is as specified."/>

--- a/svg/painting/parsing/fill-rule-computed.svg
+++ b/svg/painting/parsing/fill-rule-computed.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().fillRule</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty"/>
+    <h:meta name="assert" content="fill-rule computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("fill-rule", "nonzero");
+test_computed_value("fill-rule", "evenodd");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/image-rendering-computed.svg
+++ b/svg/painting/parsing/image-rendering-computed.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().imageRendering</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ImageRenderingProperty"/>
+    <h:meta name="assert" content="image-rendering computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("image-rendering", "auto");
+test_computed_value("image-rendering", "optimizequality");
+test_computed_value("image-rendering", "optimizespeed");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/image-rendering-computed.svg
+++ b/svg/painting/parsing/image-rendering-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().imageRendering</title>
+  <title>SVG Painting: getComputedValue().imageRendering</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ImageRenderingProperty"/>
     <h:meta name="assert" content="image-rendering computed value is as specified."/>

--- a/svg/painting/parsing/marker-end-computed.svg
+++ b/svg/painting/parsing/marker-end-computed.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().MarkerEnd</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty"/>
+    <h:meta name="assert" content="marker-end computed value is as specified, with url values absolute."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("marker-end", "none");
+test_computed_value("marker-end", 'url("https://example.com/")');
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style['marker-end'] = 'url("a.b#c")';
+  const result = getComputedStyle(target)['marker-end'];
+  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+}, 'url values are made absolute');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/marker-end-computed.svg
+++ b/svg/painting/parsing/marker-end-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().MarkerEnd</title>
+  <title>SVG Painting: getComputedValue().MarkerEnd</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty"/>
     <h:meta name="assert" content="marker-end computed value is as specified, with url values absolute."/>
@@ -20,7 +20,8 @@ test(() => {
   const target = document.getElementById('target');
   target.style['marker-end'] = 'url("a.b#c")';
   const result = getComputedStyle(target)['marker-end'];
-  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+  const resolved = new URL("a.b#c", document.URL).href;
+  assert_equals(result, 'url("' + resolved + '")');
 }, 'url values are made absolute');
 
   ]]></script>

--- a/svg/painting/parsing/marker-mid-computed.svg
+++ b/svg/painting/parsing/marker-mid-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().markerMid</title>
+  <title>SVG Painting: getComputedValue().markerMid</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty"/>
     <h:meta name="assert" content="marker-mid computed value is as specified, with url values absolute."/>
@@ -20,7 +20,8 @@ test(() => {
   const target = document.getElementById('target');
   target.style['marker-mid'] = 'url("a.b#c")';
   const result = getComputedStyle(target)['marker-mid'];
-  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+  const resolved = new URL("a.b#c", document.URL).href;
+  assert_equals(result, 'url("' + resolved + '")');
 }, 'url values are made absolute');
 
   ]]></script>

--- a/svg/painting/parsing/marker-mid-computed.svg
+++ b/svg/painting/parsing/marker-mid-computed.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().markerMid</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty"/>
+    <h:meta name="assert" content="marker-mid computed value is as specified, with url values absolute."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("marker-mid", "none");
+test_computed_value("marker-mid", 'url("https://example.com/")');
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style['marker-mid'] = 'url("a.b#c")';
+  const result = getComputedStyle(target)['marker-mid'];
+  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+}, 'url values are made absolute');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/marker-start-computed.svg
+++ b/svg/painting/parsing/marker-start-computed.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().markerStart</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty"/>
+    <h:meta name="assert" content="marker-start computed value is as specified, with url values absolute."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("marker-start", "none");
+test_computed_value("marker-start", 'url("https://example.com/")');
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style['marker-start'] = 'url("a.b#c")';
+  const result = getComputedStyle(target)['marker-start'];
+  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+}, 'url values are made absolute');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/marker-start-computed.svg
+++ b/svg/painting/parsing/marker-start-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().markerStart</title>
+  <title>SVG Painting: getComputedValue().markerStart</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty"/>
     <h:meta name="assert" content="marker-start computed value is as specified, with url values absolute."/>
@@ -20,7 +20,8 @@ test(() => {
   const target = document.getElementById('target');
   target.style['marker-start'] = 'url("a.b#c")';
   const result = getComputedStyle(target)['marker-start'];
-  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+  const resolved = new URL("a.b#c", document.URL).href;
+  assert_equals(result, 'url("' + resolved + '")');
 }, 'url values are made absolute');
 
   ]]></script>

--- a/svg/painting/parsing/paint-order-computed.svg
+++ b/svg/painting/parsing/paint-order-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().paintOrder</title>
+  <title>SVG Painting: getComputedValue().paintOrder</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty"/>
     <h:meta name="assert" content="paint-order computed value is as specified."/>

--- a/svg/painting/parsing/paint-order-computed.svg
+++ b/svg/painting/parsing/paint-order-computed.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().paintOrder</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty"/>
+    <h:meta name="assert" content="paint-order computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("paint-order", "normal");
+
+test_computed_value("paint-order", "fill");
+test_computed_value("paint-order", "stroke");
+test_computed_value("paint-order", "markers");
+
+test_computed_value("paint-order", "fill stroke", "fill");
+test_computed_value("paint-order", "fill markers");
+test_computed_value("paint-order", "stroke fill", "stroke");
+test_computed_value("paint-order", "stroke markers");
+test_computed_value("paint-order", "markers fill", "markers");
+test_computed_value("paint-order", "markers stroke");
+
+test_computed_value("paint-order", "fill stroke markers", "fill");
+test_computed_value("paint-order", "fill markers stroke", "fill markers");
+test_computed_value("paint-order", "stroke fill markers", "stroke");
+test_computed_value("paint-order", "stroke markers fill", "stroke markers");
+test_computed_value("paint-order", "markers fill stroke", "markers");
+test_computed_value("paint-order", "markers stroke fill", "markers stroke");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/shape-rendering-computed.svg
+++ b/svg/painting/parsing/shape-rendering-computed.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().shapeRendering</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"/>
+    <h:meta name="assert" content="shape-rendering computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("shape-rendering", "auto");
+test_computed_value("shape-rendering", "optimizespeed");
+test_computed_value("shape-rendering", "crispedges");
+test_computed_value("shape-rendering", "geometricprecision");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/shape-rendering-computed.svg
+++ b/svg/painting/parsing/shape-rendering-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().shapeRendering</title>
+  <title>SVG Painting: getComputedValue().shapeRendering</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"/>
     <h:meta name="assert" content="shape-rendering computed value is as specified."/>

--- a/svg/painting/parsing/stroke-computed.svg
+++ b/svg/painting/parsing/stroke-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().stroke</title>
+  <title>SVG Painting: getComputedValue().stroke</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty"/>
     <h:meta name="assert" content="stroke computed value is as specified, with url values absolute."/>
@@ -26,7 +26,8 @@ test(() => {
   const target = document.getElementById('target');
   target.style['stroke'] = 'url("a.b#c")';
   const result = getComputedStyle(target)['stroke'];
-  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+  const resolved = new URL("a.b#c", document.URL).href;
+  assert_equals(result, 'url("' + resolved + '")');
 }, 'url values are made absolute');
 
   ]]></script>

--- a/svg/painting/parsing/stroke-computed.svg
+++ b/svg/painting/parsing/stroke-computed.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().stroke</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty"/>
+    <h:meta name="assert" content="stroke computed value is as specified, with url values absolute."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("stroke", "none");
+test_computed_value("stroke", "rgb(12, 34, 56)");
+
+test_computed_value("stroke", 'url("https://example.com/")');
+test_computed_value("stroke", 'url("https://example.com/") none');
+test_computed_value("stroke", 'url("https://example.com/") rgb(12, 34, 56)');
+
+// context-fill and context-stroke are not yet supported by browsers.
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style['stroke'] = 'url("a.b#c")';
+  const result = getComputedStyle(target)['stroke'];
+  assert_true(result.includes('/a.b#c'), result + ' is absolute');
+}, 'url values are made absolute');
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-dasharray-computed.svg
+++ b/svg/painting/parsing/stroke-dasharray-computed.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().strokeDasharray</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty"/>
+    <h:meta name="assert" content="stroke-dasharray computed value uses absolute lengths.">
+  </metadata>
+  <g id="target"></g>
+  <style>
+    #target {
+      font-size: 40px;
+    }
+  </style>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("stroke-dasharray", "none");
+
+test_computed_value("stroke-dasharray", "10", "10px");
+test_computed_value("stroke-dasharray", "calc(10px + 0.5em)", "30px");
+test_computed_value("stroke-dasharray", "calc(10px - 0.5em)", "0px");
+test_computed_value("stroke-dasharray", "40%");
+test_computed_value("stroke-dasharray", "calc(50% + 60px)");
+
+test_computed_value("stroke-dasharray", "10px, 20%, 30px");
+test_computed_value("stroke-dasharray", "0, 5", "0px, 5px");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-dasharray-computed.svg
+++ b/svg/painting/parsing/stroke-dasharray-computed.svg
@@ -5,7 +5,7 @@
   <title>SVG Geometry Properties: getComputedValue().strokeDasharray</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty"/>
-    <h:meta name="assert" content="stroke-dasharray computed value uses absolute lengths.">
+    <h:meta name="assert" content="stroke-dasharray computed value uses absolute lengths."/>
   </metadata>
   <g id="target"></g>
   <style>
@@ -26,7 +26,7 @@ test_computed_value("stroke-dasharray", "calc(10px - 0.5em)", "0px");
 test_computed_value("stroke-dasharray", "40%");
 test_computed_value("stroke-dasharray", "calc(50% + 60px)");
 
-test_computed_value("stroke-dasharray", "10px, 20%, 30px");
+test_computed_value("stroke-dasharray", "10px 20% 30px", "10px, 20%, 30px");
 test_computed_value("stroke-dasharray", "0, 5", "0px, 5px");
 
   ]]></script>

--- a/svg/painting/parsing/stroke-dasharray-computed.svg
+++ b/svg/painting/parsing/stroke-dasharray-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().strokeDasharray</title>
+  <title>SVG Painting: getComputedValue().strokeDasharray</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty"/>
     <h:meta name="assert" content="stroke-dasharray computed value uses absolute lengths."/>

--- a/svg/painting/parsing/stroke-dashoffset-computed.svg
+++ b/svg/painting/parsing/stroke-dashoffset-computed.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().strokeDashoffset</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
+    <h:meta name="assert" content="stroke-dashoffset computed value is absolute length.">
+  </metadata>
+  <g id="target"></g>
+  <style>
+    #target {
+      font-size: 40px;
+    }
+  </style>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("stroke-dashoffset", "10", "10px");
+test_computed_value("stroke-dashoffset", "calc(10px + 0.5em)", "30px");
+test_computed_value("stroke-dashoffset", "calc(10px - 0.5em)", "-10px");
+test_computed_value("stroke-dashoffset", "-40%");
+test_computed_value("stroke-dashoffset", "calc(50% + 60px)");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-dashoffset-computed.svg
+++ b/svg/painting/parsing/stroke-dashoffset-computed.svg
@@ -5,7 +5,7 @@
   <title>SVG Geometry Properties: getComputedValue().strokeDashoffset</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
-    <h:meta name="assert" content="stroke-dashoffset computed value is absolute length.">
+    <h:meta name="assert" content="stroke-dashoffset computed value is absolute length."/>
   </metadata>
   <g id="target"></g>
   <style>
@@ -19,10 +19,19 @@
   <script><![CDATA[
 
 test_computed_value("stroke-dashoffset", "10", "10px");
+test_computed_value("stroke-dashoffset", "0.5em", "20px");
 test_computed_value("stroke-dashoffset", "calc(10px + 0.5em)", "30px");
 test_computed_value("stroke-dashoffset", "calc(10px - 0.5em)", "-10px");
 test_computed_value("stroke-dashoffset", "-40%");
 test_computed_value("stroke-dashoffset", "calc(50% + 60px)");
+
+// https://www.w3.org/TR/css-values-3/#absolute-lengths
+test_computed_value("stroke-dashoffset", "254cm", "9600px");
+test_computed_value("stroke-dashoffset", "2540mm", "9600px");
+test_computed_value("stroke-dashoffset", "10160Q", "9600px");
+test_computed_value("stroke-dashoffset", "1in", "96px");
+test_computed_value("stroke-dashoffset", "6pc", "96px");
+test_computed_value("stroke-dashoffset", "72pt", "96px");
 
   ]]></script>
 </svg>

--- a/svg/painting/parsing/stroke-dashoffset-computed.svg
+++ b/svg/painting/parsing/stroke-dashoffset-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().strokeDashoffset</title>
+  <title>SVG Painting: getComputedValue().strokeDashoffset</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
     <h:meta name="assert" content="stroke-dashoffset computed value is absolute length."/>

--- a/svg/painting/parsing/stroke-linecap-computed.svg
+++ b/svg/painting/parsing/stroke-linecap-computed.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().strokeLinecap</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty"/>
+    <h:meta name="assert" content="stroke-linecap computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("stroke-linecap", "butt");
+test_computed_value("stroke-linecap", "round");
+test_computed_value("stroke-linecap", "square");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-linecap-computed.svg
+++ b/svg/painting/parsing/stroke-linecap-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().strokeLinecap</title>
+  <title>SVG Painting: getComputedValue().strokeLinecap</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty"/>
     <h:meta name="assert" content="stroke-linecap computed value is as specified."/>

--- a/svg/painting/parsing/stroke-linejoin-computed.svg
+++ b/svg/painting/parsing/stroke-linejoin-computed.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().strokeLinejoin</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty"/>
+    <h:meta name="assert" content="stroke-linejoin computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("stroke-linejoin", "miter");
+test_computed_value("stroke-linejoin", "round");
+test_computed_value("stroke-linejoin", "bevel");
+// "miter-clip" and "arcs" are not yet supported by browsers.
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-linejoin-computed.svg
+++ b/svg/painting/parsing/stroke-linejoin-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().strokeLinejoin</title>
+  <title>SVG Painting: getComputedValue().strokeLinejoin</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty"/>
     <h:meta name="assert" content="stroke-linejoin computed value is as specified."/>

--- a/svg/painting/parsing/stroke-miterlimit-computed.svg
+++ b/svg/painting/parsing/stroke-miterlimit-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().strokeMiterlimit</title>
+  <title>SVG Painting: getComputedValue().strokeMiterlimit</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
     <h:meta name="assert" content="stroke-miterlimit computed value is as specified."/>

--- a/svg/painting/parsing/stroke-miterlimit-computed.svg
+++ b/svg/painting/parsing/stroke-miterlimit-computed.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().strokeMiterlimit</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty"/>
+    <h:meta name="assert" content="stroke-miterlimit computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("stroke-miterlimit", "0");
+test_computed_value("stroke-miterlimit", "0.5");
+test_computed_value("stroke-miterlimit", "1");
+test_computed_value("stroke-miterlimit", "7.5");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/stroke-opacity-computed.svg
+++ b/svg/painting/parsing/stroke-opacity-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().strokeOpacity</title>
+  <title>SVG Painting: getComputedValue().strokeOpacity</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty"/>
     <h:meta name="assert" content="stroke-opacity computed value is clamped to the range [0,1]."/>

--- a/svg/painting/parsing/stroke-width-computed.svg
+++ b/svg/painting/parsing/stroke-width-computed.svg
@@ -5,6 +5,7 @@
   <title>SVG Geometry Properties: getComputedValue().strokeWidth</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeWidth"/>
+    <h:meta name="assert" content="stroke-width computed value is absolute length.">
   </metadata>
   <g id="target"></g>
   <style>

--- a/svg/painting/parsing/stroke-width-computed.svg
+++ b/svg/painting/parsing/stroke-width-computed.svg
@@ -5,11 +5,12 @@
   <title>SVG Geometry Properties: getComputedValue().strokeWidth</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeWidth"/>
-    <h:meta name="assert" content="stroke-width computed value is absolute length.">
+    <h:meta name="assert" content="stroke-width computed value is absolute length."/>
   </metadata>
   <g id="target"></g>
+  <g id="ref"></g>
   <style>
-    #target {
+    #target, #ref {
       font-size: 40px;
     }
   </style>
@@ -23,6 +24,37 @@ test_computed_value("stroke-width", "calc(10px + 0.5em)", "30px");
 test_computed_value("stroke-width", "calc(10px - 0.5em)", "0px");
 test_computed_value("stroke-width", "40%");
 test_computed_value("stroke-width", "calc(50% + 60px)");
+
+const lengthUnits = [
+  'em',
+  'ex',
+  'ch',
+  'rem',
+  'vw',
+  'vh',
+  'vmin',
+  'vmax',
+  'cm',
+  'mm',
+  'Q',
+  'in',
+  'pt',
+  'pc',
+  'px'
+];
+
+for (let lengthUnit of lengthUnits) {
+  const length = '987' + lengthUnit;
+  test(() => {
+    const target = document.getElementById('target');
+    target.style.strokeWidth = length;
+
+    const ref = document.getElementById('ref');
+    ref.style.wordSpacing = length;
+
+    assert_equals(getComputedStyle(target).strokeWidth, getComputedStyle(ref).wordSpacing);
+  }, 'stroke-width computes ' + lengthUnit + ' lengths');
+}
 
   ]]></script>
 </svg>

--- a/svg/painting/parsing/stroke-width-computed.svg
+++ b/svg/painting/parsing/stroke-width-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().strokeWidth</title>
+  <title>SVG Painting: getComputedValue().strokeWidth</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeWidth"/>
     <h:meta name="assert" content="stroke-width computed value is absolute length."/>

--- a/svg/painting/parsing/text-rendering-computed.svg
+++ b/svg/painting/parsing/text-rendering-computed.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: getComputedValue().textRendering</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty"/>
+    <h:meta name="assert" content="text-rendering computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("text-rendering", "auto");
+test_computed_value("text-rendering", "optimizespeed");
+test_computed_value("text-rendering", "optimizelegibility");
+test_computed_value("text-rendering", "geometricprecision");
+
+  ]]></script>
+</svg>

--- a/svg/painting/parsing/text-rendering-computed.svg
+++ b/svg/painting/parsing/text-rendering-computed.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:h="http://www.w3.org/1999/xhtml"
      width="800px" height="800px">
-  <title>SVG Geometry Properties: getComputedValue().textRendering</title>
+  <title>SVG Painting: getComputedValue().textRendering</title>
   <metadata>
     <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty"/>
     <h:meta name="assert" content="text-rendering computed value is as specified."/>


### PR DESCRIPTION
Keyword values are as specified.
Lengths are converted to absolute lengths.
Urls are converted to absolute paths.

Found bug:
https://bugs.chromium.org/p/chromium/issues/detail?id=908058
*-opacity should be clamped to [0.1]