### PR TITLE
Set default for manifest_update flag appropriately.

### DIFF
--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -47,7 +47,7 @@ def create_parser(product_choices=None):
 
 TEST is either the full path to a test file to run, or the URL of a test excluding
 scheme host and port.""")
-    parser.add_argument("--manifest-update", action="store_true", default=True,
+    parser.add_argument("--manifest-update", action="store_true", default=None,
                         help="Regenerate the test manifest.")
     parser.add_argument("--no-manifest-update", action="store_false", dest="manifest_update",
                         help="Prevent regeneration of the test manifest.")
@@ -430,6 +430,9 @@ def check_args(kwargs):
 
     if kwargs["product"] is None:
         kwargs["product"] = "firefox"
+
+    if kwargs["manifest_update"] is None:
+        kwargs["manifest_update"] = True
 
     if "sauce" in kwargs["product"]:
         kwargs["pause_after_test"] = False


### PR DESCRIPTION
This is required as part of https://github.com/servo/servo/pull/22258/ in order to unbreak Servo's nightly sync process.