### PR TITLE
[testharness.js] Disallow use of null byte in name

### DIFF
--- a/css/selectors/attribute-selectors/attribute-case/semantics.html
+++ b/css/selectors/attribute-selectors/attribute-case/semantics.html
@@ -75,6 +75,9 @@ var nomatch = [
   ["[foo='bar' i]", ["", "baz", "BAR"]],
 ];
 var mode = "standards mode";
+function replace_null(str) {
+  return str.replace(/\u0000/g, "\\u0000");
+}
 function format_attrs(attrs) {
   var rv = [];
   attrs.forEach(function(attr) {
@@ -87,7 +90,7 @@ function format_attrs(attrs) {
     str += name + "=\"" + value + "\"";
     rv.push(str);
   });
-  return rv.join(" ");
+  return replace_null(rv.join(" "));
 }
 onload = function() {
   var quirks = document.getElementById('quirks').contentWindow;
@@ -117,11 +120,11 @@ onload = function() {
         style.textContent = s + ' { visibility:hidden }';
         assert_equals(style.sheet.cssRules.length, (ns_decl ? 2 : 1), 'rule didn\'t parse into CSSOM');
         assert_equals(global.getComputedStyle(elm).visibility, 'hidden', 'selector didn\'t match');
-      }, s + ' <div ' + format_attrs(attrs) + '> in ' + global.mode);
+      }, replace_null(s) + ' <div ' + format_attrs(attrs) + '> in ' + global.mode);
       if (!ns_decl) {
         test(function() {
           assert_equals(global.document.querySelector(s), elm, 'selector didn\'t match');
-        }, s + ' <div ' + format_attrs(attrs) + '> with querySelector in ' + global.mode);
+        }, replace_null(s) + ' <div ' + format_attrs(attrs) + '> with querySelector in ' + global.mode);
       }
     });
     nomatch.forEach(function(arr) {
@@ -134,11 +137,11 @@ onload = function() {
         style.textContent = s + ' { visibility:hidden }';
         assert_equals(style.sheet.cssRules.length, (ns_decl ? 2 : 1), 'rule didn\'t parse into CSSOM');
         assert_equals(global.getComputedStyle(elm).visibility, 'visible', 'selector matched');
-      }, s + ' <div ' + format_attrs(attrs) + '> in ' + global.mode);
+      }, replace_null(s) + ' <div ' + format_attrs(attrs) + '> in ' + global.mode);
       if (!ns_decl) {
         test(function() {
           assert_equals(global.document.querySelector(s), null, 'selector matched');
-        }, s + ' <div ' + format_attrs(attrs) + '> with querySelector in ' + global.mode);
+        }, replace_null(s) + ' <div ' + format_attrs(attrs) + '> with querySelector in ' + global.mode);
       }
     });
   });

--- a/css/selectors/attribute-selectors/attribute-case/syntax.html
+++ b/css/selectors/attribute-selectors/attribute-case/syntax.html
@@ -77,6 +77,9 @@ var invalid = [
   "[foo/**/i]",
 ];
 var mode = "standards mode";
+function sanitize_name(name) {
+  return name.replace(/\u0000/g, "\\u0000");
+}
 onload = function() {
   var quirks = document.getElementById('quirks').contentWindow;
   var xml = document.getElementById('xml').contentWindow;
@@ -94,10 +97,10 @@ onload = function() {
         style.textContent = s + ' { visibility:hidden }';
         assert_equals(style.sheet.cssRules.length, 1, 'valid rule didn\'t parse into CSSOM');
         assert_equals(global.getComputedStyle(elm).visibility, 'hidden', 'valid selector didn\'t match');
-      }, s + ' in ' + global.mode);
+      }, sanitize_name(s + ' in ' + global.mode));
       test(function() {
         assert_equals(global.document.querySelector(s), elm, 'valid selector');
-      }, s + ' with querySelector in ' + global.mode);
+      }, sanitize_name(s + ' with querySelector in ' + global.mode));
     });
     invalid.forEach(function(s) {
       test(function() {
@@ -105,12 +108,12 @@ onload = function() {
         style.textContent = s + ' { visibility:hidden }';
         assert_equals(style.sheet.cssRules.length, 0, 'invalid rule parsed into CSSOM');
         assert_equals(global.getComputedStyle(elm).visibility, 'visible', 'invalid selector matched');
-      }, s + ' in ' + global.mode);
+      }, sanitize_name(s + ' in ' + global.mode));
       test(function() {
         assert_throws("SyntaxError", function() {
           global.document.querySelector(s);
         }, 'invalid selector');
-      }, s + ' with querySelector in ' + global.mode);
+      }, sanitize_name(s + ' with querySelector in ' + global.mode));
     });
   });
   done();

--- a/encoding/legacy-mb-tchinese/big5/big5-enc-ascii.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-enc-ascii.html
@@ -44,10 +44,7 @@ for (var a = 0; a < 0x7f; a++) {
   encode(
     String.fromCharCode(a),
     "%" + hex,
-    "test for ASCII codepoint 0x" +
-      a.toString(16) +
-      " " +
-      String.fromCharCode(a)
+    "test for ASCII codepoint 0x" + a.toString(16)
   );
 }
 </script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/type-argument-plaintext.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/type-argument-plaintext.window.js
@@ -19,5 +19,7 @@
       assert_equals(frame.contentDocument.body.textContent, "heya");
       assert_equals(frame.contentDocument.contentType, "text/plain");
     });
-  }, "document.open() on plaintext document with type set to: " + type + " (type argument is supposed to be ignored)");
+  }, "document.open() on plaintext document with type set to: " +
+    type.replace(/\u0000/g, "\\u0000") +
+    " (type argument is supposed to be ignored)");
 });

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/type-argument.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/type-argument.window.js
@@ -16,5 +16,7 @@
     assert_equals(frame.contentDocument.body.textContent, "heya");
     assert_equals(frame.contentDocument.contentType, "text/html");
     t.done();
-  }, "document.open() with type set to: " + type + " (type argument is supposed to be ignored)");
+  }, "document.open() with type set to: " +
+    type.replace(/\u0000/g, "\\u0000") +
+    " (type argument is supposed to be ignored)");
 });

--- a/mimesniff/mime-types/parsing.any.js
+++ b/mimesniff/mime-types/parsing.any.js
@@ -25,11 +25,12 @@ function runTests(tests) {
     if(typeof val === "string") {
       return;
     }
+    const title = val.input.replace(/\u0000/g, "\\u0000");
     const output = val.output === null ? "" : val.output
     test(() => {
       assert_equals(new Blob([], { type: val.input}).type, output, "Blob");
       assert_equals(new File([], "noname", { type: val.input}).type, output, "File");
-    }, val.input + " (Blob/File)");
+    }, title + " (Blob/File)");
 
     promise_test(() => {
       const compatibleNess = isByteCompatible(val.input);
@@ -43,6 +44,6 @@ function runTests(tests) {
           new Response(null, { headers: [["Content-Type", val.input]] }).blob().then(blob => assert_equals(blob.type, output))
         ]);
       }
-    }, val.input + " (Request/Response)");
+    }, title + " (Request/Response)");
   });
 }

--- a/resources/test/tests/functional/name_null_byte.html
+++ b/resources/test/tests/functional/name_null_byte.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
+<title>Test with null byte in name</title>
+<script src="../../variants.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+"use strict";
+
+test(function() {}, "before (should PASS)");
+
+test(function() {}, "Null byte: '\u0000'");
+
+test(function() {}, "after");
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "ERROR",
+    "message": "Error: Test names may not include the null byte: \"Null byte: '\\u0000'\"."
+  },
+  "summarized_tests": [
+    {
+      "status_string": "PASS",
+      "name": "before (should PASS)",
+      "properties": {},
+      "message": null
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+</html>
+

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1476,6 +1476,19 @@ policies and contribution forms [3].
         if (tests.file_is_test && tests.tests.length) {
             throw new Error("Tried to create a test with file_is_test");
         }
+
+        if (/\u0000/.test(name)) {
+            try {
+                name = JSON.stringify(name);
+            } catch (err) {
+                name = "'" + name + "'";
+            }
+
+            throw new Error(
+                "Test names may not include the null byte: " + name + "."
+            );
+        }
+
         this.name = name;
 
         this.phase = tests.is_aborted ?

--- a/url/failure.html
+++ b/url/failure.html
@@ -14,7 +14,7 @@ function runTests(testData) {
       continue
     }
 
-    const name = test.input + " should throw"
+    const name = test.input.replace(/\u0000/g, "\\u0000") + " should throw"
 
     self.test(() => { // URL's constructor's first argument is tested by url-constructor.html
       // If a URL fails to parse with any valid base, it must also fail to parse with no base, i.e.

--- a/url/url-constructor.html
+++ b/url/url-constructor.html
@@ -13,6 +13,9 @@ function runURLTests(urltests) {
     var expected = urltests[i]
     if (typeof expected === "string") continue // skip comments
 
+    var name = "Parsing: <" + expected.input.replace(/\u0000/g, "\\u0000") +
+        "> against <" + expected.base.replace(/\u0000/g, "\\u0000") + ">"
+
     test(function() {
       if (expected.failure) {
         assert_throws(new TypeError(), function() {
@@ -36,7 +39,7 @@ function runURLTests(urltests) {
         assert_equals(url.searchParams.toString(), expected.searchParams, "searchParams")
       }
       assert_equals(url.hash, expected.hash, "hash")
-    }, "Parsing: <" + expected.input + "> against <" + expected.base + ">")
+    }, name)
   }
 }
 

--- a/url/url-origin.html
+++ b/url/url-origin.html
@@ -14,11 +14,14 @@ function runURLTests(urltests) {
   for(var i = 0, l = urltests.length; i < l; i++) {
     var expected = urltests[i]
     if (typeof expected === "string" || !("origin" in expected)) continue
+    var name = "Origin parsing: <" +
+      expected.input.replace(/\u0000/g, "\\u0000") + "> against <" +
+      expected.base + ">"
 
     test(function() {
       var url = bURL(expected.input, expected.base)
       assert_equals(url.origin, expected.origin, "origin")
-    }, "Origin parsing: <" + expected.input + "> against <" + expected.base + ">")
+    }, name)
   }
 }
 </script>

--- a/url/url-setters.html
+++ b/url/url-setters.html
@@ -19,6 +19,9 @@ function runURLSettersTests(all_test_cases) {
       if ("comment" in test_case) {
         name += " " + test_case.comment;
       }
+
+      name = name.replace(/\u0000/g, "\\u0000");
+
       test(function() {
         var url = new URL(test_case.href);
         url[attribute_to_be_set] = test_case.new_value;

--- a/xhr/send-entity-body-basic.htm
+++ b/xhr/send-entity-body-basic.htm
@@ -15,7 +15,7 @@
           client.open("POST", "resources/content.py", false)
           client.send(input)
           assert_equals(client.responseText, output)
-        }, document.title + " (" + output + ")")
+        }, document.title + " (" + output.replace(/\u0000/g, "\\u0000") + ")")
       }
       request(1, "1")
       request(10000000, "10000000")


### PR DESCRIPTION
Because the null byte is a non-printable character, its use in test
names can be difficult for humans to interpret. Further, the Edge
browser is currently incapable of reporting data that includes the null
byte.

Rename all tests which previously included the null byte to instead
reference it via its JavaScript escape sequence. Update testharness.js
to disallow the character in test names.

---

Although this change is motivated by [a deficiency in Edge](https://github.com/web-platform-tests/wpt/issues/14003), I think there's good reason to enforce it as a constraint on test authors. Test names are intended for human use, so non-printable characters are generally inappropriate.

This could be addressed completely within testharness.js by silently sanitizing the test titles prior to reporting results. In some ways, that would be preferable because we could translate *all* non-printable characters (not just the problematic null byte) without modifying a single test. I'm suggesting that we implement this as a constraint instead because it seems important to avoid any changes between what test authors write and what they see reported.

To validate this patch, I [inserted a null byte in an existing test name and logged all infractions to disk (`suspicious.txt`)](https://github.com/bocoup/wpt/commit/35c7ac8f2719f298b513fce3ea6642a8de7af8bd). I added that commit to [a new branch on Bocoup's fork of WPT](https://github.com/bocoup/wpt/commits/testharness-disallow-null-byte-verify), triggering [a complete trial in Chrome and Firefox](https://tools.taskcluster.net/groups/P0PCeY7MRcywRe4dT-Dx6g). When it was through, I collected the contents of the log files and verified that only the "control" null byte was reported:

    $ ./wpt tc-download --ref testharness-disallow-null-byte-verify --artifact-name suspicious.txt --repo-name bocoup/wpt --out-dir edge-2        
    INFO:tc-download:edge-2/wpt-chrome-dev-testharness-4-ANkbKtjhRXCDecRxGAUIFQ-suspicious.txt
    INFO:tc-download:edge-2/wpt-firefox-nightly-testharness-4-GAj8QqurSLeHO_bBa8Y9JQ-suspicious.txt
    $ cat edge-2/*
    http://web-platform.test:8000/dom/events/CustomEvent.html - "CustomEvent [\u0000] dispatching."
    http://web-platform.test:8000/dom/events/CustomEvent.html - "CustomEvent [\u0000] dispatching."