### PR TITLE
[resource-timing] Test behavior with cached assets

### DIFF
--- a/resource-timing/single-entry-per-resource-cached.html
+++ b/resource-timing/single-entry-per-resource-cached.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<meta name="timeout" content="long">
+<title>One resource when reusing data (cached resources)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<p>
+Chrome 70 emits delayed performance events for &lt;script&gt; elements in the
+document head which reference chached resources. This test attempts to prompt
+that condition by first loading <code>testharness.js</code> and then loading
+the relevant web-platform-test in an iframe. The nested test's reference to
+<code>testharness.js</code> is expected to cause a cache hit, prompting Chrome
+to emit the unexpected performance event.
+</p>
+<iframe id="subject" src="single-entry-per-resource.html"></iframe>
+<script>
+fetch_tests_from_window(document.getElementById('subject').contentWindow);
+</script>
+</body>

--- a/resource-timing/single-entry-per-resource.html
+++ b/resource-timing/single-entry-per-resource.html
@@ -6,6 +6,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
+  // This test is referenced by `single-entry-per-resource-cached.html`.
   var img_entries = 0;
   var observed = 0;
   var img_url = "resources/blue.png";


### PR DESCRIPTION
Add a note to the referenced test file to avoid accidental errors in
future renaming/deletion operations.

---

This is on the edge of "testable from WPT." It fails consistently on my machine, but because we don't have explicit control over the browser cache, it might actually be flaky in some configurations. Though Chromium is currently flaky when running the referenced test in a batch (since it may cache the resources while executing a prior test).

[I've filed a bug against the Chromium project to report the behavior](https://bugs.chromium.org/p/chromium/issues/detail?id=909094) in case we decide WPT isn't the right place to be testing this particular behavior.