### PR TITLE
Attempt to monitor memory from userspace

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -61,7 +61,7 @@ tasks:
               owner: ${event.pusher.email}
               source: ${event.repository.url}
             payload:
-              image: harjgam/web-platform-tests:0.22
+              image: hexcles/web-platform-tests:0.23
               maxRunTime: 7200
               artifacts:
                 public/results:
@@ -125,7 +125,7 @@ tasks:
                 owner: ${event.pull_request.user.login}@users.noreply.github.com
                 source: ${event.repository.url}
               payload:
-                image: harjgam/web-platform-tests:0.22
+                image: hexcles/web-platform-tests:0.23
                 maxRunTime: 7200
                 artifacts:
                   public/results:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get -qqy update \
     bzip2 \
     ca-certificates \
     dbus-x11 \
+    earlyoom \
     gdebi \
     git \
     locales \

--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -17,6 +17,10 @@ REVISION=${3:-FETCH_HEAD}
 BROWSER=${4:-all}
 CHANNEL=${5:-nightly}
 
+# Start userspace OOM killer: https://github.com/rfjakob/earlyoom
+# It will report memory usage every minute and prefer to kill browsers.
+sudo earlyoom -p -r 60 --prefer '(chrome|firefox)' --avoid 'python' &
+
 cd ~
 
 mkdir web-platform-tests


### PR DESCRIPTION
It is suspected that Taskcluster jobs sometimes fail due to OOM. It is
hard to know what exactly happens if the kernel OOM killer kicks in.
This change attempts to use a user-space solution: earlyoom.

There are two benefits of earlyoom:
1. Logging: we can log the memory usage periodically and the actions
   taken by earlyoom when the system is low on memory.
2. Recovery: we can teach earlyoom to prefer to kill browser processes
   and avoid python processes (wpt) so that the runner has a chance to
   recover (marking the test as CRASH and carrying on).

This is an effort to investigate (and hopefully alleviate) #13989.