### PR TITLE
[wptrunner] Correct support for eager page loading

### DIFF
--- a/tools/wptrunner/wptrunner/executors/reftest-wait_marionette.js
+++ b/tools/wptrunner/wptrunner/executors/reftest-wait_marionette.js
@@ -13,7 +13,7 @@ var observer = new MutationObserver(test);
 observer.observe(root, {attributes: true});
 
 if (document.readyState != "complete") {
-  onload = test
+  addEventListener('load', test);
 } else {
   test();
 }

--- a/tools/wptrunner/wptrunner/executors/reftest-wait_webdriver.js
+++ b/tools/wptrunner/wptrunner/executors/reftest-wait_webdriver.js
@@ -38,7 +38,7 @@ var observer = new MutationObserver(root_wait);
 observer.observe(root, {attributes: true});
 
 if (document.readyState != "complete") {
-    onload = root_wait;
+    addEventListener('load', root_wait);
 } else {
     root_wait();
 }


### PR DESCRIPTION
Many reftests schedule behavior to occur when the document reaches the
"complete" readyState by setting the `onload` property of the document
element.

Previously, the automation scripts were written to conditionally defer
execution for that event by setting the `onload` property of the global
object.

The two strategies are mutually exclusive. The sequence of script
execution is not controlled, so either consumer of the "load" event
could be blocked by the other.

Update the automation scripts to register for the event using
`addEventListener` in order to avoid unintended interaction with test
code.

---

This hasn't caused an issue to date because WebDriver's [default page loading strategy](https://w3c.github.io/webdriver/#dfn-table-of-page-load-strategies) pauses until after the "load" event fires. Technically, we could remove the branch altogether. I'm suggesting we fix it instead because it seems preferable to make the infrastructure resilient to bugs in the WebDriver implementation (those will be easier to understand and less disruptive if reported by explicit tests in the WebDriver test suite).