### PR TITLE
Implement --affected in `wpt run` and use it on Taskcluster

### DIFF
--- a/check_stability.ini
+++ b/check_stability.ini
@@ -1,5 +1,4 @@
 [file detection]
-skip_tests: conformance-checkers docs tools
 # The vast majority of tests rely on files located within the `resources`
 # directory. Because of this, modifications to that directory's contents have
 # the potential to introduce instability in a large number of tests.

--- a/tools/ci/check_stability.py
+++ b/tools/ci/check_stability.py
@@ -176,7 +176,7 @@ def pr():
     return pr if pr != "false" else None
 
 
-def get_changed_files(manifest_path, rev, ignore_changes, skip_tests):
+def get_changed_files(manifest_path, rev, ignore_changes):
     if not rev:
         branch_point = testfiles.branch_point()
         revish = "%s..HEAD" % branch_point
@@ -189,7 +189,7 @@ def get_changed_files(manifest_path, rev, ignore_changes, skip_tests):
         logger.info("Ignoring %s changed files:\n%s" %
                     (len(files_ignored), "".join(" * %s\n" % item for item in files_ignored)))
 
-    tests_changed, files_affected = testfiles.affected_testfiles(files_changed, skip_tests,
+    tests_changed, files_affected = testfiles.affected_testfiles(files_changed,
                                                                  manifest_path=manifest_path)
 
     return tests_changed, files_affected
@@ -217,7 +217,6 @@ def run(venv, wpt_args, **kwargs):
     with open(kwargs["config_file"], 'r') as config_fp:
         config = SafeConfigParser()
         config.readfp(config_fp)
-        skip_tests = config.get("file detection", "skip_tests").split()
         ignore_changes = set(config.get("file detection", "ignore_changes").split())
 
     if kwargs["output_bytes"] is not None:
@@ -250,7 +249,7 @@ def run(venv, wpt_args, **kwargs):
         if not wpt_kwargs["test_list"]:
             manifest_path = os.path.join(wpt_kwargs["metadata_root"], "MANIFEST.json")
             tests_changed, files_affected = get_changed_files(manifest_path, kwargs["rev"],
-                                                              ignore_changes, skip_tests)
+                                                              ignore_changes)
 
             if not (tests_changed or files_affected):
                 logger.info("No tests changed")

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -11,19 +11,6 @@ browser_specific_args = {
     "firefox": ["--install-browser"]
 }
 
-def tests_affected(commit_range):
-    output = subprocess.check_output([
-        "python", "./wpt", "tests-affected", "--null", commit_range
-    ], stderr=open(os.devnull, "w"))
-
-    tests = output.split("\0")
-
-    # Account for trailing null byte
-    if tests and not tests[-1]:
-        tests.pop()
-
-    return tests
-
 
 def find_wptreport(args):
     parser = argparse.ArgumentParser()
@@ -56,16 +43,10 @@ def main(product, commit_range, wpt_args):
 
     if commit_range:
         logger.info(
-            "Identifying tests affected in range '%s'..." % commit_range
+            "Running tests affected in range '%s'..." % commit_range
         )
-        tests = tests_affected(commit_range)
-        logger.info("Identified %s affected tests" % len(tests))
-
-        if not tests:
-            logger.info("Quitting because no tests were affected.")
-            return
+        wpt_args += ['--affected', commit_range]
     else:
-        tests = []
         logger.info("Running all tests")
 
     wpt_args += [
@@ -79,7 +60,7 @@ def main(product, commit_range, wpt_args):
     ]
     wpt_args += browser_specific_args.get(product, [])
 
-    command = ["python", "./wpt", "run"] + wpt_args + [product] + tests
+    command = ["python", "./wpt", "run"] + wpt_args + [product]
 
     logger.info("Executing command: %s" % " ".join(command))
 

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -162,9 +162,12 @@ def exclude_ignored(files, ignore_rules):
 
 
 def files_changed(revish, ignore_rules=None, include_uncommitted=False, include_new=False):
-    """Get and return files changed since current branch diverged from master,
-    excluding those that are located within any path matched by
-    `ignore_rules`."""
+    """Find files changed in certain revisions.
+
+    The function passes `revish` directly to `git diff`, so `revish` can have a
+    variety of forms; see `git diff --help` for details. Files in the diff that
+    are matched by `ignore_rules` are excluded.
+    """
     files = repo_files_changed(revish,
                                include_uncommitted=include_uncommitted,
                                include_new=include_new)
@@ -183,7 +186,7 @@ def _in_repo_root(full_path):
 def _init_manifest_cache():
     c = {}
 
-    def load(manifest_path=None):
+    def load(manifest_path=None, manifest_update=True):
         if manifest_path is None:
             manifest_path = os.path.join(wpt_root, "MANIFEST.json")
         if c.get(manifest_path):
@@ -191,7 +194,7 @@ def _init_manifest_cache():
         # cache at most one path:manifest
         c.clear()
         wpt_manifest = manifest.load_and_update(wpt_root, manifest_path, "/",
-                                                update=True)
+                                                update=manifest_update)
         c[manifest_path] = wpt_manifest
         return c[manifest_path]
     return load
@@ -200,14 +203,17 @@ def _init_manifest_cache():
 load_manifest = _init_manifest_cache()
 
 
-def affected_testfiles(files_changed, skip_tests, manifest_path=None):
+def affected_testfiles(files_changed, skip_dirs=None,
+                       manifest_path=None, manifest_update=True):
     """Determine and return list of test files that reference changed files."""
+    if skip_dirs is None:
+        skip_dirs = set(["conformance-checkers", "docs", "tools"])
     affected_testfiles = set()
     # Exclude files that are in the repo root, because
     # they are not part of any test.
     files_changed = [f for f in files_changed if not _in_repo_root(f)]
     nontests_changed = set(files_changed)
-    wpt_manifest = load_manifest(manifest_path)
+    wpt_manifest = load_manifest(manifest_path, manifest_update)
 
     test_types = ["testharness", "reftest", "wdspec"]
     support_files = {os.path.join(wpt_root, path)
@@ -232,7 +238,7 @@ def affected_testfiles(files_changed, skip_tests, manifest_path=None):
         rel_path = os.path.relpath(full_path, wpt_root)
         path_components = rel_path.split(os.sep)
         top_level_subdir = path_components[0]
-        if top_level_subdir in skip_tests:
+        if top_level_subdir in skip_dirs:
             continue
         repo_path = "/" + os.path.relpath(full_path, wpt_root).replace(os.path.sep, "/")
         if repo_path in rewrites:
@@ -271,7 +277,7 @@ def affected_testfiles(files_changed, skip_tests, manifest_path=None):
         # Walk top_level_subdir looking for test files containing either the
         # relative filepath or absolute filepath to the changed files.
         if root == wpt_root:
-            for dir_name in skip_tests:
+            for dir_name in skip_dirs:
                 dirs.remove(dir_name)
         for fname in fnames:
             test_full_path = os.path.join(root, fname)


### PR DESCRIPTION
There are two major parts in this PR:

1. Refactor the non-Safari-specific part out of #14156 : add the `--affected` flag to `wpt run` so that we can do `tests-affected` and `run` in one command.
2. Modify `taskcluster-run.py` to use the new `wpt run --affected` instead of calling and parsing the output of `wpt tests-affected`.

The reason why we want to do this is to reuse the code on multiple CIs, e.g. #14156 . Ideally, `taskcluster-run.py` should be very minimal with all resuable logic ported into `wpt` or `wptrunner`.