### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=192706

### DIFF
--- a/webrtc/RTCPeerConnection-setDescription-transceiver.html
+++ b/webrtc/RTCPeerConnection-setDescription-transceiver.html
@@ -257,6 +257,8 @@
     await pc1.setRemoteDescription(answer);
 
     assert_true(pc1.getTransceivers()[0].stopped, 'Transceiver is stopped');
+    assert_equals(pc1.getReceivers().length, 0, 'getReceivers does not expose a receiver of a stopped transceiver');
+    assert_equals(pc1.getSenders().length, 0, 'getSenders does not expose a sender of a stopped transceiver');
   }, 'setRemoteDescription should stop the transceiver if its corresponding m section is rejected');
 
   /*

--- a/webrtc/RTCRtpTransceiver.https.html
+++ b/webrtc/RTCRtpTransceiver.https.html
@@ -1175,6 +1175,8 @@
       stoppedTransceiver.receiver.track.onended = resolve;
     });
     stoppedTransceiver.stop();
+    assert_equals(pc1.getReceivers().length, 0, 'getReceivers does not expose a receiver of a stopped transceiver');
+    assert_equals(pc1.getSenders().length, 0, 'getSenders does not expose a sender of a stopped transceiver');
 
     await onended;
 


### PR DESCRIPTION
WebKit export from bug: [getSenders/getReceivers() should not return closed transceiver senders/receivers](https://bugs.webkit.org/show_bug.cgi?id=192706)