### PR TITLE
wptserve: Add a header_or_default function which works when the request header is absent.

### DIFF
--- a/tools/wptserve/docs/pipes.rst
+++ b/tools/wptserve/docs/pipes.rst
@@ -52,6 +52,10 @@ and `}}`. Inside the block the following variables are available:
     The HTTP headers in the request
       e.g. `{{headers[X-Test]}}` for a hypothetical `X-Test` header.
 
+  `{{header_or_default(header, default)}}`
+    The value of an HTTP header, or a default value if it is absent.
+      e.g. `{{header_or_default(X-Test, test-header-absent)}}`
+
   `{{GET[]}}`
     The query parameters for the request
       e.g. `{{GET[id]}}` for an id parameter sent with the request.

--- a/tools/wptserve/tests/functional/docroot/sub_header_or_default.sub.txt
+++ b/tools/wptserve/tests/functional/docroot/sub_header_or_default.sub.txt
@@ -1,0 +1,2 @@
+{{header_or_default(X-Present, present-default)}}
+{{header_or_default(X-Absent, absent-default)}}

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -126,6 +126,11 @@ server: http://localhost:{0}""".format(self.server.port).encode("ascii")
 """ % {"root": root, "sep": os.path.sep}
         self.assertEqual(resp.read(), expected.encode("utf8"))
 
+    def test_sub_header_or_default(self):
+        resp = self.request("/sub_header_or_default.sub.txt", headers={"X-Present": "OK"})
+        expected = b"OK\nabsent-default"
+        self.assertEqual(resp.read().rstrip(), expected)
+
 class TestTrickle(TestUsingServer):
     def test_trickle(self):
         #Actually testing that the response trickles in is not that easy

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -345,6 +345,11 @@ def sub(request, response, escape_type="html"):
        includes the leading '?', but other delimiters are omitted.
     headers
       A dictionary of HTTP headers in the request.
+    header_or_default(header, default)
+      The value of an HTTP header, or a default value if it is absent.
+      For example:
+
+        {{header_or_default(X-Test, test-header-absent)}}
     GET
       A dictionary of query parameters supplied with the request.
     uuid()
@@ -430,6 +435,10 @@ class SubFunctions(object):
         if ".." in os.path.relpath(absolute_path, request.doc_root):
             raise ValueError("Path outside wpt root")
         return absolute_path
+
+    @staticmethod
+    def header_or_default(request, name, default):
+        return request.headers.get(name, default)
 
 def template(request, content, escape_type="html"):
     #TODO: There basically isn't any error handling here


### PR DESCRIPTION
wptserve: Produce an empty string if indexed access fails during sub template substitution.

Fixes #14572.