### PR TITLE
[css-text] line-height fix on overflow-wrap-break-word-004 and -005

### DIFF
--- a/css/css-text/overflow-wrap/overflow-wrap-break-word-004.html
+++ b/css/css-text/overflow-wrap/overflow-wrap-break-word-004.html
@@ -8,9 +8,10 @@
 <meta name="assert" content="A Single leading white-space constitutes a soft breaking opportunity, honoring the 'white-space: pre-wrap' property, that must prevent the word to be broken.">
 <style>
 div {
-   position: relative;
-   font-size: 20px;
-   font-family: Ahem;
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
 }
 .red {
   position: absolute;
@@ -22,7 +23,6 @@ div {
 }
 .test {
   color: green;
-  line-height: 1em;
   width: 5ch;
 
   white-space: pre-wrap;

--- a/css/css-text/overflow-wrap/overflow-wrap-break-word-005.html
+++ b/css/css-text/overflow-wrap/overflow-wrap-break-word-005.html
@@ -9,9 +9,10 @@
 <meta name="assert" content="A Single leading white-space constitutes a soft breaking opportunity, honoring the 'white-space: pre-wrap' property, that must prevent the word to be broken.">
 <style>
 div {
-   position: relative;
-   font-size: 20px;
-   font-family: Ahem;
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
 }
 .fail {
   position: absolute;
@@ -21,7 +22,6 @@ div {
 span { color: green; }
 .test {
   color: green;
-  line-height: 1em;
   width: 5ch;
 
   white-space: pre-wrap;


### PR DESCRIPTION
- `line-height: 1em` was specified on the `.test {...}` but not on the `.red` and `.fail` blocks.  As a result, the line-height of the `.red` and `.fail` blocks depended on the browser, and the red color appeared on Firefox.