### PR TITLE
[wptrunner] Support any Sauce Connect argument

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -133,6 +133,7 @@ class SauceConnect():
         self.sauce_key = kwargs["sauce_key"]
         self.sauce_tunnel_id = kwargs["sauce_tunnel_id"]
         self.sauce_connect_binary = kwargs.get("sauce_connect_binary")
+        self.sauce_connect_args = kwargs.get("sauce_connect_args")
         self.sauce_init_timeout = kwargs.get("sauce_init_timeout")
         self.sc_process = None
         self.temp_dir = None
@@ -171,7 +172,7 @@ class SauceConnect():
             "--readyfile=./sauce_is_ready",
             "--tunnel-domains",
             ",".join(self.env_config.domains_set)
-        ])
+        ] + self.sauce_connect_args)
 
         tot_wait = 0
         while not os.path.exists('./sauce_is_ready') and self.sc_process.poll() is None:

--- a/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
@@ -25,7 +25,8 @@ def test_sauceconnect_success():
             sauce_user="aaa",
             sauce_key="bbb",
             sauce_tunnel_id="ccc",
-            sauce_connect_binary="ddd")
+            sauce_connect_binary="ddd",
+            sauce_connect_args=[])
 
         with ConfigBuilder(browser_host="example.net") as env_config:
             sauce_connect(None, env_config)
@@ -54,7 +55,8 @@ def test_sauceconnect_failure_exit(readyfile, returncode):
             sauce_user="aaa",
             sauce_key="bbb",
             sauce_tunnel_id="ccc",
-            sauce_connect_binary="ddd")
+            sauce_connect_binary="ddd",
+            sauce_connect_args=[])
 
         with ConfigBuilder(browser_host="example.net") as env_config:
             sauce_connect(None, env_config)
@@ -82,7 +84,8 @@ def test_sauceconnect_cleanup():
             sauce_user="aaa",
             sauce_key="bbb",
             sauce_tunnel_id="ccc",
-            sauce_connect_binary="ddd")
+            sauce_connect_binary="ddd",
+            sauce_connect_args=[])
 
         with ConfigBuilder(browser_host="example.net") as env_config:
             sauce_connect(None, env_config)
@@ -106,7 +109,8 @@ def test_sauceconnect_failure_never_ready():
             sauce_user="aaa",
             sauce_key="bbb",
             sauce_tunnel_id="ccc",
-            sauce_connect_binary="ddd")
+            sauce_connect_binary="ddd",
+            sauce_connect_args=[])
 
         with ConfigBuilder(browser_host="example.net") as env_config:
             sauce_connect(None, env_config)
@@ -134,7 +138,8 @@ def test_sauceconnect_tunnel_domains():
             sauce_user="aaa",
             sauce_key="bbb",
             sauce_tunnel_id="ccc",
-            sauce_connect_binary="ddd")
+            sauce_connect_binary="ddd",
+            sauce_connect_args=[])
 
         with ConfigBuilder(browser_host="example.net",
                            alternate_hosts={"alt": "example.org"},

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -302,6 +302,10 @@ scheme host and port.""")
                              help="Number of seconds to wait for Sauce "
                                   "Connect tunnel to be available before "
                                   "aborting")
+    sauce_group.add_argument("--sauce-connect-arg", action="append",
+                             default=[], dest="sauce_connect_args",
+                             help="Command-line argument to forward to the "
+                                  "Sauce Connect binary (repeatable)")
 
     webkit_group = parser.add_argument_group("WebKit-specific")
     webkit_group.add_argument("--webkit-port", dest="webkit_port",


### PR DESCRIPTION
Implement the command-line argument `--sauce-connect-arg` as a
pass-through to the Sauce Connect binary. This gives users more control
over the way the binary is configured which is particularly important in
combination with the existing `--sauce-connect-binary` argument (since
the list of available arguments is subject to change between releases).