### PR TITLE
Made the trusted-types tests run correctly in a vanilla wptrunner.

### DIFF
--- a/trusted-types/TrustedTypePolicyFactory-createPolicy-createXYZTests.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-createPolicy-createXYZTests.tentative.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
+<head>
 <script src="/resources/testharness.js" ></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/helper.sub.js"></script>
+</head>
 <body>
 <script>
   //HTML tests

--- a/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-noNamesGiven.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-noNamesGiven.tentative.html
@@ -1,15 +1,20 @@
 <!DOCTYPE html>
+<head>
 <script src="/resources/testharness.js" ></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/helper.sub.js"></script>
-<meta http-equiv="Content-Security-Policy" content="trusted-types">
+</head>
 <body>
 <script>
-  //No name given test
-  test(t => {
-    assert_throws(new TypeError(), _ => {
-      window.TrustedTypes.createPolicy('SomeName', { createHTML: s => s } );
-    });
-  }, "No name list given - policy creation throws");
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types">',
+  () => {
+    //No name given test
+    test(t => {
+      assert_throws(new TypeError(), _ => {
+        window.TrustedTypes.createPolicy('SomeName', { createHTML: s => s } );
+      });
+    }, "No name list given - policy creation throws");
+  });
 </script>
 

--- a/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-wildcard.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-wildcard.tentative.html
@@ -1,14 +1,19 @@
 <!DOCTYPE html>
+<head>
 <script src="/resources/testharness.js" ></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/helper.sub.js"></script>
-<meta http-equiv="Content-Security-Policy" content="trusted-types *">
+</head>
 <body>
 <script>
-  //No name given test
-  test(t => {
-    let policy = window.TrustedTypes.createPolicy('SomeName', { createHTML: s => s } );
-    assert_equals(policy.name, 'SomeName');
-  }, "Wildcard given - policy creation works");
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    //No name given test
+    test(t => {
+      let policy = window.TrustedTypes.createPolicy('SomeName', { createHTML: s => s } );
+      assert_equals(policy.name, 'SomeName');
+    }, "Wildcard given - policy creation works");
+  });
 </script>
 

--- a/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests.tentative.html
@@ -1,27 +1,31 @@
 <!DOCTYPE html>
+<head>
 <script src="/resources/testharness.js" ></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/helper.sub.js"></script>
-
-<meta http-equiv="Content-Security-Policy" content="trusted-types SomeName JustOneMoreName">
+</head>
 <body>
 <script>
-  // Whitelisted name test
-  test(t => {
-    let policy = window.TrustedTypes.createPolicy('SomeName', { createHTML: s => s } );
-    assert_equals(policy.name, 'SomeName');
-  }, "Whitelisted policy creation works.");
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types SomeName JustOneMoreName">',
+  () => {
+    // Whitelisted name test
+    test(t => {
+      let policy = window.TrustedTypes.createPolicy('SomeName', { createHTML: s => s } );
+      assert_equals(policy.name, 'SomeName');
+    }, "Whitelisted policy creation works.");
 
-  // Another whitelisted name test
-  test(t => {
-    let policy = window.TrustedTypes.createPolicy('JustOneMoreName', { createHTML: s => s } );
-    assert_equals(policy.name, 'JustOneMoreName');
-  }, "Another whitelisted policy creation works.");
+    // Another whitelisted name test
+    test(t => {
+      let policy = window.TrustedTypes.createPolicy('JustOneMoreName', { createHTML: s => s } );
+      assert_equals(policy.name, 'JustOneMoreName');
+    }, "Another whitelisted policy creation works.");
 
-  // Non-whitelisted names test
-  test(t => {
-    assert_throws(new TypeError(), _ => {
-     window.TrustedTypes.createPolicy('SomeOtherName', { createURL: s => s } );
-    });
-  }, "Non-whitelisted policy creation throws.");
+    // Non-whitelisted names test
+    test(t => {
+      assert_throws(new TypeError(), _ => {
+       window.TrustedTypes.createPolicy('SomeOtherName', { createURL: s => s } );
+      });
+    }, "Non-whitelisted policy creation throws.");
+  });
 </script>

--- a/trusted-types/TrustedTypePolicyFactory-isXXX.tentative.html
+++ b/trusted-types/TrustedTypePolicyFactory-isXXX.tentative.html
@@ -1,131 +1,135 @@
 <!DOCTYPE html>
+<head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/helper.sub.js"></script>
-
-<meta http-equiv="Content-Security-Policy" content="trusted-types *">
+</head>
 <body>
 <script>
-  // Policy settings for all tests
-  const noopPolicy = {
-    'createHTML': (s) => s,
-    'createScriptURL': (s) => s,
-    'createURL': (s) => s,
-    'createScript': (s) => s,
-  };
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
 
-  // isHTML tests
-  test(t => {
-    const p = TrustedTypes.createPolicy('html', noopPolicy);
-    let html = p.createHTML(INPUTS.HTML);
+    // Policy settings for all tests
+    const noopPolicy = {
+      'createHTML': (s) => s,
+      'createScriptURL': (s) => s,
+      'createURL': (s) => s,
+      'createScript': (s) => s,
+    };
 
-    assert_true(TrustedTypes.isHTML(html));
-    let html2 = Object.create(html);
+    // isHTML tests
+    test(t => {
+      const p = TrustedTypes.createPolicy('html', noopPolicy);
+      let html = p.createHTML(INPUTS.HTML);
 
-    // instanceof can pass, but we rely on isHTML
-    assert_true(html2 instanceof TrustedHTML);
-    assert_false(TrustedTypes.isHTML(html2));
+      assert_true(TrustedTypes.isHTML(html));
+      let html2 = Object.create(html);
 
-    let html3 = Object.assign({}, html, {toString: () => 'fake'});
+      // instanceof can pass, but we rely on isHTML
+      assert_true(html2 instanceof TrustedHTML);
+      assert_false(TrustedTypes.isHTML(html2));
 
-    assert_false(TrustedTypes.isHTML(html3));
-  }, 'TrustedTypePolicyFactory.isHTML requires the object to be created via policy.');
+      let html3 = Object.assign({}, html, {toString: () => 'fake'});
 
-  // isScript tests
-  test(t => {
-    const p = TrustedTypes.createPolicy('script', noopPolicy);
-    let script = p.createScript(INPUTS.SCRIPT);
+      assert_false(TrustedTypes.isHTML(html3));
+    }, 'TrustedTypePolicyFactory.isHTML requires the object to be created via policy.');
 
-    assert_true(TrustedTypes.isScript(script));
-    let script2 = Object.create(script);
+    // isScript tests
+    test(t => {
+      const p = TrustedTypes.createPolicy('script', noopPolicy);
+      let script = p.createScript(INPUTS.SCRIPT);
 
-    // instanceof can pass, but we rely on isScript
-    assert_true(script2 instanceof TrustedScript);
-    assert_false(TrustedTypes.isScript(script2));
+      assert_true(TrustedTypes.isScript(script));
+      let script2 = Object.create(script);
 
-    let script3 = Object.assign({}, script, {toString: () => 'fake'});
+      // instanceof can pass, but we rely on isScript
+      assert_true(script2 instanceof TrustedScript);
+      assert_false(TrustedTypes.isScript(script2));
 
-    assert_false(TrustedTypes.isScript(script3));
-  }, 'TrustedTypePolicyFactory.isScript requires the object to be created via policy.');
+      let script3 = Object.assign({}, script, {toString: () => 'fake'});
 
-  // isScriptURL tests
-  test(t => {
-    const p = TrustedTypes.createPolicy('script_url', noopPolicy);
-    let script = p.createScriptURL(INPUTS.SCRIPTURL);
+      assert_false(TrustedTypes.isScript(script3));
+    }, 'TrustedTypePolicyFactory.isScript requires the object to be created via policy.');
 
-    assert_true(TrustedTypes.isScriptURL(script));
-    let script2 = Object.create(script);
+    // isScriptURL tests
+    test(t => {
+      const p = TrustedTypes.createPolicy('script_url', noopPolicy);
+      let script = p.createScriptURL(INPUTS.SCRIPTURL);
 
-    // instanceof can pass, but we rely on isScript
-    assert_true(script2 instanceof TrustedScriptURL);
-    assert_false(TrustedTypes.isScriptURL(script2));
+      assert_true(TrustedTypes.isScriptURL(script));
+      let script2 = Object.create(script);
 
-    let script3 = Object.assign({}, script, {toString: () => 'fake'});
+      // instanceof can pass, but we rely on isScript
+      assert_true(script2 instanceof TrustedScriptURL);
+      assert_false(TrustedTypes.isScriptURL(script2));
 
-    assert_false(TrustedTypes.isScriptURL(script3));
-  }, 'TrustedTypePolicyFactory.isScriptURL requires the object to be created via policy.');
+      let script3 = Object.assign({}, script, {toString: () => 'fake'});
 
-  // isURL tests
-  test(t => {
-    const p = TrustedTypes.createPolicy('url', noopPolicy);
-    let url = p.createURL(INPUTS.URL);
+      assert_false(TrustedTypes.isScriptURL(script3));
+    }, 'TrustedTypePolicyFactory.isScriptURL requires the object to be created via policy.');
 
-    assert_true(TrustedTypes.isURL(url));
-    let url2 = Object.create(url);
+    // isURL tests
+    test(t => {
+      const p = TrustedTypes.createPolicy('url', noopPolicy);
+      let url = p.createURL(INPUTS.URL);
 
-    // instanceof can pass, but we rely on isScript
-    assert_true(url2 instanceof TrustedURL);
-    assert_false(TrustedTypes.isURL(url2));
+      assert_true(TrustedTypes.isURL(url));
+      let url2 = Object.create(url);
 
-    let url3 = Object.assign({}, url, {toString: () => 'fake'});
+      // instanceof can pass, but we rely on isScript
+      assert_true(url2 instanceof TrustedURL);
+      assert_false(TrustedTypes.isURL(url2));
 
-    assert_false(TrustedTypes.isURL(url3));
-  }, 'TrustedTypePolicyFactory.isURL requires the object to be created via policy.');
+      let url3 = Object.assign({}, url, {toString: () => 'fake'});
 
-  // Redefinition tests, assign to property.
-  // (Assignments will through in the polyfill (because the objects are frozen)
-  //  but will be silently dropped in the native implementation (because that's
-  //  what [Unforgeable] does. Hence, the tests use try {..} catch {} to cover
-  //  both situationsm rather than expect_throws(...).)
-  test(t => {
-    try { TrustedTypes.isHTML = () => 'fake'; } catch { }
-    assert_false(TrustedTypes.isHTML({}));
-  }, 'TrustedTypePolicyFactory.IsHTML cannot be redefined.');
+      assert_false(TrustedTypes.isURL(url3));
+    }, 'TrustedTypePolicyFactory.isURL requires the object to be created via policy.');
 
-  test(t => {
-    try { TrustedTypes.isScript = () => 'fake'; } catch { }
-    assert_false(TrustedTypes.isScript({}));
-  }, 'TrustedTypePolicyFactory.isScript cannot be redefined.');
+    // Redefinition tests, assign to property.
+    // (Assignments will through in the polyfill (because the objects are frozen)
+    //  but will be silently dropped in the native implementation (because that's
+    //  what [Unforgeable] does. Hence, the tests use try {..} catch {} to cover
+    //  both situationsm rather than expect_throws(...).)
+    test(t => {
+      try { TrustedTypes.isHTML = () => 'fake'; } catch { }
+      assert_false(TrustedTypes.isHTML({}));
+    }, 'TrustedTypePolicyFactory.IsHTML cannot be redefined.');
 
-  test(t => {
-    try { TrustedTypes.isScriptURL = () => 'fake'; } catch { }
-    assert_false(TrustedTypes.isScriptURL({}));
-  }, 'TrustedTypePolicyFactory.isScriptURL cannot be redefined.');
+    test(t => {
+      try { TrustedTypes.isScript = () => 'fake'; } catch { }
+      assert_false(TrustedTypes.isScript({}));
+    }, 'TrustedTypePolicyFactory.isScript cannot be redefined.');
 
-  test(t => {
-    try { TrustedTypes.isURL = () => 'fake'; } catch { }
-    assert_false(TrustedTypes.isURL({}));
-  }, 'TrustedTypePolicyFactory.isURL cannot be redefined.');
+    test(t => {
+      try { TrustedTypes.isScriptURL = () => 'fake'; } catch { }
+      assert_false(TrustedTypes.isScriptURL({}));
+    }, 'TrustedTypePolicyFactory.isScriptURL cannot be redefined.');
 
-  // Redefinition tests, via Object.defineProperty.
-  test(t => {
-    try { Object.defineProperty(TrustedTypes, 'isHTML', () => 'fake'); } catch { }
-    assert_false(TrustedTypes.isHTML({}));
-  }, 'TrustedTypePolicyFactory.IsHTML cannot be redefined via defineProperty.');
+    test(t => {
+      try { TrustedTypes.isURL = () => 'fake'; } catch { }
+      assert_false(TrustedTypes.isURL({}));
+    }, 'TrustedTypePolicyFactory.isURL cannot be redefined.');
 
-  test(t => {
-    try { Object.defineProperty(TrustedTypes, 'isScript', () => 'fake'); } catch { }
-    assert_false(TrustedTypes.isScript({}));
-  }, 'TrustedTypePolicyFactory.isScript cannot be redefined via definePropert.');
+    // Redefinition tests, via Object.defineProperty.
+    test(t => {
+      try { Object.defineProperty(TrustedTypes, 'isHTML', () => 'fake'); } catch { }
+      assert_false(TrustedTypes.isHTML({}));
+    }, 'TrustedTypePolicyFactory.IsHTML cannot be redefined via defineProperty.');
 
-  test(t => {
-    try { Object.defineProperty(TrustedTypes, 'isScriptURL', () => 'fake'); } catch { }
-    assert_false(TrustedTypes.isScriptURL({}));
-  }, 'TrustedTypePolicyFactory.isScriptURL cannot be redefined via definePropert.');
+    test(t => {
+      try { Object.defineProperty(TrustedTypes, 'isScript', () => 'fake'); } catch { }
+      assert_false(TrustedTypes.isScript({}));
+    }, 'TrustedTypePolicyFactory.isScript cannot be redefined via definePropert.');
 
-  test(t => {
-    try { Object.defineProperty(TrustedTypes, 'isURL', () => 'fake'); } catch { }
-    assert_false(TrustedTypes.isURL({}));
-  }, 'TrustedTypePolicyFactory.isURL cannot be redefined via definePropert.');
+    test(t => {
+      try { Object.defineProperty(TrustedTypes, 'isScriptURL', () => 'fake'); } catch { }
+      assert_false(TrustedTypes.isScriptURL({}));
+    }, 'TrustedTypePolicyFactory.isScriptURL cannot be redefined via definePropert.');
 
+    test(t => {
+      try { Object.defineProperty(TrustedTypes, 'isURL', () => 'fake'); } catch { }
+      assert_false(TrustedTypes.isURL({}));
+    }, 'TrustedTypePolicyFactory.isURL cannot be redefined via definePropert.');
+  });
 </script>

--- a/trusted-types/block-string-assignment-to-DOMParser-parseFromString.tentative.html
+++ b/trusted-types/block-string-assignment-to-DOMParser-parseFromString.tentative.html
@@ -1,48 +1,52 @@
 <!DOCTYPE html>
+<head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/helper.sub.js"></script>
-
-<meta http-equiv="Content-Security-Policy" content="trusted-types *">
+</head>
 <body>
 <script>
-  // Trusted HTML assignments do not throw.
-  test(t => {
-    let p = createHTML_policy(window, 1);
-    let html = p.createHTML(INPUTS.HTML);
-    let parser = new DOMParser();
-    let doc = parser.parseFromString(html, "text/html");
-    assert_equals(doc.body.innerText, RESULTS.HTML);
-  }, "document.innerText assigned via policy (successful HTML transformation).");
+  run_tests_in_child_frame(
+    '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+    () => {
+    // Trusted HTML assignments do not throw.
+    test(t => {
+      let p = createHTML_policy(window, 1);
+      let html = p.createHTML(INPUTS.HTML);
+      let parser = new DOMParser();
+      let doc = parser.parseFromString(html, "text/html");
+      assert_equals(doc.body.innerText, RESULTS.HTML);
+    }, "document.innerText assigned via policy (successful HTML transformation).");
 
-  // String assignments throw.
-  test(t => {
-    var parser = new DOMParser();
-    assert_throws(new TypeError(), _ => {
-      var doc = parser.parseFromString("Fail", "text/html");
-    });
-  }, "`document.innerText = string` throws.");
+    // String assignments throw.
+    test(t => {
+      var parser = new DOMParser();
+      assert_throws(new TypeError(), _ => {
+        var doc = parser.parseFromString("Fail", "text/html");
+      });
+    }, "`document.innerText = string` throws.");
 
-  // Null assignment throws.
-  test(t => {
-    var parser = new DOMParser();
-    assert_throws(new TypeError(), _ => {
+    // Null assignment throws.
+    test(t => {
+      var parser = new DOMParser();
+      assert_throws(new TypeError(), _ => {
+        var doc = parser.parseFromString(null, "text/html");
+      });
+    }, "'document.innerText = null' throws");
+
+    // After default policy creation string assignment implicitly calls createHTML.
+    test(t => {
+      let p = window.TrustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
+      let parser = new DOMParser();
+      let doc = parser.parseFromString(INPUTS.HTML, "text/html");
+      assert_equals(doc.body.innerText, RESULTS.HTML);
+    }, "'document.innerText = string' assigned via default policy (successful HTML transformation).");
+
+    // After default policy creation null assignment implicitly calls createHTML.
+    test(t => {
+      var parser = new DOMParser();
       var doc = parser.parseFromString(null, "text/html");
-    });
-  }, "'document.innerText = null' throws");
-
-  // After default policy creation string assignment implicitly calls createHTML.
-  test(t => {
-    let p = window.TrustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
-    let parser = new DOMParser();
-    let doc = parser.parseFromString(INPUTS.HTML, "text/html");
-    assert_equals(doc.body.innerText, RESULTS.HTML);
-  }, "'document.innerText = string' assigned via default policy (successful HTML transformation).");
-
-  // After default policy creation null assignment implicitly calls createHTML.
-  test(t => {
-    var parser = new DOMParser();
-    var doc = parser.parseFromString(null, "text/html");
-    assert_equals(doc.body.innerText, "null");
-  }, "'document.innerText = null' assigned via default policy does not throw");
+      assert_equals(doc.body.innerText, "null");
+    }, "'document.innerText = null' assigned via default policy does not throw");
+  });
 </script>

--- a/trusted-types/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.tentative.html
+++ b/trusted-types/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.tentative.html
@@ -1,69 +1,73 @@
 <!DOCTYPE html>
+<head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/helper.sub.js"></script>
-
-<meta http-equiv="Content-Security-Policy" content="trusted-types *">
+</head>
 <body>
 <script>
-  // setTimeout tests
-  // TrustedScript assignments do not throw.
-  async_test(t => {
-    window.timeoutTest = t;
-    let policy = createScript_policy(window, 'timeout');
-    let script = policy.createScript("window.timeoutTest.done();");
-    setTimeout(script);
-  }, "window.setTimeout assigned via policy (successful Script transformation).");
+  run_tests_in_child_frame(
+    '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+    () => {
+    // setTimeout tests
+    // TrustedScript assignments do not throw.
+    async_test(t => {
+      window.timeoutTest = t;
+      let policy = createScript_policy(window, 'timeout');
+      let script = policy.createScript("window.timeoutTest.done();");
+      setTimeout(script);
+    }, "window.setTimeout assigned via policy (successful Script transformation).");
 
-  // String assignments throw.
-  test(t => {
-    window.timeoutTestString = t.unreached_func();
-    assert_throws(new TypeError(), _ => {
-      setTimeout("window.timeoutTestString();");
-    });
-  }, "`window.setTimeout(string)` throws.");
+    // String assignments throw.
+    test(t => {
+      window.timeoutTestString = t.unreached_func();
+      assert_throws(new TypeError(), _ => {
+        setTimeout("window.timeoutTestString();");
+      });
+    }, "`window.setTimeout(string)` throws.");
 
-  // Null assignment throws.
-  test(t => {
-    assert_throws(new TypeError(), _ => {
+    // Null assignment throws.
+    test(t => {
+      assert_throws(new TypeError(), _ => {
+        setTimeout(null);
+      });
+    }, "`window.setTimeout(null)` throws.");
+
+    // setInterval tests
+    // TrustedScript assignments do not throw.
+    async_test(t => {
+      window.intervalTest = t;
+      let policy = createScript_policy(window, 'script');
+      let script = policy.createScript("window.intervalTest.done();");
+      setInterval(script);
+    }, "window.setInterval assigned via policy (successful Script transformation).");
+
+    // String assignments throw.
+    test(t => {
+      window.intervalTestString = t.unreached_func();
+      assert_throws(new TypeError(), _ => {
+        setInterval("window.intervalTestString()");
+      });
+    }, "`window.setInterval(string)` throws.");
+
+    // Null assignment throws.
+    test(t => {
+      assert_throws(new TypeError(), _ => {
+        setInterval(null);
+      });
+    }, "`window.setInterval(null)` throws.");
+
+    // After default policy creation string assignment implicitly calls createScript.
+    test(t => {
+      let policy = window.TrustedTypes.createPolicy("default", { createScript: createScriptJS }, true);
+      setTimeout(INPUTS.SCRIPT);
+      setInterval(INPUTS.SCRIPT);
+    }, "`setTimeout(string)`, `setInterval(string)` via default policy (successful Script transformation).");
+
+    // After default policy creation null assignment implicitly calls createScript.
+    test(t => {
       setTimeout(null);
-    });
-  }, "`window.setTimeout(null)` throws.");
-
-  // setInterval tests
-  // TrustedScript assignments do not throw.
-  async_test(t => {
-    window.intervalTest = t;
-    let policy = createScript_policy(window, 'script');
-    let script = policy.createScript("window.intervalTest.done();");
-    setInterval(script);
-  }, "window.setInterval assigned via policy (successful Script transformation).");
-
-  // String assignments throw.
-  test(t => {
-    window.intervalTestString = t.unreached_func();
-    assert_throws(new TypeError(), _ => {
-      setInterval("window.intervalTestString()");
-    });
-  }, "`window.setInterval(string)` throws.");
-
-  // Null assignment throws.
-  test(t => {
-    assert_throws(new TypeError(), _ => {
       setInterval(null);
-    });
-  }, "`window.setInterval(null)` throws.");
-
-  // After default policy creation string assignment implicitly calls createScript.
-  test(t => {
-    let policy = window.TrustedTypes.createPolicy("default", { createScript: createScriptJS }, true);
-    setTimeout(INPUTS.SCRIPT);
-    setInterval(INPUTS.SCRIPT);
-  }, "`setTimeout(string)`, `setInterval(string)` via default policy (successful Script transformation).");
-
-  // After default policy creation null assignment implicitly calls createScript.
-  test(t => {
-    setTimeout(null);
-    setInterval(null);
-  }, "`setTimeout(null)`, `setInterval(null)` via default policy (successful Script transformation).");
+    }, "`setTimeout(null)`, `setInterval(null)` via default policy (successful Script transformation).");
+  });
 </script>

--- a/trusted-types/block-string-assignment-to-Document-write.tentative.html
+++ b/trusted-types/block-string-assignment-to-Document-write.tentative.html
@@ -4,35 +4,38 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
 <script>
-  // TrustedURL assignments do not throw.
-  test(t => {
-    document.body.innerText = '';
-    let p = createHTML_policy(window, 1);
-    let html = p.createHTML(INPUTS.HTML);
-    document.write(html);
-    assert_equals(document.body.innerText, RESULTS.HTML);
-  }, "document.write with html assigned via policy (successful URL transformation).");
+  run_tests_in_child_frame(
+    '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+    () => {
+      // TrustedURL assignments do not throw.
+      test(t => {
+        document.body.innerText = '';
+        let p = createHTML_policy(window, 1);
+        let html = p.createHTML(INPUTS.HTML);
+        document.write(html);
+        assert_equals(document.body.innerText, RESULTS.HTML);
+      }, "document.write with html assigned via policy (successful URL transformation).");
 
-  // String assignments throw.
-  test(t => {
-    const old = document.body.innerText;
-    assert_throws(new TypeError(), _ => {
-      document.write('A string');
-    });
-    assert_equals(document.body.innerText, old);
-  }, "`document.write(string)` throws");
+      // String assignments throw.
+      test(t => {
+        const old = document.body.innerText;
+        assert_throws(new TypeError(), _ => {
+          document.write('A string');
+        });
+        assert_equals(document.body.innerText, old);
+      }, "`document.write(string)` throws");
 
-  // Null assignment throws.
-  test(t => {
-    const old = document.body.innerText;
-    assert_throws(new TypeError(), _ => {
-      document.write(null);
-    });
-    assert_equals(document.body.innerText, old);
-  }, "`document.write(null)` throws");
+      // Null assignment throws.
+      test(t => {
+        const old = document.body.innerText;
+        assert_throws(new TypeError(), _ => {
+          document.write(null);
+        });
+        assert_equals(document.body.innerText, old);
+      }, "`document.write(null)` throws");
+    }
+  );
 </script>

--- a/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML.tentative.html
+++ b/trusted-types/block-string-assignment-to-Element-insertAdjacentHTML.tentative.html
@@ -4,144 +4,147 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
-<div id="container"></div>
 <script>
-  var container = document.querySelector('#container');
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    var container = document.createElement('div');
+    container.id = 'container';
+    document.body.appendChild(container);
 
-  // Trusted HTML assignments do not throw.
-  test(t => {
-    let p = createHTML_policy(window, 1);
-    let html = p.createHTML(INPUTS.HTML);
-    let before = 'before';
-    let after = 'after';
-    let htmlBefore = p.createHTML(before);
-    let htmlAfter = p.createHTML(after);
+    // Trusted HTML assignments do not throw.
+    test(t => {
+      let p = createHTML_policy(window, 1);
+      let html = p.createHTML(INPUTS.HTML);
+      let before = 'before';
+      let after = 'after';
+      let htmlBefore = p.createHTML(before);
+      let htmlAfter = p.createHTML(after);
 
-    var d = document.createElement('div');
-    container.appendChild(d);
+      var d = document.createElement('div');
+      container.appendChild(d);
 
-    d.insertAdjacentHTML('beforebegin', html);
-    assert_equals(d.previousSibling.nodeType, Node.TEXT_NODE);
-    assert_equals(d.previousSibling.data, RESULTS.HTML);
+      d.insertAdjacentHTML('beforebegin', html);
+      assert_equals(d.previousSibling.nodeType, Node.TEXT_NODE);
+      assert_equals(d.previousSibling.data, RESULTS.HTML);
 
-    d.insertAdjacentHTML('afterbegin', htmlBefore);
-    d.insertAdjacentHTML('beforeend', htmlAfter);
-    assert_equals(d.innerHTML, before + after);
+      d.insertAdjacentHTML('afterbegin', htmlBefore);
+      d.insertAdjacentHTML('beforeend', htmlAfter);
+      assert_equals(d.innerHTML, before + after);
 
-    d.insertAdjacentHTML('afterend', html);
-    assert_equals(d.nextSibling.nodeType, Node.TEXT_NODE);
-    assert_equals(d.nextSibling.data, RESULTS.HTML);
+      d.insertAdjacentHTML('afterend', html);
+      assert_equals(d.nextSibling.nodeType, Node.TEXT_NODE);
+      assert_equals(d.nextSibling.data, RESULTS.HTML);
 
-    while (container.firstChild)
-      container.firstChild.remove();
-  }, "insertAdjacentHTML with html assigned via policy (successful HTML transformation).");
+      while (container.firstChild)
+        container.firstChild.remove();
+    }, "insertAdjacentHTML with html assigned via policy (successful HTML transformation).");
 
-  // String assignments throw.
-  test(t => {
-    var d = document.createElement('div');
-    container.appendChild(d);
+    // String assignments throw.
+    test(t => {
+      var d = document.createElement('div');
+      container.appendChild(d);
 
-    assert_throws(new TypeError(), _ => {
-      d.insertAdjacentHTML('beforebegin', "<p>Fail</p>");
-    });
-    assert_throws(new TypeError(), _ => {
-      d.insertAdjacentHTML('afterbegin', "<p>Fail</p>");
-    });
-    assert_throws(new TypeError(), _ => {
-      d.insertAdjacentHTML('beforeend', "<p>Fail</p>");
-    });
-    assert_throws(new TypeError(), _ => {
-      d.insertAdjacentHTML('afterend', "<p>Fail</p>");
-    });
+      assert_throws(new TypeError(), _ => {
+        d.insertAdjacentHTML('beforebegin', "<p>Fail</p>");
+      });
+      assert_throws(new TypeError(), _ => {
+        d.insertAdjacentHTML('afterbegin', "<p>Fail</p>");
+      });
+      assert_throws(new TypeError(), _ => {
+        d.insertAdjacentHTML('beforeend', "<p>Fail</p>");
+      });
+      assert_throws(new TypeError(), _ => {
+        d.insertAdjacentHTML('afterend', "<p>Fail</p>");
+      });
 
-    assert_equals(d.previousSibling, null);
-    assert_equals(d.firstChild, null);
-    assert_equals(d.lastChild, null);
-    assert_equals(d.nextSibling, null);
+      assert_equals(d.previousSibling, null);
+      assert_equals(d.firstChild, null);
+      assert_equals(d.lastChild, null);
+      assert_equals(d.nextSibling, null);
 
-    while (container.firstChild)
-      container.firstChild.remove();
-  }, "`insertAdjacentHTML(string)` throws.");
+      while (container.firstChild)
+        container.firstChild.remove();
+    }, "`insertAdjacentHTML(string)` throws.");
 
-  // Null assignment throws.
-  test(t => {
-    var d = document.createElement('div');
-    container.appendChild(d);
+    // Null assignment throws.
+    test(t => {
+      var d = document.createElement('div');
+      container.appendChild(d);
 
-    assert_throws(new TypeError(), _ => {
+      assert_throws(new TypeError(), _ => {
+        d.insertAdjacentHTML('beforebegin', null);
+      });
+      assert_throws(new TypeError(), _ => {
+        d.insertAdjacentHTML('afterbegin', null);
+      });
+      assert_throws(new TypeError(), _ => {
+        d.insertAdjacentHTML('beforeend', null);
+      });
+      assert_throws(new TypeError(), _ => {
+        d.insertAdjacentHTML('afterend', null);
+      });
+
+      assert_equals(d.previousSibling, null);
+      assert_equals(d.firstChild, null);
+      assert_equals(d.lastChild, null);
+      assert_equals(d.nextSibling, null);
+    }, "`insertAdjacentHTML(null)` throws.");
+
+    // After default policy creation string assignment implicitly calls createHTML.
+    test(t => {
+      let p = window.TrustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
+
+      var d = document.createElement('div');
+      container.appendChild(d);
+
+      d.insertAdjacentHTML('beforebegin', INPUTS.HTML);
+      assert_equals(d.previousSibling.nodeType, Node.TEXT_NODE);
+      assert_equals(d.previousSibling.data, RESULTS.HTML);
+
+      d.insertAdjacentHTML('afterbegin', INPUTS.HTML);
+      assert_equals(d.firstChild.nodeType, Node.TEXT_NODE);
+      assert_equals(d.firstChild.data, RESULTS.HTML);
+
+      d.insertAdjacentHTML('beforeend', INPUTS.HTML);
+      assert_equals(d.lastChild.nodeType, Node.TEXT_NODE);
+      assert_equals(d.lastChild.data, RESULTS.HTML);
+
+      d.insertAdjacentHTML('afterend', INPUTS.HTML);
+      assert_equals(d.nextSibling.nodeType, Node.TEXT_NODE);
+      assert_equals(d.nextSibling.data, RESULTS.HTML);
+
+      while (container.firstChild)
+        container.firstChild.remove();
+    }, "`insertAdjacentHTML(string)` assigned via default policy (successful HTML transformation).");
+
+     // After default policy creation null assignment implicitly calls createHTML.
+    test(t => {
+      var d = document.createElement('div');
+      container.appendChild(d);
+
       d.insertAdjacentHTML('beforebegin', null);
-    });
-    assert_throws(new TypeError(), _ => {
+      assert_equals(d.previousSibling.nodeType, Node.TEXT_NODE);
+      assert_equals(d.previousSibling.data, "null");
+
       d.insertAdjacentHTML('afterbegin', null);
-    });
-    assert_throws(new TypeError(), _ => {
+      assert_equals(d.firstChild.nodeType, Node.TEXT_NODE);
+      assert_equals(d.firstChild.data, "null");
+
       d.insertAdjacentHTML('beforeend', null);
-    });
-    assert_throws(new TypeError(), _ => {
+      assert_equals(d.lastChild.nodeType, Node.TEXT_NODE);
+      assert_equals(d.lastChild.data, "null");
+
       d.insertAdjacentHTML('afterend', null);
-    });
+      assert_equals(d.nextSibling.nodeType, Node.TEXT_NODE);
+      assert_equals(d.nextSibling.data, "null");
 
-    assert_equals(d.previousSibling, null);
-    assert_equals(d.firstChild, null);
-    assert_equals(d.lastChild, null);
-    assert_equals(d.nextSibling, null);
-  }, "`insertAdjacentHTML(null)` throws.");
-
-  // After default policy creation string assignment implicitly calls createHTML.
-  test(t => {
-    let p = window.TrustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
-
-    var d = document.createElement('div');
-    container.appendChild(d);
-
-    d.insertAdjacentHTML('beforebegin', INPUTS.HTML);
-    assert_equals(d.previousSibling.nodeType, Node.TEXT_NODE);
-    assert_equals(d.previousSibling.data, RESULTS.HTML);
-
-    d.insertAdjacentHTML('afterbegin', INPUTS.HTML);
-    assert_equals(d.firstChild.nodeType, Node.TEXT_NODE);
-    assert_equals(d.firstChild.data, RESULTS.HTML);
-
-    d.insertAdjacentHTML('beforeend', INPUTS.HTML);
-    assert_equals(d.lastChild.nodeType, Node.TEXT_NODE);
-    assert_equals(d.lastChild.data, RESULTS.HTML);
-
-    d.insertAdjacentHTML('afterend', INPUTS.HTML);
-    assert_equals(d.nextSibling.nodeType, Node.TEXT_NODE);
-    assert_equals(d.nextSibling.data, RESULTS.HTML);
-
-    while (container.firstChild)
-      container.firstChild.remove();
-  }, "`insertAdjacentHTML(string)` assigned via default policy (successful HTML transformation).");
-
-   // After default policy creation null assignment implicitly calls createHTML.
-  test(t => {
-    var d = document.createElement('div');
-    container.appendChild(d);
-
-    d.insertAdjacentHTML('beforebegin', null);
-    assert_equals(d.previousSibling.nodeType, Node.TEXT_NODE);
-    assert_equals(d.previousSibling.data, "null");
-
-    d.insertAdjacentHTML('afterbegin', null);
-    assert_equals(d.firstChild.nodeType, Node.TEXT_NODE);
-    assert_equals(d.firstChild.data, "null");
-
-    d.insertAdjacentHTML('beforeend', null);
-    assert_equals(d.lastChild.nodeType, Node.TEXT_NODE);
-    assert_equals(d.lastChild.data, "null");
-
-    d.insertAdjacentHTML('afterend', null);
-    assert_equals(d.nextSibling.nodeType, Node.TEXT_NODE);
-    assert_equals(d.nextSibling.data, "null");
-
-    while (container.firstChild)
-      container.firstChild.remove();
-  }, "`insertAdjacentHTML(null)` assigned via default policy does not throw.");
+      while (container.firstChild)
+        container.firstChild.remove();
+    }, "`insertAdjacentHTML(null)` assigned via default policy does not throw.");
+  });
 </script>
 </body>
 </html>

--- a/trusted-types/block-string-assignment-to-Element-outerHTML.tentative.html
+++ b/trusted-types/block-string-assignment-to-Element-outerHTML.tentative.html
@@ -4,75 +4,79 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
 <div id="container"></div>
 <script>
-  var container = document.querySelector('#container')
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    var container = document.createElement('div');
+    container.id = 'container';
+    document.body.appendChild(container);
 
-  // TrustedHTML assignments do not throw.
-  test(t => {
-    let p = createHTML_policy(window, 1);
-    let html = p.createHTML(INPUTS.HTML);
+    // TrustedHTML assignments do not throw.
+    test(t => {
+      let p = createHTML_policy(window, 1);
+      let html = p.createHTML(INPUTS.HTML);
 
-    var d = document.createElement('div');
-    document.querySelector('#container').appendChild(d);
-    d.outerHTML = html;
-    assert_equals(container.innerText, RESULTS.HTML);
+      var d = document.createElement('div');
+      document.querySelector('#container').appendChild(d);
+      d.outerHTML = html;
+      assert_equals(container.innerText, RESULTS.HTML);
 
-    while (container.firstChild)
-      container.firstChild.remove();
-  }, "outerHTML with html assigned via policy (successful HTML transformation).");
+      while (container.firstChild)
+        container.firstChild.remove();
+    }, "outerHTML with html assigned via policy (successful HTML transformation).");
 
-  // String assignments throw.
-  test(t => {
-    var d = document.createElement('div');
-    container.appendChild(d);
-    assert_throws(new TypeError(), _ => {
-      d.outerHTML = "Fail.";
-    });
-    assert_equals(container.innerText, "");
-    while (container.firstChild)
-      container.firstChild.remove();
-  }, "`outerHTML = string` throws.");
+    // String assignments throw.
+    test(t => {
+      var d = document.createElement('div');
+      container.appendChild(d);
+      assert_throws(new TypeError(), _ => {
+        d.outerHTML = "Fail.";
+      });
+      assert_equals(container.innerText, "");
+      while (container.firstChild)
+        container.firstChild.remove();
+    }, "`outerHTML = string` throws.");
 
-  // Null assignment throws.
-  test(t => {
-    var d = document.createElement('div');
-    container.appendChild(d);
-    assert_throws(new TypeError(), _ => {
+    // Null assignment throws.
+    test(t => {
+      var d = document.createElement('div');
+      container.appendChild(d);
+      assert_throws(new TypeError(), _ => {
+        d.outerHTML = null;
+      });
+      assert_equals(container.innerText, "");
+      while (container.firstChild)
+        container.firstChild.remove();
+    }, "`outerHTML = null` throws.");
+
+    // After default policy creation string assignment implicitly calls createHTML.
+    test(t => {
+      let p = window.TrustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
+
+      var d = document.createElement('div');
+      document.querySelector('#container').appendChild(d);
+      d.outerHTML = INPUTS.HTML;
+      assert_equals(container.innerText, RESULTS.HTML);
+
+      while (container.firstChild)
+        container.firstChild.remove();
+    }, "`outerHTML = string` assigned via default policy (successful HTML transformation).");
+
+    // After default policy creation null assignment implicitly calls createHTML.
+    test(t => {
+      var d = document.createElement('div');
+      container.appendChild(d);
       d.outerHTML = null;
-    });
-    assert_equals(container.innerText, "");
-    while (container.firstChild)
-      container.firstChild.remove();
-  }, "`outerHTML = null` throws.");
+      assert_equals(container.innerText, "null");
 
-  // After default policy creation string assignment implicitly calls createHTML.
-  test(t => {
-    let p = window.TrustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
-
-    var d = document.createElement('div');
-    document.querySelector('#container').appendChild(d);
-    d.outerHTML = INPUTS.HTML;
-    assert_equals(container.innerText, RESULTS.HTML);
-
-    while (container.firstChild)
-      container.firstChild.remove();
-  }, "`outerHTML = string` assigned via default policy (successful HTML transformation).");
-
-  // After default policy creation null assignment implicitly calls createHTML.
-  test(t => {
-    var d = document.createElement('div');
-    container.appendChild(d);
-    d.outerHTML = null;
-    assert_equals(container.innerText, "null");
-
-    while (container.firstChild)
-      container.firstChild.remove();
-  }, "`outerHTML = null` assigned via default policy does not throw");
+      while (container.firstChild)
+        container.firstChild.remove();
+    }, "`outerHTML = null` assigned via default policy does not throw");
+  });
 </script>
 </body>
 </html>

--- a/trusted-types/block-string-assignment-to-Element-setAttribute.tentative.html
+++ b/trusted-types/block-string-assignment-to-Element-setAttribute.tentative.html
@@ -4,124 +4,126 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
 <script>
-  // TrustedURL Assignments
-  const URLTestCases = [
-    [ 'a', 'href' ],
-    [ 'area', 'href' ],
-    [ 'base', 'href' ],
-    [ 'frame', 'src' ],
-    [ 'iframe', 'src' ],
-    [ 'img', 'src' ],
-    [ 'input', 'src' ],
-    [ 'link', 'href' ],
-    [ 'video', 'src' ],
-    [ 'object', 'data' ],
-    [ 'object', 'codeBase' ],
-    [ 'source', 'src' ],
-    [ 'track', 'src' ]
-  ];
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    // TrustedURL Assignments
+    const URLTestCases = [
+      [ 'a', 'href' ],
+      [ 'area', 'href' ],
+      [ 'base', 'href' ],
+      [ 'frame', 'src' ],
+      [ 'iframe', 'src' ],
+      [ 'img', 'src' ],
+      [ 'input', 'src' ],
+      [ 'link', 'href' ],
+      [ 'video', 'src' ],
+      [ 'object', 'data' ],
+      [ 'object', 'codeBase' ],
+      [ 'source', 'src' ],
+      [ 'track', 'src' ]
+    ];
 
-  URLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_url_explicit_set(window, c, t, c[0], c[1], RESULTS.URL);
-      assert_throws_no_trusted_type_explicit_set(c[0], c[1], 'A string');
-      assert_throws_no_trusted_type_explicit_set(c[0], c[1], null);
-    }, c[0] + "." + c[1] + " accepts only TrustedURL");
-  });
-
-  // TrustedScriptURL Assignments
-  const scriptURLTestCases = [
-    [ 'embed', 'src' ],
-    [ 'script', 'src' ]
-  ];
-
-  scriptURLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_script_url_explicit_set(window, c, t, c[0], c[1], RESULTS.SCRIPTURL);
-      assert_throws_no_trusted_type_explicit_set(c[0], c[1], 'A string');
-      assert_throws_no_trusted_type_explicit_set(c[0], c[1], null);
-    }, c[0] + "." + c[1] + " accepts only TrustedScriptURL");
-  });
-
-  // TrustedHTML Assignments
-  const HTMLTestCases = [
-    [ 'iframe', 'srcdoc' ]
-  ];
-
-  HTMLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_html_explicit_set(window, c, t, c[0], c[1], RESULTS.HTML);
-      assert_throws_no_trusted_type_explicit_set(c[0], c[1], 'A string');
-      assert_throws_no_trusted_type_explicit_set(c[0], c[1], null);
-    }, c[0] + "." + c[1] + " accepts only TrustedHTML");
-  });
-
-  // After default policy creation string and null assignments implicitly call createXYZ
-  let p = window.TrustedTypes.createPolicy("default", { createURL: createURLJS, createScriptURL: createScriptURLJS, createHTML: createHTMLJS }, true);
-  URLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_type(c[0], c[1], INPUTS.URL, RESULTS.URL);
-
-      // Properties that actually parse the URLs will resort to the base URL
-      // when given a null or empty URL.
-      assert_element_accepts_trusted_type(c[0], c[1], null, "" + window.location);
-    }, c[0] + "." + c[1] + " accepts string and null after default policy was created.");
-  });
-
-  scriptURLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_type(c[0], c[1], INPUTS.SCRIPTURL, RESULTS.SCRIPTURL);
-
-      // Properties that actually parse the URLs will resort to the base URL
-      // when given a null or empty URL.
-      assert_element_accepts_trusted_type(c[0], c[1], null, "" + window.location);
-    }, c[0] + "." + c[1] + " accepts string and null after default policy was created.");
-  });
-
-  HTMLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_type(c[0], c[1], INPUTS.HTML, RESULTS.HTML);
-      assert_element_accepts_trusted_type(c[0], c[1], null, "null");
-    }, c[0] + "." + c[1] + " accepts string and null after default policy was created.");
-  });
-
-  // Other attributes can be assigned with TrustedTypes or strings or null values
-  test(t => {
-    assert_element_accepts_trusted_url_explicit_set(window, 'arel', t, 'a', 'rel', RESULTS.URL);
-  }, "a.rel assigned via policy (successful URL transformation)");
-
-  test(t => {
-    assert_element_accepts_non_trusted_type_explicit_set('a', 'rel', 'A string', 'A string');
-  }, "a.rel accepts strings");
-
-  test(t => {
-    assert_element_accepts_non_trusted_type_explicit_set('a', 'rel', null, 'null');
-  }, "a.rel accepts null");
-
-  test(t => {
-    let div = document.createElement('div');
-    let span = document.createElement('span');
-
-    div.setAttribute('src', INPUTS.URL);
-    let attr = div.getAttributeNode('src');
-    div.removeAttributeNode(attr);
-    span.setAttributeNode(attr);
-
-    assert_equals(span.getAttribute('src'), INPUTS.URL);
-  }, "`span.src = setAttributeNode(div.src)` with string works.");
-
-  test(t => {
-    let el = document.createElement('iframe');
-
-    assert_throws(new TypeError(), _ => {
-      el.setAttribute('SrC', INPUTS.URL);
+    URLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_url_explicit_set(window, c, t, c[0], c[1], RESULTS.URL);
+        assert_throws_no_trusted_type_explicit_set(c[0], c[1], 'A string');
+        assert_throws_no_trusted_type_explicit_set(c[0], c[1], null);
+      }, c[0] + "." + c[1] + " accepts only TrustedURL");
     });
 
-    assert_equals(el.src, '');
-  }, "`Element.prototype.setAttribute.SrC = string` throws.");
+    // TrustedScriptURL Assignments
+    const scriptURLTestCases = [
+      [ 'embed', 'src' ],
+      [ 'script', 'src' ]
+    ];
+
+    scriptURLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_script_url_explicit_set(window, c, t, c[0], c[1], RESULTS.SCRIPTURL);
+        assert_throws_no_trusted_type_explicit_set(c[0], c[1], 'A string');
+        assert_throws_no_trusted_type_explicit_set(c[0], c[1], null);
+      }, c[0] + "." + c[1] + " accepts only TrustedScriptURL");
+    });
+
+    // TrustedHTML Assignments
+    const HTMLTestCases = [
+      [ 'iframe', 'srcdoc' ]
+    ];
+
+    HTMLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_html_explicit_set(window, c, t, c[0], c[1], RESULTS.HTML);
+        assert_throws_no_trusted_type_explicit_set(c[0], c[1], 'A string');
+        assert_throws_no_trusted_type_explicit_set(c[0], c[1], null);
+      }, c[0] + "." + c[1] + " accepts only TrustedHTML");
+    });
+
+    // After default policy creation string and null assignments implicitly call createXYZ
+    let p = window.TrustedTypes.createPolicy("default", { createURL: createURLJS, createScriptURL: createScriptURLJS, createHTML: createHTMLJS }, true);
+    URLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_type(c[0], c[1], INPUTS.URL, RESULTS.URL);
+
+        // Properties that actually parse the URLs will resort to the base URL
+        // when given a null or empty URL.
+        assert_element_accepts_trusted_type(c[0], c[1], null, "" + document.baseURI);
+      }, c[0] + "." + c[1] + " accepts string and null after default policy was created.");
+    });
+
+    scriptURLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_type(c[0], c[1], INPUTS.SCRIPTURL, RESULTS.SCRIPTURL);
+
+        // Properties that actually parse the URLs will resort to the base URL
+        // when given a null or empty URL.
+        assert_element_accepts_trusted_type(c[0], c[1], null, "" + document.baseURI);
+      }, c[0] + "." + c[1] + " accepts string and null after default policy was created.");
+    });
+
+    HTMLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_type(c[0], c[1], INPUTS.HTML, RESULTS.HTML);
+        assert_element_accepts_trusted_type(c[0], c[1], null, "null");
+      }, c[0] + "." + c[1] + " accepts string and null after default policy was created.");
+    });
+
+    // Other attributes can be assigned with TrustedTypes or strings or null values
+    test(t => {
+      assert_element_accepts_trusted_url_explicit_set(window, 'arel', t, 'a', 'rel', RESULTS.URL);
+    }, "a.rel assigned via policy (successful URL transformation)");
+
+    test(t => {
+      assert_element_accepts_non_trusted_type_explicit_set('a', 'rel', 'A string', 'A string');
+    }, "a.rel accepts strings");
+
+    test(t => {
+      assert_element_accepts_non_trusted_type_explicit_set('a', 'rel', null, 'null');
+    }, "a.rel accepts null");
+
+    test(t => {
+      let div = document.createElement('div');
+      let span = document.createElement('span');
+
+      div.setAttribute('src', INPUTS.URL);
+      let attr = div.getAttributeNode('src');
+      div.removeAttributeNode(attr);
+      span.setAttributeNode(attr);
+
+      assert_equals(span.getAttribute('src'), INPUTS.URL);
+    }, "`span.src = setAttributeNode(div.src)` with string works.");
+
+    test(t => {
+      let el = document.createElement('iframe');
+
+      assert_throws(new TypeError(), _ => {
+        el.setAttribute('SrC', INPUTS.URL);
+      });
+
+      assert_equals(el.src, '');
+    }, "`Element.prototype.setAttribute.SrC = string` throws.");
+  });
 </script>

--- a/trusted-types/block-string-assignment-to-Element-setAttributeNS.tentative.html
+++ b/trusted-types/block-string-assignment-to-Element-setAttributeNS.tentative.html
@@ -4,11 +4,12 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
 <script>
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
     test(t => {
       assert_element_accepts_trusted_html_set_ns(window, '0', t, 'a', 'b', RESULTS.HTML);
     }, "Element.setAttributeNS assigned via policy (successful HTML transformation)");
@@ -32,4 +33,5 @@
     test(t => {
       assert_throws_no_trusted_type_set_ns('a', 'b', null);
     }, "`Element.setAttributeNS = null` throws");
+  });
 </script>

--- a/trusted-types/block-string-assignment-to-HTMLElement-generic.tentative.html
+++ b/trusted-types/block-string-assignment-to-HTMLElement-generic.tentative.html
@@ -4,105 +4,107 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
 <script>
-  var testnb = 0;
-  // TrustedURL Assignments
-  const URLTestCases = [
-    [ 'a', 'href' ],
-    [ 'area', 'href' ],
-    [ 'base', 'href' ],
-    [ 'frame', 'src' ],
-    [ 'iframe', 'src' ],
-    [ 'img', 'src' ],
-    [ 'input', 'src' ],
-    [ 'link', 'href' ],
-    [ 'video', 'src' ],
-    [ 'object', 'data' ],
-    [ 'object', 'codeBase' ],
-    [ 'source', 'src' ],
-    [ 'track', 'src' ]
-  ];
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    var testnb = 0;
+    // TrustedURL Assignments
+    const URLTestCases = [
+      [ 'a', 'href' ],
+      [ 'area', 'href' ],
+      [ 'base', 'href' ],
+      [ 'frame', 'src' ],
+      [ 'iframe', 'src' ],
+      [ 'img', 'src' ],
+      [ 'input', 'src' ],
+      [ 'link', 'href' ],
+      [ 'video', 'src' ],
+      [ 'object', 'data' ],
+      [ 'object', 'codeBase' ],
+      [ 'source', 'src' ],
+      [ 'track', 'src' ]
+    ];
 
-  URLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_url(window, ++testnb, t, c[0], c[1], RESULTS.URL);
-      assert_throws_no_trusted_type(c[0], c[1], 'A string');
-      assert_throws_no_trusted_type(c[0], c[1], null);
-    }, c[0] + "." + c[1] + " accepts only TrustedURL");
-  });
+    URLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_url(window, ++testnb, t, c[0], c[1], RESULTS.URL);
+        assert_throws_no_trusted_type(c[0], c[1], 'A string');
+        assert_throws_no_trusted_type(c[0], c[1], null);
+      }, c[0] + "." + c[1] + " accepts only TrustedURL");
+    });
 
-  // TrustedScriptURL Assignments
-  const scriptURLTestCases = [
-    [ 'embed', 'src' ],
-    [ 'script', 'src' ]
-  ];
+    // TrustedScriptURL Assignments
+    const scriptURLTestCases = [
+      [ 'embed', 'src' ],
+      [ 'script', 'src' ]
+    ];
 
-  testnb = 0;
-  scriptURLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_script_url(window, ++testnb, t, c[0], c[1], RESULTS.SCRIPTURL);
-      assert_throws_no_trusted_type(c[0], c[1], 'A string');
-      assert_throws_no_trusted_type(c[0], c[1], null);
-    }, c[0] + "." + c[1] + " accepts only TrustedScriptURL");
-  });
+    testnb = 0;
+    scriptURLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_script_url(window, ++testnb, t, c[0], c[1], RESULTS.SCRIPTURL);
+        assert_throws_no_trusted_type(c[0], c[1], 'A string');
+        assert_throws_no_trusted_type(c[0], c[1], null);
+      }, c[0] + "." + c[1] + " accepts only TrustedScriptURL");
+    });
 
-  // TrustedHTML Assignments
-  const HTMLTestCases = [
-    [ 'div', 'innerHTML' ],
-    [ 'iframe', 'srcdoc' ]
-  ];
+    // TrustedHTML Assignments
+    const HTMLTestCases = [
+      [ 'div', 'innerHTML' ],
+      [ 'iframe', 'srcdoc' ]
+    ];
 
-  testnb = 0;
-  HTMLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_html(window, ++testnb, t, c[0], c[1], RESULTS.HTML);
-      assert_throws_no_trusted_type(c[0], c[1], 'A string');
-      assert_throws_no_trusted_type(c[0], c[1], null);
-    }, c[0] + "." + c[1] + " accepts only TrustedHTML");
-  });
+    testnb = 0;
+    HTMLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_html(window, ++testnb, t, c[0], c[1], RESULTS.HTML);
+        assert_throws_no_trusted_type(c[0], c[1], 'A string');
+        assert_throws_no_trusted_type(c[0], c[1], null);
+      }, c[0] + "." + c[1] + " accepts only TrustedHTML");
+    });
 
-  // After default policy creation string and null assignments implicitly call createHTML
-  let p = window.TrustedTypes.createPolicy("default", { createURL: createURLJS, createScriptURL: createScriptURLJS, createHTML: createHTMLJS }, true);
+    // After default policy creation string and null assignments implicitly call createHTML
+    let p = window.TrustedTypes.createPolicy("default", { createURL: createURLJS, createScriptURL: createScriptURLJS, createHTML: createHTMLJS }, true);
 
-  URLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_type(c[0], c[1], INPUTS.URL, RESULTS.URL);
-      assert_element_accepts_trusted_type(c[0], c[1], null, "" + window.location);
-    }, c[0] + "." + c[1] + " accepts string and null after default policy was created");
-  });
+    URLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_type(c[0], c[1], INPUTS.URL, RESULTS.URL);
+        assert_element_accepts_trusted_type(c[0], c[1], null, "" + document.baseURI);
+      }, c[0] + "." + c[1] + " accepts string and null after default policy was created");
+    });
 
-  scriptURLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_type(c[0], c[1], INPUTS.SCRIPTURL, RESULTS.SCRIPTURL);
-      assert_element_accepts_trusted_type(c[0], c[1], null, "" + window.location);
-    }, c[0] + "." + c[1] + " accepts string and null after default policy was created");
-  });
+    scriptURLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_type(c[0], c[1], INPUTS.SCRIPTURL, RESULTS.SCRIPTURL);
+        assert_element_accepts_trusted_type(c[0], c[1], null, "" + document.baseURI);
+      }, c[0] + "." + c[1] + " accepts string and null after default policy was created");
+    });
 
 
-  HTMLTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_type(c[0], c[1], INPUTS.HTML, RESULTS.HTML);
-      assert_element_accepts_trusted_type(c[0], c[1], null, "null");
-    }, c[0] + "." + c[1] + " accepts string and null after default policy was created");
-  });
+    HTMLTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_type(c[0], c[1], INPUTS.HTML, RESULTS.HTML);
+        assert_element_accepts_trusted_type(c[0], c[1], null, "null");
+      }, c[0] + "." + c[1] + " accepts string and null after default policy was created");
+    });
 
-  // TrustedScript Assignments
-  const scriptTestCases = [
-    [ 'script', 'text' ],
-    [ 'script', 'innerText' ],
-    [ 'script', 'textContent' ]
-  ];
+    // TrustedScript Assignments
+    const scriptTestCases = [
+      [ 'script', 'text' ],
+      [ 'script', 'innerText' ],
+      [ 'script', 'textContent' ]
+    ];
 
-  testnb = 0;
-  scriptTestCases.forEach(c => {
-    test(t => {
-      assert_element_accepts_trusted_script(window, ++testnb, t, c[0], c[1], RESULTS.SCRIPT);
-      assert_throws_no_trusted_type(c[0], c[1], 'A string');
-      assert_throws_no_trusted_type(c[0], c[1], null);
-    }, c[0] + "." + c[1] + " accepts only TrustedScript");
+    testnb = 0;
+    scriptTestCases.forEach(c => {
+      test(t => {
+        assert_element_accepts_trusted_script(window, ++testnb, t, c[0], c[1], RESULTS.SCRIPT);
+        assert_throws_no_trusted_type(c[0], c[1], 'A string');
+        assert_throws_no_trusted_type(c[0], c[1], null);
+      }, c[0] + "." + c[1] + " accepts only TrustedScript");
+    });
   });
 </script>

--- a/trusted-types/block-string-assignment-to-Location-assign.tentative.html
+++ b/trusted-types/block-string-assignment-to-Location-assign.tentative.html
@@ -4,50 +4,52 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
 <script>
-  // TrustedURL assignments do not throw.
-  test(t => {
-    let p = createURL_policy(window, 1);
-    let url = p.createURL(location.href + "#xxx");
-    location.assign(url);
-    assert_equals("" + url, location.href, "location href");
-  }, "location.assign via policy (successful URL transformation).");
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    // TrustedURL assignments do not throw.
+    test(t => {
+      let p = createURL_policy(window, 1);
+      let url = p.createURL(location.href + "#xxx");
+      location.assign(url);
+      assert_equals("" + url, location.href, "location href");
+    }, "location.assign via policy (successful URL transformation).");
 
-  // String assignments throw.
-  test(t => {
-    let href = location.href;
-    assert_throws(new TypeError(), _ => {
-      location.assign("A string");
-    });
-    assert_equals(location.href, href);
-  }, "`location.assign = string` throws");
+    // String assignments throw.
+    test(t => {
+      let href = location.href;
+      assert_throws(new TypeError(), _ => {
+        location.assign("A string");
+      });
+      assert_equals(location.href, href);
+    }, "`location.assign = string` throws");
 
-  // Null assignment throws.
-  test(t => {
-    let href = location.href;
-    assert_throws(new TypeError(), _ => {
+    // Null assignment throws.
+    test(t => {
+      let href = location.href;
+      assert_throws(new TypeError(), _ => {
+        location.assign(null);
+      });
+      assert_equals(location.href, href);
+    }, "`location.assign = null` throws");
+
+    // Create default policy. Applies to all subsequent tests.
+    let p = window.TrustedTypes.createPolicy("default",
+        { createURL: createLocationURLJS }, true);
+
+    // After default policy creation string assignment implicitly calls createURL.
+    test(t => {
+      location.assign("abcdefg");
+      assert_true(location.href.endsWith("#abcdefg"));
+    }, "`location.assign = string` via default policy (successful URL transformation).");
+
+    // After default policy creation null assignment implicitly calls createURL.
+    test(t => {
       location.assign(null);
-    });
-    assert_equals(location.href, href);
-  }, "`location.assign = null` throws");
-
-  // Create default policy. Applies to all subsequent tests.
-  let p = window.TrustedTypes.createPolicy("default",
-      { createURL: createLocationURLJS }, true);
-
-  // After default policy creation string assignment implicitly calls createURL.
-  test(t => {
-    location.assign("abcdefg");
-    assert_true(location.href.endsWith("#abcdefg"));
-  }, "`location.assign = string` via default policy (successful URL transformation).");
-
-  // After default policy creation null assignment implicitly calls createURL.
-  test(t => {
-    location.assign(null);
-    assert_true(location.href.endsWith("#null"));
-  }, "`location.assign = null` via default policy does not throw.");
+      assert_true(location.href.endsWith("#null"));
+    }, "`location.assign = null` via default policy does not throw.");
+  });
 </script>

--- a/trusted-types/block-string-assignment-to-Location-href.tentative.html
+++ b/trusted-types/block-string-assignment-to-Location-href.tentative.html
@@ -4,50 +4,52 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
 <script>
-  // TrustedURL assignments do not throw.
-  test(t => {
-    let p = createURL_policy(window, 1);
-    let url = p.createURL(location.href + "#xxx");
-    location.href = url;
-    assert_equals("" + url, location.href, "location href");
-  }, "location.href assigned via policy (successful URL transformation).");
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    // TrustedURL assignments do not throw.
+    test(t => {
+      let p = createURL_policy(window, 1);
+      let url = p.createURL(location.href + "#xxx");
+      location.href = url;
+      assert_equals("" + url, location.href, "location href");
+    }, "location.href assigned via policy (successful URL transformation).");
 
-  // String assignments throw.
-  test(t => {
-    let href = location.href;
-    assert_throws(new TypeError(), _ => {
-      location.href = 'A string';
-    });
-    assert_equals(location.href, href);
-  }, "`location.href = string` throws");
+    // String assignments throw.
+    test(t => {
+      let href = location.href;
+      assert_throws(new TypeError(), _ => {
+        location.href = 'A string';
+      });
+      assert_equals(location.href, href);
+    }, "`location.href = string` throws");
 
-  // Null assignment throws.
-  test(t => {
-    let href = location.href;
-    assert_throws(new TypeError(), _ => {
+    // Null assignment throws.
+    test(t => {
+      let href = location.href;
+      assert_throws(new TypeError(), _ => {
+        location.href = null;
+      });
+      assert_equals(location.href, href);
+    }, "`location.href = null` throws");
+
+    // Create default policy. Applies to all subsequent tests.
+    let p = window.TrustedTypes.createPolicy("default",
+        { createURL: createLocationURLJS }, true);
+
+    // After default policy creation string assignment implicitly calls createURL.
+    test(t => {
+      location.href = "xxxx";
+      assert_true(location.href.endsWith("#xxxx"));
+    }, "`location.href = string` via default policy (successful URL transformation).");
+
+    // After default policy creation null assignment implicitly calls createURL.
+    test(t => {
       location.href = null;
-    });
-    assert_equals(location.href, href);
-  }, "`location.href = null` throws");
-
-  // Create default policy. Applies to all subsequent tests.
-  let p = window.TrustedTypes.createPolicy("default",
-      { createURL: createLocationURLJS }, true);
-
-  // After default policy creation string assignment implicitly calls createURL.
-  test(t => {
-    location.href = "xxxx";
-    assert_true(location.href.endsWith("#xxxx"));
-  }, "`location.href = string` via default policy (successful URL transformation).");
-
-  // After default policy creation null assignment implicitly calls createURL.
-  test(t => {
-    location.href = null;
-    assert_true(location.href.endsWith("#null"));
-  }, "`location.href = null` assigned via default policy does not throw.");
+      assert_true(location.href.endsWith("#null"));
+    }, "`location.href = null` assigned via default policy does not throw.");
+  });
 </script>

--- a/trusted-types/block-string-assignment-to-Location-replace.tentative.html
+++ b/trusted-types/block-string-assignment-to-Location-replace.tentative.html
@@ -4,50 +4,52 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
 <script>
-  // TrustedURL replacements do not throw.
-  test(t => {
-    let p = createURL_policy(window, 1);
-    let url = p.createURL(location.href + "#xxx");
-    location.replace(url);
-    assert_equals("" + url, location.href, "location href");
-  }, "location.replace via policy (successful URL transformation).");
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    // TrustedURL replacements do not throw.
+    test(t => {
+      let p = createURL_policy(window, 1);
+      let url = p.createURL(location.href + "#xxx");
+      location.replace(url);
+      assert_equals("" + url, location.href, "location href");
+    }, "location.replace via policy (successful URL transformation).");
 
-  // String replacements throw.
-  test(t => {
-    let href = location.href;
-    assert_throws(new TypeError(), _ => {
-      location.replace("A string");
-    });
-    assert_equals(location.href, href);
-  }, "`location.replace = string` throws");
+    // String replacements throw.
+    test(t => {
+      let href = location.href;
+      assert_throws(new TypeError(), _ => {
+        location.replace("A string");
+      });
+      assert_equals(location.href, href);
+    }, "`location.replace = string` throws");
 
-  // Null replacement throws.
-  test(t => {
-    let href = location.href;
-    assert_throws(new TypeError(), _ => {
+    // Null replacement throws.
+    test(t => {
+      let href = location.href;
+      assert_throws(new TypeError(), _ => {
+        location.replace(null);
+      });
+      assert_equals(location.href, href);
+    }, "`location.replace = null` throws");
+
+    // Create default policy. Applies to all subsequent tests.
+    let p = window.TrustedTypes.createPolicy("default",
+        { createURL: createLocationURLJS }, true);
+
+    // After default policy creation string assignment implicitly calls createURL.
+    test(t => {
+      location.replace("potato");
+      assert_true(location.href.endsWith("#potato"));
+    }, "`location.replace = string` via default policy (successful URL transformation).");
+
+    // After default policy creation null assignment implicitly calls createURL.
+    test(t => {
       location.replace(null);
-    });
-    assert_equals(location.href, href);
-  }, "`location.replace = null` throws");
-
-  // Create default policy. Applies to all subsequent tests.
-  let p = window.TrustedTypes.createPolicy("default",
-      { createURL: createLocationURLJS }, true);
-
-  // After default policy creation string assignment implicitly calls createURL.
-  test(t => {
-    location.replace("potato");
-    assert_true(location.href.endsWith("#potato"));
-  }, "`location.replace = string` via default policy (successful URL transformation).");
-
-  // After default policy creation null assignment implicitly calls createURL.
-  test(t => {
-    location.replace(null);
-    assert_true(location.href.endsWith("#null"));
-  }, "`location.replace = null` via default policy (successful URL transformation).");
+      assert_true(location.href.endsWith("#null"));
+    }, "`location.replace = null` via default policy (successful URL transformation).");
+  });
 </script>

--- a/trusted-types/block-string-assignment-to-Range-createContextualFragment.tentative.html
+++ b/trusted-types/block-string-assignment-to-Range-createContextualFragment.tentative.html
@@ -1,53 +1,57 @@
 <!DOCTYPE html>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="support/helper.sub.js"></script>
-
-<meta http-equiv="Content-Security-Policy" content="trusted-types *">
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="support/helper.sub.js"></script>
+</head>
 <body>
 <script>
-  // TrustedHTML assignments do not throw.
-  test(t => {
-    let p = createHTML_policy(window, 1);
-    let html = p.createHTML(INPUTS.HTML);
-    var range = document.createRange();
-    range.selectNodeContents(document.documentElement);
-    var result = range.createContextualFragment(html);
-    assert_equals(result.textContent, RESULTS.HTML);
-  }, "range.createContextualFragment assigned via policy (successful HTML transformation).");
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    // TrustedHTML assignments do not throw.
+    test(t => {
+      let p = createHTML_policy(window, 1);
+      let html = p.createHTML(INPUTS.HTML);
+      var range = document.createRange();
+      range.selectNodeContents(document.documentElement);
+      var result = range.createContextualFragment(html);
+      assert_equals(result.textContent, RESULTS.HTML);
+    }, "range.createContextualFragment assigned via policy (successful HTML transformation).");
 
-  // String assignments throw.
-  test(t => {
-    var range = document.createRange();
-    range.selectNodeContents(document.documentElement);
-    assert_throws(new TypeError(), _ => {
-      var result = range.createContextualFragment("A string");
-    });
-  }, "`range.createContextualFragment(string)` throws.");
+    // String assignments throw.
+    test(t => {
+      var range = document.createRange();
+      range.selectNodeContents(document.documentElement);
+      assert_throws(new TypeError(), _ => {
+        var result = range.createContextualFragment("A string");
+      });
+    }, "`range.createContextualFragment(string)` throws.");
 
-  // Null assignment throws.
-  test(t => {
-    var range = document.createRange();
-    range.selectNodeContents(document.documentElement);
-    assert_throws(new TypeError(), _ => {
+    // Null assignment throws.
+    test(t => {
+      var range = document.createRange();
+      range.selectNodeContents(document.documentElement);
+      assert_throws(new TypeError(), _ => {
+        var result = range.createContextualFragment(null);
+      });
+    }, "`range.createContextualFragment(null)` throws.");
+
+    // After default policy creation string assignment implicitly calls createHTML
+    test(t => {
+      let p = window.TrustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
+      var range = document.createRange();
+      range.selectNodeContents(document.documentElement);
+      var result = range.createContextualFragment(INPUTS.HTML);
+      assert_equals(result.textContent, RESULTS.HTML);
+    }, "`range.createContextualFragment(string)` assigned via default policy (successful HTML transformation).");
+
+    // After default policy creation null assignment implicitly calls createHTML
+    test(t => {
+      var range = document.createRange();
+      range.selectNodeContents(document.documentElement);
       var result = range.createContextualFragment(null);
-    });
-  }, "`range.createContextualFragment(null)` throws.");
-
-  // After default policy creation string assignment implicitly calls createHTML
-  test(t => {
-    let p = window.TrustedTypes.createPolicy("default", { createHTML: createHTMLJS }, true);
-    var range = document.createRange();
-    range.selectNodeContents(document.documentElement);
-    var result = range.createContextualFragment(INPUTS.HTML);
-    assert_equals(result.textContent, RESULTS.HTML);
-  }, "`range.createContextualFragment(string)` assigned via default policy (successful HTML transformation).");
-
-  // After default policy creation null assignment implicitly calls createHTML
-  test(t => {
-    var range = document.createRange();
-    range.selectNodeContents(document.documentElement);
-    var result = range.createContextualFragment(null);
-    assert_equals(result.textContent, "null");
-  }, "`range.createContextualFragment(null)` assigned via default policy does not throw.");
+      assert_equals(result.textContent, "null");
+    }, "`range.createContextualFragment(null)` assigned via default policy does not throw.");
+  });
 </script>

--- a/trusted-types/block-string-assignment-to-Window-open.tentative.html
+++ b/trusted-types/block-string-assignment-to-Window-open.tentative.html
@@ -4,83 +4,85 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="support/helper.sub.js"></script>
-
-  <meta http-equiv="Content-Security-Policy" content="trusted-types *">
 </head>
 <body>
 <script>
-  var testnb = 0;
-  // helper functions for the tests
-  function testWindowOpen(t, win, nb) {
-    let p = createURL_policy(window, nb);
-    let url = p.createURL(INPUTS.URL);
-    let child_window = win.open(url, "", "");
-    child_window.onload = t.step_func_done(_ => {
-      assert_equals(child_window.location.href, "" + url);
-      child_window.close();
-    });
-  }
-
-  function testWindowThrows(t, url, win, nb) {
-    let p = createURL_policy(window, nb);
-    assert_throws(new TypeError(), _ => {
+  run_tests_in_child_frame(
+  '<meta http-equiv="Content-Security-Policy" content="trusted-types *">',
+  () => {
+    var testnb = 0;
+    // helper functions for the tests
+    function testWindowOpen(t, win, nb) {
+      let p = createURL_policy(window, nb);
+      let url = p.createURL(INPUTS.URL);
       let child_window = win.open(url, "", "");
-      child_window.close();
-    });
-  }
+      child_window.onload = t.step_func_done(_ => {
+        assert_equals(child_window.location.href, "" + url);
+        child_window.close();
+      });
+    }
 
-  function testWindowDoesntThrow(t, url, expected, win) {
-    let child_window = win.open(url, "", "");
-    child_window.onload = t.step_func_done(_ => {
-      assert_equals(child_window.location.href, expected);
-      child_window.close();
-    });
-  }
+    function testWindowThrows(t, url, win, nb) {
+      let p = createURL_policy(window, nb);
+      assert_throws(new TypeError(), _ => {
+        let child_window = win.open(url, "", "");
+        child_window.close();
+      });
+    }
 
-  // TrustedURL assignments do not throw.
-  test(t => {
-    testWindowOpen(t, window, ++testnb);
-  }, "window.open via policy (successful URL transformation).");
+    function testWindowDoesntThrow(t, url, expected, win) {
+      let child_window = win.open(url, "", "");
+      child_window.onload = t.step_func_done(_ => {
+        assert_equals(child_window.location.href, expected);
+        child_window.close();
+      });
+    }
 
-  test(t => {
-    testWindowOpen(t, document, ++testnb);
-  }, "document.open via policy (successful URL transformation).");
+    // TrustedURL assignments do not throw.
+    test(t => {
+      testWindowOpen(t, window, ++testnb);
+    }, "window.open via policy (successful URL transformation).");
 
-  // String assignments throw.
-  test(t => {
-    testWindowThrows(t, 'A string', window, ++testnb);
-  }, "`window.open(string)` throws.");
+    test(t => {
+      testWindowOpen(t, document, ++testnb);
+    }, "document.open via policy (successful URL transformation).");
 
-  test(t => {
-    testWindowThrows(t, 'A string', document, ++testnb);
-  }, "`document.open(string)` throws.");
+    // String assignments throw.
+    test(t => {
+      testWindowThrows(t, 'A string', window, ++testnb);
+    }, "`window.open(string)` throws.");
 
-  // Null assignment throws.
-  test(t => {
-    testWindowThrows(t, null, window, ++testnb);
-  }, "`window.open(null)` throws.");
+    test(t => {
+      testWindowThrows(t, 'A string', document, ++testnb);
+    }, "`document.open(string)` throws.");
 
-  test(t => {
-    testWindowThrows(t, null, document, ++testnb);
-  }, "`document.open(null)` throws.");
+    // Null assignment throws.
+    test(t => {
+      testWindowThrows(t, null, window, ++testnb);
+    }, "`window.open(null)` throws.");
 
-  // After default policy creation string assignment implicitly calls createURL.
-  let p = window.TrustedTypes.createPolicy("default", { createURL: createURLJS }, true);
-  test(t => {
-    testWindowDoesntThrow(t, INPUTS.URL, RESULTS.URL, window);
-  }, "'window.open(string)' assigned via default policy (successful URL transformation).");
+    test(t => {
+      testWindowThrows(t, null, document, ++testnb);
+    }, "`document.open(null)` throws.");
 
-  test(t => {
-    testWindowDoesntThrow(t, INPUTS.URL, RESULTS.URL, document);
-  }, "'document.open(string)' assigned via default policy (successful URL transformation).");
+    // After default policy creation string assignment implicitly calls createURL.
+    let p = window.TrustedTypes.createPolicy("default", { createURL: createURLJS }, true);
+    test(t => {
+      testWindowDoesntThrow(t, INPUTS.URL, RESULTS.URL, window);
+    }, "'window.open(string)' assigned via default policy (successful URL transformation).");
 
-  test(t => {
-    testWindowDoesntThrow(t, null, "null", window);
-  }, "'window.open(null)' assigned via default policy does not throw.");
+    test(t => {
+      testWindowDoesntThrow(t, INPUTS.URL, RESULTS.URL, document);
+    }, "'document.open(string)' assigned via default policy (successful URL transformation).");
 
-  test(t => {
-    testWindowDoesntThrow(t, null, "null", document);
-  }, "'document.open(null)' assigned via default policy does not throw.");
+    test(t => {
+      testWindowDoesntThrow(t, null, "null", window);
+    }, "'window.open(null)' assigned via default policy does not throw.");
+
+    test(t => {
+      testWindowDoesntThrow(t, null, "null", document);
+    }, "'document.open(null)' assigned via default policy does not throw.");
+  });
 </script>
 </body>
 </html>

--- a/trusted-types/support/helper.sub.js
+++ b/trusted-types/support/helper.sub.js
@@ -187,3 +187,22 @@ function assert_element_accepts_non_trusted_type_set_ns(tag, attribute, value, e
   let attr_node = elem.getAttributeNodeNS(namespace, attribute);
   assert_equals(attr_node.value + "", expected);
 }
+
+function run_tests_in_child_frame(meta, tests) {
+  const frame = document.createElement('iframe');
+  frame.name = 'child-frame';
+  let srcdoc = meta;
+  // Add all scripts from the main document head, apart from testharnessreport.
+  [].slice.call(document.head.querySelectorAll('script[src]'))
+    .filter((script) => script.src.indexOf('testharnessreport') === -1)
+    .forEach((script) => {
+      srcdoc += '<script src="' + script.src + '"></sc' + 'ript>';
+    });
+  srcdoc += '<body><script>';
+  // Disabling string output in the harness as it clashes with TT-enforcing CSP.
+  srcdoc += 'setup({output: false});';
+  srcdoc += '(' + tests.toString() + ')()' + '</sc'+'ript>';
+  frame.srcdoc = srcdoc;
+  document.body.appendChild(frame);
+  fetch_tests_from_window(frame.contentWindow);
+}


### PR DESCRIPTION
Tests that set up trusted-types-enforcing CSP now execute in a separate iframe, not to clash with the harness using the DOM directly.