### PR TITLE
Remove trailing spaces from MANIFEST.json

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -11,8 +11,10 @@ from .utils import from_os_path, to_os_path
 
 try:
     import ujson as json
+    JSON_LIBRARY = 'ujson'
 except ImportError:
     import json
+    JSON_LIBRARY = 'json'
 
 CURRENT_VERSION = 5
 
@@ -473,5 +475,12 @@ def write(manifest, manifest_path):
     if not os.path.exists(dir_name):
         os.makedirs(dir_name)
     with open(manifest_path, "wb") as f:
-        json.dump(manifest.to_json(), f, sort_keys=True, indent=1)
+        if JSON_LIBRARY == 'ujson':
+            # ujson does not support the separators flag.
+            json.dump(manifest.to_json(), f, sort_keys=True, indent=1)
+        else:
+            # Use ',' instead of the default ', ' separator to prevent trailing
+            # spaces: https://docs.python.org/2/library/json.html#json.dump
+            json.dump(manifest.to_json(), f,
+                      sort_keys=True, indent=1, separators=(',', ': '))
         f.write("\n")


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/commit/1ca46e0bec3da78ea11a824f7e6d07755e1f8399#diff-2a239eec150d25cf7486394513fb1e63L255
removed the `separators=(',', ': ')` argument to `json.dump`, which
caused `json.dump` to use the default ", " separator that will add a
trailing space after each item.

Doc: https://docs.python.org/2/library/json.html#json.dump