### PR TITLE
[css-ruby] Add ruby-align tests

### DIFF
--- a/css/css-ruby/ruby-align-property/ruby-align-center-001.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-center-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: center, long base</title>
+<meta name="assert" content="ruby-align:center will centre annotations shorter than the base within its box, and set them solid.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: center; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the annotation is centered relative to the base text, and set solid.</p>
+<div class="test" lang="ja"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<!-- Notes:
+In this test the annotation is shorter than the base text.
+-->
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-center-002.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-center-002.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: center, long annotation</title>
+<meta name="assert" content="ruby-align: center will centre base text shorter than the annotations within its box, and set it solid.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: center; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the base text is centered relative to the annotation text, and set solid.</p>
+<div class="test" lang="ja"><ruby><rb>昔話</rb><rt>むかしばなし</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>昔話</rb><rt>むかしばなし</rt></ruby></div>
+<!-- Notes:
+In this test the base text is longer than the annotation.
+-->
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-center-101.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-center-101.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: center, long base (v)</title>
+<meta name="assert" content="ruby-align:center will centre annotations shorter than the base within its box, and set them solid.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+ruby { ruby-align: center; }
+</style>
+</head>
+<body>
+<p class="instructions">Skip if the text is not vertical.<br/>Test passes if the text is vertically set and the annotation is centered relative to the base text, and set solid.</p>
+<div class="test" lang="ja"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<!-- Notes:
+In this test the annotation is shorter than the base text.
+-->
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-center-102.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-center-102.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: center, long annotation (v)</title>
+<meta name="assert" content="ruby-align: center will centre base text shorter than the annotations within its box, and set it solid.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+ruby { ruby-align: center; }
+</style>
+</head>
+<body>
+<p class="instructions">Skip if the text is not vertical.<br/>Test passes if the text is vertically set and the base text is centered relative to the annotation text, and set solid.</p>
+<div class="test" lang="ja"><ruby><rb>昔話</rb><rt>むかしばなし</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>昔話</rb><rt>むかしばなし</rt></ruby></div>
+<!-- Notes:
+In this test the base text is longer than the annotation.
+-->
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-001.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-001.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-around, long base</title>
+<meta name="assert" content="For a wide-cell annotation shorter than its base, ruby-align:space-around adds equal space between annotation characters, with a half-character space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the ANNOTATION are about half a character width from the side of the box, and the intervening space is equally distributed.</p>
+<div class="test" lang="ja"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-002.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-002.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-around, long annotation</title>
+<meta name="assert" content="For a wide-cell base shorter than its annotation, ruby-align:space-around adds equal space base between characters, with a half-character space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the BASE text are about half a character width from the side of the box, and the intervening space is equally distributed.</p>
+<div class="test" lang="ja"><ruby><rb>境界面</rb><rt>インターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>境界面</rb><rt>インターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-003.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-003.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-around, long base, one word latin annotation</title>
+<meta name="assert" content="For a narrow-cell annotation containing no spaces over a wider base, ruby-align:space-around will centre the annotation.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the annotation is centred in the box.</p>
+<div class="test" lang="ja"><ruby><rb>萬國碼</rb><rt>Unicode</rt></ruby></div>
+<div class="test" lang="zh-hant"><ruby><rb>萬國碼</rb><rt>Unicode</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-004.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-004.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-around, long base, multiword latin annotation</title>
+<meta name="assert" content="For a narrow-cell annotation with multiple words over a wider base, ruby-align: space-around will justify the words, with a small amount of space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the ANNOTATION are about half a character width from the side of the box, and the text is justified between.</p>
+<div class="test" lang="ja"><ruby><rb>基斯愛默生</rb><rt>Mr K Emerson</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>基斯愛默生</rb><rt>Mr K Emerson</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-005.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-005.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-around, multiword latin annotation (zh)</title>
+<meta name="assert" content="If the language of the annotation starts with zh, ruby-align: space-around will center the latin words in an annotation, due to the default style sheet, with a small amount of space either side. Latin words are not letter-spaced.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the two words are centered over the base text, and there are no spaces between the letters in each word.</p>
+<div class="test" lang="zh-hant"><ruby><rb>基斯愛默生</rb><rt>Keith Emerson</rt></ruby></div>
+<!-- Notes:
+This test checks whether the browser implements the non-normative default UA style sheet recommendations in Appendix A. -->
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-006.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-006.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align:space-around, long annotation, one word latin base</title>
+<meta name="assert" content="For a narrow-cell base containing no spaces that is shorter than its annotation, ruby-align:space-around will centre the base.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the BASE is centred in the box.</p>
+<div class="test" lang="ja"><ruby><rb>UI</rb><rt>インターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>UI</rb><rt>インターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-007.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-007.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align:space-around, long annotation, multiword latin base</title>
+<meta name="assert" content="For a narrow-cell base with multiple words that is shorter than its annotation, ruby-align:space-around will justify the words, with a small amount of space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the BASE are about half a character width from the side of the box, and the text is justified between.</p>
+<div class="test" lang="ja"><ruby><rb>a web UI</rb><rt>ウェブインターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>a web UI</rb><rt>ウェブインターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-101.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-101.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-around, long base (v)</title>
+<meta name="assert" content="For a wide-cell annotation shorter than its base, ruby-align:space-around adds equal space between annotation characters, with a half-character space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the ANNOTATION are about half a character width from the side of the box, and the intervening space is equally distributed.</p>
+<div class="test" lang="ja"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-102.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-102.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-around, long annotation (v)</title>
+<meta name="assert" content="For a wide-cell base shorter than its annotation, ruby-align:space-around adds equal space base between characters, with a half-character space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the BASE text are about half a character width from the side of the box, and the intervening space is equally distributed.</p>
+<div class="test" lang="ja"><ruby><rb>境界面</rb><rt>インターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>境界面</rb><rt>インターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-103.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-103.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-around, long base, one word latin annotation (v)</title>
+<meta name="assert" content="For a narrow-cell annotation containing no spaces over a wider base, ruby-align:space-around will centre the annotation.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the annotation is centred in the box.</p>
+<div class="test" lang="ja"><ruby><rb>萬國碼</rb><rt>Unicode</rt></ruby></div>
+<div class="test" lang="zh-hant"><ruby><rb>萬國碼</rb><rt>Unicode</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-104.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-104.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-around, long base, multiword latin annotation (v)</title>
+<meta name="assert" content="For a narrow-cell annotation with multiple words over a wider base, ruby-align: space-around will justify the words, with a small amount of space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the ANNOTATION are about half a character width from the side of the box, and the text is justified between.</p>
+<div class="test" lang="ja"><ruby><rb>基斯愛默生</rb><rt>Mr K Emerson</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>基斯愛默生</rb><rt>Mr K Emerson</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-106.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-106.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align:space-around, long annotation, one word latin base (v)</title>
+<meta name="assert" content="For a narrow-cell base containing no spaces that is shorter than its annotation, ruby-align:space-around will centre the base.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the BASE is centred in the box.</p>
+<div class="test" lang="ja"><ruby><rb>UI</rb><rt>インターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>UI</rb><rt>インターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-around-107.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-around-107.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align:space-around, long annotation, multiword latin base (v)</title>
+<meta name="assert" content="For a narrow-cell base with multiple words that is shorter than its annotation, ruby-align:space-around will justify the words, with a small amount of space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-around; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the BASE are about half a character width from the side of the box, and the text is justified between.</p>
+<div class="test" lang="ja"><ruby><rb>a web UI</rb><rt>ウェブインターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>a web UI</rb><rt>ウェブインターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-001.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-001.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-between, long base</title>
+<meta name="assert" content="For a wide-cell annotation shorter than its base, ruby-align:space-between adds equal space between annotation characters, with no extra space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the ANNOTATION are flush with the sides of the box, and the intervening space is equally distributed.</p>
+<div class="test" lang="ja"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-002.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-002.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-between, long annotation</title>
+<meta name="assert" content="For a wide-cell base shorter than its annotation, ruby-align:space-between adds equal space base between characters, with no extra space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the BASE text are flush with the sides of the box, and the intervening space is equally distributed.</p>
+<div class="test" lang="ja"><ruby><rb>境界面</rb><rt>インターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>境界面</rb><rt>インターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-003.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-003.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-between, long base, one word latin annotation</title>
+<meta name="assert" content="For a narrow-cell annotation containing no spaces over a wider base, ruby-align:space-between will centre the annotation.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the annotation is centred in the box.</p>
+<div class="test" lang="ja"><ruby><rb>萬國碼</rb><rt>Unicode</rt></ruby></div>
+<div class="test" lang="zh-hant"><ruby><rb>萬國碼</rb><rt>Unicode</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-004.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-004.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-between, long base, multiword latin annotation</title>
+<meta name="assert" content="For a narrow-cell annotation with multiple words over a wider base, ruby-align: space-between will justify the words, with no extra space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the ANNOTATION are flush with the sides of the box, and the text is justified between.</p>
+<div class="test" lang="ja"><ruby><rb>基斯愛默生</rb><rt>Mr K Emerson</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>基斯愛默生</rb><rt>Mr K Emerson</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-006.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-006.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align:space-between, long annotation, one word latin base</title>
+<meta name="assert" content="For a narrow-cell base containing no spaces that is shorter than its annotation, ruby-align:space-between will centre the base.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the BASE is centred in the box.</p>
+<div class="test" lang="ja"><ruby><rb>UI</rb><rt>インターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>UI</rb><rt>インターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-007.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-007.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align:space-between, long annotation, multiword latin base</title>
+<meta name="assert" content="For a narrow-cell base with multiple words that is shorter than its annotation, ruby-align:space-between will justify the words, with no extra space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the BASE are flush with the sides of the box, and the text is justified between.</p>
+<div class="test" lang="ja"><ruby><rb>a web UI</rb><rt>ウェブインターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>a web UI</rb><rt>ウェブインターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-101.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-101.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-between, long base (v)</title>
+<meta name="assert" content="For a wide-cell annotation shorter than its base, ruby-align:space-between adds equal space between annotation characters, with no extra space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the ANNOTATION are flush with the sides of the box, and the intervening space is equally distributed.</p>
+<div class="test" lang="ja"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-102.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-102.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-between, long annotation (v)</title>
+<meta name="assert" content="For a wide-cell base shorter than its annotation, ruby-align:space-between adds equal space base between characters, with no extra space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the BASE text are flush with the sides of the box, and the intervening space is equally distributed.</p>
+<div class="test" lang="ja"><ruby><rb>境界面</rb><rt>インターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>境界面</rb><rt>インターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-103.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-103.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-between, long base, one word latin annotation (v)</title>
+<meta name="assert" content="For a narrow-cell annotation containing no spaces over a wider base, ruby-align:space-between will centre the annotation.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the annotation is centred in the box.</p>
+<div class="test" lang="ja"><ruby><rb>萬國碼</rb><rt>Unicode</rt></ruby></div>
+<div class="test" lang="zh-hant"><ruby><rb>萬國碼</rb><rt>Unicode</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-104.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-104.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: space-between, long base, multiword latin annotation (v)</title>
+<meta name="assert" content="For a narrow-cell annotation with multiple words over a wider base, ruby-align: space-between will justify the words, with no extra space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the ANNOTATION are flush with the sides of the box, and the text is justified between.</p>
+<div class="test" lang="ja"><ruby><rb>基斯愛默生</rb><rt>Mr K Emerson</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>基斯愛默生</rb><rt>Mr K Emerson</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-106.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-106.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align:space-between, long annotation, one word latin base (v)</title>
+<meta name="assert" content="For a narrow-cell base containing no spaces that is shorter than its annotation, ruby-align:space-between will centre the base.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the BASE is centred in the box.</p>
+<div class="test" lang="ja"><ruby><rb>UI</rb><rt>インターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>UI</rb><rt>インターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-space-between-107.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-space-between-107.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align:space-between, long annotation, multiword latin base (v)</title>
+<meta name="assert" content="For a narrow-cell base with multiple words that is shorter than its annotation, ruby-align:space-between will justify the words, with no extra space either side.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: space-between; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first and last characters of the BASE are flush with the sides of the box, and the text is justified between.</p>
+<div class="test" lang="ja"><ruby><rb>a web UI</rb><rt>ウェブインターフェース</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>a web UI</rb><rt>ウェブインターフェース</rt></ruby></div>
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-start-001.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-start-001.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: start, long base</title>
+<meta name="assert" content="ruby-align: start will make ruby content aligned with the start edge of its box. Short ruby text will be flush left and set solid.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+/*ruby { border: 1px solid #b1d7fe; }*/
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: start; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the annotation is flush with the left edge of the base text, and set solid.</p>
+<div class="test" lang="ja"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<!-- Notes:
+In this test the annotation is shorter than the base text.
+-->
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-start-002.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-start-002.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: start, long annotation</title>
+<meta name="assert" content="ruby-align: start will make ruby content aligned with the start edge of its box. Short base text will be flush left and set solid.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: start; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the base text is flush with the left edge of the annotation text, and set solid.</p>
+<div class="test" lang="ja"><ruby><rb>昔話</rb><rt>むかしばなし</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>昔話</rb><rt>むかしばなし</rt></ruby></div>
+<!-- Notes:
+In this test the base text is shorter than the annotation.
+-->
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-start-101.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-start-101.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: start, long base (v)</title>
+<meta name="assert" content="ruby-align: start will make ruby content aligned with the start edge of its box. Short ruby text will be flush left and set solid.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: start; }
+</style>
+</head>
+<body>
+<p class="instructions">Skip if the text is not vertical.<br/>Test passes if the text is vertically set and the annotation is flush with the left edge of the base text, and set solid.</p>
+<div class="test" lang="ja"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>浮世絵</rb><rt>うきよえ</rt></ruby></div>
+<!-- Notes:
+In this test the annotation is shorter than the base text.
+-->
+</body>
+</html>

--- a/css/css-ruby/ruby-align-property/ruby-align-start-102.html
+++ b/css/css-ruby/ruby-align-property/ruby-align-start-102.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-align: start, long annotation (v)</title>
+<meta name="assert" content="ruby-align: start will make ruby content aligned with the start edge of its box. Short base text will be flush left and set solid.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#rubypos">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#rubypos">
+<style type="text/css">/* this is not part of the test */
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+rt { color: blue; }
+</style>
+<style type="text/css">/* this is the test */
+ruby { ruby-align: start; }
+</style>
+</head>
+<body>
+<p class="instructions">Skip if the text is not vertical.<br/>Test passes if the text is vertically set and the base text is flush with the left edge of the annotation text, and set solid.</p>
+<div class="test" lang="ja"><ruby><rb>昔話</rb><rt>むかしばなし</rt></ruby></div>
+<div class="test" lang="zh"><ruby><rb>昔話</rb><rt>むかしばなし</rt></ruby></div>
+<!-- Notes:
+In this test the base text is shorter than the annotation.
+-->
+</body>
+</html>


### PR DESCRIPTION
This PR ports https://w3c.github.io/i18n-tests/results/css-ruby#ruby_align to WPT. Currently, the tests are manual tests, since we're unable to come up with a way to automate them.

The `-00X.html` tests are in horizontal writing mode, and `-10X.html` tests are in vertical writing mode. Each test has two variants, **long base** and **long annotation**. For `space-between` and `space-around` tests, there're variants for one Latin word and multiple Latin word as ruby bases/annotations.

/cc @r12a @himorin