### PR TITLE
Add a way for single layout test to report all assertions and continue execution after the first failing assertion

### DIFF
--- a/html/browsers/the-window-object/detached-frame-property.html
+++ b/html/browsers/the-window-object/detached-frame-property.html
@@ -1,0 +1,38 @@
+<title>Checks the value of detached subframe properties</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+execute_single_page_test_after_failing_assertion();
+
+onload = function()
+{
+    detachedWindow = frames[0];
+    document.body.removeChild(document.getElementsByTagName("iframe")[0]);
+
+    assert_true(!!detachedWindow.postMessage, "detachedWindow.postMessage is defined");
+    assert_true(!!detachedWindow.close, "detachedWindow.close is defined");
+    assert_true(!!detachedWindow.locationbar, "detachedWindow.locationbar is defined");
+    assert_true(!!detachedWindow.history, "detachedWindow.history is defined");
+    assert_true(!!detachedWindow.screen, "detachedWindow.screen is defined");
+    assert_true(!!detachedWindow.location, "detachedWindon.location is defined");
+    assert_true(detachedWindow.closed, "detachedWindow.closed is true");
+    assert_equals(detachedWindow.top, null, "detachedWindow.top is null");
+    assert_equals(detachedWindow.opener, null, "detachedWindow.opener is null");
+    assert_equals(detachedWindow.parent, null, "detachedWindow.parent is null");
+    assert_equals(detachedWindow.frameElement, null, "detachedWindow.frameElement is null");
+    assert_equals(detachedWindow.window, null, "detachedWindow.window is null");
+    assert_equals(detachedWindow.frames, null, "detachedWindow.frames is null");
+    assert_equals(detachedWindow.self, null, "detachedWindow.self is null");
+
+    assert_true(!detachedWindow.localStorage, "detachedWindow.localStorage is undefined");
+    assert_true(!!detachedWindow.document, "detachedWindow.document is defined");
+    assert_true(!!detachedWindow.XMLHttpRequest, "detachedWindow.XMLHttpRequest is defined");
+    assert_true(!!detachedWindow.getComputedStyle, "detachedWindow.getComputedStyle is defined");
+
+    assert_equals(detachedWindow.innerHeight, 0, "detachedWindow.innerHeight is 0");
+    assert_equals(detachedWindow.innerWidth, 0, "detachedWindow.innerWidth is 0");
+
+    done();
+}
+</script>
+<iframe src="about:blank"></iframe>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1494,6 +1494,8 @@ policies and contribution forms [3].
         this.message = null;
         this.stack = null;
 
+        this.assertions = [];
+
         this.steps = [];
         this._is_promise_test = false;
 
@@ -1539,6 +1541,10 @@ policies and contribution forms [3].
         this._structured_clone.phase = this.phase;
         return this._structured_clone;
     };
+
+    Test.prototype.add_assertion = function(assertion) {
+        this.assertions.push(assertion);
+    }
 
     Test.prototype.step = function(func, this_obj)
     {
@@ -1684,7 +1690,7 @@ policies and contribution forms [3].
             return;
         }
 
-        if (this.phase <= this.phases.STARTED) {
+        if (this.phase <= this.phases.STARTED && this.status !== this.FAIL) {
             this.set_status(this.PASS, null);
         }
 
@@ -2979,10 +2985,29 @@ policies and contribution forms [3].
     /*
      * Utility functions
      */
+
+    let continue_execution_after_failing_assertion = false;
+    function execute_single_page_test_after_failing_assertion()
+    {
+        continue_execution_after_failing_assertion = true;
+    }
+    expose(execute_single_page_test_after_failing_assertion, 'execute_single_page_test_after_failing_assertion');
+
     function assert(expected_true, function_name, description, error, substitutions)
     {
         if (tests.tests.length === 0) {
             tests.set_file_is_test();
+        }
+        if (tests.file_is_test) {
+            let test = tests.tests[0];
+            let message = expected_true ? description : make_message(function_name, description, error, substitutions);
+            test.add_assertion({passed: !!expected_true, message: message});
+            if (continue_execution_after_failing_assertion) {
+                if (!expected_true && test.status !== test.FAIL) {
+                    test.set_status(test.FAIL, "At least one assertion failed: " + message);
+                }
+                return;
+            }
         }
         if (expected_true !== true) {
             var msg = make_message(function_name, description,

--- a/resources/testharnessreport.js
+++ b/resources/testharnessreport.js
@@ -28,6 +28,15 @@ function dump_test_results(tests, status) {
                 stack: status.stack};
     results_element.textContent = JSON.stringify(data);
 
+    if (tests.length === 1) {
+        for (let assertion of tests[0].assertions) {
+            if (assertion.passed)
+                console.log("PASS " + assertion.message);
+            else
+                console.error("FAIL " + assertion.message);
+        }
+    }
+
     // To avoid a HierarchyRequestError with XML documents, ensure that 'results_element'
     // is inserted at a location that results in a valid document.
     var parent = document.body


### PR DESCRIPTION
This PR records all executed assertions for single test files.
These assertions are passed to the completion callback so that results can be displayed in various ways.

This PR adds a method to enable continue executing the test even if an assertion is failing.
A test opts in by calling a specific method.

A test using this new mode is added to validate the mechanism.
This test is a testharness-based version of https://github.com/WebKit/webkit/blob/master/LayoutTests/fast/frames/detached-frame-property.html