### PR TITLE
[css-text] Update 'line-break' tests

### DIFF
--- a/css/css-text/line-break/line-break-loose-011.xht
+++ b/css/css-text/line-break/line-break-loose-011.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and iteration marks</title>
-		<!-- iteration marks -->
+		<title>CSS Text Test: line-break - loose and Japanese small kana</title>
+		<!-- Japanese small kana -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-014-ref.xht" />
+		<link rel="match" href="reference/line-break-loose-011-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before iteration marks such as IDEOGRAPHIC ITERATION MARK (U+3005) and VERTICAL IDEOGRAPHIC ITERATION MARK (U+303B)." />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking before Japanese small kana such as 'Japanese small kana a (U+3041)' and  'Japanese small kana i (U+3043)'." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: loose;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -44,54 +44,51 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- iteration marks -->
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL A -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3041;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3041;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL I -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3043;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3043;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL U -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3045;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3045;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL E -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3047;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3047;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL O -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30fd;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3049;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30fe;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3049;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>
 </html>
+

--- a/css/css-text/line-break/line-break-loose-012.xht
+++ b/css/css-text/line-break/line-break-loose-012.xht
@@ -2,13 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - normal and  inseparable characters</title>
-		<!-- inseparable characters -->
+		<title>CSS Text Test: line-break - loose and  Katakana-Hiragana prolonged sound marks</title>
+		<!-- Katakana-Hiragana prolonged sound marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
-		<link rel="match" href="reference/line-break-normal-022-ref.xht" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
+		<link rel="match" href="reference/line-break-loose-012-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking before inseparable characters such as TWO DOT LEADER (U+2025) and HORIZONTAL ELLIPSIS (U+2026)." />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking before Katakana-Hiragana prolonged sound marks such as (U+30FC) and (U+FF70)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: normal;						// The property to be tested
+				line-break: loose;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -44,21 +45,21 @@
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
 		<div class="wrapper">
-			<!-- inseparable characters TWO DOT LEADER -->
+			<!-- Katakana-Hiragana prolonged sound mark - fullwidth -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x30FC;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30FC;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
-			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
+			<!-- Katakana-Hiragana prolonged sound mark - halfwidth -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#xff70;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff70;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-loose-013.xht
+++ b/css/css-text/line-break/line-break-loose-013.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and hyphens</title>
+		<title>CSS Text Test: line-break - loose and hyphens</title>
 		<!-- hyphens -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-013-ref.xht" />
+		<link rel="match" href="reference/line-break-loose-013-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: loose;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -50,7 +50,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2010;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2010;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -58,7 +58,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2013;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2013;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -66,7 +66,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x301c;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x301c;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x301c;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -74,7 +74,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x30a0;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30a0;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-loose-014.xht
+++ b/css/css-text/line-break/line-break-loose-014.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and iteration marks</title>
+		<title>CSS Text Test: line-break - loose and iteration marks</title>
 		<!-- iteration marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-014-ref.xht" />
+		<link rel="match" href="reference/line-break-loose-014-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before iteration marks such as IDEOGRAPHIC ITERATION MARK (U+3005) and VERTICAL IDEOGRAPHIC ITERATION MARK (U+303B)." />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking before iteration marks such as IDEOGRAPHIC ITERATION MARK (U+3005) and VERTICAL IDEOGRAPHIC ITERATION MARK (U+303B)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: loose;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -50,7 +50,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x3005;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3005;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -58,7 +58,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x303b;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x303b;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -66,7 +66,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x309d;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x309d;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -74,7 +74,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x309e;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x309e;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -82,7 +82,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x30fd;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30fd;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -90,7 +90,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x30fe;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30fe;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-loose-015.xht
+++ b/css/css-text/line-break/line-break-loose-015.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and hyphens</title>
-		<!-- hyphens -->
+		<title>CSS Text Test: line-break - loose and  inseparable characters</title>
+		<!-- inseparable characters -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-013-ref.xht" />
+		<link rel="match" href="reference/line-break-loose-015-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking between inseparable characters such as TWO DOT LEADER (U+2025) and HORIZONTAL ELLIPSIS (U+2026)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: loose;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -44,37 +44,22 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- hyphens -->
 		<div class="wrapper">
+			<!-- inseparable characters TWO DOT LEADER -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2025;<br />&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2013;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x301c;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x301c;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30a0;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2026;<br />&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-loose-016a.xht
+++ b/css/css-text/line-break/line-break-loose-016a.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and hyphens</title>
-		<!-- hyphens -->
+		<title>CSS Text Test: line-break - loose and centered punctuation marks</title>
+		<!-- centered punctuation marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-013-ref.xht" />
+		<link rel="match" href="reference/line-break-loose-016a-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking before centered punctuation marks." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: loose;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -35,8 +35,8 @@
 			div.wrapper {
 				display: inline-block;
 				border: 1px solid;
-				margin: 10px;
-				padding: 10px;
+				margin: 5px;
+				padding: 5px;
 			}
 		</style>
 	</head>
@@ -44,37 +44,40 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- hyphens -->
 		<div class="wrapper">
+			<!-- centered punctuation marks KATAKANA MIDDLE DOT -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x30fb;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30fb;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- centered punctuation marks FULLWIDTH COLON -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#xff1a;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff1a;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- centered punctuation marks FULLWIDTH SEMICOLON -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x301c;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#xff1b;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x301c;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff1b;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- centered punctuation marks HALFWIDTH KATAKANA MIDDLE DOT -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#xff65;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff65;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-loose-016b.xht
+++ b/css/css-text/line-break/line-break-loose-016b.xht
@@ -2,13 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - normal and centered punctuation marks</title>
+		<title>CSS Text Test: line-break - loose and centered punctuation marks</title>
 		<!-- centered punctuation marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
-		<link rel="match" href="reference/line-break-normal-023b-ref.xht" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
+		<link rel="match" href="reference/line-break-loose-016b-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking before centered punctuation marks such as COLON (U+003A) and SEMICOLON (U+003B)." />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking before centered punctuation marks." />
 		<style type="text/css">
 			@font-face
 			{
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: normal;						// The property to be tested
+				line-break: loose;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -49,7 +50,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x203c;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x203c;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x203c;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -58,7 +59,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2047;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2047;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2047;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -67,7 +68,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2048;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2048;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2048;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -76,7 +77,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2049;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2049;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2049;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -85,7 +86,7 @@
 				<span>サンプル文サンプル文<span class="target">&#xff01;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xff01;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff01;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -94,7 +95,7 @@
 				<span>サンプル文サンプル文<span class="target">&#xff1f;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xff1f;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff1f;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-loose-017a.xht
+++ b/css/css-text/line-break/line-break-loose-017a.xht
@@ -2,13 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - normal and postfixes</title>
+		<title>CSS Text Test: line-break - loose and postfixes</title>
 		<!-- postfixes -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
-		<link rel="match" href="reference/line-break-normal-024a-ref.xht" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
+		<link rel="match" href="reference/line-break-loose-017a-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking before postfixes such as PERCENT SIGN (U+0025) and CENT SIGN (U+00A2)." />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking before postfixes." />
 		<style type="text/css">
 			@font-face
 			{
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: normal;						// The property to be tested
+				line-break: loose;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -44,30 +45,12 @@
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
 		<div class="wrapper">
-			<!-- postfixes PERCENT SIGN -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x0025;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0025;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- postfixes CENT SIGN -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x00a2;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x00a2;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
 			<!-- postfixes DEGREE SIGN -->
 			<p class="test" lang="ja">
 				<span>サンプル文サンプル文<span class="target">&#x00b0;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x00b0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x00b0;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -76,7 +59,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2030;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2030;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2030;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -85,7 +68,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2032;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2032;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2032;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -94,7 +77,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2033;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2033;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2033;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-loose-017b.xht
+++ b/css/css-text/line-break/line-break-loose-017b.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and hyphens</title>
-		<!-- hyphens -->
+		<title>CSS Text Test: line-break - loose and postfixes</title>
+		<!-- postfixes -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-013-ref.xht" />
+		<link rel="match" href="reference/line-break-loose-017b-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking before postfixes." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: loose;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -44,37 +44,31 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- hyphens -->
 		<div class="wrapper">
+			<!-- postfixes DEGREE CELSIUS -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x2103;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2103;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- postfixes FULLWIDTH PERCENT SIGN -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#xff05;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff05;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- postfixes FULLWIDTH CENT SIGN -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x301c;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#xffe0;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x301c;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30a0;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xffe0;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-loose-018.xht
+++ b/css/css-text/line-break/line-break-loose-018.xht
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title>CSS Text Test: line-break - loose and prefixes</title>
+		<!-- prefixes -->
+		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
+		<link rel="match" href="reference/line-break-loose-018-ref.xht" />
+		<meta http-equiv="content-language" content="en, ja" />
+		<meta name="assert" content="This test verifies that 'line-break: loose' allows line breaking after prefixes." />
+		<style type="text/css">
+			@font-face
+			{
+				font-family: "mplus-1p-regular";
+				src: url("/fonts/mplus-1p-regular.woff") format("woff");
+				/* filesize: 803300 bytes (784.5 KBytes) */
+				/*
+				mplus-1p-regular.ttf can be downloaded at/from [TBD later]
+				*/
+			}
+			.test span {
+				line-break: loose;						/* The property to be tested */
+			}
+			p.test, p.control {
+				border: 1px solid gray;
+				color: blue;
+				font-family: "mplus-1p-regular";
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
+			}
+			span.target {
+				background-color: aqua;
+			}
+			div.wrapper {
+				display: inline-block;
+				border: 1px solid;
+				margin: 10px;
+				padding: 10px;
+			}
+		</style>
+	</head>
+	<body lang="en">
+		<p>
+			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
+		</p>
+		<div class="wrapper">
+            <!-- prefixes EURO SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x20ac;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x20ac;</span><br />サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes NUMERO SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x2116;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x2116;</span><br />サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH DOLLAR SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xff04;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xff04;</span><br />サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH POUND SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe1;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe1;</span><br />サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH YEN SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe5;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe5;</span><br />サンプル文</span>
+            </p>
+		</div>
+	</body>
+</html>

--- a/css/css-text/line-break/line-break-normal-011.xht
+++ b/css/css-text/line-break/line-break-normal-011.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and iteration marks</title>
-		<!-- iteration marks -->
+		<title>CSS Text Test: line-break - normal and Japanese small kana</title>
+		<!-- Japanese small kana -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-014-ref.xht" />
+		<link rel="match" href="reference/line-break-normal-011-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before iteration marks such as IDEOGRAPHIC ITERATION MARK (U+3005) and VERTICAL IDEOGRAPHIC ITERATION MARK (U+303B)." />
+		<meta name="assert" content="This test verifies that 'line-break: normal' allows line breaking before Japanese small kana such as 'Japanese small kana a (U+3041)' and  'Japanese small kana i (U+3043)'." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: normal;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -44,54 +44,51 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- iteration marks -->
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL A -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3041;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3041;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL I -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3043;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3043;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL U -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3045;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3045;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL E -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3047;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3047;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL O -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30fd;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x3049;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30fe;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3049;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>
 </html>
+

--- a/css/css-text/line-break/line-break-normal-012.xht
+++ b/css/css-text/line-break/line-break-normal-012.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and hyphens</title>
-		<!-- hyphens -->
+		<title>CSS Text Test: line-break - normal and  Katakana-Hiragana prolonged sound marks</title>
+		<!-- Katakana-Hiragana prolonged sound marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-013-ref.xht" />
+		<link rel="match" href="reference/line-break-normal-012-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
+		<meta name="assert" content="This test verifies that 'line-break: normal' allows line breaking before Katakana-Hiragana prolonged sound marks such as (U+30FC) and (U+FF70)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: normal;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -44,37 +44,22 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- hyphens -->
 		<div class="wrapper">
+			<!-- Katakana-Hiragana prolonged sound mark - fullwidth -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x30FC;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30FC;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Katakana-Hiragana prolonged sound mark - halfwidth -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#xff70;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2013;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x301c;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x301c;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30a0;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff70;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-normal-013.xht
+++ b/css/css-text/line-break/line-break-normal-013.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and hyphens</title>
+		<title>CSS Text Test: line-break - normal and hyphens</title>
 		<!-- hyphens -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-013-ref.xht" />
+		<link rel="match" href="reference/line-break-normal-013-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
+		<meta name="assert" content="This test verifies that 'line-break: normal' allows line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: normal;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -50,7 +50,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2010;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2010;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -58,7 +58,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x2013;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2013;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -66,7 +66,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x301c;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x301c;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x301c;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -74,7 +74,7 @@
 				<span>サンプル文サンプル文<span class="target">&#x30a0;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30a0;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-normal-014.xht
+++ b/css/css-text/line-break/line-break-normal-014.xht
@@ -5,10 +5,11 @@
 		<title>CSS Text Test: line-break - normal and iteration marks</title>
 		<!-- iteration marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
-		<link rel="match" href="reference/line-break-normal-021-ref.xht" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
+		<link rel="match" href="reference/line-break-normal-014-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking before iteration marks such as IDEOGRAPHIC ITERATION MARK (U+3005) and VERTICAL IDEOGRAPHIC ITERATION MARK (U+3B)." />
+		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking before iteration marks such as IDEOGRAPHIC ITERATION MARK (U+3005) and VERTICAL IDEOGRAPHIC ITERATION MARK (U+303B)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: normal;						// The property to be tested
+				line-break: normal;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/line-break-normal-015.xht
+++ b/css/css-text/line-break/line-break-normal-015.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and hyphens</title>
-		<!-- hyphens -->
+		<title>CSS Text Test: line-break - normal and  inseparable characters</title>
+		<!-- inseparable characters -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-013-ref.xht" />
+		<link rel="match" href="reference/line-break-normal-015-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
+		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking between inseparable characters such as TWO DOT LEADER (U+2025) and HORIZONTAL ELLIPSIS (U+2026)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: normal;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -44,37 +44,22 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- hyphens -->
 		<div class="wrapper">
+			<!-- inseparable characters TWO DOT LEADER -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2013;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x301c;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x301c;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30a0;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-normal-016a.xht
+++ b/css/css-text/line-break/line-break-normal-016a.xht
@@ -5,8 +5,9 @@
 		<title>CSS Text Test: line-break - normal and centered punctuation marks</title>
 		<!-- centered punctuation marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
-		<link rel="match" href="reference/line-break-normal-023a-ref.xht" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
+		<link rel="match" href="reference/line-break-normal-016a-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking before centered punctuation marks such as COLON (U+003A) and SEMICOLON (U+003B)." />
 		<style type="text/css">
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: normal;						// The property to be tested
+				line-break: normal;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -43,24 +44,6 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<div class="wrapper">
-			<!-- centered punctuation marks COLON -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x003a;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003a;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks SEMICOLON -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x003b;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003b;</span>サンプル文</span>
-			</p>
-		</div>
 		<div class="wrapper">
 			<!-- centered punctuation marks KATAKANA MIDDLE DOT -->
 			<p class="test" lang="ja">
@@ -95,24 +78,6 @@
 			</p>
 			<p class="control" lang="ja">
 				<span>サンプル文サンプル<br />文<span class="target">&#xff65;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks EXCLAMATION MARK -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x0021;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0021;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks QUESTION MARK -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x003f;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003f;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-normal-016b.xht
+++ b/css/css-text/line-break/line-break-normal-016b.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and centered punctuation marks</title>
+		<title>CSS Text Test: line-break - normal and centered punctuation marks</title>
 		<!-- centered punctuation marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-016b-ref.xht" />
+		<link rel="match" href="reference/line-break-normal-016b-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before centered punctuation marks." />
+		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking before centered punctuation marks such as COLON (U+003A) and SEMICOLON (U+003B)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: normal;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;

--- a/css/css-text/line-break/line-break-normal-017a.xht
+++ b/css/css-text/line-break/line-break-normal-017a.xht
@@ -2,14 +2,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and hyphens</title>
-		<!-- hyphens -->
+		<title>CSS Text Test: line-break - normal and postfixes</title>
+		<!-- postfixes -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-013-ref.xht" />
+		<link rel="match" href="reference/line-break-normal-017a-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before hyphens such as HYPHEN (U+2010) and ENDASH (U+2013)." />
+		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking before postfixes such as PERCENT SIGN (U+0025) and CENT SIGN (U+00A2)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -21,7 +21,7 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						/* The property to be tested */
+				line-break: normal;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
@@ -44,37 +44,40 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- hyphens -->
 		<div class="wrapper">
+			<!-- postfixes DEGREE SIGN -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x00b0;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2010;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x00b0;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- postfixes PER MILLE SIGN -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x2030;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2013;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2030;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- postfixes PRIME -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x301c;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x2032;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x301c;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2032;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- postfixes DOUBLE PRIME -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<span class="target">&#x2033;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30a0;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2033;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-normal-017b.xht
+++ b/css/css-text/line-break/line-break-normal-017b.xht
@@ -5,8 +5,9 @@
 		<title>CSS Text Test: line-break - normal and postfixes</title>
 		<!-- postfixes -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
-		<link rel="match" href="reference/line-break-normal-024b-ref.xht" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
+		<link rel="match" href="reference/line-break-normal-017b-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking before postfixes such as PERCENT SIGN (U+0025) and CENT SIGN (U+00A2)." />
 		<style type="text/css">
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: normal;						// The property to be tested
+				line-break: normal;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/line-break-normal-018.xht
+++ b/css/css-text/line-break/line-break-normal-018.xht
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title>CSS Text Test: line-break - normal and prefixes</title>
+		<!-- prefixes -->
+		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
+		<link rel="match" href="reference/line-break-normal-018-ref.xht" />
+		<meta http-equiv="content-language" content="en, ja" />
+		<meta name="assert" content="This test verifies that 'line-break: normal' does not allow line breaking after prefixes." />
+		<style type="text/css">
+			@font-face
+			{
+				font-family: "mplus-1p-regular";
+				src: url("/fonts/mplus-1p-regular.woff") format("woff");
+				/* filesize: 803300 bytes (784.5 KBytes) */
+				/*
+				mplus-1p-regular.ttf can be downloaded at/from [TBD later]
+				*/
+			}
+			.test span {
+				line-break: normal;						/* The property to be tested */
+			}
+			p.test, p.control {
+				border: 1px solid gray;
+				color: blue;
+				font-family: "mplus-1p-regular";
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
+			}
+			span.target {
+				background-color: aqua;
+			}
+			div.wrapper {
+				display: inline-block;
+				border: 1px solid;
+				margin: 10px;
+				padding: 10px;
+			}
+		</style>
+	</head>
+	<body lang="en">
+		<p>
+			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
+		</p>
+		<div class="wrapper">
+            <!-- prefixes EURO SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x20ac;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x20ac;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes NUMERO SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x2116;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x2116;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH DOLLAR SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xff04;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xff04;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH POUND SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe1;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe1;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH YEN SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe5;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe5;</span>サンプル文</span>
+            </p>
+		</div>
+	</body>
+</html>

--- a/css/css-text/line-break/line-break-strict-011.xht
+++ b/css/css-text/line-break/line-break-strict-011.xht
@@ -5,7 +5,8 @@
 		<title>CSS Text Test: line-break - strict and Japanese small kana</title>
 		<!-- Japanese small kana -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
 		<link rel="match" href="reference/line-break-strict-011-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before Japanese small kana such as 'Japanese small kana a (U+3041)' and  'Japanese small kana i (U+3043)'." />
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						// The property to be tested
+				line-break: strict;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/line-break-strict-012.xht
+++ b/css/css-text/line-break/line-break-strict-012.xht
@@ -5,7 +5,8 @@
 		<title>CSS Text Test: line-break - strict and  Katakana-Hiragana prolonged sound marks</title>
 		<!-- Katakana-Hiragana prolonged sound marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
 		<link rel="match" href="reference/line-break-strict-012-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before Katakana-Hiragana prolonged sound marks such as (U+30FC) and (U+FF70)." />
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						// The property to be tested
+				line-break: strict;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/line-break-strict-015.xht
+++ b/css/css-text/line-break/line-break-strict-015.xht
@@ -5,10 +5,11 @@
 		<title>CSS Text Test: line-break - strict and  inseparable characters</title>
 		<!-- inseparable characters -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
 		<link rel="match" href="reference/line-break-strict-015-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before inseparable characters such as TWO DOT LEADER (U+2025) and HORIZONTAL ELLIPSIS (U+2026)." />
+		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking between inseparable characters such as TWO DOT LEADER (U+2025) and HORIZONTAL ELLIPSIS (U+2026)." />
 		<style type="text/css">
 			@font-face
 			{
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						// The property to be tested
+				line-break: strict;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -46,19 +47,19 @@
 		<div class="wrapper">
 			<!-- inseparable characters TWO DOT LEADER -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
 			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-strict-016a.xht
+++ b/css/css-text/line-break/line-break-strict-016a.xht
@@ -5,10 +5,11 @@
 		<title>CSS Text Test: line-break - strict and centered punctuation marks</title>
 		<!-- centered punctuation marks -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
 		<link rel="match" href="reference/line-break-strict-016a-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before centered punctuation marks such as COLON (U+003A) and SEMICOLON (U+003B)." />
+		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before centered punctuation marks." />
 		<style type="text/css">
 			@font-face
 			{
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						// The property to be tested
+				line-break: strict;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -43,24 +44,6 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<div class="wrapper">
-			<!-- centered punctuation marks COLON -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x003a;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003a;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks SEMICOLON -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x003b;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003b;</span>サンプル文</span>
-			</p>
-		</div>
 		<div class="wrapper">
 			<!-- centered punctuation marks KATAKANA MIDDLE DOT -->
 			<p class="test" lang="ja">
@@ -95,24 +78,6 @@
 			</p>
 			<p class="control" lang="ja">
 				<span>サンプル文サンプル<br />文<span class="target">&#xff65;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks EXCLAMATION MARK -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x0021;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0021;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks QUESTION MARK -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x003f;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003f;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-strict-017b.xht
+++ b/css/css-text/line-break/line-break-strict-017b.xht
@@ -5,10 +5,11 @@
 		<title>CSS Text Test: line-break - strict and postfixes</title>
 		<!-- postfixes -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
-		<link rel="help" title="5.2. Breaking Rules for Punctuation: the 'line-break' property" href="http://www.w3.org/TR/css-text-3/#line-break" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
 		<link rel="match" href="reference/line-break-strict-017b-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before postfixes such as PERCENT SIGN (U+0025) and CENT SIGN (U+00A2)." />
+		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before postfixes." />
 		<style type="text/css">
 			@font-face
 			{
@@ -20,13 +21,13 @@
 				*/
 			}
 			.test span {
-				line-break: strict;						// The property to be tested
+				line-break: strict;						/* The property to be tested */
 			}
 			p.test, p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/line-break-strict-018.xht
+++ b/css/css-text/line-break/line-break-strict-018.xht
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title>CSS Text Test: line-break - strict and prefixes</title>
+		<!-- prefixes -->
+		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
+		<link rel="match" href="reference/line-break-strict-018-ref.xht" />
+		<meta http-equiv="content-language" content="en, ja" />
+		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking after prefixes." />
+		<style type="text/css">
+			@font-face
+			{
+				font-family: "mplus-1p-regular";
+				src: url("/fonts/mplus-1p-regular.woff") format("woff");
+				/* filesize: 803300 bytes (784.5 KBytes) */
+				/*
+				mplus-1p-regular.ttf can be downloaded at/from [TBD later]
+				*/
+			}
+			.test span {
+				line-break: strict;						/* The property to be tested */
+			}
+			p.test, p.control {
+				border: 1px solid gray;
+				color: blue;
+				font-family: "mplus-1p-regular";
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
+			}
+			span.target {
+				background-color: aqua;
+			}
+			div.wrapper {
+				display: inline-block;
+				border: 1px solid;
+				margin: 10px;
+				padding: 10px;
+			}
+		</style>
+	</head>
+	<body lang="en">
+		<p>
+			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
+		</p>
+		<div class="wrapper">
+            <!-- prefixes EURO SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x20ac;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x20ac;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes NUMERO SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x2116;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x2116;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH DOLLAR SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xff04;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xff04;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH POUND SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe1;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe1;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH YEN SIGN -->
+            <p class="test" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe5;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe5;</span>サンプル文</span>
+            </p>
+		</div>
+	</body>
+</html>

--- a/css/css-text/line-break/reference/line-break-loose-011-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-011-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-014.xht -->
+		<!-- reftest for line-break-loose-011.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -34,57 +34,53 @@
 			}
 		</style>
 	</head>
-	<body  lang="en">
+	<body lang="en">
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- iteration marks -->
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL A -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3041;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3041;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL I -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3043;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3043;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL U -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3045;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3045;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL E -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3047;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3047;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL O -->
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x3049;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x3049;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-loose-012-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-012-ref.xht
@@ -3,8 +3,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-normal-022.xht -->
+		<!-- reftest for line-break-loose-012.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -38,21 +39,21 @@
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
 		<div class="wrapper">
-			<!-- inseparable characters TWO DOT LEADER -->
+			<!-- Katakana-Hiragana prolonged sound mark - fullwidth -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30FC;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30FC;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
-			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
+			<!-- Katakana-Hiragana prolonged sound mark - halfwidth -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff70;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff70;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-loose-013-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-013-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-014.xht -->
+		<!-- reftest for line-break-loose-013.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -38,53 +38,37 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- iteration marks -->
+		<!-- hyphens -->
 		<div class="wrapper">
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2010;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2010;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2013;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2013;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x301c;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x301c;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30a0;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30a0;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-loose-014-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-014-ref.xht
@@ -3,8 +3,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-normal-024.xht -->
+		<!-- reftest for line-break-loose-014.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -37,58 +38,53 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
+		<!-- iteration marks -->
 		<div class="wrapper">
-			<!-- postfixes PERCENT SIGN -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3005;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3005;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
-			<!-- postfixes CENT SIGN -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x00a2;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x303b;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x00a2;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- postfixes DEGREE SIGN -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x00b0;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x00b0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x303b;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
-			<!-- postfixes PER MILLE SIGN -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2030;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x309d;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2030;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- postfixes PRIME -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2032;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2032;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x309d;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
-			<!-- postfixes DOUBLE PRIME -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2033;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x309e;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2033;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x309e;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x30fd;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x30fd;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x30fe;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x30fe;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-loose-015-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-015-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-015.xht -->
+		<!-- reftest for line-break-loose-015.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -41,19 +41,19 @@
 		<div class="wrapper">
 			<!-- inseparable characters TWO DOT LEADER -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2025;<br />&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2025;<br />&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2026;<br />&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプル。<span class="target">&#x2026;<br />&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-loose-016a-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-016a-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-014.xht -->
+		<!-- reftest for line-break-loose-016a.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -29,8 +29,8 @@
 			div.wrapper {
 				display: inline-block;
 				border: 1px solid;
-				margin: 10px;
-				padding: 10px;
+				margin: 5px;
+				padding: 5px;
 			}
 		</style>
 	</head>
@@ -38,53 +38,40 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- iteration marks -->
 		<div class="wrapper">
+			<!-- centered punctuation marks KATAKANA MIDDLE DOT -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30fb;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30fb;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- centered punctuation marks FULLWIDTH COLON -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff1a;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff1a;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- centered punctuation marks FULLWIDTH SEMICOLON -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff1b;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff1b;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- centered punctuation marks HALFWIDTH KATAKANA MIDDLE DOT -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff65;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff65;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-loose-016b-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-016b-ref.xht
@@ -3,8 +3,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-normal-023.xht -->
+		<!-- reftest for line-break-loose-016b.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -40,55 +41,55 @@
 		<div class="wrapper">
 			<!-- centered punctuation marks DOUBLE EXCLAMATION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x203c;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x203c;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x203c;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x203c;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- centered punctuation marks DOUBLE QUESTION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2047;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2047;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2047;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2047;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- centered punctuation marks QUESTION EXCLAMATION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2048;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2048;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2048;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2048;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- centered punctuation marks EXCLAMATION QUESTION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2049;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2049;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2049;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2049;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- centered punctuation marks FULLWIDTH EXCLAMATION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xff01;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff01;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xff01;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff01;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- centered punctuation marks FULLWIDTH QUESTION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xff1f;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff1f;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xff1f;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff1f;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-loose-017a-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-017a-ref.xht
@@ -3,8 +3,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-normal-024.xht -->
+		<!-- reftest for line-break-loose-017a.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -38,30 +39,39 @@
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
 		<div class="wrapper">
-			<!-- postfixes DEGREE CELSIUS -->
+			<!-- postfixes DEGREE SIGN -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2103;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x00b0;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x2103;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- postfixes FULLWIDTH PERCENT SIGN -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xff05;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xff05;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x00b0;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
-			<!-- postfixes FULLWIDTH CENT SIGN -->
+			<!-- postfixes PER MILLE SIGN -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xffe0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2030;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#xffe0;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2030;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<!-- postfixes PRIME -->
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x2032;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x2032;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<!-- postfixes DOUBLE PRIME -->
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x2033;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x2033;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-loose-017b-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-017b-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-015.xht -->
+		<!-- reftest for line-break-loose-017b.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -39,21 +39,30 @@
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
 		<div class="wrapper">
-			<!-- inseparable characters TWO DOT LEADER -->
+			<!-- postfixes DEGREE CELSIUS -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2103;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2103;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
-			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
+			<!-- postfixes FULLWIDTH PERCENT SIGN -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff05;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff05;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<!-- postfixes FULLWIDTH CENT SIGN -->
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#xffe0;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#xffe0;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-loose-018-ref.xht
+++ b/css/css-text/line-break/reference/line-break-loose-018-ref.xht
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title>CSS Reftest Reference</title>
+		<!-- reftest for line-break-loose-018.xht -->
+		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<meta http-equiv="content-language" content="en, ja" />
+		<style type="text/css">
+			@font-face
+			{
+				font-family: "mplus-1p-regular";
+				src: url("/fonts/mplus-1p-regular.woff") format("woff");
+				/* filesize: 803300 bytes (784.5 KBytes) */
+				/*
+				mplus-1p-regular.ttf can be downloaded at/from [TBD later]
+				*/
+			}
+			p.control {
+				border: 1px solid gray;
+				color: blue;
+				font-family: "mplus-1p-regular";
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
+			}
+			span.target {
+				background-color: aqua;
+			}
+			div.wrapper {
+				display: inline-block;
+				border: 1px solid;
+				margin: 10px;
+				padding: 10px;
+			}
+		</style>
+	</head>
+	<body  lang="en">
+		<p>
+			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
+		</p>
+		<div class="wrapper">
+            <!-- prefixes EURO SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x20ac;</span><br />サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x20ac;</span><br />サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes NUMERO SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x2116;</span><br />サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#x2116;</span><br />サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH DOLLAR SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xff04;</span><br />サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xff04;</span><br />サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH POUND SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe1;</span><br />サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe1;</span><br />サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH YEN SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe5;</span><br />サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<span class="target">&#xffe5;</span><br />サンプル文</span>
+            </p>
+		</div>
+	</body>
+</html>

--- a/css/css-text/line-break/reference/line-break-normal-011-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-011-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-014.xht -->
+		<!-- reftest for line-break-normal-011.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -34,57 +34,53 @@
 			}
 		</style>
 	</head>
-	<body  lang="en">
+	<body lang="en">
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- iteration marks -->
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL A -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3041;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3041;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL I -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3043;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3043;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL U -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3045;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3045;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL E -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3047;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x3047;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<!-- Japanese small kana: HIRAGANA LETTER SMALL O -->
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x3049;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル文<br /><span class="target">&#x3049;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-normal-012-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-012-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-015.xht -->
+		<!-- reftest for line-break-normal-012.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -39,21 +39,21 @@
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
 		<div class="wrapper">
-			<!-- inseparable characters TWO DOT LEADER -->
+			<!-- Katakana-Hiragana prolonged sound mark - fullwidth -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30FC;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30FC;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
-			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
+			<!-- Katakana-Hiragana prolonged sound mark - halfwidth -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff70;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#xff70;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-normal-013-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-013-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-014.xht -->
+		<!-- reftest for line-break-normal-013.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -38,53 +38,37 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- iteration marks -->
+		<!-- hyphens -->
 		<div class="wrapper">
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2010;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2010;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2013;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x2013;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x301c;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x301c;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30a0;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル文<br /><span class="target">&#x30a0;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-normal-014-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-014-ref.xht
@@ -3,8 +3,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-normal-021.xht -->
+		<!-- reftest for line-break-normal-014.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/reference/line-break-normal-015-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-015-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-015.xht -->
+		<!-- reftest for line-break-normal-015.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />

--- a/css/css-text/line-break/reference/line-break-normal-016a-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-016a-ref.xht
@@ -3,8 +3,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-normal-023.xht -->
+		<!-- reftest for line-break-normal-016a.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -37,24 +38,6 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- centered punctuation marks COLON -->
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003a;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003a;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks SEMICOLON -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003b;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003b;</span>サンプル文</span>
-			</p>
-		</div>
 		<div class="wrapper">
 			<!-- centered punctuation marks KATAKANA MIDDLE DOT -->
 			<p class="control" lang="ja">
@@ -89,24 +72,6 @@
 			</p>
 			<p class="control" lang="ja">
 				<span>サンプル文サンプル<br />文<span class="target">&#xff65;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks EXCLAMATION MARK -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0021;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0021;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks QUESTION MARK -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003f;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003f;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-normal-016b-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-016b-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-014.xht -->
+		<!-- reftest for line-break-normal-016b.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -29,8 +29,8 @@
 			div.wrapper {
 				display: inline-block;
 				border: 1px solid;
-				margin: 10px;
-				padding: 10px;
+				margin: 5px;
+				padding: 5px;
 			}
 		</style>
 	</head>
@@ -38,53 +38,58 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<!-- iteration marks -->
 		<div class="wrapper">
+			<!-- centered punctuation marks DOUBLE EXCLAMATION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x203c;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x3005;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x203c;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- centered punctuation marks DOUBLE QUESTION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2047;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x303b;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309d;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2047;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- centered punctuation marks QUESTION EXCLAMATION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2048;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x309e;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fd;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2048;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
+			<!-- centered punctuation marks EXCLAMATION QUESTION MARK -->
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2049;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x30fe;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2049;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<!-- centered punctuation marks FULLWIDTH EXCLAMATION MARK -->
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#xff01;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#xff01;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<!-- centered punctuation marks FULLWIDTH QUESTION MARK -->
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#xff1f;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#xff1f;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-normal-017a-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-017a-ref.xht
@@ -2,14 +2,11 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>CSS Text Test: line-break - strict and postfixes</title>
-		<!-- postfixes -->
+		<title>CSS Reftest Reference</title>
+		<!-- reftest for line-break-normal-017a.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
-		<link rel="help" title="5.3. Line Breaking Rules: the 'line-break' property" href="https://drafts.csswg.org/css-text-3/#line-break-property" />
-		<link rel="match" href="reference/line-break-strict-017a-ref.xht" />
 		<meta http-equiv="content-language" content="en, ja" />
-		<meta name="assert" content="This test verifies that 'line-break: strict' does not allow line breaking before postfixes." />
 		<style type="text/css">
 			@font-face
 			{
@@ -20,10 +17,7 @@
 				mplus-1p-regular.ttf can be downloaded at/from [TBD later]
 				*/
 			}
-			.test span {
-				line-break: strict;						/* The property to be tested */
-			}
-			p.test, p.control {
+			p.control {
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
@@ -40,14 +34,14 @@
 			}
 		</style>
 	</head>
-	<body lang="en">
+	<body  lang="en">
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
 		<div class="wrapper">
 			<!-- postfixes DEGREE SIGN -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x00b0;</span>サンプル文</span>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#x00b0;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
 				<span>サンプル文サンプル<br />文<span class="target">&#x00b0;</span>サンプル文</span>
@@ -55,8 +49,8 @@
 		</div>
 		<div class="wrapper">
 			<!-- postfixes PER MILLE SIGN -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2030;</span>サンプル文</span>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#x2030;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
 				<span>サンプル文サンプル<br />文<span class="target">&#x2030;</span>サンプル文</span>
@@ -64,8 +58,8 @@
 		</div>
 		<div class="wrapper">
 			<!-- postfixes PRIME -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2032;</span>サンプル文</span>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#x2032;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
 				<span>サンプル文サンプル<br />文<span class="target">&#x2032;</span>サンプル文</span>
@@ -73,8 +67,8 @@
 		</div>
 		<div class="wrapper">
 			<!-- postfixes DOUBLE PRIME -->
-			<p class="test" lang="ja">
-				<span>サンプル文サンプル文<span class="target">&#x2033;</span>サンプル文</span>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#x2033;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
 				<span>サンプル文サンプル<br />文<span class="target">&#x2033;</span>サンプル文</span>

--- a/css/css-text/line-break/reference/line-break-normal-017b-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-017b-ref.xht
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-015.xht -->
+		<!-- reftest for line-break-normal-024.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
 		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
@@ -39,21 +39,30 @@
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
 		<div class="wrapper">
-			<!-- inseparable characters TWO DOT LEADER -->
+			<!-- postfixes DEGREE CELSIUS -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2103;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#x2103;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
-			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
+			<!-- postfixes FULLWIDTH PERCENT SIGN -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#xff05;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプル文サンプル<br />文<span class="target">&#xff05;</span>サンプル文</span>
+			</p>
+		</div>
+		<div class="wrapper">
+			<!-- postfixes FULLWIDTH CENT SIGN -->
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#xffe0;</span>サンプル文</span>
+			</p>
+			<p class="control" lang="ja">
+				<span>サンプル文サンプル<br />文<span class="target">&#xffe0;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-normal-018-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-018-ref.xht
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title>CSS Reftest Reference</title>
+		<!-- reftest for line-break-normal-018.xht -->
+		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<meta http-equiv="content-language" content="en, ja" />
+		<style type="text/css">
+			@font-face
+			{
+				font-family: "mplus-1p-regular";
+				src: url("/fonts/mplus-1p-regular.woff") format("woff");
+				/* filesize: 803300 bytes (784.5 KBytes) */
+				/*
+				mplus-1p-regular.ttf can be downloaded at/from [TBD later]
+				*/
+			}
+			p.control {
+				border: 1px solid gray;
+				color: blue;
+				font-family: "mplus-1p-regular";
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
+			}
+			span.target {
+				background-color: aqua;
+			}
+			div.wrapper {
+				display: inline-block;
+				border: 1px solid;
+				margin: 10px;
+				padding: 10px;
+			}
+		</style>
+	</head>
+	<body  lang="en">
+		<p>
+			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
+		</p>
+		<div class="wrapper">
+            <!-- prefixes EURO SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x20ac;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x20ac;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes NUMERO SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x2116;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x2116;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH DOLLAR SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xff04;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xff04;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH POUND SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe1;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe1;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH YEN SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe5;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe5;</span>サンプル文</span>
+            </p>
+		</div>
+	</body>
+</html>

--- a/css/css-text/line-break/reference/line-break-strict-011-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-011-ref.xht
@@ -5,6 +5,7 @@
 		<title>CSS Reftest Reference</title>
 		<!-- reftest for line-break-strict-011.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/reference/line-break-strict-012-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-012-ref.xht
@@ -5,6 +5,7 @@
 		<title>CSS Reftest Reference</title>
 		<!-- reftest for line-break-strict-012.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/reference/line-break-strict-013-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-013-ref.xht
@@ -5,6 +5,7 @@
 		<title>CSS Reftest Reference</title>
 		<!-- reftest for line-break-strict-013.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/reference/line-break-strict-016a-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-016a-ref.xht
@@ -5,6 +5,7 @@
 		<title>CSS Reftest Reference</title>
 		<!-- reftest for line-break-strict-016.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -37,24 +38,6 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<div class="wrapper">
-			<!-- centered punctuation marks COLON -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003a;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003a;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks SEMICOLON -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003b;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003b;</span>サンプル文</span>
-			</p>
-		</div>
 		<div class="wrapper">
 			<!-- centered punctuation marks KATAKANA MIDDLE DOT -->
 			<p class="control" lang="ja">
@@ -89,24 +72,6 @@
 			</p>
 			<p class="control" lang="ja">
 				<span>サンプル文サンプル<br />文<span class="target">&#xff65;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks EXCLAMATION MARK -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0021;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0021;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- centered punctuation marks QUESTION MARK -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003f;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x003f;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-strict-016b-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-016b-ref.xht
@@ -5,6 +5,7 @@
 		<title>CSS Reftest Reference</title>
 		<!-- reftest for line-break-strict-016.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/reference/line-break-strict-017a-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-017a-ref.xht
@@ -5,6 +5,7 @@
 		<title>CSS Reftest Reference</title>
 		<!-- reftest for line-break-strict-017.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;
@@ -37,24 +38,6 @@
 		<p>
 			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
 		</p>
-		<div class="wrapper">
-			<!-- postfixes PERCENT SIGN -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0025;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x0025;</span>サンプル文</span>
-			</p>
-		</div>
-		<div class="wrapper">
-			<!-- postfixes CENT SIGN -->
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x00a2;</span>サンプル文</span>
-			</p>
-			<p class="control" lang="ja">
-				<span>サンプル文サンプル<br />文<span class="target">&#x00a2;</span>サンプル文</span>
-			</p>
-		</div>
 		<div class="wrapper">
 			<!-- postfixes DEGREE SIGN -->
 			<p class="control" lang="ja">

--- a/css/css-text/line-break/reference/line-break-strict-017b-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-017b-ref.xht
@@ -3,8 +3,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Reftest Reference</title>
-		<!-- reftest for line-break-strict-017.xht -->
+		<!-- reftest for line-break-strict-017b.xht -->
 		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
 		<meta http-equiv="content-language" content="en, ja" />
 		<style type="text/css">
 			@font-face
@@ -20,7 +21,7 @@
 				border: 1px solid gray;
 				color: blue;
 				font-family: "mplus-1p-regular";
-				width: 10em;
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
 			}
 			span.target {
 				background-color: aqua;

--- a/css/css-text/line-break/reference/line-break-strict-018-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-018-ref.xht
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title>CSS Reftest Reference</title>
+		<!-- reftest for line-break-strict-018.xht -->
+		<link rel="author" title="Taka Oshiyama" href="mailto:takaoshiyama@gmail.com" />
+		<link rel="author" title="Shinyu Murakami" href="mailto:murakami@vivliostyle.org" />
+		<meta http-equiv="content-language" content="en, ja" />
+		<style type="text/css">
+			@font-face
+			{
+				font-family: "mplus-1p-regular";
+				src: url("/fonts/mplus-1p-regular.woff") format("woff");
+				/* filesize: 803300 bytes (784.5 KBytes) */
+				/*
+				mplus-1p-regular.ttf can be downloaded at/from [TBD later]
+				*/
+			}
+			p.control {
+				border: 1px solid gray;
+				color: blue;
+				font-family: "mplus-1p-regular";
+				width: 10.2em;		/* added extra .2em for some symbols wider than 1em */
+			}
+			span.target {
+				background-color: aqua;
+			}
+			div.wrapper {
+				display: inline-block;
+				border: 1px solid;
+				margin: 10px;
+				padding: 10px;
+			}
+		</style>
+	</head>
+	<body  lang="en">
+		<p>
+			Test passes if the highlighted characters in each pair of rectangles are at the exact same horizontal position.
+		</p>
+		<div class="wrapper">
+            <!-- prefixes EURO SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x20ac;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x20ac;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes NUMERO SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x2116;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#x2116;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH DOLLAR SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xff04;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xff04;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH POUND SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe1;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe1;</span>サンプル文</span>
+            </p>
+		</div>
+		<div class="wrapper">
+            <!-- prefixes FULLWIDTH YEN SIGN -->
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe5;</span>サンプル文</span>
+            </p>
+            <p class="control" lang="ja">
+                <span>サンプル文サンプル<br /><span class="target">&#xffe5;</span>サンプル文</span>
+            </p>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
### Fix test file name numbering

The problem was that `line-break-normal-*` and `line-break-strict-*` had diffrent numbering for same ranges, e.g. `line-break-normal-021` and `line-break-strict-014` for same iteration marks. It was confusing, so I changed the numbering for 'normal' to be the same as for 'strict'.

- line-break-normal-021  → line-break-normal-014
- line-break-normal-022  → line-break-normal-015
- line-break-normal-023a → line-break-normal-016a
- line-break-normal-023b → line-break-normal-016b
- line-break-normal-024a → line-break-normal-017a
- line-break-normal-024b → line-break-normal-017b

### Fix tests for Inseparatable characters

The tests for Inseparatable characters `line-break-strict-015` and `line-break-normal-015` (was `line-break-normal-022`) had wrong assertion "does not allow line breaking **before** inseparable characters". This should be "does not allow line breaking **between** inseparable characters".

I changed the tests to test line breaking **between** (not **before**) two inseparable characters.

### Fix tests for Centered punctuation marks

The tests for Centered punctuation marks `line-break-strict-016a` and `line-break-normal-016a` (was `line-break-normal-023a`) contained tests for EAW=Narrow characters (U+003A, U+003B, U+0021, U+003F) that are excluded in the current 'line-break' spec.

### Fix tests for Postfixes

The tests for Postfixes `line-break-strict-017a` and `line-break-normal-017a` (was `line-break-normal-024a`) contained tests for EAW=Narrow characters (U+0025 and U+00A2) that are excluded in the current 'line-break' spec.

### Add tests for Prefixes

Added the tests for line breaking after Prefixes `line-break-*-018`.

### Add 'loose' and 'normal' values tests that were missing

- line-break-loose-011 .. line-break-loose-017b
- line-break-normal-011 .. line-break-normal-013

### Adjust width of the test block

I changed the width of the test block `p.test, p.control {...}` that was `width: 10em` to `width: 10.2em`. This extra (.2em) width is needed to prevent unexpected line breaking caused by some symbol characters wider than 1em.

I found this problem with `line-break-loose-018`. The width of U+2116 "№" is slightly wider than 1em and if the block width is 10em the line breaking occurs before that character, and the test always fails.