### PR TITLE
Sync Mozilla CSS tests as of 2018-12-05

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-suppress-baseline-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-suppress-baseline-002.html
@@ -6,7 +6,7 @@
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-layout">
   <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#valdef-align-items-baseline">
-  <link rel="match" href="contain-layout-suppress-baseline-001-ref.html">
+  <link rel="match" href="contain-layout-suppress-baseline-002-ref.html">
   <style>
   .flexBaselineCheck {
     display: flex;


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/caae48e4e6cf4477e11b6464bccdd5ba679ae31a .

This contains changes from [bug 1511963](https://bugzilla.mozilla.org/show_bug.cgi?id=1511963) by @mrego, reviewed by @emilio.