### PR TITLE
Revamp how idlharness.js handles iterable declarations

### DIFF
--- a/interfaces/dom.idl
+++ b/interfaces/dom.idl
@@ -145,7 +145,7 @@ Text includes Slotable;
 interface NodeList {
   getter Node? item(unsigned long index);
   readonly attribute unsigned long length;
-//  iterable<Node>;
+  iterable<Node>;
 };
 
 [Exposed=Window, LegacyUnenumerableNamedProperties]
@@ -548,5 +548,5 @@ interface DOMTokenList {
   [CEReactions] boolean replace(DOMString token, DOMString newToken);
   boolean supports(DOMString token);
   [CEReactions] stringifier attribute DOMString value;
-  //  iterable<DOMString>;
+  iterable<DOMString>;
 };


### PR DESCRIPTION
Instead of adding IDL interface members in `add_iterable_members` in
the style of what webidl2.js would have added if the declaration were
expanded, instead test directly for what effect a single `iterable<T>`
or `iterable<T1,T2>` declaration should have.

This is more along the lines of `test_member_stringifier`, where no
`toString` is added as IDL members.

Alternative to https://github.com/web-platform-tests/wpt/pull/9790.