### PR TITLE
Remove the timeout in async_test for missing tests

### DIFF
--- a/geolocation-API/getCurrentPosition_IDL.https.html
+++ b/geolocation-API/getCurrentPosition_IDL.https.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <meta charset="utf-8">
+<meta name=timeout content=long>
 <title>Geolocation Test: getCurrentPosition tests</title>
 <link rel="help" href="http://www.w3.org/TR/geolocation-API/">
 <script src="/resources/testharness.js"></script>
@@ -125,7 +126,7 @@ function errorCallback(error)
   fail.done();
 }
 
-success = async_test("getCurrentPosition success callback tests", {timeout:20000});
+success = async_test("getCurrentPosition success callback tests");
 
 // with a longer timeout and with the user accepting the position request,
 // this should test the successcallback

--- a/webrtc/simplecall-no-ssrcs.https.html
+++ b/webrtc/simplecall-no-ssrcs.https.html
@@ -17,7 +17,7 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script type="text/javascript">
-  var test = async_test('Can set up a basic WebRTC call without announcing ssrcs.', {timeout: 5000});
+  var test = async_test('Can set up a basic WebRTC call without announcing ssrcs.');
 
   var gFirstConnection = null;
   var gSecondConnection = null;

--- a/webrtc/simplecall.https.html
+++ b/webrtc/simplecall.https.html
@@ -17,7 +17,7 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script type="text/javascript">
-  var test = async_test('Can set up a basic WebRTC call.', {timeout: 5000});
+  var test = async_test('Can set up a basic WebRTC call.');
 
   var gFirstConnection = null;
   var gSecondConnection = null;

--- a/xhr/abort-during-upload.htm
+++ b/xhr/abort-during-upload.htm
@@ -11,7 +11,7 @@
   <body>
     <div id="log"></div>
     <script>
-      var test = async_test(document.title, {timeout:1100})
+      var test = async_test(document.title);
       test.step(function() {
         var client = new XMLHttpRequest()
         prepare_xhr_for_event_order_test(client);

--- a/xhr/abort-during-upload.htm
+++ b/xhr/abort-during-upload.htm
@@ -11,7 +11,7 @@
   <body>
     <div id="log"></div>
     <script>
-      var test = async_test(document.title);
+      var test = async_test()
       test.step(function() {
         var client = new XMLHttpRequest()
         prepare_xhr_for_event_order_test(client);

--- a/xhr/send-redirect-bogus.htm
+++ b/xhr/send-redirect-bogus.htm
@@ -11,7 +11,7 @@
     <div id="log"></div>
     <script>
       function redirect(code, location) {
-        var test = async_test(document.title + " (" + code + ": " + location + ")", {timeout: 20000})
+        var test = async_test(document.title + " (" + code + ": " + location + ")");
         test.step(function() {
           var client = new XMLHttpRequest()
           client.onreadystatechange = function() {


### PR DESCRIPTION
Some async_test tests in webrtc and xhr with timeout are missed during
removing all the timeout in async_test. As part of goal #11120, this tests
should be updated too.