### PR TITLE
Make resources tests work better with positional arguments

### DIFF
--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -27,7 +27,11 @@ def pytest_collect_file(path, parent):
         return
 
     # Tests are organized in directories by type
-    test_type = os.path.relpath(str(path), HERE).split(os.path.sep)[1]
+    test_type = os.path.relpath(str(path), HERE)
+    if os.path.sep not in test_type or ".." in test_type:
+        # HTML files in this directory are not tests
+        return
+    test_type = test_type.split(os.path.sep)[1]
 
     return HTMLItem(str(path), test_type, parent)
 

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -14,4 +14,4 @@ deps =
   six
   requests
 
-commands = pytest {posargs} -vv tests
+commands = pytest -vv {posargs}


### PR DESCRIPTION
Previously we did two slightly broken things; we applied the
supplied arguments before the mandatory arguments, which prevented
passing -- to seperate named arguments from positional arguments, and
we depending on explictly passing in tests/ to avoid collecting HTML
files in the resources/test/ directory as tests.

To fix the latter we restrict the paths that can form tests in the
collector rather than relying on specific command line arguments.