### PR TITLE
Remove support for the timeout from testharness.js

### DIFF
--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -190,10 +190,7 @@
 
     async_test("test should timeout (fail) with the default of 2 seconds").step(function(){});
 
-    async_test("test should timeout (fail) with a custom set timeout value of 1 second",
-               {timeout:1000}).step(function(){});
-
-    async_test("async test that is never started, should have status Not Run", {timeout:1000});
+    async_test("async test that is never started, should have status Not Run");
 
 
     test(function(t) {
@@ -344,9 +341,7 @@
       "status_string": "NOTRUN",
       "name": "async test that is never started, should have status Not Run",
       "message": null,
-      "properties": {
-        "timeout": 1000
-      }
+      "properties": {}
     },
     {
       "status_string": "PASS",
@@ -401,14 +396,6 @@
       "name": "test for assert[_not]_own_property and insert_inherits",
       "message": null,
       "properties": {}
-    },
-    {
-      "status_string": "TIMEOUT",
-      "name": "test should timeout (fail) with a custom set timeout value of 1 second",
-      "message": "Test timed out",
-      "properties": {
-        "timeout": 1000
-      }
     },
     {
       "status_string": "TIMEOUT",

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1476,9 +1476,6 @@ policies and contribution forms [3].
         if (tests.file_is_test && tests.tests.length) {
             throw new Error("Tried to create a test with file_is_test");
         }
-        if (properties.timeout) {
-            throw new Error("Tried to create a test with timeout");
-        }
         this.name = name;
 
         this.phase = tests.is_aborted ?
@@ -1489,10 +1486,9 @@ policies and contribution forms [3].
         this.index = null;
 
         this.properties = properties;
-        if (settings.test_timeout !== null) {
-            this.timeout_length = settings.test_timeout * tests.timeout_multiplier;
-        } else {
-            this.timeout_length = null;
+        this.timeout_length = settings.test_timeout;
+        if (this.timeout_length !== null) {
+            this.timeout_length *= tests.timeout_multiplier;
         }
 
         this.message = null;

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1476,6 +1476,9 @@ policies and contribution forms [3].
         if (tests.file_is_test && tests.tests.length) {
             throw new Error("Tried to create a test with file_is_test");
         }
+        if (properties.timeout) {
+            throw new Error("Tried to create a test with timeout");
+        }
         this.name = name;
 
         this.phase = tests.is_aborted ?
@@ -1486,9 +1489,8 @@ policies and contribution forms [3].
         this.index = null;
 
         this.properties = properties;
-        var timeout = properties.timeout ? properties.timeout : settings.test_timeout;
-        if (timeout !== null) {
-            this.timeout_length = timeout * tests.timeout_multiplier;
+        if (settings.test_timeout !== null) {
+            this.timeout_length = settings.test_timeout * tests.timeout_multiplier;
         } else {
             this.timeout_length = null;
         }


### PR DESCRIPTION
As part of goal #11120, timeout should be removed from testharness.js
at the test-level.