### PR TITLE
Remove browserName from default Chrome capabilities

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -36,7 +36,6 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     executor_kwargs["close_after_done"] = True
 
     capabilities = {
-        "browserName": "chrome",
         "goog:chromeOptions": {
             "prefs": {
                 "profile": {


### PR DESCRIPTION
The configuration for Chrome currently sends 'browserName' capability
to ChromeDriver by default. This is unnecessary, and causes errors in
several test cases in webdriver/tests/new_session, whenever a test case
wants to set a different browserName.