### PR TITLE
Cache manifest everywhere

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -117,6 +117,7 @@ jobs:
   - template: tools/ci/azure/install_chrome.yml
   - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
+  - template: tools/ci/azure/update_manifest.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
       directory: tools/wpt/

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -400,8 +400,16 @@ def load(tests_root, manifest, types=None, meta_filters=None):
     return _load(logger, tests_root, manifest, types, meta_filters)
 
 
+__load_cache = {}
+
+
 def _load(logger, tests_root, manifest, types=None, meta_filters=None):
     # "manifest" is a path or file-like object.
+    manifest_path = (manifest if isinstance(manifest, string_types)
+                     else manifest.name)
+    if manifest_path in __load_cache:
+        return __load_cache[manifest_path]
+
     if isinstance(manifest, string_types):
         if os.path.exists(manifest):
             logger.debug("Opening manifest at %s" % manifest)
@@ -418,12 +426,14 @@ def _load(logger, tests_root, manifest, types=None, meta_filters=None):
         except ValueError:
             logger.warning("%r may be corrupted", manifest)
             return None
-        return rv
+    else:
+        rv = Manifest.from_json(tests_root,
+                                json.load(manifest),
+                                types=types,
+                                meta_filters=meta_filters)
 
-    return Manifest.from_json(tests_root,
-                              json.load(manifest),
-                              types=types,
-                              meta_filters=meta_filters)
+    __load_cache[manifest_path] = rv
+    return rv
 
 
 def load_and_update(tests_root,

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -8,8 +8,6 @@ import sys
 from collections import OrderedDict
 from six import iteritems
 
-from ..manifest import manifest
-
 here = os.path.dirname(__file__)
 wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
 
@@ -183,24 +181,15 @@ def _in_repo_root(full_path):
     return len(path_components) < 2
 
 
-def _init_manifest_cache():
-    c = {}
-
-    def load(manifest_path=None, manifest_update=True):
-        if manifest_path is None:
-            manifest_path = os.path.join(wpt_root, "MANIFEST.json")
-        if c.get(manifest_path):
-            return c[manifest_path]
-        # cache at most one path:manifest
-        c.clear()
-        wpt_manifest = manifest.load_and_update(wpt_root, manifest_path, "/",
-                                                update=manifest_update)
-        c[manifest_path] = wpt_manifest
-        return c[manifest_path]
-    return load
-
-
-load_manifest = _init_manifest_cache()
+def load_manifest(manifest_path=None, manifest_update=True):
+    # Delay import after localpaths sets up sys.path, because otherwise the
+    # import path will be "..manifest" and Python will treat it as a different
+    # manifest module.
+    from manifest import manifest
+    if manifest_path is None:
+        manifest_path = os.path.join(wpt_root, "MANIFEST.json")
+    return manifest.load_and_update(wpt_root, manifest_path, "/",
+                                    update=manifest_update)
 
 
 def affected_testfiles(files_changed, skip_dirs=None,

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -30,27 +30,29 @@ def is_port_8000_in_use():
     return False
 
 
-@pytest.fixture(scope="module")
-def manifest_dir():
-    def update_manifest():
-        with pytest.raises(SystemExit) as excinfo:
-            wpt.main(argv=["manifest", "--no-download", "--path", os.path.join(path, "MANIFEST.json")])
-        assert excinfo.value.code == 0
+def get_persistent_manifest_path():
+    directory = ("~/meta" if os.environ.get('TRAVIS') == "true"
+                 else wpt.localpaths.repo_root)
+    return os.path.join(directory, "MANIFEST.json")
 
-    if os.environ.get('TRAVIS') == "true":
-        path = "~/meta"
-        update_manifest()
+
+@pytest.fixture(scope="module", autouse=True)
+def init_manifest():
+    with pytest.raises(SystemExit) as excinfo:
+        wpt.main(argv=["manifest", "--no-download",
+                       "--path", get_persistent_manifest_path()])
+    assert excinfo.value.code == 0
+
+
+@pytest.fixture
+def manifest_dir():
+    try:
+        path = tempfile.mkdtemp()
+        shutil.copyfile(get_persistent_manifest_path(),
+                        os.path.join(path, "MANIFEST.json"))
         yield path
-    else:
-        try:
-            path = tempfile.mkdtemp()
-            old_path = os.path.join(wpt.localpaths.repo_root, "MANIFEST.json")
-            if os.path.exists(os.path.join(wpt.localpaths.repo_root, "MANIFEST.json")):
-                shutil.copyfile(old_path, os.path.join(path, "MANIFEST.json"))
-            update_manifest()
-            yield path
-        finally:
-            shutil.rmtree(path)
+    finally:
+        shutil.rmtree(path)
 
 
 @pytest.fixture


### PR DESCRIPTION
Move the cache layer of manifest objects from wpt.testfiles to
manifest.manifest so that all users of the manifest module can benefit.

This prevents us from having two in-memory copies of the manifest when
running affected tests (one loaded by wpt.testfiles and the other loaded
by wptrunner.testloader). Partly fixes #14421 (the memory usage part of
it, but not the code health part).