### PR TITLE
[WebCryptoAPI] Remove race condition

### DIFF
--- a/WebCryptoAPI/sign_verify/ecdsa.js
+++ b/WebCryptoAPI/sign_verify/ecdsa.js
@@ -1,5 +1,7 @@
 
 function run_test() {
+    setup({explicit_done: true});
+
     var subtle = self.crypto.subtle; // Change to test prefixed implementations
 
     // When are all these tests really done? When all the promises they use have resolved.

--- a/WebCryptoAPI/sign_verify/hmac.js
+++ b/WebCryptoAPI/sign_verify/hmac.js
@@ -1,5 +1,7 @@
 
 function run_test() {
+    setup({explicit_done: true});
+
     var subtle = self.crypto.subtle; // Change to test prefixed implementations
 
     // When are all these tests really done? When all the promises they use have resolved.

--- a/WebCryptoAPI/sign_verify/rsa.js
+++ b/WebCryptoAPI/sign_verify/rsa.js
@@ -1,5 +1,7 @@
 
 function run_test() {
+    setup({explicit_done: true});
+
     var subtle = self.crypto.subtle; // Change to test prefixed implementations
 
     // When are all these tests really done? When all the promises they use have resolved.


### PR DESCRIPTION
Configure testharness.js to wait until the global `done` function is
invoked before reporting results. This ensures that all
asynchronously-declared tests are defined and subsequently executed
regardless of variations in timing.

---

The instability is apparent when comparing the test results between Chrome, Firefox, and Safari, e.g. https://wpt.fyi/results/WebCryptoAPI/sign_verify?sha=58523789a0

![2018-11-28-crypto-race](https://user-images.githubusercontent.com/677252/49188529-17a25480-f339-11e8-89bc-e4608ca7b954.png)

Firefox and Safari are missing results from tests that depend on `WebCryptoAPI/sign_verify/ecdsa.js` due to the race condition which this patch corrects.