### PR TITLE
[Azure Pipelines] Clarify the job dependencies by reordering/renaming

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -13,24 +13,8 @@
 trigger: none # disable builds for branches
 
 jobs:
-- job: root
-  displayName: './wpt test-jobs'
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - template: tools/ci/azure/checkout.yml
-  - script: |
-      ./wpt test-jobs | while read job; do
-        echo "$job"
-        echo "##vso[task.setvariable variable=$job;isOutput=true]true";
-      done
-    name: test_jobs
-    displayName: 'Run ./wpt test-jobs'
-
-# Note: the affected tests jobs could depend on test_jobs.stability, but are
-# unconditional for speed, as most PRs have one or more affected tests:
-# https://github.com/web-platform-tests/wpt/issues/13936
-
+# The affected tests jobs are unconditional for speed, as most PRs have one or
+# more affected tests: https://github.com/web-platform-tests/wpt/issues/13936.
 - job: affected_macOS
   displayName: 'affected tests (Safari Technology Preview)'
   pool:
@@ -51,10 +35,26 @@ jobs:
       affectedRange: 'HEAD@{1}'
       artifactName: 'results-without-changes'
 
+# The decision jobs runs `./wpt test-jobs` to determine which jobs to run,
+# and all following jobs wait for it to finish and depend on its output.
+- job: decision
+  displayName: './wpt test-jobs'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - template: tools/ci/azure/checkout.yml
+  - script: |
+      ./wpt test-jobs | while read job; do
+        echo "$job"
+        echo "##vso[task.setvariable variable=$job;isOutput=true]true";
+      done
+    name: test_jobs
+    displayName: 'Run ./wpt test-jobs'
+
 - job: infrastructure_macOS
   displayName: 'infrastructure/ tests (macOS)'
-  dependsOn: root
-  condition: dependencies.root.outputs['test_jobs.wptrunner_infrastructure']
+  dependsOn: decision
+  condition: dependencies.decision.outputs['test_jobs.wptrunner_infrastructure']
   pool:
     vmImage: 'macOS-10.13'
   steps:
@@ -78,8 +78,8 @@ jobs:
 
 - job: tools_unittest_macOS
   displayName: 'tools/ unittests (macOS)'
-  dependsOn: root
-  condition: dependencies.root.outputs['test_jobs.tools_unittest']
+  dependsOn: decision
+  condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
     vmImage: 'macOS-10.13'
   steps:
@@ -91,8 +91,8 @@ jobs:
 
 - job: wptrunner_unittest_macOS
   displayName: 'tools/wptrunner/ unittests (macOS)'
-  dependsOn: root
-  condition: dependencies.root.outputs['test_jobs.wptrunner_unittest']
+  dependsOn: decision
+  condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
     vmImage: 'macOS-10.13'
   steps:
@@ -103,8 +103,8 @@ jobs:
 
 - job: wpt_integration_macOS
   displayName: 'tools/wpt/ tests (macOS)'
-  dependsOn: root
-  condition: dependencies.root.outputs['test_jobs.wpt_integration']
+  dependsOn: decision
+  condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
     vmImage: 'macOS-10.13'
   steps:


### PR DESCRIPTION
With the affected test jobs, the root job is no longer *the* root. Use
"decision" following the terminology of Taskcluster:
https://docs.taskcluster.net/docs/tutorial/gecko-decision-task