### PR TITLE
Rewrite `async_test(document.title)` to just `async_test()`

### DIFF
--- a/IndexedDB/idbcursor_advance_index2.htm
+++ b/IndexedDB/idbcursor_advance_index2.htm
@@ -10,7 +10,7 @@
 <script>
 
     var db,
-      t = async_test(document.title),
+      t = async_test(),
       records = [ { pKey: "primaryKey_0", iKey: "indexKey_0" },
                   { pKey: "primaryKey_1", iKey: "indexKey_1" } ];
 

--- a/IndexedDB/idbcursor_advance_index3.htm
+++ b/IndexedDB/idbcursor_advance_index3.htm
@@ -10,7 +10,7 @@
 <script type="text/javascript">
 
     var db,
-      t = async_test(document.title),
+      t = async_test(),
       records = [ { pKey: "primaryKey_0", iKey: "indexKey_0" },
                   { pKey: "primaryKey_1", iKey: "indexKey_1" } ];
 

--- a/IndexedDB/idbcursor_advance_index5.htm
+++ b/IndexedDB/idbcursor_advance_index5.htm
@@ -11,7 +11,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title),
+      t = async_test(),
       records = [ { pKey: "primaryKey_0",   iKey: "indexKey_0" },
                   { pKey: "primaryKey_1",   iKey: "indexKey_1" },
                   { pKey: "primaryKey_1-2", iKey: "indexKey_1" } ],

--- a/IndexedDB/idbcursor_continue_index5.htm
+++ b/IndexedDB/idbcursor_continue_index5.htm
@@ -11,7 +11,7 @@
 <script>
 
     var db,
-      t = async_test(document.title),
+      t = async_test(),
       records = [ { pKey: "primaryKey_0",   iKey: "indexKey_0" },
                   { pKey: "primaryKey_1",   iKey: "indexKey_1" },
                   { pKey: "primaryKey_1-2", iKey: "indexKey_1" },

--- a/IndexedDB/idbcursor_continue_index6.htm
+++ b/IndexedDB/idbcursor_continue_index6.htm
@@ -11,7 +11,7 @@
 <script>
 
     var db,
-      t = async_test(document.title),
+      t = async_test(),
       records = [ { pKey: "primaryKey_0",   iKey: "indexKey_0" },
                   { pKey: "primaryKey_1",   iKey: "indexKey_1" },
                   { pKey: "primaryKey_1-2", iKey: "indexKey_1" },

--- a/IndexedDB/idbcursor_continue_invalid.htm
+++ b/IndexedDB/idbcursor_continue_invalid.htm
@@ -8,7 +8,7 @@
 <script>
 
     var db,
-      t = async_test(document.title);
+      t = async_test();
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbcursor_iterating.htm
+++ b/IndexedDB/idbcursor_iterating.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title);
+      t = async_test();
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbcursor_iterating_index.htm
+++ b/IndexedDB/idbcursor_iterating_index.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title),
+      t = async_test(),
       records = [ { pKey: "primaryKey_0", obj: { iKey: "iKey_0" }},
                   { pKey: "primaryKey_1", obj: { iKey: "iKey_1" }},
                   { pKey: "primaryKey_2", obj: { iKey: "iKey_2" }} ],

--- a/IndexedDB/idbcursor_iterating_index2.htm
+++ b/IndexedDB/idbcursor_iterating_index2.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title),
+      t = async_test(),
       records = [ { pKey: "primaryKey_0", obj: { iKey: "iKey_0" }},
                   { pKey: "primaryKey_2", obj: { iKey: "iKey_2" }} ],
 

--- a/IndexedDB/idbcursor_iterating_objectstore.htm
+++ b/IndexedDB/idbcursor_iterating_objectstore.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title),
+      t = async_test(),
       records = [ { pKey: "primaryKey_0" },
                   { pKey: "primaryKey_1" },
                   { pKey: "primaryKey_2" } ],

--- a/IndexedDB/idbcursor_iterating_objectstore2.htm
+++ b/IndexedDB/idbcursor_iterating_objectstore2.htm
@@ -8,7 +8,7 @@
 <script>
     var db,
       count = 0,
-      t = async_test(document.title),
+      t = async_test(),
       records = [ { pKey: "primaryKey_0" },
                   { pKey: "primaryKey_2" } ],
       expected_records = [ { pKey: "primaryKey_0" },

--- a/IndexedDB/idbcursor_update_objectstore4.htm
+++ b/IndexedDB/idbcursor_update_objectstore4.htm
@@ -8,7 +8,7 @@
 <script>
 
     var db,
-      t = async_test(document.title)
+      t = async_test()
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbdatabase_createObjectStore10-1000ends.htm
+++ b/IndexedDB/idbdatabase_createObjectStore10-1000ends.htm
@@ -7,7 +7,7 @@
 
 <script>
 var db,
-    t = async_test(document.title),
+    t = async_test(),
     open_rq = createdb(t)
 
 open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbdatabase_createObjectStore7.htm
+++ b/IndexedDB/idbdatabase_createObjectStore7.htm
@@ -7,7 +7,7 @@
 
 <script>
 
-var t = async_test(document.title),
+var t = async_test(),
     open_rq = createdb(t)
 
 open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbdatabase_deleteObjectStore4-not_reused.htm
+++ b/IndexedDB/idbdatabase_deleteObjectStore4-not_reused.htm
@@ -8,7 +8,7 @@
 
 <script>
 
-var t = async_test(document.title),
+var t = async_test(),
     keys = [],
     open_rq = createdb(t)
 

--- a/IndexedDB/idbdatabase_transaction4.htm
+++ b/IndexedDB/idbdatabase_transaction4.htm
@@ -7,7 +7,7 @@
 
 <script>
     var db,
-      t = async_test(document.title),
+      t = async_test(),
       open_rq = createdb(t);
 
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbfactory_deleteDatabase3.htm
+++ b/IndexedDB/idbfactory_deleteDatabase3.htm
@@ -9,7 +9,7 @@
 
 <script>
     var db
-    var open_rq = createdb(async_test(document.title), undefined, 9)
+    var open_rq = createdb(async_test(), undefined, 9)
 
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result

--- a/IndexedDB/idbfactory_open10.htm
+++ b/IndexedDB/idbfactory_open10.htm
@@ -7,7 +7,7 @@
 
 <script>
     var db, db2;
-    var open_rq = createdb(async_test(document.title), undefined, 9);
+    var open_rq = createdb(async_test(), undefined, 9);
 
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;

--- a/IndexedDB/idbfactory_open11.htm
+++ b/IndexedDB/idbfactory_open11.htm
@@ -8,7 +8,7 @@
 <script>
     var db;
     var count_done = 0;
-    var open_rq = createdb(async_test(document.title));
+    var open_rq = createdb(async_test());
 
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;

--- a/IndexedDB/idbindex-multientry-arraykeypath.htm
+++ b/IndexedDB/idbindex-multientry-arraykeypath.htm
@@ -9,7 +9,7 @@
 <script src="support.js"></script>
 
 <script>
-    createdb(async_test(document.title)).onupgradeneeded = function(e) {
+    createdb(async_test()).onupgradeneeded = function(e) {
         var store = e.target.result.createObjectStore("store");
 
         assert_throws('InvalidAccessError', function() {

--- a/IndexedDB/idbindex-multientry.htm
+++ b/IndexedDB/idbindex-multientry.htm
@@ -12,7 +12,7 @@
     var db,
         expected_keys = [1, 2, 2, 3, 3];
 
-    var open_rq = createdb(async_test(document.title))
+    var open_rq = createdb(async_test())
 
     open_rq.onupgradeneeded = function(e) {
         db = e.target.result;

--- a/IndexedDB/idbindex_indexNames.htm
+++ b/IndexedDB/idbindex_indexNames.htm
@@ -8,7 +8,7 @@
 
 <script>
     var db,
-      t = async_test(document.title);
+      t = async_test();
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex3-usable-right-away.htm
+++ b/IndexedDB/idbobjectstore_createIndex3-usable-right-away.htm
@@ -9,7 +9,7 @@
 
 <script>
     var db, aborted,
-      t = async_test(document.title)
+      t = async_test()
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex4-deleteIndex-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex4-deleteIndex-event_order.htm
@@ -9,7 +9,7 @@
 <script>
     var db,
       events = [],
-      t = async_test(document.title)
+      t = async_test()
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex5-emptykeypath.htm
+++ b/IndexedDB/idbobjectstore_createIndex5-emptykeypath.htm
@@ -8,7 +8,7 @@
 
 <script>
     var db, aborted,
-      t = async_test(document.title)
+      t = async_test()
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex6-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex6-event_order.htm
@@ -16,7 +16,7 @@
 
     var db,
       events = [],
-      t = async_test(document.title)
+      t = async_test()
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex7-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex7-event_order.htm
@@ -18,7 +18,7 @@
 
     var db,
       events = [],
-      t = async_test(document.title)
+      t = async_test()
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbobjectstore_createIndex8-valid_keys.htm
+++ b/IndexedDB/idbobjectstore_createIndex8-valid_keys.htm
@@ -9,7 +9,7 @@
 
 <script>
     var db,
-      t = async_test(document.title),
+      t = async_test(),
       now = new Date(),
       mar18 = new Date(1111111111111),
       ar = ["Yay", 2, -Infinity],

--- a/IndexedDB/idbobjectstore_deleted.htm
+++ b/IndexedDB/idbobjectstore_deleted.htm
@@ -11,7 +11,7 @@
 <script>
     var db,
       add_success = false,
-      t = async_test(document.title)
+      t = async_test()
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {

--- a/IndexedDB/idbtransaction-oncomplete.htm
+++ b/IndexedDB/idbtransaction-oncomplete.htm
@@ -7,7 +7,7 @@
 
 <script>
     var db, store,
-      t = async_test(document.title),
+      t = async_test(),
       open_rq = createdb(t),
       stages = [];
 

--- a/IndexedDB/idbtransaction_abort.htm
+++ b/IndexedDB/idbtransaction_abort.htm
@@ -8,7 +8,7 @@
 
 <script>
     var db, aborted,
-      t = async_test(document.title),
+      t = async_test(),
       record = { indexedProperty: "bar" };
 
     var open_rq = createdb(t);

--- a/IndexedDB/idbversionchangeevent.htm
+++ b/IndexedDB/idbversionchangeevent.htm
@@ -13,7 +13,7 @@
 <script>
 
     var db,
-        t = async_test(document.title);
+        t = async_test();
 
     t.step(function() {
         var openrq = indexedDB.open('db', 3);

--- a/IndexedDB/keygenerator-constrainterror.htm
+++ b/IndexedDB/keygenerator-constrainterror.htm
@@ -9,7 +9,7 @@
 <script>
 
     var db,
-      t = async_test(document.title),
+      t = async_test(),
       objects = [1, null, {id: 2}, null, 2.00001, 5, null, {id: 6} ],
       expected = [1, 2, 2.00001, 3, 5, 6],
       errors = 0;

--- a/IndexedDB/keygenerator-overflow.htm
+++ b/IndexedDB/keygenerator-overflow.htm
@@ -11,7 +11,7 @@
 <script>
 
     var db,
-      t = async_test(document.title),
+      t = async_test(),
       overflow_error_fired = false,
       objects =  [9007199254740991, null, "error", 2, "error" ],
       expected_keys = [2, 9007199254740991, 9007199254740992];

--- a/IndexedDB/request_bubble-and-capture.htm
+++ b/IndexedDB/request_bubble-and-capture.htm
@@ -9,7 +9,7 @@
 <script>
     var events = [];
 
-    var open_rq = createdb(async_test(document.title));
+    var open_rq = createdb(async_test());
     open_rq.onupgradeneeded = function(e) {
         var db = e.target.result;
         var txn = e.target.transaction;

--- a/IndexedDB/transaction-lifetime-blocked.htm
+++ b/IndexedDB/transaction-lifetime-blocked.htm
@@ -11,7 +11,7 @@
 
     var db, db_got_versionchange, db2,
         events = [],
-        t = async_test(document.title);
+        t = async_test();
 
     t.step(function() {
         var openrq = indexedDB.open('db', 3);

--- a/IndexedDB/transaction-lifetime.htm
+++ b/IndexedDB/transaction-lifetime.htm
@@ -11,7 +11,7 @@
 
     var db, db_got_versionchange, db2,
         events = [],
-        t = async_test(document.title);
+        t = async_test();
 
     t.step(function() {
         var openrq = indexedDB.open('db', 3);

--- a/IndexedDB/transaction-requestqueue.htm
+++ b/IndexedDB/transaction-requestqueue.htm
@@ -8,7 +8,7 @@
 
 <script>
 
-var db, t = async_test(document.title),
+var db, t = async_test(),
     keys = { txn: [], txn2: [] },
     open_rq = createdb(t)
 

--- a/IndexedDB/transaction_bubble-and-capture.htm
+++ b/IndexedDB/transaction_bubble-and-capture.htm
@@ -9,7 +9,7 @@
 <script>
     var events = [];
 
-    var open_rq = createdb(async_test(document.title));
+    var open_rq = createdb(async_test());
     open_rq.onupgradeneeded = function(e) {
         var db = e.target.result;
         var txn = e.target.transaction;

--- a/css/css-backgrounds/border-image-repeat_repeatnegx_none_50px.html
+++ b/css/css-backgrounds/border-image-repeat_repeatnegx_none_50px.html
@@ -22,7 +22,7 @@
     <div id="test"></div>
     <script type="text/javascript">
         var div = document.querySelector("#test");
-        var t = async_test(document.title);
+        var t = async_test();
         t.step(function () {
             div.style[headProp("border-image-repeat")] = "repeat-x";
             div.style[headProp("height")] = "200px";

--- a/css/css-flexbox/display_flex_exist.html
+++ b/css/css-flexbox/display_flex_exist.html
@@ -18,7 +18,7 @@
     <div id=log></div>
     <div id=test></div>
     <script type="text/javascript">
-        var t = async_test(document.title);
+        var t = async_test();
         t.step(function () {
             assert_equals(window.getComputedStyle(document.querySelector('div#test')).display, "flex", "Display value is");
         });

--- a/css/css-flexbox/display_inline-flex_exist.html
+++ b/css/css-flexbox/display_inline-flex_exist.html
@@ -18,7 +18,7 @@
     <div id=log></div>
     <div id=test></div>
     <script type="text/javascript">
-        var t = async_test(document.title);
+        var t = async_test();
         t.step(function () {
             assert_equals(window.getComputedStyle(document.querySelector('div#test')).display, "inline-flex", "Display value is");
         });

--- a/css/css-flexbox/order_value.html
+++ b/css/css-flexbox/order_value.html
@@ -24,7 +24,7 @@
     <div id=log></div>
     <div id=test><div id=test01>1</div><div id=test02>2</div><div id=test03>3</div></div>
     <script type="text/javascript">
-        var t = async_test(document.title);
+        var t = async_test();
         t.step(function () {
             assert_equals(document.getElementById("test01").offsetTop, document.getElementById("test02").offsetTop, "Rectangle 1 and 2 have the same offsetTop value");
             assert_equals((document.getElementById("test02").offsetLeft >= document.getElementById("test01").offsetLeft), false, "Rectangle 2 have a smaller offsetLeft value than 1.");

--- a/eventsource/event-data.html
+++ b/eventsource/event-data.html
@@ -20,7 +20,7 @@ Process the field using the steps described below, using the whole line as the f
   <body>
     <div id="log"></div>
     <script>
-      var test = async_test(document.title);
+      var test = async_test();
       test.step(function() {
         var source = new EventSource("resources/message2.py"),
             counter = 0;

--- a/eventsource/format-field-retry-bogus.htm
+++ b/eventsource/format-field-retry-bogus.htm
@@ -8,7 +8,7 @@
   <body>
     <div id="log"></div>
     <script>
-      var test = async_test(document.title)
+      var test = async_test()
       test.step(function() {
         var timeoutms = 3000,
             source = new EventSource("resources/message.py?message=retry%3A3000%0Aretry%3A1000x%0Adata%3Ax"),

--- a/eventsource/format-field-retry.htm
+++ b/eventsource/format-field-retry.htm
@@ -8,7 +8,7 @@
   <body>
     <div id="log"></div>
     <script>
-      var test = async_test(document.title);
+      var test = async_test();
       test.step(function() {
         var timeoutms = 3000,
             timeoutstr = "03000", // 1536 in octal, but should be 3000

--- a/html/semantics/embedded-content/media-elements/track/track-element/cors/support/common.js
+++ b/html/semantics/embedded-content/media-elements/track/track-element/cors/support/common.js
@@ -12,7 +12,7 @@ setup(function(){
 }, {timeout:10000, explicit_done:true});
 
 onload = function() {
-    (async_test(document.title)).step(function() {
+    (async_test()).step(function() {
         // fail early if track isn't supported
         assert_true('HTMLTrackElement' in window, 'track not supported');
         window.corsMode = document.title.match(/^track CORS: (No CORS|Anonymous|Use Credentials)/)[1];

--- a/orientation-event/free-fall-manual.html
+++ b/orientation-event/free-fall-manual.html
@@ -11,7 +11,7 @@
     <p>Free fall the device to run the test, with the screen horizontal and upmost.</p>
     <div id="log"></div>
     <script>
-      var t = async_test(document.title);
+      var t = async_test();
       var run = false;
 
       /*

--- a/orientation-event/screen-upmost-manual.html
+++ b/orientation-event/screen-upmost-manual.html
@@ -11,7 +11,7 @@
     <p>Put the device on a horizontal surface with the screen upmost.</p>
     <div id="log"></div>
     <script>
-      var t = async_test(document.title);
+      var t = async_test();
       var run = false;
 
       /*

--- a/orientation-event/screen-upright-manual.html
+++ b/orientation-event/screen-upright-manual.html
@@ -11,7 +11,7 @@
     <p>Put the device with the screen upright.</p>
     <div id="log"></div>
     <script>
-      var t = async_test(document.title);
+      var t = async_test();
       var run = false;
 
       /*

--- a/xhr/timeout-cors-async.htm
+++ b/xhr/timeout-cors-async.htm
@@ -13,7 +13,7 @@
   <body>
     <div id="log"></div>
     <script>
-      var test = async_test(document.title)
+      var test = async_test()
       var client = new XMLHttpRequest()
       var gotTimeout = false
       client.open("GET", "http://www2." + location.hostname + (location.port ? ":" + location.port : "") +(location.pathname.replace(/[^\/]+$/, '')+'resources/corsenabled.py')+"?delay=2&code=200")


### PR DESCRIPTION
If no test name is given, `document.title` is effectively already used
in testharness.js:
https://github.com/web-platform-tests/wpt/blob/0ddb31913184805fa3725e22e5b88046e961996b/resources/testharness.js#L3218-L3224