### PR TITLE
Update <button type="menu"> test to reflect its removal

### DIFF
--- a/html/semantics/forms/the-button-element/button-validation.html
+++ b/html/semantics/forms/the-button-element/button-validation.html
@@ -24,6 +24,6 @@
   willValid(document.getElementById('btn2'), "submit", true, "submit type attribute");
   willValid(document.getElementById('btn3'), "reset", false, "reset type attribute");
   willValid(document.getElementById('btn4'), "button", false, "button type attribute");
-  willValid(document.getElementById('btn5'), "menu", false, "menu type attribute");
+  willValid(document.getElementById('btn5'), "submit", true, "historical menu type attribute");
   willValid(document.getElementById('btn6'), "submit", true, "invalid type attribute");
 </script>


### PR DESCRIPTION
`<button type="menu">` got removed in https://github.com/whatwg/html/pull/2342 and this test was [failing](https://wpt.fyi/results/html/semantics/forms/the-button-element/button-validation.html?label=stable&aligned&q=the-button-element) in all browsers.