### PR TITLE
Run affected tests on Taskcluster without the patch

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -98,14 +98,25 @@ tasks:
           each(browser):
             $map:
               - name: wpt-${browser.name}-${browser.channel}-stability
+                checkout: FETCH_HEAD
+                diff_range: HEAD^
                 description: >-
                   Verify that all tests affected by a pull request are stable
                   when executed in ${browser.name}.
                 extra_args: '--verify'
               - name: wpt-${browser.name}-${browser.channel}-results
+                checkout: FETCH_HEAD
+                diff_range: HEAD^
                 description: >-
                   Collect results for all tests affected by a pull request in
                   ${browser.name}.
+                extra_args: '--no-fail-on-unexpected --log-wptreport=../artifacts/wpt_report.json'
+              - name: wpt-${browser.name}-${browser.channel}-results-without-changes
+                checkout: FETCH_HEAD^
+                diff_range: FETCH_HEAD
+                description: >-
+                  Collect results for all tests affected by a pull request in
+                  ${browser.name} but without the changes in the PR.
                 extra_args: '--no-fail-on-unexpected --log-wptreport=../artifacts/wpt_report.json'
             each(operation):
               taskId: {$eval: 'as_slugid(operation.name)'}
@@ -125,7 +136,7 @@ tasks:
                 owner: ${event.pull_request.user.login}@users.noreply.github.com
                 source: ${event.repository.url}
               payload:
-                image: hexcles/web-platform-tests:0.23
+                image: harjgam/web-platform-tests:0.25
                 maxRunTime: 7200
                 artifacts:
                   public/results:
@@ -145,12 +156,12 @@ tasks:
                     ~/start.sh
                       ${event.repository.clone_url}
                       refs/pull/${event.number}/merge
-                      FETCH_HEAD
+                      ${operation.checkout}
                       ${browser.name}
                       ${browser.channel};
                     cd ~/web-platform-tests;
                     ./tools/ci/taskcluster-run.py
-                      --commit-range HEAD^
+                      --commit-range ${operation.diff_range}
                       ${browser.name}
                       --
                       --channel=${browser.channel}


### PR DESCRIPTION
This PR adds one task to each browser on Taskcluster for PRs to run the affected tests *without* the patch by running the tests on the first parent of the GitHub merge commit (which is the latest revision of the target branch of the PR when the merge commit is generated by GitHub, shortly after the PR is updated).

This is crucial for reliable regression detection, because without it, we have to use heuristics to compare the PR results against some revision on master.