### PR TITLE
Removed redundant h2+hyperframe+hpack packages

### DIFF
--- a/tools/wptserve/tests/functional/base.py
+++ b/tools/wptserve/tests/functional/base.py
@@ -106,7 +106,6 @@ class TestUsingH2Server:
         self.conn.connect()
 
     def teardown_method(self, test_method):
-        self.conn.close()
         self.server.stop()
 
 

--- a/tools/wptserve/tests/functional/test_response.py
+++ b/tools/wptserve/tests/functional/test_response.py
@@ -9,7 +9,7 @@ from six import create_bound_method
 
 wptserve = pytest.importorskip("wptserve")
 from .base import TestUsingServer, TestUsingH2Server, doc_root
-from hyper.h2.exceptions import ProtocolError
+from h2.exceptions import ProtocolError
 
 def send_body_as_header(self):
     if self._response.add_required_headers:


### PR DESCRIPTION
As mentioned in #12603, the third_party/hyper library has its own older version of the h2 library. I've updated hyper to use the newer version of h2 that the server itself uses so as to not need the redundant copy. I'm slightly worried this might cause some issues in TaskCluster even though it shouldn't, @jgraham will hopefully be able to put my concerns to rest once this PR goes up?