### PR TITLE
Remove options parameter from mediasource.

### DIFF
--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -330,16 +330,15 @@
     };
 
     window['MediaSourceUtil'] = MediaSourceUtil;
-    window['media_test'] = function(testFunction, description, options)
+    window['media_test'] = function(testFunction, description)
     {
-        options = options || {};
         return async_test(function(test)
         {
             addExtraTestMethods(test);
             testFunction(test);
-        }, description, options);
+        }, description);
     };
-    window['mediasource_test'] = function(testFunction, description, options)
+    window['mediasource_test'] = function(testFunction, description)
     {
         return media_test(function(test)
         {
@@ -362,10 +361,10 @@
             {
                 testFunction(test, mediaTag, mediaSource);
             });
-        }, description, options);
+        }, description);
     };
 
-    window['mediasource_testafterdataloaded'] = function(testFunction, description, options)
+    window['mediasource_testafterdataloaded'] = function(testFunction, description)
     {
         mediasource_test(function(test, mediaElement, mediaSource)
         {
@@ -383,7 +382,7 @@
             {
                 testFunction(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData);
             });
-        }, description, options);
+        }, description);
     }
 
     function timeRangesToString(ranges)


### PR DESCRIPTION
Part of removing the support of test-level properties from testharness.js