### PR TITLE
HTML: test that non-synthetic errors get muted too

### DIFF
--- a/html/semantics/scripting-1/the-script-element/muted-errors.sub.html
+++ b/html/semantics/scripting-1/the-script-element/muted-errors.sub.html
@@ -53,6 +53,11 @@
                            "same-origin url should be muted");
     var check5 = test5.step_func_done(() => check(true));
 
+    const test6 = async_test("Non-synthetic errors for same-origin scripts redirected to a " +
+                             "cross-origin URL and redirected back to same-origin should be " +
+                             "muted");
+    const check6 = test6.step_func_done(() => check(true));
+
     function unreachable() { log.push("unexpected"); }
 </script>
 <script src="cacheable-script-throw.py" onerror="test1.unreached_func()()" onload="check1()"></script>
@@ -67,3 +72,6 @@ onerror="test4.unreached_func()()" onload="check4()"></script>
 <script src="//{{domains[www2]}}:{{ports[http][0]}}/fetch/api/resources/redirect.py?location=
 //{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/cacheable-script-throw.py?cross-same"
 onerror="test5.unreached_func()()" onload="check5()"></script>
+<script src="//{{domains[www2]}}:{{ports[http][0]}}/fetch/api/resources/redirect.py?location=
+//{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/resources/throw.js"
+onerror="test6.unreached_func()()" onload="check6()"></script>

--- a/html/semantics/scripting-1/the-script-element/resources/throw.js
+++ b/html/semantics/scripting-1/the-script-element/resources/throw.js
@@ -1,0 +1,1 @@
+document.querySelector(":::not-going-to-be-valid");


### PR DESCRIPTION
Per request from @bzbarsky in https://bugzilla.mozilla.org/show_bug.cgi?id=1512965#c5.