### PR TITLE
SVG: percentages reference viewport dimensions

### DIFF
--- a/svg/geometry/reftests/percentage-attribute.svg
+++ b/svg/geometry/reftests/percentage-attribute.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="310" height="170" viewBox="0, 0, 620, 340"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Percentages in shapes</title>
+  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="match"  href="percentage-ref.svg" />
+
+  <style>
+    svg {
+      fill: none;
+      stroke-width: 30px;
+    }
+  </style>
+
+  <circle cx="70%" cy="60%" r="50%" stroke="cyan" />
+  <ellipse cx="40%" cy="30%" rx="10%" ry="20%" stroke="green" />
+  <rect x="10%" y="20%" width="70%" height="60%" stroke="blue" />
+</svg>

--- a/svg/geometry/reftests/percentage-ref.svg
+++ b/svg/geometry/reftests/percentage-ref.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="310" height="170" viewBox="0, 0, 620, 340"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+
+  <style>
+    svg {
+      fill: none;
+      stroke-width: 30px;
+    }
+  </style>
+
+  <circle cx="434" cy="204" r="250" stroke="cyan" />
+  <ellipse cx="248" cy="102" rx="62" ry="68" stroke="green" />
+  <rect x="62" y="68" width="434" height="204" stroke="blue" />
+</svg>

--- a/svg/geometry/reftests/percentage.svg
+++ b/svg/geometry/reftests/percentage.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="310" height="170" viewBox="0, 0, 620, 340"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Percentages in shapes</title>
+  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="match"  href="percentage-ref.svg" />
+
+  <style>
+    svg {
+      fill: none;
+      stroke-width: 30px;
+    }
+    circle {
+      cx: 70%;
+      cy: 60%;
+      r: 50%;
+    }
+    ellipse {
+      cx: 40%;
+      cy: 30%;
+      rx: 10%;
+      ry: 20%;
+    }
+    rect {
+      x: 10%;
+      y: 20%;
+      width: 70%;
+      height: 60%;
+    }
+  </style>
+
+  <circle stroke="cyan" />
+  <ellipse stroke="green" />
+  <rect stroke="blue" />
+</svg>

--- a/svg/painting/reftests/percentage-attribute.svg
+++ b/svg/painting/reftests/percentage-attribute.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="310" height="170" viewBox="0, 0, 620, 340"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Percentages in stroke dimensions</title>
+  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="match"  href="percentage-ref.svg" />
+
+  <style>
+    rect {
+      fill: none;
+      stroke: blue;
+    }
+  </style>
+
+  <rect x="62" y="68" width="434" height="204"
+    stroke-width="10%" stroke-dasharray="20% 30%" stroke-dashoffset="-10%" />
+</svg>

--- a/svg/painting/reftests/percentage-ref.svg
+++ b/svg/painting/reftests/percentage-ref.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="310" height="170" viewBox="0, 0, 620, 340"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+
+  <style>
+    rect {
+      fill: none;
+      stroke: blue;
+      stroke-width: 50px;
+      stroke-dasharray: 100px 150px;
+      stroke-dashoffset: -50px;
+    }
+  </style>
+
+  <rect x="62" y="68" width="434" height="204" />
+</svg>

--- a/svg/painting/reftests/percentage.svg
+++ b/svg/painting/reftests/percentage.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="310" height="170" viewBox="0, 0, 620, 340"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Percentages in stroke dimensions</title>
+  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="match"  href="percentage-ref.svg" />
+
+  <style>
+    rect {
+      fill: none;
+      stroke: blue;
+      stroke-width: 10%;
+      stroke-dasharray: 20% 30%;
+      stroke-dashoffset: -10%;
+    }
+  </style>
+
+  <rect x="62" y="68" width="434" height="204" />
+</svg>


### PR DESCRIPTION
WPT for https://github.com/w3c/svgwg/pull/615

% cx,rx,x,width reference viewport width
% cy,ry,y,height reference viewport height
% r,stroke-width,stroke-dasharray,stroke-dashoffset reference
normalized viewport diagonal, i.e. diagonal/sqrt(2).