### PR TITLE
[cookie-store] Improve cleanup logic

### DIFF
--- a/cookie-store/cookieListItem_attributes.tentative.https.window.js
+++ b/cookie-store/cookieListItem_attributes.tentative.https.window.js
@@ -1,15 +1,5 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 const kCurrentHostname = (new URL(self.location.href)).hostname;
 
 const kOneDay = 24 * 60 * 60 * 1000;
@@ -23,6 +13,7 @@ promise_test(async testCase => {
   await cookieStore.delete('cookie-name');
 
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
@@ -33,14 +24,14 @@ promise_test(async testCase => {
   assert_equals(cookie.secure, true);
   assert_equals(cookie.sameSite, 'strict');
   assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'CookieListItem - cookieStore.set defaults with positional name and value');
 
 promise_test(async testCase => {
   await cookieStore.delete('cookie-name');
 
   await cookieStore.set({ name: 'cookie-name', value: 'cookie-value' });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
@@ -50,8 +41,6 @@ promise_test(async testCase => {
   assert_equals(cookie.secure, true);
   assert_equals(cookie.sameSite, 'strict');
   assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'CookieListItem - cookieStore.set defaults with name and value in options');
 
 promise_test(async testCase => {
@@ -59,6 +48,8 @@ promise_test(async testCase => {
 
   await cookieStore.set('cookie-name', 'cookie-value',
                         { expires: kTenYearsFromNow });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
@@ -68,8 +59,6 @@ promise_test(async testCase => {
   assert_equals(cookie.secure, true);
   assert_equals(cookie.sameSite, 'strict');
   assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'CookieListItem - cookieStore.set with expires set to a timestamp 10 ' +
    'years in the future');
 
@@ -78,6 +67,8 @@ promise_test(async testCase => {
 
   await cookieStore.set({ name: 'cookie-name', value: 'cookie-value',
                           expires: kTenYearsFromNow });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
@@ -87,8 +78,6 @@ promise_test(async testCase => {
   assert_equals(cookie.secure, true);
   assert_equals(cookie.sameSite, 'strict');
   assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'CookieListItem - cookieStore.set with name and value in options and ' +
    'expires set to a future timestamp');
 
@@ -97,6 +86,8 @@ promise_test(async testCase => {
 
   await cookieStore.set('cookie-name', 'cookie-value',
                         { expires: new Date(kTenYearsFromNow) });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
@@ -104,8 +95,6 @@ promise_test(async testCase => {
   assert_equals(cookie.path, '/');
   assert_approx_equals(cookie.expires, kTenYearsFromNow, kOneDay);
   assert_equals(cookie.secure, true);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'CookieListItem - cookieStore.set with expires set to a Date 10 ' +
    'years in the future');
 
@@ -114,6 +103,8 @@ promise_test(async testCase => {
 
   await cookieStore.set({ name: 'cookie-name', value: 'cookie-value',
                           expires: new Date(kTenYearsFromNow) });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
@@ -123,8 +114,6 @@ promise_test(async testCase => {
   assert_equals(cookie.secure, true);
   assert_equals(cookie.sameSite, 'strict');
   assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'CookieListItem - cookieStore.set with name and value in options and ' +
    'expires set to a future Date');
 
@@ -133,6 +122,10 @@ promise_test(async testCase => {
 
   await cookieStore.set('cookie-name', 'cookie-value',
                         { domain: kCurrentHostname });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: kCurrentHostname });
+  });
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
@@ -142,10 +135,6 @@ promise_test(async testCase => {
   assert_equals(cookie.secure, true);
   assert_equals(cookie.sameSite, 'strict');
   assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-  await async_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', domain: kCurrentHostname });
-  });
 }, 'CookieListItem - cookieStore.set with domain set to the current hostname');
 
 promise_test(async testCase => {
@@ -157,6 +146,10 @@ promise_test(async testCase => {
 
   await cookieStore.set('cookie-name', 'cookie-value',
                         { path: currentDirectory });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
@@ -166,16 +159,14 @@ promise_test(async testCase => {
   assert_equals(cookie.secure, true);
   assert_equals(cookie.sameSite, 'strict');
   assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-  await async_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
-  });
 }, 'CookieListItem - cookieStore.set with path set to the current directory');
 
 promise_test(async testCase => {
   await cookieStore.delete('cookie-name');
 
   await cookieStore.set('cookie-name', 'cookie-value', { secure: false });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
@@ -185,8 +176,6 @@ promise_test(async testCase => {
   assert_equals(cookie.secure, false);
   assert_equals(cookie.sameSite, 'strict');
   assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'CookieListItem - cookieStore.set with secure set to false');
 
 ['strict', 'lax', 'unrestricted'].forEach(sameSiteValue => {
@@ -195,6 +184,8 @@ promise_test(async testCase => {
 
     await cookieStore.set({
         name: 'cookie-name', value: 'cookie-value', sameSite: sameSiteValue });
+    testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
     const cookie = await cookieStore.get('cookie-name');
     assert_equals(cookie.name, 'cookie-name');
     assert_equals(cookie.value, 'cookie-value');
@@ -204,8 +195,6 @@ promise_test(async testCase => {
     assert_equals(cookie.secure, true);
     assert_equals(cookie.sameSite, sameSiteValue);
     assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-    await async_cleanup(() => cookieStore.delete('cookie-name'));
   }, `CookieListItem - cookieStore.set with sameSite set to ${sameSiteValue}`);
 
   promise_test(async testCase => {
@@ -213,6 +202,8 @@ promise_test(async testCase => {
 
     await cookieStore.set('cookie-name', 'cookie-value',
                           { sameSite: sameSiteValue });
+    testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
     const cookie = await cookieStore.get('cookie-name');
     assert_equals(cookie.name, 'cookie-name');
     assert_equals(cookie.value, 'cookie-value');
@@ -222,8 +213,6 @@ promise_test(async testCase => {
     assert_equals(cookie.secure, true);
     assert_equals(cookie.sameSite, sameSiteValue);
     assert_array_equals(Object.keys(cookie).sort(), kCookieListItemKeys);
-
-    await async_cleanup(() => cookieStore.delete('cookie-name'));
   }, 'CookieListItem - cookieStore.set with positional name and value and ' +
      `sameSite set to ${sameSiteValue}`);
 });

--- a/cookie-store/cookieStore_delete_arguments.tentative.https.window.js
+++ b/cookie-store/cookieStore_delete_arguments.tentative.https.window.js
@@ -124,7 +124,7 @@ promise_test(async testCase => {
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
 
-  async_cleanup(async () => {
+  await async_cleanup(async () => {
     await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
   });
 }, 'cookieStore.delete with path set to the current directory');

--- a/cookie-store/cookieStore_delete_arguments.tentative.https.window.js
+++ b/cookie-store/cookieStore_delete_arguments.tentative.https.window.js
@@ -1,15 +1,5 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
 
@@ -22,20 +12,20 @@ promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
 
   await cookieStore.delete({ name: 'cookie-name' });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.delete with name in options');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
 
   await cookieStore.delete('cookie-name', { name: 'wrong-cookie-name' });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.delete with name in both positional arguments and options');
 
 promise_test(async testCase => {
@@ -43,14 +33,13 @@ promise_test(async testCase => {
   const currentDomain = currentUrl.hostname;
   await cookieStore.set(
       'cookie-name', 'cookie-value', { domain: currentDomain });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
+  });
 
   await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
-
-  await async_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
-  });
 }, 'cookieStore.delete with domain set to the current hostname');
 
 promise_test(async testCase => {
@@ -79,14 +68,13 @@ promise_test(async testCase => {
   const currentDomain = currentUrl.hostname;
   await cookieStore.set(
       'cookie-name', 'cookie-value', { domain: currentDomain });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
+  });
 
   await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
-
-  await async_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
-  });
 }, 'cookieStore.delete with name in options and domain set to the current ' +
    'hostname');
 
@@ -119,14 +107,13 @@ promise_test(async testCase => {
       currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
   await cookieStore.set(
       'cookie-name', 'cookie-value', { path: currentDirectory });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
 
   await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
-
-  await async_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
-  });
 }, 'cookieStore.delete with path set to the current directory');
 
 promise_test(async testCase => {
@@ -137,19 +124,19 @@ promise_test(async testCase => {
   const subDirectory = currentDirectory + "subdir/";
   await cookieStore.set(
       'cookie-name', 'cookie-value', { path: currentDirectory });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
 
   await cookieStore.delete({ name: 'cookie-name', path: subDirectory });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
-  });
 }, 'cookieStore.delete with path set to subdirectory of the current directory');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie_attributes = await cookieStore.get('cookie-name');
   assert_equals(cookie_attributes.name, 'cookie-name');
@@ -158,6 +145,4 @@ promise_test(async testCase => {
   await cookieStore.delete(cookie_attributes);
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.delete with get result');

--- a/cookie-store/cookieStore_event_basic.tentative.https.window.js
+++ b/cookie-store/cookieStore_event_basic.tentative.https.window.js
@@ -1,21 +1,12 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   const eventPromise = new Promise((resolve) => {
     cookieStore.onchange = resolve;
   });
 
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const event = await eventPromise;
   assert_true(event instanceof CookieChangeEvent);
@@ -24,6 +15,4 @@ promise_test(async testCase => {
   assert_equals(event.changed[0].name, 'cookie-name');
   assert_equals(event.changed[0].value, 'cookie-value');
   assert_equals(event.deleted.length, 0);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore fires change event for cookie set by cookieStore.set()');

--- a/cookie-store/cookieStore_event_delete.tenative.https.window.js
+++ b/cookie-store/cookieStore_event_delete.tenative.https.window.js
@@ -1,17 +1,8 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const eventPromise = new Promise((resolve) => {
     cookieStore.onchange = resolve;
@@ -26,6 +17,4 @@ promise_test(async testCase => {
       event.deleted[0].value, undefined,
       'Cookie change events for deletions should not have cookie values');
   assert_equals(event.changed.length, 0);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore fires change event for cookie deleted by cookieStore.delete()');

--- a/cookie-store/cookieStore_event_overwrite.tentative.https.window.js
+++ b/cookie-store/cookieStore_event_overwrite.tentative.https.window.js
@@ -1,15 +1,5 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
 
@@ -18,6 +8,7 @@ promise_test(async testCase => {
   });
 
   await cookieStore.set('cookie-name', 'new-cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const event = await eventPromise;
   assert_true(event instanceof CookieChangeEvent);
@@ -27,5 +18,4 @@ promise_test(async testCase => {
   assert_equals(event.changed[0].value, 'new-cookie-value');
   assert_equals(event.deleted.length, 0);
 
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore fires change event for cookie overwritten by cookieStore.set()');

--- a/cookie-store/cookieStore_getAll_arguments.tentative.https.window.js
+++ b/cookie-store/cookieStore_getAll_arguments.tentative.https.window.js
@@ -1,18 +1,10 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name-2'));
 
   const cookies = await cookieStore.getAll();
   cookies.sort((a, b) => a.name.localeCompare(b.name));
@@ -21,53 +13,48 @@ promise_test(async testCase => {
   assert_equals(cookies[0].value, 'cookie-value');
   assert_equals(cookies[1].name, 'cookie-name-2');
   assert_equals(cookies[1].value, 'cookie-value-2');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
-  await async_cleanup(() => cookieStore.delete('cookie-name-2'));
 }, 'cookieStore.getAll with no arguments');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name-2'));
 
   const cookies = await cookieStore.getAll('cookie-name');
   assert_equals(cookies.length, 1);
   assert_equals(cookies[0].name, 'cookie-name');
   assert_equals(cookies[0].value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
-  await async_cleanup(() => cookieStore.delete('cookie-name-2'));
 }, 'cookieStore.getAll with positional name');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name-2'));
 
   const cookies = await cookieStore.getAll({ name: 'cookie-name' });
   assert_equals(cookies.length, 1);
   assert_equals(cookies[0].name, 'cookie-name');
   assert_equals(cookies[0].value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
-  await async_cleanup(() => cookieStore.delete('cookie-name-2'));
 }, 'cookieStore.getAll with name in options');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name-2'));
 
   const cookies = await cookieStore.getAll('cookie-name',
                                            { name: 'wrong-cookie-name' });
   assert_equals(cookies.length, 1);
   assert_equals(cookies[0].name, 'cookie-name');
   assert_equals(cookies[0].value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
-  await async_cleanup(() => cookieStore.delete('cookie-name-2'));
 }, 'cookieStore.getAll with name in both positional arguments and options');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookies = await cookieStore.getAll({ name: 'cookie-name',
                                              matchType: 'equals' });
@@ -78,53 +65,47 @@ promise_test(async testCase => {
   const no_cookies = await cookieStore.getAll(
       'cookie-na', { matchType: 'equals' });
   assert_equals(no_cookies.length, 0);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.getAll with matchType explicitly set to equals');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name-2'));
 
   const cookies = await cookieStore.getAll({ name: 'cookie-name-',
                                              matchType: 'starts-with' });
   assert_equals(cookies.length, 1);
   assert_equals(cookies[0].name, 'cookie-name-2');
   assert_equals(cookies[0].value, 'cookie-value-2');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
-  await async_cleanup(() => cookieStore.delete('cookie-name-2'));
 }, 'cookieStore.getAll with matchType set to starts-with');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name-2'));
 
   await promise_rejects(testCase, new TypeError(), cookieStore.getAll(
       { name: 'cookie-name', matchType: 'invalid' }));
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
-  await async_cleanup(() => cookieStore.delete('cookie-name-2'));
 }, 'cookieStore.getAll with invalid matchType');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookies = await cookieStore.getAll({ matchType: 'equals' });
   assert_equals(cookies.length, 1);
   assert_equals(cookies[0].name, 'cookie-name');
   assert_equals(cookies[0].value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.getAll with matchType set to equals and missing name');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookies = await cookieStore.getAll({ matchType: 'starts-with' });
   assert_equals(cookies.length, 1);
   assert_equals(cookies[0].name, 'cookie-name');
   assert_equals(cookies[0].value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.getAll with matchType set to starts-with and missing name');

--- a/cookie-store/cookieStore_getAll_arguments.tentative.https.window.js
+++ b/cookie-store/cookieStore_getAll_arguments.tentative.https.window.js
@@ -115,7 +115,7 @@ promise_test(async testCase => {
   assert_equals(cookies[0].name, 'cookie-name');
   assert_equals(cookies[0].value, 'cookie-value');
 
-  async_cleanup(() => cookieStore.delete('cookie-name'));
+  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.getAll with matchType set to equals and missing name');
 
 promise_test(async testCase => {
@@ -126,5 +126,5 @@ promise_test(async testCase => {
   assert_equals(cookies[0].name, 'cookie-name');
   assert_equals(cookies[0].value, 'cookie-value');
 
-  async_cleanup(() => cookieStore.delete('cookie-name'));
+  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.getAll with matchType set to starts-with and missing name');

--- a/cookie-store/cookieStore_getAll_multiple.tentative.https.window.js
+++ b/cookie-store/cookieStore_getAll_multiple.tentative.https.window.js
@@ -1,19 +1,12 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.set('cookie-name-2', 'cookie-value-2');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name-2'));
   await cookieStore.set('cookie-name-3', 'cookie-value-3');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name-3'));
 
   const cookies = await cookieStore.getAll();
   cookies.sort((a, b) => a.name.localeCompare(b.name));
@@ -24,8 +17,4 @@ promise_test(async testCase => {
   assert_equals(cookies[1].value, 'cookie-value-2');
   assert_equals(cookies[2].name, 'cookie-name-3');
   assert_equals(cookies[2].value, 'cookie-value-3');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
-  await async_cleanup(() => cookieStore.delete('cookie-name-2'));
-  await async_cleanup(() => cookieStore.delete('cookie-name-3'));
 }, 'cookieStore.getAll returns multiple cookies written by cookieStore.set');

--- a/cookie-store/cookieStore_getAll_set_basic.tentative.https.window.js
+++ b/cookie-store/cookieStore_getAll_set_basic.tentative.https.window.js
@@ -1,22 +1,11 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   const cookies = await cookieStore.getAll('cookie-name');
 
   assert_equals(cookies.length, 1);
   assert_equals(cookies[0].name, 'cookie-name');
   assert_equals(cookies[0].value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.getAll returns the cookie written by cookieStore.set');

--- a/cookie-store/cookieStore_get_arguments.tentative.https.window.js
+++ b/cookie-store/cookieStore_get_arguments.tentative.https.window.js
@@ -72,7 +72,7 @@ promise_test(async testCase => {
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
 
-  async_cleanup(() => cookieStore.delete('cookie-name'));
+  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with matchType set to starts-with');
 
 promise_test(async testCase => {
@@ -91,7 +91,7 @@ promise_test(async testCase => {
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
 
-  async_cleanup(() => cookieStore.delete('cookie-name'));
+  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with matchType set to equals and missing name');
 
 promise_test(async testCase => {
@@ -101,5 +101,5 @@ promise_test(async testCase => {
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
 
-  async_cleanup(() => cookieStore.delete('cookie-name'));
+  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with matchType set to starts-with and missing name');

--- a/cookie-store/cookieStore_get_arguments.tentative.https.window.js
+++ b/cookie-store/cookieStore_get_arguments.tentative.https.window.js
@@ -1,56 +1,43 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get();
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with no arguments');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with positional name');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get({ name: 'cookie-name' });
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with name in options');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get('cookie-name',
                                        { name: 'wrong-cookie-name' });
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with name in both positional arguments and options');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get(
       'cookie-name', { matchType: 'equals' });
@@ -60,46 +47,40 @@ promise_test(async testCase => {
   const no_cookie = await cookieStore.get({ name: 'cookie-na',
                                             matchType: 'equals' });
   assert_equals(no_cookie, null);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with matchType explicitly set to equals');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get({ name: 'cookie-na',
                                          matchType: 'starts-with' });
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with matchType set to starts-with');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   await promise_rejects(testCase, new TypeError(), cookieStore.get(
       { name: 'cookie-name', matchType: 'invalid' }));
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with invalid matchType');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get({ matchType: 'equals' });
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with matchType set to equals and missing name');
 
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get({ matchType: 'starts-with' });
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get with matchType set to starts-with and missing name');

--- a/cookie-store/cookieStore_get_delete_basic.tentative.https.window.js
+++ b/cookie-store/cookieStore_get_delete_basic.tentative.https.window.js
@@ -1,20 +1,9 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.delete('cookie-name');
   const cookie = await cookieStore.get();
   assert_equals(cookie, null);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get returns null for a cookie deleted by cookieStore.delete');

--- a/cookie-store/cookieStore_get_set_basic.tentative.https.window.js
+++ b/cookie-store/cookieStore_get_set_basic.tentative.https.window.js
@@ -1,21 +1,10 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   const cookie = await cookieStore.get('cookie-name');
 
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.get returns the cookie written by cookieStore.set');

--- a/cookie-store/cookieStore_set_arguments.tentative.https.window.js
+++ b/cookie-store/cookieStore_set_arguments.tentative.https.window.js
@@ -1,47 +1,36 @@
 'use strict';
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 promise_test(async testCase => {
   await cookieStore.delete('cookie-name');
 
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with positional name and value');
 
 promise_test(async testCase => {
   await cookieStore.delete('cookie-name');
 
   await cookieStore.set({ name: 'cookie-name', value: 'cookie-value' });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with name and value in options');
 
 promise_test(async testCase => {
   await cookieStore.delete('cookie-name');
 
   cookieStore.set('cookie-name', 'cookie-value', { name: 'wrong-cookie-name' });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with name in both positional arguments and options');
 
 promise_test(async testCase => {
@@ -49,11 +38,11 @@ promise_test(async testCase => {
 
   cookieStore.set('cookie-name', 'cookie-value',
                   { value: 'wrong-cookie-value' });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with value in both positional arguments and options');
 
 promise_test(async testCase => {
@@ -63,11 +52,11 @@ promise_test(async testCase => {
 
   await cookieStore.set(
       'cookie-name', 'cookie-value', { expires: tenYearsFromNow });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with expires set to a future timestamp');
 
 promise_test(async testCase => {
@@ -77,10 +66,10 @@ promise_test(async testCase => {
 
   await cookieStore.set(
       'cookie-name', 'cookie-value', { expires: tenYearsAgo });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with expires set to a past timestamp');
 
 promise_test(async testCase => {
@@ -90,11 +79,11 @@ promise_test(async testCase => {
 
   await cookieStore.set(
       'cookie-name', 'cookie-value', { expires: new Date(tenYearsFromNow) });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with expires set to a future Date');
 
 promise_test(async testCase => {
@@ -104,10 +93,10 @@ promise_test(async testCase => {
 
   await cookieStore.set(
       'cookie-name', 'cookie-value', { expires: new Date(tenYearsAgo) });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with expires set to a past Date');
 
 promise_test(async testCase => {
@@ -117,11 +106,11 @@ promise_test(async testCase => {
 
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', expires: tenYearsFromNow });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with name and value in options and expires in the future');
 
 promise_test(async testCase => {
@@ -131,10 +120,10 @@ promise_test(async testCase => {
 
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', expires: tenYearsAgo });
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with name and value in options and expires in the past');
 
 promise_test(async testCase => {
@@ -144,13 +133,13 @@ promise_test(async testCase => {
 
   await cookieStore.set(
       'cookie-name', 'cookie-value', { domain: currentDomain });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
+  });
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
-  });
 }, 'cookieStore.set with domain set to the current hostname');
 
 promise_test(async testCase => {
@@ -184,8 +173,11 @@ promise_test(async testCase => {
   await cookieStore.delete('cookie-name');
 
   await cookieStore.set('cookie-name', 'cookie-value1');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.set('cookie-name', 'cookie-value2',
                         { domain: currentDomain });
+  testCase.add_cleanup(() => cookieStore.delete(
+      { name: 'cookie-name', domain: currentDomain }));
 
   const cookies = await cookieStore.getAll('cookie-name');
   assert_equals(cookies.length, 2);
@@ -196,11 +188,6 @@ promise_test(async testCase => {
   const values = cookies.map((cookie) => cookie.value);
   values.sort();
   assert_array_equals(values, ['cookie-value1', 'cookie-value2']);
-
-  await async_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
-    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
-  });
 }, 'cookieStore.set default domain is null and differs from current hostname');
 
 promise_test(async testCase => {
@@ -212,13 +199,13 @@ promise_test(async testCase => {
 
   await cookieStore.set(
       'cookie-name', 'cookie-value', { path: currentDirectory });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'cookie-value');
-
-  await async_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
-  });
 }, 'cookieStore.set with path set to the current directory');
 
 promise_test(async testCase => {
@@ -232,29 +219,27 @@ promise_test(async testCase => {
 
   await cookieStore.set(
       'cookie-name', 'cookie-value', { path: subDirectory });
-  const cookie = await cookieStore.get('cookie-name');
-  assert_equals(cookie, null);
-
-  await async_cleanup(async () => {
+  testCase.add_cleanup(async () => {
     await cookieStore.delete({ name: 'cookie-name', path: subDirectory });
   });
+
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
 }, 'cookieStore.set with path set to a subdirectory of the current directory');
 
 promise_test(async testCase => {
   await cookieStore.delete('cookie-name');
 
   await cookieStore.set('cookie-name', 'cookie-old-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
   await cookieStore.set('cookie-name', 'cookie-new-value', { path: '/' });
+  testCase.add_cleanup(() => cookieStore.delete(
+      { name: 'cookie-name',  path: '/' }));
 
   const cookies = await cookieStore.getAll('cookie-name');
   assert_equals(cookies.length, 1);
   assert_equals(cookies[0].name, 'cookie-name');
   assert_equals(cookies[0].value, 'cookie-new-value');
-
-  await async_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
-    await cookieStore.delete({ name: 'cookie-name',  path: '/' });
-  });
 }, 'cookieStore.set default path is /');
 
 promise_test(async testCase => {
@@ -266,9 +251,9 @@ promise_test(async testCase => {
 
   cookie_attributes.value = 'new-cookie-value';
   await cookieStore.set(cookie_attributes);
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
+
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'new-cookie-value');
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookieStore.set with get result');

--- a/cookie-store/serviceworker_cookieStore_subscriptions_basic.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_basic.js
@@ -11,16 +11,6 @@ self.addEventListener('install', (event) => {
   })());
 });
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 // Resolves when the service worker receives the 'activate' event.
 const kServiceWorkerActivatedPromise = new Promise(resolve => {
   self.addEventListener('activate', event => { resolve(); });
@@ -47,6 +37,7 @@ promise_test(async testCase => {
   });
 
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const event = await cookie_change_received_promise;
   assert_equals(event.type, 'cookiechange');
@@ -56,8 +47,6 @@ promise_test(async testCase => {
   assert_equals(event.deleted.length, 0);
   assert_true(event instanceof ExtendableCookieChangeEvent);
   assert_true(event instanceof ExtendableEvent);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookiechange dispatched with cookie change that matches subscription ' +
    'to event handler registered with addEventListener');
 

--- a/cookie-store/serviceworker_cookieStore_subscriptions_empty.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_empty.js
@@ -10,16 +10,6 @@ self.addEventListener('install', (event) => {
   })());
 });
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/w3c/web-platform-tests/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 // Resolves when the service worker receives the 'activate' event.
 const kServiceWorkerActivatedPromise = new Promise(resolve => {
   self.addEventListener('activate', event => { resolve(); });

--- a/cookie-store/serviceworker_cookieStore_subscriptions_eventhandler_attribute.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_eventhandler_attribute.js
@@ -11,16 +11,6 @@ self.addEventListener('install', (event) => {
   })());
 });
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/web-platform-tests/wpt/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 // Resolves when the service worker receives the 'activate' event.
 const kServiceWorkerActivatedPromise = new Promise(resolve => {
   self.addEventListener('activate', event => { resolve(); });
@@ -34,6 +24,7 @@ promise_test(async testCase => {
   });
 
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const event = await cookie_change_received_promise;
   assert_equals(event.type, 'cookiechange');
@@ -43,8 +34,6 @@ promise_test(async testCase => {
   assert_equals(event.deleted.length, 0);
   assert_true(event instanceof ExtendableCookieChangeEvent);
   assert_true(event instanceof ExtendableEvent);
-
-  await async_cleanup(() => cookieStore.delete('cookie-name'));
 }, 'cookiechange dispatched with cookie change that matches subscription ' +
    'to event handler registered with oncookiechange');
 

--- a/cookie-store/serviceworker_cookieStore_subscriptions_mismatch.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_mismatch.js
@@ -11,16 +11,6 @@ self.addEventListener('install', (event) => {
   })());
 });
 
-// Workaround because add_cleanup doesn't support async functions yet.
-// See https://github.com/w3c/web-platform-tests/issues/6075
-async function async_cleanup(cleanup_function) {
-  try {
-    await cleanup_function();
-  } catch (e) {
-    // Errors in cleanup functions shouldn't result in test failures.
-  }
-}
-
 // Resolves when the service worker receives the 'activate' event.
 const kServiceWorkerActivatedPromise = new Promise(resolve => {
   self.addEventListener('activate', event => { resolve(); });
@@ -36,18 +26,15 @@ promise_test(async testCase => {
   });
 
   await cookieStore.set('another-cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('another-cookie-name'));
   await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(() => cookieStore.delete('cookie-name'));
 
   const event = await cookie_change_received_promise;
   assert_equals(event.type, 'cookiechange');
   assert_equals(event.changed.length, 1);
   assert_equals(event.changed[0].name, 'cookie-name');
   assert_equals(event.changed[0].value, 'cookie-value');
-
-  await async_cleanup(async () => {
-    await cookieStore.delete('another-cookie-name');
-    await cookieStore.delete('cookie-name');
-  });
 }, 'cookiechange not dispatched for change that does not match subscription');
 
 done();


### PR DESCRIPTION
While researching for a WPT infrastructure project, I found these tests to be behaving erratically. In a handful of cases, the cleanup invocation was not properly awaited. Since [we've been meaning to take advantage of the new "async cleanup" functionality](https://github.com/web-platform-tests/wpt/issues/13127), I took the opportunity to use that API. I'm submitting this in two commits to make the bug fix easier to identify.

To validate this change set, I ran the tests in Chromium (70.0.3538.77) on `master` (3960fff73862bd9745f8b0add9358e923f916dcb) and on this branch via the command

     $ xvfb-run --auto-servernum ./wpt run --no-pause --log-mach - --log-mach-level DEBUG --channel dev --no-manifest chrome cookie-store/

The results were identical:

On master:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 338 checks (35 tests, 303 subtests)
    Expected results: 328
    Unexpected results: 10
      subtest: 10 (10 fail)

With patch applied:

    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 338 checks (35 tests, 303 subtests)
    Expected results: 328
    Unexpected results: 10
      subtest: 10 (10 fail)