### PR TITLE
Add muted error tests for redirected scripts

### DIFF
--- a/html/semantics/scripting-1/the-script-element/muted-errors.sub.html
+++ b/html/semantics/scripting-1/the-script-element/muted-errors.sub.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-// https://html.spec.whatwg.org/#report-the-error
+// https://html.spec.whatwg.org/multipage/webappapis.html#report-the-error
 // If script's muted errors is true, then set message to "Script error.",
 // urlString to the empty string, line and col to 0, and errorValue to null.
     setup({allow_uncaught_exception: true});
@@ -43,6 +43,16 @@
       script.onload = test3.step_func_done(() => check(true));
       document.body.appendChild(script);
     }
+
+    var test4 = async_test("Errors for same-origin scripts redirected to a " +
+                           "cross-origin url and redirected back to " +
+                           "same-origin should be muted");
+    var check4 = test4.step_func_done(() => check(true));
+
+    var test5 = async_test("Errors for cross-origin scripts redirected to a " +
+                           "same-origin url should be muted");
+    var check5 = test5.step_func_done(() => check(true));
+
     function unreachable() { log.push("unexpected"); }
 </script>
 <script src="cacheable-script-throw.py" onerror="test1.unreached_func()()" onload="check1()"></script>
@@ -50,3 +60,10 @@
     onerror="test2.unreached_func()()" onload="check2()"></script>
 <iframe src="//{{domains[www2]}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/muted-errors-iframe.html"
     onerror="test3.unreached_func()()" onload="step3()"></iframe>
+<script src="/fetch/api/resources/redirect.py?location=
+//{{domains[www2]}}:{{ports[http][0]}}/fetch/api/resources/redirect.py?location=
+//{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/cacheable-script-throw.py?a-b-a"
+onerror="test4.unreached_func()()" onload="check4()"></script>
+<script src="//{{domains[www2]}}:{{ports[http][0]}}/fetch/api/resources/redirect.py?location=
+//{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/cacheable-script-throw.py?b-a"
+onerror="test5.unreached_func()()" onload="check5()"></script>

--- a/html/semantics/scripting-1/the-script-element/muted-errors.sub.html
+++ b/html/semantics/scripting-1/the-script-element/muted-errors.sub.html
@@ -62,8 +62,8 @@
     onerror="test3.unreached_func()()" onload="step3()"></iframe>
 <script src="/fetch/api/resources/redirect.py?location=
 //{{domains[www2]}}:{{ports[http][0]}}/fetch/api/resources/redirect.py?location=
-//{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/cacheable-script-throw.py?a-b-a"
+//{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/cacheable-script-throw.py?same-cross-same"
 onerror="test4.unreached_func()()" onload="check4()"></script>
 <script src="//{{domains[www2]}}:{{ports[http][0]}}/fetch/api/resources/redirect.py?location=
-//{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/cacheable-script-throw.py?b-a"
+//{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/cacheable-script-throw.py?cross-same"
 onerror="test5.unreached_func()()" onload="check5()"></script>


### PR DESCRIPTION
Follows https://github.com/whatwg/fetch/pull/834 and https://github.com/web-platform-tests/wpt/pull/14112; adds muted error tests for scripts that redirect as follows:

 - same-origin ->cross-origin ->same-origin
 - cross-origin -> same-origin