### PR TITLE
[css-text] Typo in Thai text

### DIFF
--- a/css/css-text/word-break/reference/word-break-keep-all-ref-003.html
+++ b/css/css-text/word-break/reference/word-break-keep-all-ref-003.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <div id='instructions'>Test passes if the two orange boxes are the same.</div>
-<div class="ref" lang="th"><span>แและ แและ<br/>แและ</span></div>
-<div class="ref" lang="th"><span>แและ แและ<br/>แและ</span></div>
+<div class="ref" lang="th"><span>และ และ<br/>และ</span></div>
+<div class="ref" lang="th"><span>และ และ<br/>และ</span></div>
 </body>
 </html>

--- a/css/css-text/word-break/word-break-keep-all-003.html
+++ b/css/css-text/word-break/word-break-keep-all-003.html
@@ -15,8 +15,8 @@
 </head>
 <body>
 <div id='instructions'>Test passes if the two orange boxes are the same.</div>
-<div class="test" lang="th"><div id="testdiv"><span id="testspan">แและ แและแและ</span></div></div>
-<div class="ref" lang="th"><span>แและ แและ<br/>แและ</span></div>
+<div class="test" lang="th"><div id="testdiv"><span id="testspan">และ และและ</span></div></div>
+<div class="ref" lang="th"><span>และ และ<br/>และ</span></div>
 <script>
 var sentenceWidth = document.getElementById('testspan').offsetWidth
 document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'


### PR DESCRIPTION
Since we're testing dictionary based word-boundary detection, it seems
quite important to avoid spelling mistakes. The Thai word “and” is
spelled “และ” and not “แและ”.