### PR TITLE
[css-ruby] Add ruby-merge tests

### DIFF
--- a/css/css-ruby/collapsed-ruby/ruby-merge-auto-002.html
+++ b/css/css-ruby/collapsed-ruby/ruby-merge-auto-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-merge: auto, line break</title>
+<meta name="assert" content="When a line break occurs between base characters while applying ruby-merge:auto, ruby annotations are kept together with their respective ruby bases.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#collapsed-ruby">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#collapsed-ruby">
+<style type="text/css">
+.test { margin: 20px;  padding: 40px; font-size: 110px; width: 200px; }
+rt { color: blue; }
+rt#middle { color: #b1d7fe; }
+/* the CSS above is not part of the test */
+ruby { ruby-merge: auto; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first base character is associated with 1 annotation character; the second with 3; and the last with 1.</p>
+<div class="test" lang="ja"><ruby><rb>思</rb><rt>し</rt><rb>春</rb><rt id="middle">しゅん</rt><rb>期</rb><rt>き</rt></ruby></div>
+<!-- Notes:
+This test doesn't give a reliable result if ruby-merge: auto doesn't merge annotation characters without a line break (ie. if ruby-merge-auto-001 fails).
+-->
+</body>
+</html>

--- a/css/css-ruby/collapsed-ruby/ruby-merge-auto-102.html
+++ b/css/css-ruby/collapsed-ruby/ruby-merge-auto-102.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-merge: auto, line break (v)</title>
+<meta name="assert" content="When a line break occurs between base characters while applying ruby-merge:auto, ruby annotations are kept together with their respective ruby bases.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#collapsed-ruby">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#collapsed-ruby">
+<style type="text/css">
+.test { margin: 20px;  padding: 40px; font-size: 110px; height: 200px; }
+rt { color: blue; }
+rt#middle { color: #b1d7fe; }
+</style>
+<style type="text/css">/* this is the test */
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+ruby { ruby-merge: auto; }
+</style>
+</head>
+<body>
+<p class="instructions">Skip if the text is not vertical.<br/>Test passes if the text is vertical and the first base character is associated with 1 annotation character; the second with 3; and the last with 1.</p>
+<div class="test" lang="ja"><ruby><rb>思</rb><rt>し</rt><rb>春</rb><rt id="middle">しゅん</rt><rb>期</rb><rt>き</rt></ruby></div>
+<!-- Notes:
+This test doesn't give a reliable result if ruby-merge: auto doesn't merge annotation characters without a line break (ie. if ruby-merge-auto-001 fails).
+-->
+</body>
+</html>

--- a/css/css-ruby/collapsed-ruby/ruby-merge-collapse-001.html
+++ b/css/css-ruby/collapsed-ruby/ruby-merge-collapse-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-merge: collapse</title>
+<meta name="assert" content="ruby-merge:collapse will render all annotations evenly across the base text.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#collapsed-ruby">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#collapsed-ruby">
+<style type="text/css">
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+rt#middle { color: #b1d7fe; }
+/* the CSS above is not part of the test */
+ruby { ruby-merge: collapse; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the annotation characters are spread evenly across both the base characters.</p>
+<div class="test" lang="ja"><ruby><rb>思</rb><rt>し</rt><rb>春</rb><rt id="middle">しゅん</rt><rb>期</rb><rt>き</rt></ruby></div>
+<!-- Notes:
+-->
+</body>
+</html>

--- a/css/css-ruby/collapsed-ruby/ruby-merge-collapse-002.html
+++ b/css/css-ruby/collapsed-ruby/ruby-merge-collapse-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-merge: collapse, line break</title>
+<meta name="assert" content="When a line break occurs between base characters while applying ruby-merge:collapse, ruby annotations are kept together with their respective ruby bases.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#collapsed-ruby">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#collapsed-ruby">
+<style type="text/css">
+.test { margin: 20px;  padding: 40px; font-size: 110px; width: 200px; }
+rt { color: blue; }
+rt#middle { color: #b1d7fe; }
+/* the CSS above is not part of the test */
+ruby { ruby-merge: collapse; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first base character is associated with 1 annotation character; the second with 3; and the last with 1.</p>
+<div class="test" lang="ja"><ruby><rb>思</rb><rt>し</rt><rb>春</rb><rt id="middle">しゅん</rt><rb>期</rb><rt>き</rt></ruby></div>
+<!-- Notes:
+This test doesn't give a reliable result if ruby-merge: collapse doesn't merge annotation characters without a line break (ie. if ruby-merge-collapse-001 fails).
+-->
+</body>
+</html>

--- a/css/css-ruby/collapsed-ruby/ruby-merge-collapse-101.html
+++ b/css/css-ruby/collapsed-ruby/ruby-merge-collapse-101.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-merge: collapse (v)</title>
+<meta name="assert" content="ruby-merge:collapse will render all annotations evenly across the base text.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#collapsed-ruby">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#collapsed-ruby">
+<style type="text/css">
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+rt#middle { color: #b1d7fe; }
+</style>
+<style type="text/css">/* this is the test */
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+ruby { ruby-merge: collapse; }
+</style>
+</head>
+<body>
+<p class="instructions">Skip if the text is not vertical.<br/>Test passes if the text is vertical and the annotation characters are spread evenly across both the base characters.</p>
+<div class="test" lang="ja"><ruby><rb>思</rb><rt>し</rt><rb>春</rb><rt id="middle">しゅん</rt><rb>期</rb><rt>き</rt></ruby></div>
+<!-- Notes:
+-->
+</body>
+</html>

--- a/css/css-ruby/collapsed-ruby/ruby-merge-collapse-102.html
+++ b/css/css-ruby/collapsed-ruby/ruby-merge-collapse-102.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-merge: collapse, line break (v)</title>
+<meta name="assert" content="When a line break occurs between base characters while applying ruby-merge:collapse, ruby annotations are kept together with their respective ruby bases.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#collapsed-ruby">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#collapsed-ruby">
+<style type="text/css">
+.test { margin: 20px;  padding: 40px; font-size: 110px; height: 100px; }
+rt { color: blue; }
+rt#middle { color: #b1d7fe; }
+</style>
+<style type="text/css">/* this is the test */
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+ruby { ruby-merge: collapse; }
+</style>
+</head>
+<body>
+<p class="instructions">Skip if the text is not vertical.<br/>Test passes if the text is vertical and the first base character is associated with 1 annotation character; the second with 3; and the last with 1.</p>
+<div class="test" lang="ja"><ruby><rb>思</rb><rt>し</rt><rb>春</rb><rt id="middle">しゅん</rt><rb>期</rb><rt>き</rt></ruby></div>
+<!-- Notes:
+This test doesn't give a reliable result if ruby-merge: collapse doesn't merge annotation characters without a line break (ie. if ruby-merge-collapse-001 fails).
+-->
+</body>
+</html>

--- a/css/css-ruby/collapsed-ruby/ruby-merge-separate-001.html
+++ b/css/css-ruby/collapsed-ruby/ruby-merge-separate-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-merge: separate</title>
+<meta name="assert" content="ruby-merge:separate will render each annotation in the same column as its base text.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#collapsed-ruby">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#collapsed-ruby">
+<style type="text/css">
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+rt#middle { color: #b1d7fe; }
+/* the CSS above is not part of the test */
+ruby { ruby-merge: separate; }
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if the first annotation character is above the first base character, the next 3 above the second, and the last one is above the third.</p>
+<div class="test" lang="ja"><ruby><rb>思</rb><rt>し</rt><rb>春</rb><rt id="middle">しゅん</rt><rb>期</rb><rt>き</rt></ruby></div>
+<!-- Notes:
+-->
+</body>
+</html>

--- a/css/css-ruby/collapsed-ruby/ruby-merge-separate-101.html
+++ b/css/css-ruby/collapsed-ruby/ruby-merge-separate-101.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8">
+<title>ruby-merge: separate (v)</title>
+<meta name="assert" content="ruby-merge:separate will render each annotation in the same column as its base text.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="http://www.w3.org/TR/css-ruby-1/#collapsed-ruby">
+<link rel="help" href="https://drafts.csswg.org/css-ruby-1/#collapsed-ruby">
+<style type="text/css">
+.test { margin: 20px;  padding: 40px; font-size: 110px; }
+rt { color: blue; }
+rt#middle { color: #b1d7fe; }
+</style>
+<style type="text/css">/* this is the test */
+.test { -webkit-writing-mode: vertical-lr; writing-mode: tb-rl; writing-mode: vertical-rl; }
+ruby { ruby-merge: separate; }
+</style>
+</head>
+<body>
+<p class="instructions">Skip if the text is not vertical.<br/>Test passes if the text is vertical and the first annotation character is associated with the first base character, the next 3 with the second, and the last one with the third.</p>
+<div class="test" lang="ja"><ruby><rb>思</rb><rt>し</rt><rb>春</rb><rt id="middle">しゅん</rt><rb>期</rb><rt>き</rt></ruby></div>
+<!-- Notes:
+-->
+</body>
+</html>


### PR DESCRIPTION
This PR ports https://w3c.github.io/i18n-tests/results/css-ruby#ruby_merge to WPT. Currently, the tests are manual tests, since we're unable to come up with a way to automate them.

The `-00X.html` tests are in horizontal writing mode, and `-10X.html` tests are in vertical writing mode.

Please note that if `ruby-merge-{collapse,auto}-001` fails in a browser (or non-browser impl), the corresponding line break tests (i.e., `ruby-merge-{collapse,auto}-{0,1}02`) will not give a reliable result.

I didn't include `ruby-merge-auto-{0,1}01.html` because it's an exploratory test and the behavior is not in the normative text of the spec currently.

/cc @r12a @himorin
