### PR TITLE
Let `./wpt run --affected revish` ignore testharness*

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -497,7 +497,9 @@ def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
     affected_revish = kwargs.pop("affected", None)
     if affected_revish is not None:
         files_changed, _ = testfiles.files_changed(
-            affected_revish, include_uncommitted=True, include_new=True)
+            affected_revish,
+            ignore_rules=["resources/testharness*"],
+            include_uncommitted=True, include_new=True)
         # TODO: Perhaps use wptrunner.testloader.ManifestLoader here
         # and remove the manifest-related code from testfiles.
         # https://github.com/web-platform-tests/wpt/issues/14421

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -496,6 +496,8 @@ def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
 
     affected_revish = kwargs.pop("affected", None)
     if affected_revish is not None:
+        # TODO: Consolidate with `./wpt tests-affected --ignore-rules`:
+        # https://github.com/web-platform-tests/wpt/issues/14560
         files_changed, _ = testfiles.files_changed(
             affected_revish,
             ignore_rules=["resources/testharness*"],

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -309,6 +309,8 @@ def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("revish", default=None, help="Commits to consider. Defaults to the "
                         "commits on the current branch", nargs="?")
+    # TODO: Consolidate with `./wpt run --affected`:
+    # https://github.com/web-platform-tests/wpt/issues/14560
     parser.add_argument("--ignore-rules", nargs="*", type=set,
                         default=set(["resources/testharness*"]),
                         help="Rules for paths to exclude from lists of changes. Rules are paths "


### PR DESCRIPTION
This matches the behavior of `./wpt tests-affected`:
https://github.com/web-platform-tests/wpt/blob/503a7143f0bd8b719e8ef62d12530b6390d0241d/tools/wpt/testfiles.py#L312-L317

Reported in https://github.com/web-platform-tests/wpt/pull/14540.