### PR TITLE
Remove support for testharness/reftest tests in IE

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/ie.py
+++ b/tools/wptrunner/wptrunner/browsers/ie.py
@@ -2,16 +2,12 @@ from .base import Browser, ExecutorBrowser, require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from ..webdriver_server import InternetExplorerDriverServer
 from ..executors import executor_kwargs as base_executor_kwargs
-from ..executors.executorselenium import (SeleniumTestharnessExecutor,  # noqa: F401
-                                          SeleniumRefTestExecutor)  # noqa: F401
 from ..executors.executorinternetexplorer import InternetExplorerDriverWdspecExecutor  # noqa: F401
 
 __wptrunner__ = {"product": "ie",
                  "check_args": "check_args",
                  "browser": "InternetExplorerBrowser",
-                 "executor": {"testharness": "SeleniumTestharnessExecutor",
-                              "reftest": "SeleniumRefTestExecutor",
-                              "wdspec": "InternetExplorerDriverWdspecExecutor"},
+                 "executor": {"wdspec": "InternetExplorerDriverWdspecExecutor"},
                  "browser_kwargs": "browser_kwargs",
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",


### PR DESCRIPTION
In reality, all that's been run for a long time is WebDriver tests, and the testharness/reftest automation scripts almost certainly don't work in any version of IE.

cc/ @jimevans