### PR TITLE
[resource-timing] Avoid race condition

### DIFF
--- a/resource-timing/single-entry-per-resource.html
+++ b/resource-timing/single-entry-per-resource.html
@@ -13,6 +13,11 @@
     function (entryList, obs) {
       var entries = entryList.getEntriesByType("resource");
       for (var i = 0; i < entries.length; ++i) {
+        // Ignore any entries for the test harness files if present.
+        if (/testharness(report)?\.js/.test(entries[i].name)) {
+          continue;
+        }
+
         ++observed;
         if (entries[i].name.indexOf(img_url) != -1)
             ++img_entries;


### PR DESCRIPTION
Depending on the scheduling of resource retrieval, performance entries
for the test harness files may be observable by this test. That behavior
is beyond the focus of this test, so such entries should be ignored if
present.