### PR TITLE
Plumb empty test_list when using --affected

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -345,12 +345,12 @@ class TestFilter(object):
             self.manifest = manifestinclude.IncludeManifest.create()
             self.manifest.set_defaults()
 
-        if include:
+        if include != None:
             self.manifest.set("skip", "true")
             for item in include:
                 self.manifest.add_include(test_manifests, item)
 
-        if exclude:
+        if exclude != None:
             for item in exclude:
                 self.manifest.add_exclude(test_manifests, item)
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -441,11 +441,12 @@ def check_args(kwargs):
     if "sauce" in kwargs["product"]:
         kwargs["pause_after_test"] = False
 
-    if kwargs["test_list"]:
+    if kwargs["test_list"] or "affected" in kwargs:
+        test_list = kwargs["test_list"] or []
         if kwargs["include"] is not None:
-            kwargs["include"].extend(kwargs["test_list"])
+            kwargs["include"].extend(test_list)
         else:
-            kwargs["include"] = kwargs["test_list"]
+            kwargs["include"] = test_list
 
     if kwargs["run_info"] is None:
         kwargs["run_info"] = kwargs["config_path"]

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -59,7 +59,7 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, **kwargs):
     manifest_filters = []
     meta_filters = []
 
-    if kwargs["include"] or kwargs["exclude"] or kwargs["include_manifest"]:
+    if kwargs["include"] != None or kwargs["exclude"] != None or kwargs["include_manifest"]:
         manifest_filters.append(testloader.TestFilter(include=kwargs["include"],
                                                       exclude=kwargs["exclude"],
                                                       manifest_path=kwargs["include_manifest"],
@@ -294,7 +294,7 @@ def run_tests(config, test_paths, product, **kwargs):
             logger.warning("All requested tests were skipped")
         else:
             logger.error("No tests ran")
-            return False
+        return True
 
     if unexpected_total and not kwargs["fail_on_unexpected"]:
         logger.info("Tolerating %s unexpected results" % unexpected_total)


### PR DESCRIPTION
This changes the filtering setup for `TestLoader` to treat an empty `include` list differently than a null one. Also changes the plumbing for wptcommandline to forward an empty `test_list` when `--affected` was specified, and to not pop `--affected` from the args to be able to make this check later.
The error-code of the run is also affected, with a value of `0` for no executed tests.
Executing without specifying a whitelist of test paths has the same behaviour as before (runs the full test suite as per the manifest.)
The effect on the output is that we still produce a report, which has `results: []`, rather than no report file, for the case that `--affected` produces no test results.

Fixes https://github.com/web-platform-tests/wpt/issues/14471