### PR TITLE
Make `--verbose` as an alias of `--log-mach-level debug`

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -473,7 +473,7 @@ def setup_logging(kwargs, default_config=None):
         else:
             default_formatter = "mach"
         default_config = {default_formatter: sys.stdout}
-    wptcommandline.check_log_verbose(kwargs)
+    wptcommandline.check_verbose(kwargs)
     wptrunner.setup_logging(kwargs, default_config)
     logger = wptrunner.logger
     return logger

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -473,7 +473,7 @@ def setup_logging(kwargs, default_config=None):
         else:
             default_formatter = "mach"
         default_config = {default_formatter: sys.stdout}
-    wptcommandline.check_verbose(kwargs)
+    wptcommandline.check_log_verbose(kwargs)
     wptrunner.setup_logging(kwargs, default_config)
     logger = wptrunner.logger
     return logger

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -462,6 +462,7 @@ product_setup = {
 def setup_logging(kwargs, default_config=None):
     import mozlog
     from wptrunner import wptrunner
+    from wptrunner import wptcommandline
 
     global logger
 
@@ -472,6 +473,7 @@ def setup_logging(kwargs, default_config=None):
         else:
             default_formatter = "mach"
         default_config = {default_formatter: sys.stdout}
+    wptcommandline.check_log_verbose(kwargs)
     wptrunner.setup_logging(kwargs, default_config)
     logger = wptrunner.logger
     return logger

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -71,57 +71,44 @@ def test_setup_wptrunner(venv, logger, product):
         kwargs["product"] = "sauce:firefox:63"
     run.setup_wptrunner(venv, **kwargs)
 
+def run_cmdline_test(cmdline, key, value):
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args(cmdline.split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs.get(key) == value
 
 def test_opt_mach_verbose():
-    parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--log-mach - --verbose chrome".split()))
-    wptcommandline.check_verbose(kwargs)
-    assert kwargs["log_mach_level"] == "debug"
+    run_cmdline_test("--log-mach - --verbose chrome",
+                     "log_mach_level", "debug")
 
 def test_opt_verbose_log_mach_level_debug():
-    parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--log-mach - --verbose --log-mach-level debug chrome".split()))
-    wptcommandline.check_verbose(kwargs)
-    assert kwargs["log_mach_level"] == "debug"
+    run_cmdline_test("--log-mach - --verbose --log-mach-level debug chrome",
+                     "log_mach_level", "debug")
 
 def test_opt_verbose_log_mach_level_info():
-    parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--log-mach - --verbose --log-mach-level info chrome".split()))
-    wptcommandline.check_verbose(kwargs)
-    assert kwargs["log_mach_level"] == "info"
+    run_cmdline_test("--log-mach - --verbose --log-mach-level info chrome",
+                     "log_mach_level", "info")
 
 def test_opt_raw_verbose():
-    parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--log-raw - --verbose chrome".split()))
-    wptcommandline.check_verbose(kwargs)
-    assert kwargs["log_raw_level"] == "debug"
+    run_cmdline_test("--log-raw - --verbose chrome",
+                     "log_raw_level", "debug")
 
 def test_opt_verbose_log_raw_level_debug():
-    parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--log-raw - --verbose --log-raw-level debug chrome".split()))
-    wptcommandline.check_verbose(kwargs)
-    assert kwargs["log_raw_level"] == "debug"
+    run_cmdline_test("--log-raw - --verbose --log-raw-level debug chrome",
+                     "log_raw_level", "debug")
 
 def test_opt_verbose_log_raw_level_info():
-    parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--log-raw - --verbose --log-raw-level info chrome".split()))
-    wptcommandline.check_verbose(kwargs)
-    assert kwargs["log_raw_level"] == "info"
+    run_cmdline_test("--log-raw - --verbose --log-raw-level info chrome",
+                     "log_raw_level", "info")
 
 def test_opt_tbpl_verbose():
-    parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--log-tbpl - --verbose chrome".split()))
-    wptcommandline.check_verbose(kwargs)
-    assert kwargs["log_tbpl_level"] == "debug"
+    run_cmdline_test("--log-tbpl - --verbose chrome",
+                     "log_tbpl_level", "debug")
 
 def test_opt_verbose_log_tbpl_level_debug():
-    parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--log-tbpl - --verbose --log-tbpl-level debug chrome".split()))
-    wptcommandline.check_verbose(kwargs)
-    assert kwargs["log_tbpl_level"] == "debug"
+    run_cmdline_test("--log-tbpl - --verbose --log-tbpl-level debug chrome",
+                     "log_tbpl_level", "debug")
 
 def test_opt_verbose_log_tbpl_level_info():
-    parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--log-tbpl - --verbose --log-tbpl-level info chrome".split()))
-    wptcommandline.check_verbose(kwargs)
-    assert kwargs["log_tbpl_level"] == "info"
+    run_cmdline_test("--log-tbpl - --verbose --log-tbpl-level info chrome",
+                     "log_tbpl_level", "info")

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -9,6 +9,8 @@ from tools.wpt import run
 from tools import localpaths  # noqa: F401
 from wptrunner.browsers import product_list
 
+from wptrunner import wptcommandline
+
 
 @pytest.fixture(scope="module")
 def venv():
@@ -68,3 +70,22 @@ def test_setup_wptrunner(venv, logger, product):
     if kwargs["product"] == "sauce":
         kwargs["product"] = "sauce:firefox:63"
     run.setup_wptrunner(venv, **kwargs)
+
+
+def test_opt_verbose():
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args("--verbose chrome".split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs["log_mach_level"] == "debug"
+
+def test_opt_verbose_log_mach_level_debug():
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args("--verbose --log-mach-level debug chrome".split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs["log_mach_level"] == "debug"
+
+def test_opt_verbose_log_mach_level_info():
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args("--verbose --log-mach-level info chrome".split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs["log_mach_level"] == "info"

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -74,7 +74,7 @@ def test_setup_wptrunner(venv, logger, product):
 def run_cmdline_test(cmdline, key, value):
     parser = run.create_parser()
     kwargs = vars(parser.parse_args(cmdline.split()))
-    wptcommandline.check_verbose(kwargs)
+    wptcommandline.check_log_verbose(kwargs)
     assert kwargs.get(key) == value
 
 def test_opt_mach_verbose():

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -74,7 +74,7 @@ def test_setup_wptrunner(venv, logger, product):
 def run_cmdline_test(cmdline, key, value):
     parser = run.create_parser()
     kwargs = vars(parser.parse_args(cmdline.split()))
-    wptcommandline.check_log_verbose(kwargs)
+    wptcommandline.check_verbose(kwargs)
     assert kwargs.get(key) == value
 
 def test_opt_mach_verbose():

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -72,20 +72,56 @@ def test_setup_wptrunner(venv, logger, product):
     run.setup_wptrunner(venv, **kwargs)
 
 
-def test_opt_verbose():
+def test_opt_mach_verbose():
     parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--verbose chrome".split()))
+    kwargs = vars(parser.parse_args("--log-mach - --verbose chrome".split()))
     wptcommandline.check_verbose(kwargs)
     assert kwargs["log_mach_level"] == "debug"
 
 def test_opt_verbose_log_mach_level_debug():
     parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--verbose --log-mach-level debug chrome".split()))
+    kwargs = vars(parser.parse_args("--log-mach - --verbose --log-mach-level debug chrome".split()))
     wptcommandline.check_verbose(kwargs)
     assert kwargs["log_mach_level"] == "debug"
 
 def test_opt_verbose_log_mach_level_info():
     parser = run.create_parser()
-    kwargs = vars(parser.parse_args("--verbose --log-mach-level info chrome".split()))
+    kwargs = vars(parser.parse_args("--log-mach - --verbose --log-mach-level info chrome".split()))
     wptcommandline.check_verbose(kwargs)
     assert kwargs["log_mach_level"] == "info"
+
+def test_opt_raw_verbose():
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args("--log-raw - --verbose chrome".split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs["log_raw_level"] == "debug"
+
+def test_opt_verbose_log_raw_level_debug():
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args("--log-raw - --verbose --log-raw-level debug chrome".split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs["log_raw_level"] == "debug"
+
+def test_opt_verbose_log_raw_level_info():
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args("--log-raw - --verbose --log-raw-level info chrome".split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs["log_raw_level"] == "info"
+
+def test_opt_tbpl_verbose():
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args("--log-tbpl - --verbose chrome".split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs["log_tbpl_level"] == "debug"
+
+def test_opt_verbose_log_tbpl_level_debug():
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args("--log-tbpl - --verbose --log-tbpl-level debug chrome".split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs["log_tbpl_level"] == "debug"
+
+def test_opt_verbose_log_tbpl_level_info():
+    parser = run.create_parser()
+    kwargs = vars(parser.parse_args("--log-tbpl - --verbose --log-tbpl-level info chrome".split()))
+    wptcommandline.check_verbose(kwargs)
+    assert kwargs["log_tbpl_level"] == "info"

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -124,9 +124,6 @@ def main(prog=None, argv=None):
     else:
         args = extras
 
-    from wptrunner import wptcommandline
-    wptcommandline.check_verbose(kwargs)
-
     if script:
         try:
             rv = script(*args, **kwargs)

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -9,7 +9,6 @@ from tools import localpaths  # noqa: flake8
 from six import iteritems
 from . import virtualenv
 
-from wptrunner import wptcommandline
 
 here = os.path.dirname(__file__)
 wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
@@ -125,6 +124,7 @@ def main(prog=None, argv=None):
     else:
         args = extras
 
+    from wptrunner import wptcommandline
     wptcommandline.check_verbose(kwargs)
 
     if script:

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -9,6 +9,7 @@ from tools import localpaths  # noqa: flake8
 from six import iteritems
 from . import virtualenv
 
+from wptrunner import wptcommandline
 
 here = os.path.dirname(__file__)
 wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
@@ -123,6 +124,8 @@ def main(prog=None, argv=None):
         args = (venv,) + extras
     else:
         args = extras
+
+    wptcommandline.check_verbose(kwargs)
 
     if script:
         try:

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -529,8 +529,10 @@ def check_args(kwargs):
 
 def check_verbose(kwargs):
     if kwargs.get("verbose"):
-        if not kwargs.get("log_mach_level"):
-            kwargs["log_mach_level"] = "debug"
+        for key, value in kwargs.items():
+            if key.startswith("log_") and not key.endswith("_level"):
+                if kwargs.get(key):
+                    kwargs[key + "_level"] = "debug"
 
 def check_args_update(kwargs):
     set_from_config(kwargs)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -320,7 +320,7 @@ scheme host and port.""")
     commandline.add_logging_group(parser)
     # Add --verbose option as the an alias of --log-mach-level debug
     parser.add_argument("--verbose", action="store_true",
-                        help="An alias of --log-mach-level debug")
+                        help="An alias of --log-*-level debug")
     return parser
 
 
@@ -531,7 +531,7 @@ def check_log_verbose(kwargs):
     if kwargs.get("verbose"):
         for key, value in kwargs.items():
             if key.startswith("log_") and not key.endswith("_level"):
-                if kwargs.get(key):
+                if kwargs.get(key) and not kwargs.get(key + '_level'):
                     kwargs[key + "_level"] = "debug"
 
 def check_args_update(kwargs):

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -527,7 +527,7 @@ def check_args(kwargs):
 
     return kwargs
 
-def check_verbose(kwargs):
+def check_log_verbose(kwargs):
     if kwargs.get("verbose"):
         for key, value in kwargs.items():
             if key.startswith("log_") and not key.endswith("_level"):

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -318,6 +318,9 @@ scheme host and port.""")
     commandline.log_formatters["wptreport"] = (formatters.WptreportFormatter, "wptreport format")
 
     commandline.add_logging_group(parser)
+    # Add --verbose option as the an alias of --log-mach-level debug
+    parser.add_argument("--verbose", action="store_true",
+                        help="An alias of --log-mach-level debug")
     return parser
 
 
@@ -524,6 +527,10 @@ def check_args(kwargs):
 
     return kwargs
 
+def check_verbose(kwargs):
+    if kwargs.get("verbose"):
+        if not kwargs.get("log_mach_level"):
+            kwargs["log_mach_level"] = "debug"
 
 def check_args_update(kwargs):
     set_from_config(kwargs)


### PR DESCRIPTION
Add a new option `--verbose` to `./wpt run` command line as an alias
of `--log-mach-level debug`.
Fix: #7846