### PR TITLE
Remove test-level assert property from tests

### DIFF
--- a/common/performance-timeline-utils.js
+++ b/common/performance-timeline-utils.js
@@ -10,7 +10,8 @@ function wp_test(func, msg, properties)
     if (performanceNamespace === undefined || performanceNamespace == null)
     {
       // show a single error that window.performance is undefined
-      test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.", {author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+      // The window.performance attribute provides a hosting area for performance related attributes.
+      test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.", {author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
     }
   }
 

--- a/common/performance-timeline-utils.js
+++ b/common/performance-timeline-utils.js
@@ -1,3 +1,7 @@
+/*
+author: W3C http://www.w3.org/
+help: http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute
+*/
 var performanceNamespace = window.performance;
 var namespace_check = false;
 function wp_test(func, msg, properties)
@@ -11,7 +15,7 @@ function wp_test(func, msg, properties)
     {
       // show a single error that window.performance is undefined
       // The window.performance attribute provides a hosting area for performance related attributes.
-      test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.", {author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
+      test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.");
     }
   }
 

--- a/css/css-transitions/currentcolor-animation-001.html
+++ b/css/css-transitions/currentcolor-animation-001.html
@@ -15,6 +15,7 @@
 <div id="test"></div>
 <script>
 
+ // Transition does not occur when the value is currentColor and color changes
 test(function() {
        var div = document.getElementById("test");
        var cs = getComputedStyle(div, "");
@@ -32,8 +33,7 @@ test(function() {
        assert_true(quarter_interpolated != quarter_reference &&
                    quarter_interpolated == final_reference);
      },
-     "currentcolortransition",
-     { assert: "Transition does not occur when the value is currentColor and color changes" });
+     "currentcolortransition");
 
 </script>
 </body>

--- a/css/css-transitions/transitions-animatable-properties-01.html
+++ b/css/css-transitions/transitions-animatable-properties-01.html
@@ -100,10 +100,8 @@
 
       // create all the tests we need
       for (var i = 0; i < kANIMATABLE_CSS_PROPERTIES.length; i++) {
-        testsIntermediate.push(async_test(kANIMATABLE_CSS_PROPERTIES[i][0] + " intermediate",
-                                          { assert: "property " + kANIMATABLE_CSS_PROPERTIES[i][0] + " is animatable" }));
-        testsEnd.push(async_test(kANIMATABLE_CSS_PROPERTIES[i][0] + " end",
-                                          { assert: "property " + kANIMATABLE_CSS_PROPERTIES[i][0] + " has correct value after transition's end" }));
+        testsIntermediate.push(async_test(kANIMATABLE_CSS_PROPERTIES[i][0] + " intermediate"));
+        testsEnd.push(async_test(kANIMATABLE_CSS_PROPERTIES[i][0] + " end"));
       }
 
       // getComputedStyle helper

--- a/css/css-values/calc-unit-analysis.html
+++ b/css/css-values/calc-unit-analysis.html
@@ -32,8 +32,7 @@ function run() {
            test_elt.style.setProperty(property, value);
            test_elt.style.removeProperty(property);
          },
-         description_to_name(description),
-         { assert: "invalid calc expression: " + description });
+         description_to_name(description));
   }
 
   function assert_valid_value(property, value, computes_to, description) {
@@ -46,27 +45,26 @@ function run() {
                          computes_to);
            test_elt.style.removeProperty(property);
          },
-         description_to_name(description),
-         { assert: "valid calc expression: " + description });
+         description_to_name(description));
   }
 
-  assert_invalid_value("margin-left", "calc(0)",
+  assert_invalid_value("margin-left", "calc(0)", // invalid calc expression
                        "unitless zero in calc() is a numeric type, not length");
   assert_valid_value("margin-left", "calc(0px)", "0px",
                      "0px in calc()");
-  assert_invalid_value("margin-left", "calc(1px + 2)",
+  assert_invalid_value("margin-left", "calc(1px + 2)", // invalid calc expression
                        "addition of length and number");
-  assert_invalid_value("margin-left", "calc(2 + 1px)",
+  assert_invalid_value("margin-left", "calc(2 + 1px)", // invalid calc expression
                        "addition of number and length");
-  assert_invalid_value("margin-left", "calc(1px - 2)",
+  assert_invalid_value("margin-left", "calc(1px - 2)", // invalid calc expression
                        "subtraction of length and number");
-  assert_invalid_value("margin-left", "calc(2 - 1px)",
+  assert_invalid_value("margin-left", "calc(2 - 1px)", // invalid calc expression
                        "subtraction of number and length");
   assert_valid_value("margin-left", "calc(2px * 2)", "4px",
                      "multiplication of length and number");
   assert_valid_value("margin-left", "calc(2 * 2px)", "4px",
                      "multiplication of number and length");
-  assert_invalid_value("margin-left", "calc(2px * 1px)",
+  assert_invalid_value("margin-left", "calc(2px * 1px)", // invalid calc expression
                        "multiplication of length and length");
 
 }

--- a/css/css-variables/test_variable_legal_values.html
+++ b/css/css-variables/test_variable_legal_values.html
@@ -44,8 +44,7 @@ function run() {
            assert_not_equals(initial_cs, red_cs);
            assert_equals(initial_cs, test_cs.backgroundColor);
          },
-         description_to_name(description),
-         { assert: "Value allowed within variable: " + description });
+         description_to_name(description));
   }
 
   function assert_disallowed_balanced_variable_value(value, description) {
@@ -59,8 +58,7 @@ function run() {
            assert_not_equals(green_cs, red_cs);
            assert_equals(green_cs, test_cs.backgroundColor);
          },
-         description_to_name(description),
-         { assert: "Value not allowed within variable: " + description });
+         description_to_name(description));
   }
 
   assert_allowed_variable_value("25%", "percentage");

--- a/css/cssom-view/offsetParent_element_test.html
+++ b/css/cssom-view/offsetParent_element_test.html
@@ -93,6 +93,7 @@ var caption_element_child = document.getElementById('caption-element-child');
 var table_element_tr = document.getElementById('table-element-tr');
 var table_element = document.getElementById('table-element');
 
+// The offsetParent attribute algorithm rule checking passed!
 test(function() {
     assert_equals(html.offsetParent,null);
     assert_equals(body.offsetParent,null);
@@ -104,10 +105,9 @@ test(function() {
     assert_equals(none_element_child_audio.offsetParent,null);
     assert_equals(none_element_child_canvas.offsetParent,null);
     assert_equals(none_element_child_svg.offsetParent,undefined);
-}, "Valid the algorithm rule of offsetParent check step 1",
-{ assert: "The offsetParent attribute algorithm rule checking passed!" }
-);
+}, "Valid the algorithm rule of offsetParent check step 1");
 
+// The offsetParent attribute algorithm rule checking passed!
 test(function() {
     assert_equals(body_element_child.offsetParent,body);
     assert_equals(window.getComputedStyle(relative_element).position,'relative');
@@ -122,9 +122,7 @@ test(function() {
     assert_equals(caption_element_child.offsetParent,table_element);
     assert_equals(window.getComputedStyle(td_element).position,'static');
     assert_equals(td_element.offsetParent,table_element);
-}, "Valid the algorithm rule of offsetParent check step 2",
-{ assert: "The offsetParent attribute algorithm rule checking passed!" }
-);
+}, "Valid the algorithm rule of offsetParent check step 2");
 
 </script>
 

--- a/css/cssom/computed-style-001.html
+++ b/css/cssom/computed-style-001.html
@@ -33,6 +33,7 @@
     var inner = document.getElementById("inside");
     var innerStyle;
 
+    // do not allow modifications to a computed CSSStyleDeclaration
     test(function() {
         innerStyle = window.getComputedStyle(inner);
         assert_throws(  "NO_MODIFICATION_ALLOWED_ERR",
@@ -44,27 +45,22 @@
         assert_throws(  "NO_MODIFICATION_ALLOWED_ERR",
                         function() { innerStyle.color = "blue"; },
                         "do not allow setting a property on a readonly CSSStyleDeclaration");
-    }, "read_only", {
-        assert: "do not allow modifications to a computed CSSStyleDeclaration"
-    });
+    }, "read_only");
 
+    // Directly set properties are resolved
     test(function() {
         assert_equals(innerStyle.getPropertyValue("height"), "100px");
-    }, "property_values", {
-        assert: "Directly set properties are resolved"
-    });
+    }, "property_values");
 
+    // Inherited properties are resolved
     test(function() {
         assert_equals(innerStyle.getPropertyValue("font-size"), "100px");
-    }, "inherited_property_values", {
-        assert: "Inherited properties are resolved"
-    });
+    }, "inherited_property_values");
 
+    // Relative properties are resolved
     test(function() {
         assert_equals(innerStyle.getPropertyValue("width"), "100px");
-    }, "relative_property_values", {
-        assert: "Relative properties are resolved"
-    });
+    }, "relative_property_values");
  </script>
  </body>
 </html>

--- a/css/cssom/computed-style-005.html
+++ b/css/cssom/computed-style-005.html
@@ -47,19 +47,17 @@
      let elem = document.getElementById(id);
      let elemStyle = window.getComputedStyle(elem);
 
+     // positioned element's auto margins should be resolved to 10px.
      test(function() {
        assert_equals(elemStyle.getPropertyValue("margin-left"), "10px");
        assert_equals(elemStyle.getPropertyValue("margin-right"), "10px");
-     }, id + "_computed_margins", {
-       assert: id + "-positioned element's auto margins should be resolved to 10px."
-     });
+     }, id + "_computed_margins");
 
+     // positioned element should have a left and right of 0px (as authored).
      test(function() {
        assert_equals(elemStyle.getPropertyValue("left"), "0px");
        assert_equals(elemStyle.getPropertyValue("right"), "0px");
-     }, id + "_computed_left_and_right", {
-       assert: id + "-positioned element should have a left and right of 0px (as authored)."
-     });
+     }, id + "_computed_left_and_right");
    }
  </script>
  </body>

--- a/css/cssom/inline-style-001.html
+++ b/css/cssom/inline-style-001.html
@@ -14,21 +14,22 @@
  <div id="log"></div>
  <div id="test" style="margin-left: 5px;"></div>
  <script type="text/javascript">
+    // Can access CSSStyleDeclaration through style property
     test(function() {
         var test = document.getElementById("test");
         assert_idl_attribute(test, "style");
         declaration = test.style;
-    }, "CSSStyleDeclaration_accessible", {
-        assert: "Can access CSSStyleDeclaration through style property"
-    });
+    }, "CSSStyleDeclaration_accessible");
 
+    // initial property values are correct
     test(function() {
         assert_equals(declaration.cssText, "margin-left: 5px;");
         assert_equals(declaration.getPropertyValue("margin-left"), "5px");
-    }, "read", {
-        assert: "initial property values are correct"
-    });
+    }, "read");
 
+    // setting cssText adds new properties
+    // setting cssText removes existing properties
+    // properties set through cssText are reflected in the computed style
     test(function() {
         declaration.cssText = "margin-left: 10px; padding-left: 10px;";
         assert_equals(declaration.cssText, "margin-left: 10px; padding-left: 10px;");
@@ -41,12 +42,10 @@
         var computedStyle = window.getComputedStyle(document.getElementById("test"));
         assert_equals(computedStyle.getPropertyValue("margin-left"), "10px");
         assert_equals(computedStyle.getPropertyValue("padding-left"), "10px");
-    }, "csstext_write", {
-        assert: [ "setting cssText adds new properties",
-                "setting cssText removes existing properties",
-                "properties set through cssText are reflected in the computed style"]
-    });
+    }, "csstext_write");
 
+    // setProperty adds new properties
+    // properties set through setProperty are reflected in the computed style
     test(function() {
         while(declaration.length > 0)
             declaration.removeProperty(declaration.item(0));
@@ -62,11 +61,9 @@
         var computedStyle = window.getComputedStyle(document.getElementById("test"));
         assert_equals(computedStyle.getPropertyValue("margin-left"), "15px");
         assert_equals(computedStyle.getPropertyValue("padding-left"), "15px");
-    }, "property_write", {
-        assert: [ "setProperty adds new properties",
-                "properties set through setProperty are reflected in the computed style"]
-    });
+    }, "property_write");
 
+    // shorthand property is expanded
     test(function() {
         while(declaration.length > 0)
             declaration.removeProperty(declaration.item(0));
@@ -75,9 +72,7 @@
         assert_equals(declaration.getPropertyValue("margin-right"), "20px");
         assert_equals(declaration.getPropertyValue("margin-bottom"), "20px");
         assert_equals(declaration.getPropertyValue("margin-left"), "20px");
-    }, "shorthand_properties", {
-        assert: "shorthand property is expanded"
-    });
+    }, "shorthand_properties");
  </script>
  </body>
 </html>

--- a/css/cssom/medialist-interfaces-001.html
+++ b/css/cssom/medialist-interfaces-001.html
@@ -5,6 +5,8 @@
   <link rel="author" title="Ben Sheldon" href="mailto:ben@codeforamerica.org">
   <link rel="author" title="Chapman Shoop" href="mailto:chapman.shoop@gmail.com">
   <link rel="help" href="http://www.w3.org/TR/cssom-1/#the-medialist-interface">
+  <link rel="help" href="http://www.w3.org/TR/cssom-1/#serializing-media-queries">
+  <link rel="help" href="http://www.w3.org/TR/cssom-1/#serialize-a-media-query-list">
   <meta name="flags" content="dom">
   <meta name="assert" content="MediaLists are serialized according to the specification">
   <script src="/resources/testharness.js" type="text/javascript"></script>
@@ -46,8 +48,7 @@
 
         assert_equals(mediaList.mediaText, "all");
 
-    }, "mediatest_medialist_serialize_element",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serializing-media-queries"]});
+    }, "mediatest_medialist_serialize_element");
 
     // To serialize a comma-separated list concatenate all items of the list in list order while separating them by \",\" (U+002C), followed by a space (U+0020).
     test(function() {
@@ -56,8 +57,7 @@
       mediaList.appendMedium('screen');
       assert_equals(mediaList.mediaText, "all, screen");
 
-    }, "mediatest_medialist_serialize_comma",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serialize-a-media-query-list"]});
+    }, "mediatest_medialist_serialize_comma");
 
     // If the media query list is empty return the empty string.
     test(function() {
@@ -66,8 +66,7 @@
       mediaList.deleteMedium('all');
       assert_equals(mediaList.mediaText, "");
 
-    }, "mediatest_medialist_serialize_empty",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serializing-media-queries"]});
+    }, "mediatest_medialist_serialize_empty");
 
     // Each media query should be sorted in the same order as they appear in the list of media queries.
     test(function() {
@@ -77,8 +76,7 @@
       mediaList.appendMedium('print');
       assert_equals(mediaList.mediaText, "all, screen, print");
 
-    }, "mediatest_medialist_serialize_order",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serialize-a-media-query-list"]});
+    }, "mediatest_medialist_serialize_order");
 
   </script>
  </body>

--- a/css/cssom/medialist-interfaces-001.html
+++ b/css/cssom/medialist-interfaces-001.html
@@ -40,16 +40,16 @@
       mediaList = styleSheet.media;
     }
 
-
+    // MediaList.mediaText equals the 'media' value of the initial 'style' element.
     test(function() {
         setup();
 
         assert_equals(mediaList.mediaText, "all");
 
     }, "mediatest_medialist_serialize_element",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serializing-media-queries"],
-      assert: ["MediaList.mediaText equals the 'media' value of the initial 'style' element."] });
+    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serializing-media-queries"]});
 
+    // To serialize a comma-separated list concatenate all items of the list in list order while separating them by \",\" (U+002C), followed by a space (U+0020).
     test(function() {
       setup();
 
@@ -57,9 +57,9 @@
       assert_equals(mediaList.mediaText, "all, screen");
 
     }, "mediatest_medialist_serialize_comma",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serialize-a-media-query-list"],
-      assert: ["To serialize a comma-separated list concatenate all items of the list in list order while separating them by \",\" (U+002C), followed by a space (U+0020)."] });
+    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serialize-a-media-query-list"]});
 
+    // If the media query list is empty return the empty string.
     test(function() {
       setup();
 
@@ -67,9 +67,9 @@
       assert_equals(mediaList.mediaText, "");
 
     }, "mediatest_medialist_serialize_empty",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serializing-media-queries"],
-      assert: ["If the media query list is empty return the empty string."] });
+    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serializing-media-queries"]});
 
+    // Each media query should be sorted in the same order as they appear in the list of media queries.
     test(function() {
       setup();
 
@@ -78,8 +78,7 @@
       assert_equals(mediaList.mediaText, "all, screen, print");
 
     }, "mediatest_medialist_serialize_order",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serialize-a-media-query-list"],
-      assert: ["Each media query should be sorted in the same order as they appear in the list of media queries."] });
+    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serialize-a-media-query-list"]});
 
   </script>
  </body>

--- a/css/cssom/medialist-interfaces-002.html
+++ b/css/cssom/medialist-interfaces-002.html
@@ -33,12 +33,13 @@
 
   <script type="text/javascript">
 
+    // MediaList.deleteMedium called without argument throws error.
     test(function() {
       media_list = setup();
       assert_throws(new TypeError, function() { media_list.deleteMedium(); });
-    }, "deleteMedium_called_without_argument",
-    { assert: "MediaList.deleteMedium called without argument throws error." });
+    }, "deleteMedium_called_without_argument");
 
+    // MediaList.deleteMedium removes correct medium and updates corresponding properties.
     test(function() {
       media_list = setup();
 
@@ -50,9 +51,9 @@
       assert_equals(media_list.length, 1);
       assert_equals(media_list.item(0), "all");
       assert_equals(media_list.mediaText, "all");
-    }, "deleteMedium_removes_correct_medium",
-    { assert: "MediaList.deleteMedium removes correct medium and updates corresponding properties." });
+    }, "deleteMedium_removes_correct_medium");
 
+    // MediaList.deleteMedium doesn't modify MediaList when medium is not found.
     test(function() {
       media_list = setup();
 
@@ -63,8 +64,7 @@
       assert_equals(media_list.length, 1);
       assert_equals(media_list.item(0), "all");
       assert_equals(media_list.mediaText, "all");
-    }, "deleteMedium_no_matching_medium_to_remove",
-    { assert: "MediaList.deleteMedium doesn't modify MediaList when medium is not found." });
+    }, "deleteMedium_no_matching_medium_to_remove");
 
   </script>
 </body>

--- a/css/cssom/medialist-interfaces-003.html
+++ b/css/cssom/medialist-interfaces-003.html
@@ -40,22 +40,21 @@
       mediaList = styleSheet.media;
     }
 
-
+    // First explicit example input (first column) and output (second column) in specification.
     test(function() {
         setupMedia('not screen and (min-WIDTH:5px) AND (max-width:40px )');
 
         assert_equals(mediaList.mediaText, "not screen and (max-width: 40px) and (min-width: 5px)");
 
-    }, "mediatest_mediaquery_serialize_1",
-    {  assert: ["First explicit example input (first column) and output (second column) in specification."] });
+    }, "mediatest_mediaquery_serialize_1");
 
+    // Second explicit example input (first column) and output (second column) in specification.
     test(function() {
         setupMedia('all and (color) and (color)	');
 
         assert_equals(mediaList.mediaText, "(color)");
 
-    }, "mediatest_mediaquery_serialize_2",
-    { assert: ["Second explicit example input (first column) and output (second column) in specification."] });
+    }, "mediatest_mediaquery_serialize_2");
 
   </script>
  </body>

--- a/css/cssom/medialist-interfaces-004.html
+++ b/css/cssom/medialist-interfaces-004.html
@@ -32,6 +32,7 @@
 
   <script type="text/javascript">
 
+    // MediaList.appendMedium correctly adds medium to empty MediaList.
     test(function() {
       media_list = setup();
 
@@ -40,9 +41,9 @@
       assert_equals(media_list.length, 1);
       assert_equals(media_list.item(0), "all");
       assert_equals(media_list.mediaText, "all");
-    }, "appendMedium_correctly_appends_medium_to_empty_MediaList",
-    { assert: "MediaList.appendMedium correctly adds medium to empty MediaList." });
+    }, "appendMedium_correctly_appends_medium_to_empty_MediaList");
 
+    // MediaList.appendMedium correctly adds medium to a MediaList that already has a medium.
     test(function() {
       media_list = setup();
 
@@ -56,8 +57,7 @@
       assert_equals(media_list.item(0), "screen");
       assert_equals(media_list.item(1), "all");
       assert_equals(media_list.mediaText, "screen, all");
-    }, "appendMedium_correctly_appends_medium_to_nonempty_MediaList",
-    { assert: "MediaList.appendMedium correctly adds medium to a MediaList that already has a medium." });
+    }, "appendMedium_correctly_appends_medium_to_nonempty_MediaList");
 
   </script>
 </body>

--- a/css/cssom/style-sheet-interfaces-001.html
+++ b/css/cssom/style-sheet-interfaces-001.html
@@ -3,11 +3,9 @@
  <head>
   <title>CSS Test: CSSOM StyleSheet Initial Values</title>
   <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
-  <link rel="help" href="http://www.w3.org/TR/cssom-1/#css-style-sheets">
-  <link rel="help" href="http://www.w3.org/TR/cssom-1/#the-linkstyle-interface">
+  <link rel="help" href="https://www.w3.org/TR/cssom-1/#css-style-sheets">
+  <link rel="help" href="https://www.w3.org/TR/cssom-1/#the-cssimportrule-interface">
   <link rel="help" href="https://www.w3.org/TR/cssom-1/#the-linkstyle-interface">
-  <link rel="help" href="http://www.w3.org/TR/cssom-1/#css-style-sheets">
-  <link rel="help" href="http://www.w3.org/TR/cssom-1/#cssimportrule">
   <meta name="flags" content="dom">
   <meta name="assert" content="StyleSheet and CSSStyleSheet objects have the properties specified in their interfaces">
   <script src="/resources/testharness.js" type="text/javascript"></script>

--- a/css/cssom/style-sheet-interfaces-001.html
+++ b/css/cssom/style-sheet-interfaces-001.html
@@ -23,6 +23,9 @@
 
     var styleSheet;
     var linkSheet;
+
+    // styleElement.sheet exists and is a CSSStyleSheet
+    // linkElement.sheet exists and is a CSSStyleSheet
     test(function() {
         assert_idl_attribute(styleElement, "sheet");
         assert_readonly(styleElement, "sheet");
@@ -32,10 +35,9 @@
         linkSheet = linkElement.sheet;
         assert_true(linkSheet instanceof CSSStyleSheet);
     }, "sheet_property",
-    { help: "http://www.w3.org/TR/cssom-1/#the-linkstyle-interface",
-      assert: [ "styleElement.sheet exists", "styleElement.sheet is a CSSStyleSheet",
-                "linkElement.sheet exists", "linkElement.sheet is a CSSStyleSheet"] });
+    { help: "http://www.w3.org/TR/cssom-1/#the-linkstyle-interface"});
 
+    // The sheet property on LinkStyle should always return the current associated style sheet.
     test(function () {
       var style = document.createElement("style");
       document.querySelector("head").appendChild(style);
@@ -44,9 +46,10 @@
       style.appendChild(document.createTextNode("a { color: green; }"));
       assert_equals(style.sheet.cssRules.length, 1);
     }, "sheet_property_updates",
-    { help: "https://www.w3.org/TR/cssom-1/#the-linkstyle-interface",
-      assert: "The sheet property on LinkStyle should always return the current associated style sheet." });
+    { help: "https://www.w3.org/TR/cssom-1/#the-linkstyle-interface"});
 
+    // ownerRule, cssRules, insertRule and deleteRule properties exist on CSSStyleSheet
+    // ownerRule, cssRules are read only
     test(function() {
         assert_idl_attribute(styleSheet, "ownerRule");
         assert_idl_attribute(styleSheet, "cssRules");
@@ -55,11 +58,10 @@
 
         assert_readonly(styleSheet, "ownerRule");
         assert_readonly(styleSheet, "cssRules");
-    }, "CSSStyleSheet_properties",
-    { assert: [ "ownerRule, cssRules, insertRule and deleteRule properties exist on CSSStyleSheet",
-                "ownerRule, cssRules are read only"] });
+    }, "CSSStyleSheet_properties");
 
     var importSheet;
+    // CSSStyleSheet initial property values are correct
     test(function() {
         assert_equals(styleSheet.ownerRule, null);
         assert_true(styleSheet.cssRules.length > 0);
@@ -67,9 +69,10 @@
         importSheet = styleSheet.cssRules.item(0).styleSheet;
     }, "CSSStyleSheet_property_values",
     { help: [ "http://www.w3.org/TR/cssom-1/#css-style-sheets",
-              "http://www.w3.org/TR/cssom-1/#cssimportrule" ],
-      assert: "CSSStyleSheet initial property values are correct" });
+              "http://www.w3.org/TR/cssom-1/#cssimportrule" ]});
 
+    // type, disabled, ownerNode, parentStyleSheet, href, title, and media properties exist on StyleSheet
+    // type, ownerNode, parentStyleSheet, href, and title properties are read only
     test(function() {
         assert_idl_attribute(styleSheet, "type");
         assert_idl_attribute(styleSheet, "disabled");
@@ -84,10 +87,9 @@
         assert_readonly(styleSheet, "parentStyleSheet");
         assert_readonly(styleSheet, "href");
         assert_readonly(styleSheet, "title");
-    }, "StyleSheet_properties",
-    { assert: [ "type, disabled, ownerNode, parentStyleSheet, href, title, and media properties exist on StyleSheet",
-                "type, ownerNode, parentStyleSheet, href, and title properties are read only" ] });
+    }, "StyleSheet_properties");
 
+    // StyleSheet initial property values are correct
     test(function() {
         assert_equals(styleSheet.type, "text/css");
         assert_equals(styleSheet.disabled, false);
@@ -106,8 +108,7 @@
 
         assert_equals(styleSheet.title, "internal style sheet");
         assert_equals(styleSheet.media.item(0), "all");
-    }, "StyleSheet_property_values",
-    { assert: "StyleSheet initial property values are correct" });
+    }, "StyleSheet_property_values");
   </script>
  </body>
 </html>

--- a/css/cssom/style-sheet-interfaces-001.html
+++ b/css/cssom/style-sheet-interfaces-001.html
@@ -4,6 +4,10 @@
   <title>CSS Test: CSSOM StyleSheet Initial Values</title>
   <link rel="author" title="Bear Travis" href="mailto:betravis@adobe.com">
   <link rel="help" href="http://www.w3.org/TR/cssom-1/#css-style-sheets">
+  <link rel="help" href="http://www.w3.org/TR/cssom-1/#the-linkstyle-interface">
+  <link rel="help" href="https://www.w3.org/TR/cssom-1/#the-linkstyle-interface">
+  <link rel="help" href="http://www.w3.org/TR/cssom-1/#css-style-sheets">
+  <link rel="help" href="http://www.w3.org/TR/cssom-1/#cssimportrule">
   <meta name="flags" content="dom">
   <meta name="assert" content="StyleSheet and CSSStyleSheet objects have the properties specified in their interfaces">
   <script src="/resources/testharness.js" type="text/javascript"></script>
@@ -34,8 +38,7 @@
         assert_idl_attribute(linkElement, "sheet");
         linkSheet = linkElement.sheet;
         assert_true(linkSheet instanceof CSSStyleSheet);
-    }, "sheet_property",
-    { help: "http://www.w3.org/TR/cssom-1/#the-linkstyle-interface"});
+    }, "sheet_property");
 
     // The sheet property on LinkStyle should always return the current associated style sheet.
     test(function () {
@@ -45,8 +48,7 @@
       assert_equals(sheet1.cssRules.length, 0);
       style.appendChild(document.createTextNode("a { color: green; }"));
       assert_equals(style.sheet.cssRules.length, 1);
-    }, "sheet_property_updates",
-    { help: "https://www.w3.org/TR/cssom-1/#the-linkstyle-interface"});
+    }, "sheet_property_updates");
 
     // ownerRule, cssRules, insertRule and deleteRule properties exist on CSSStyleSheet
     // ownerRule, cssRules are read only
@@ -67,9 +69,7 @@
         assert_true(styleSheet.cssRules.length > 0);
         assert_true(styleSheet.cssRules.item(0) instanceof CSSImportRule);
         importSheet = styleSheet.cssRules.item(0).styleSheet;
-    }, "CSSStyleSheet_property_values",
-    { help: [ "http://www.w3.org/TR/cssom-1/#css-style-sheets",
-              "http://www.w3.org/TR/cssom-1/#cssimportrule" ]});
+    }, "CSSStyleSheet_property_values");
 
     // type, disabled, ownerNode, parentStyleSheet, href, title, and media properties exist on StyleSheet
     // type, ownerNode, parentStyleSheet, href, and title properties are read only

--- a/css/cssom/style-sheet-interfaces-002.html
+++ b/css/cssom/style-sheet-interfaces-002.html
@@ -19,24 +19,22 @@
   <div id="log"></div>
   <script type="text/javascript">
   var sheet = document.getElementById("styleElement").sheet;
+  // Initial rule list is of size 1
+  // Can add a rule at first index
   test(function() {
     assert_equals(sheet.cssRules.length, 1);
     sheet.insertRule("p { color: green; }", 0);
     assert_equals(sheet.cssRules.length, 2);
     assert_equals(sheet.cssRules.item(0).cssText, "p { color: green; }");
-  }, "add_rule", {
-    assert: [   "Initial rule list is of size 1",
-                "Can add a rule at first index" ]
-  });
+  }, "add_rule");
 
+  // Can delete rules until rule list is empty
   test(function() {
     sheet.deleteRule(0);
     assert_equals(sheet.cssRules.length, 1);
     sheet.deleteRule(0);
     assert_equals(sheet.cssRules.length, 0);
-  }, "delete_rule", {
-    assert: "Can delete rules until rule list is empty"
-  });
+  }, "delete_rule");
   </script>
  </body>
 </html>

--- a/css/mediaqueries/test_media_queries.html
+++ b/css/mediaqueries/test_media_queries.html
@@ -33,13 +33,13 @@ function run() {
     function should_apply(q) {
       test(function() {
         assert_true(query_applies(q));
-      }, "subtest_" + ++testNum, {assert: q + " should apply"});
+      }, "subtest_" + ++testNum);
     }
 
     function should_not_apply(q) {
       test(function() {
         assert_false(query_applies(q));
-      }, "subtest_" + ++testNum, {assert: q + " should not apply"});
+      }, "subtest_" + ++testNum);
     }
 
     /*
@@ -68,13 +68,13 @@ function run() {
     function query_should_be_parseable(q) {
       test(function() {
         assert_true(query_is_parseable(q))
-      }, "subtest_" + ++testNum, {assert: "query " + q + " should be parseable"});
+      }, "subtest_" + ++testNum);
     }
 
     function query_should_not_be_parseable(q) {
       test(function() {
         assert_false(query_is_parseable(q))
-      }, "subtest_" + ++testNum, {assert: "query " + q + " should not be parseable"});
+      }, "subtest_" + ++testNum);
     }
 
     /*
@@ -88,13 +88,13 @@ function run() {
     function expression_should_be_parseable(e) {
       test(function() {
         assert_true(expression_is_parseable(e));
-      }, "subtest_" + ++testNum, {assert: "expression " + e + " should be parseable"});
+      }, "subtest_" + ++testNum);
     }
 
     function expression_should_not_be_parseable(e) {
       test(function() {
         assert_false(expression_is_parseable(e));
-      }, "subtest_" + ++testNum, {assert: "expression " + e + " should not be parseable"});
+      }, "subtest_" + ++testNum);
     }
 
     // The no-type syntax doesn't mix with the not and only keywords.

--- a/hr-time/monotonic-clock.any.js
+++ b/hr-time/monotonic-clock.any.js
@@ -1,14 +1,13 @@
+// The time values returned when calling the now method MUST be monotonically increasing and not subject to system clock adjustments or system clock skew.
 test(function() {
   assert_true(self.performance.now() > 0, "self.performance.now() returns positive numbers");
-}, "self.performance.now() returns a positive number", {assert: "The time values returned when calling the now method MUST be monotonically increasing and not subject to system clock adjustments or system clock skew."});
+}, "self.performance.now() returns a positive number");
 
+// The difference between any two chronologically recorded time values returned from the now method MUST never be negative.
 test(function() {
     var now1 = self.performance.now();
     var now2 = self.performance.now();
     assert_true((now2-now1) >= 0, "self.performance.now() difference is not negative");
   },
-  "self.performance.now() difference is not negative",
-  {
-    assert: "The difference between any two chronologically recorded time values returned from the now method MUST never be negative."
-  }
+  "self.performance.now() difference is not negative"
 );

--- a/navigation-timing/resources/webperftestharness.js
+++ b/navigation-timing/resources/webperftestharness.js
@@ -39,12 +39,12 @@ function test_namespace(child_name, skip_root)
 {
     if (skip_root === undefined) {
         var msg = 'window.performance is defined';
-        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
     }
 
     if (child_name !== undefined) {
         var msg2 = 'window.performance.' + child_name + ' is defined';
-        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
     }
 }
 

--- a/navigation-timing/resources/webperftestharness.js
+++ b/navigation-timing/resources/webperftestharness.js
@@ -6,6 +6,9 @@ policies and contribution forms [3].
 [1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
 [2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
 [3] http://www.w3.org/2004/10/27-testcases
+
+author: W3C http://www.w3.org/
+help: http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute
  */
 
 //
@@ -39,12 +42,12 @@ function test_namespace(child_name, skip_root)
 {
     if (skip_root === undefined) {
         var msg = 'window.performance is defined';
-        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
+        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg);
     }
 
     if (child_name !== undefined) {
         var msg2 = 'window.performance.' + child_name + ' is defined';
-        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
+        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2);
     }
 }
 

--- a/navigation-timing/test_navigation_redirectCount_none.html
+++ b/navigation-timing/test_navigation_redirectCount_none.html
@@ -5,6 +5,7 @@
         <title>window.performance.navigation.redirectCount on a non-redirected navigation</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-timing-interface"/>
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="/common/performance-timeline-utils.js"></script>
@@ -23,7 +24,7 @@
         {
             test_equals(performanceNamespace.timing.redirectStart, 0, 'timing.redirectStart on an non-redirected navigation');
             test_equals(performanceNamespace.timing.redirectEnd, 0, 'timing.redirectEnd on an non-redirected navigation');
-            test_equals(performanceNamespace.navigation.redirectCount, 0, 'navigation.redirectCount on an non-redirected navigation',{help:"http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"});
+            test_equals(performanceNamespace.navigation.redirectCount, 0, 'navigation.redirectCount on an non-redirected navigation');
         }
         </script>
     </body>

--- a/navigation-timing/test_no_previous_document.html
+++ b/navigation-timing/test_no_previous_document.html
@@ -5,6 +5,7 @@
         <title>window.performance.timing attributes on an initial navigation</title>
         <link rel="author" title="Google" href="http://www.google.com/" />
         <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-timing-interface"/>
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="/common/performance-timeline-utils.js"></script>
@@ -21,7 +22,7 @@
                 if (performanceNamespace)
                 {
                     test_true(frame.contentWindow.performance.navigation.type == performanceNamespace.navigation.TYPE_NAVIGATE,
-                              'timing.navigation.type is TYPE_NAVIGATE',{help:"http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"});
+                              'timing.navigation.type is TYPE_NAVIGATE');
 
                     test_equals(frame.contentWindow.performance.timing.unloadEventStart, 0, 'timing.unloadEventStart == 0 on navigation with no previous document');
                     test_equals(frame.contentWindow.performance.timing.unloadEventEnd, 0, 'timing.unloadEventEnd == 0 navigation with no previous document');

--- a/navigation-timing/test_timing_attributes_order.html
+++ b/navigation-timing/test_timing_attributes_order.html
@@ -5,6 +5,7 @@
         <title>window.performance.timing attribute ordering on a simple navigation</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-timing-interface"/>
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="/common/performance-timeline-utils.js"></script>
@@ -43,7 +44,7 @@
                         //
                         test_equals(performanceNamespace.navigation.type,
                                 performanceNamespace.navigation.TYPE_NAVIGATE,
-                                'window.performance.navigation.type == TYPE_NAVIGATE',{help:"http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"});
+                                'window.performance.navigation.type == TYPE_NAVIGATE');
 
                         // navigiation must be non-0
                         test_timing_greater_than('navigationStart', 0);

--- a/navigation-timing/test_timing_client_redirect.html
+++ b/navigation-timing/test_timing_client_redirect.html
@@ -5,6 +5,7 @@
         <title>window.performance.timing.redirect attributes on a client redirect navigation</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-timing-interface"/>
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="/common/performance-timeline-utils.js"></script>
@@ -33,9 +34,9 @@
             {
                 redirect_frame.onload = "";
                 test_true(redirect_frame.contentWindow.performance.navigation.type == performanceNamespace.navigation.TYPE_NAVIGATE,
-                          'timing.navigation.type is TYPE_NAVIGATE',{help:"http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"});
+                          'timing.navigation.type is TYPE_NAVIGATE');
 
-                test_equals(redirect_frame.contentWindow.performance.navigation.redirectCount, 0, 'navigation.redirectCount == 0 on an client redirected navigation',{help:"http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"});
+                test_equals(redirect_frame.contentWindow.performance.navigation.redirectCount, 0, 'navigation.redirectCount == 0 on an client redirected navigation');
                 test_equals(redirect_frame.contentWindow.performance.timing.redirectStart, 0, 'timing.redirectStart == 0 on an client redirected navigation');
                 test_equals(redirect_frame.contentWindow.performance.timing.redirectEnd, 0, 'timing.redirectEnd == 0 on an client redirected navigation');
 

--- a/navigation-timing/test_timing_reload.html
+++ b/navigation-timing/test_timing_reload.html
@@ -5,6 +5,7 @@
         <title>window.performance.timing attributes after a reloaded navigation</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-timing-interface"/>
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="/common/performance-timeline-utils.js"></script>
@@ -56,7 +57,7 @@
                 // ensure the frame reloaded
                 test_equals(reload_frame.contentWindow.performance.navigation.type,
                             performanceNamespace.navigation.TYPE_RELOAD,
-                            "window.performance.navigation.type == TYPE_RELOAD", {help:"http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"});
+                            "window.performance.navigation.type == TYPE_RELOAD");
 
                 // ensure reload timings changed
                 var timing = reload_frame.contentWindow.performance.timing;

--- a/navigation-timing/test_timing_xserver_redirect.html
+++ b/navigation-timing/test_timing_xserver_redirect.html
@@ -5,6 +5,7 @@
         <title>window.performance.timing.redirect attributes on a cross-origin server redirected navigation</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-timing-interface"/>
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="/common/performance-timeline-utils.js"></script>
@@ -35,8 +36,8 @@
                 performanceNamespace = document.getElementById("frameContext").contentWindow.performance;
                 test_equals(performanceNamespace.navigation.type,
                         performanceNamespace.navigation.TYPE_NAVIGATE,
-                        'timing.navigation.type is TYPE_NAVIGATE',{help:"http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"});
-                test_equals(performanceNamespace.navigation.redirectCount, 0, 'navigation.redirectCount == 0 on a cross-origin server redirected navigation', {help:"http://www.w3.org/TR/navigation-timing/#sec-navigation-info-interface"});
+                        'timing.navigation.type is TYPE_NAVIGATE');
+                test_equals(performanceNamespace.navigation.redirectCount, 0, 'navigation.redirectCount == 0 on a cross-origin server redirected navigation');
 
                 test_timing_greater_than('navigationStart', 0);
 

--- a/requestidlecallback/basic.html
+++ b/requestidlecallback/basic.html
@@ -4,21 +4,25 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+// The window.requestIdleCallback function is used to request callbacks during browser-defined idle time.
 test(function() {
   assert_equals(typeof window.requestIdleCallback, "function");
-}, "window.requestIdleCallback is defined", {assert: "The window.requestIdleCallback function is used to request callbacks during browser-defined idle time."});
+}, "window.requestIdleCallback is defined");
 
+// The window.cancelIdleCallback function is used to cancel callbacks scheduled via requestIdleCallback.
 test(function() {
   assert_equals(typeof window.cancelIdleCallback, "function");
-}, "window.cancelIdleCallback is defined", {assert: "The window.cancelIdleCallback function is used to cancel callbacks scheduled via requestIdleCallback."});
+}, "window.cancelIdleCallback is defined");
 
+// The requestIdleCallback method MUST return a long
 test(function() {
   assert_equals(typeof window.requestIdleCallback(function() {}), "number");
-}, "window.requestIdleCallback() returns a number", {assert: "The requestIdleCallback method MUST return a long"});
+}, "window.requestIdleCallback() returns a number");
 
+// The cancelIdleCallback method MUST return void
 test(function() {
   assert_equals(typeof window.cancelIdleCallback(1), "undefined");
-}, "window.cancelIdleCallback() returns undefined", {assert: "The cancelIdleCallback method MUST return void"});
+}, "window.cancelIdleCallback() returns undefined");
 
 async_test(function() {
   // Check whether requestIdleCallback schedules a callback which gets executed

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -1,4 +1,8 @@
-﻿//
+﻿/*
+author: W3C http://www.w3.org/
+help: http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute
+*/
+//
 // Helper Functions for NavigationTiming W3C tests
 //
 
@@ -46,7 +50,7 @@ function wp_test(func, msg, properties)
         {
             // show a single error that window.performance is undefined
             // The window.performance attribute provides a hosting area for performance related attributes.
-            test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.", {author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
+            test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.");
         }
     }
 
@@ -58,13 +62,13 @@ function test_namespace(child_name, skip_root)
     if (skip_root === undefined) {
         var msg = 'window.performance is defined';
         // The window.performance attribute provides a hosting area for performance related attributes.
-        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
+        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg);
     }
 
     if (child_name !== undefined) {
         var msg2 = 'window.performance.' + child_name + ' is defined';
         // The window.performance attribute provides a hosting area for performance related attributes.
-        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
+        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2);
     }
 }
 

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -45,7 +45,8 @@ function wp_test(func, msg, properties)
         if (performanceNamespace === undefined || performanceNamespace == null)
         {
             // show a single error that window.performance is undefined
-            test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.", {author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+            // The window.performance attribute provides a hosting area for performance related attributes.
+            test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.", {author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
         }
     }
 
@@ -56,12 +57,14 @@ function test_namespace(child_name, skip_root)
 {
     if (skip_root === undefined) {
         var msg = 'window.performance is defined';
-        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+        // The window.performance attribute provides a hosting area for performance related attributes.
+        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
     }
 
     if (child_name !== undefined) {
         var msg2 = 'window.performance.' + child_name + ' is defined';
-        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+        // The window.performance attribute provides a hosting area for performance related attributes.
+        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
     }
 }
 

--- a/user-timing/resources/webperftestharness.js
+++ b/user-timing/resources/webperftestharness.js
@@ -55,12 +55,12 @@ function test_namespace(child_name, skip_root)
 {
     if (skip_root === undefined) {
         var msg = 'window.performance is defined';
-        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
     }
 
     if (child_name !== undefined) {
         var msg2 = 'window.performance.' + child_name + ' is defined';
-        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
     }
 }
 

--- a/user-timing/resources/webperftestharness.js
+++ b/user-timing/resources/webperftestharness.js
@@ -6,6 +6,9 @@ policies and contribution forms [3].
 [1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
 [2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
 [3] http://www.w3.org/2004/10/27-testcases
+
+author: W3C http://www.w3.org/
+help: http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute
  */
 
 //
@@ -55,12 +58,12 @@ function test_namespace(child_name, skip_root)
 {
     if (skip_root === undefined) {
         var msg = 'window.performance is defined';
-        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
+        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg);
     }
 
     if (child_name !== undefined) {
         var msg2 = 'window.performance.' + child_name + ' is defined';
-        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"});
+        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2);
     }
 }
 


### PR DESCRIPTION
test-level asserts is the only remaining use of is for test-level
assert metadata. Remove all the assert property from tests and mark
them as test comments if possible.
Related: #14394