### PR TITLE
Don't create a logging output element until we have DOMContentLoaded

### DIFF
--- a/resources/test/tests/functional/log-insertion.html
+++ b/resources/test/tests/functional/log-insertion.html
@@ -6,6 +6,12 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+test(function(t) {
+  assert_equals(document.body, null);
+}, "Log insertion before load");
+test(function(t) {
+  assert_equals(document.body, null);
+}, "Log insertion before load (again)");
 async_test(function(t) {
   window.onload = t.step_func_done(function() {
     var body = document.body;
@@ -14,7 +20,7 @@ async_test(function(t) {
     var log = document.getElementById("log");
     assert_equals(log.parentNode, body);
   });
-});
+}, "Log insertion after load");
 </script>
 <script type="text/json" id="expected">
 {
@@ -24,7 +30,17 @@ async_test(function(t) {
   },
   "summarized_tests": [{
     "status_string": "PASS",
-    "name": "Log insertion",
+    "name": "Log insertion before load",
+    "message": null,
+    "properties": {}
+  }, {
+    "status_string": "PASS",
+    "name": "Log insertion before load (again)",
+    "message": null,
+    "properties": {}
+  }, {
+    "status_string": "PASS",
+    "name": "Log insertion after load",
     "message": null,
     "properties": {}
   }],

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2557,6 +2557,9 @@ policies and contribution forms [3].
 
     Output.prototype.resolve_log = function() {
         var output_document;
+        if (this.output_node) {
+            return;
+        }
         if (typeof this.output_document === "function") {
             output_document = this.output_document.apply(undefined);
         } else {
@@ -2567,7 +2570,7 @@ policies and contribution forms [3].
         }
         var node = output_document.getElementById("log");
         if (!node) {
-            if (!document.readyState == "loading") {
+            if (output_document.readyState === "loading") {
                 return;
             }
             node = output_document.createElementNS("http://www.w3.org/1999/xhtml", "div");
@@ -2607,8 +2610,8 @@ policies and contribution forms [3].
         if (!this.enabled) {
             return;
         }
+        this.resolve_log();
         if (this.phase < this.HAVE_RESULTS) {
-            this.resolve_log();
             this.phase = this.HAVE_RESULTS;
         }
         var done_count = tests.tests.length - tests.num_pending;


### PR DESCRIPTION
Otherwise running with logs enabled can implicitly create a
document.body that can change the results of tests.