### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=192685

### DIFF
--- a/webrtc/RTCPeerConnection-setDescription-transceiver.html
+++ b/webrtc/RTCPeerConnection-setDescription-transceiver.html
@@ -238,6 +238,27 @@
     });
   }, 'setRemoteDescription(rollback) should remove newly created transceiver from transceiver list');
 
+  promise_test(async t => {
+    const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
+
+    pc1.addTransceiver('audio');
+    const offer = await pc1.createOffer();
+    await pc1.setLocalDescription(offer);
+
+    assert_false(pc1.getTransceivers()[0].stopped, 'Transceiver is not stopped');
+
+    await pc2.setRemoteDescription(offer);
+    pc2.getTransceivers()[0].stop();
+    const answer = await pc2.createAnswer();
+
+    await pc1.setRemoteDescription(answer);
+
+    assert_true(pc1.getTransceivers()[0].stopped, 'Transceiver is stopped');
+  }, 'setRemoteDescription should stop the transceiver if its corresponding m section is rejected');
+
   /*
     TODO
       - Steps for transceiver direction is added to tip of tree draft, but not yet


### PR DESCRIPTION
WebKit export from bug: [RTCRtpTransceiver.stopped should be true when applying a remote description with the corresponding m section rejected](https://bugs.webkit.org/show_bug.cgi?id=192685)