### PR TITLE
[css-text] Some fixes on 'word-break-break-all-*' tests

### DIFF
--- a/css/css-text/word-break/reference/word-break-break-all-020-ref.html
+++ b/css/css-text/word-break/reference/word-break-break-all-020-ref.html
@@ -8,9 +8,9 @@ div {
   width: 2em;
 }
 
-div::nth-of-type(1) { border-color: blue; }
-div::nth-of-type(2) { border-color: green; }
-div::nth-of-type(3) { border-color: orange; }
+div:nth-of-type(1) { border-color: blue; }
+div:nth-of-type(2) { border-color: green; }
+div:nth-of-type(3) { border-color: orange; }
 
 </style>
 

--- a/css/css-text/word-break/word-break-break-all-010.html
+++ b/css/css-text/word-break/word-break-break-all-010.html
@@ -8,9 +8,10 @@
 <meta name="assert" content="The word is broken even if pre-wrap provides a former breaking opportunity in leading white-space.">
 <style>
 div {
-   position: relative;
-   font-size: 20px;
-   font-family: Ahem;
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
 }
 .red {
   position: absolute;
@@ -23,9 +24,7 @@ div {
 }
 .test {
   color: green;
-  line-height: 1em;
   width: 5ch;
-
   white-space: pre-wrap;
   word-break: break-all;
 }

--- a/css/css-text/word-break/word-break-break-all-011.html
+++ b/css/css-text/word-break/word-break-break-all-011.html
@@ -8,9 +8,10 @@
 <meta name="assert" content="A single leading white-space should account as soft breaking opportunity, honoring the 'white-space: pre-wrap', on top to the ones provided by 'word-break: break-all'.">
 <style>
 div {
-   position: relative;
-   font-size: 20px;
-   font-family: Ahem;
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
 }
 .red {
   position: absolute;
@@ -23,7 +24,6 @@ div {
 .test {
   color: green;
   background: green;
-  line-height: 1em;
   width: 1ch;
   white-space: pre-wrap;
   word-break: break-all;

--- a/css/css-text/word-break/word-break-break-all-020.html
+++ b/css/css-text/word-break/word-break-break-all-020.html
@@ -11,11 +11,11 @@ div {
   width: 2em;
 }
 
-div::nth-of-type(1) { border-color: blue; }
-div::nth-of-type(2) { border-color: green; }
-div::nth-of-type(3) { border-color: orange; }
+div:nth-of-type(1) { border-color: blue; }
+div:nth-of-type(2) { border-color: green; }
+div:nth-of-type(3) { border-color: orange; }
 
-div::nth-of-type(3) { word-break: break-word; }
+div:nth-of-type(3) { word-break: break-all; }
 </style>
 
 <p>Test passes if the text in each of the following 3 boxes is broken into separate lines at the same points.


### PR DESCRIPTION
### word-break-break-all-010 and word-break-break-all-011

- `line-height: 1em` was specified on the `.test {...}` but not on the `.red {...}`. As a result, the line-height of the `.red` block depended on the browser, and the red color appeared on Firefox.

### word-break-break-all-020

Fix erros (typo?)
- `div::nth-of-type` → `div:nth-of-type`
- `break-word` → `break-all`