### PR TITLE
Log where we are downloading Firefox from

### DIFF
--- a/tools/wpt/install.py
+++ b/tools/wpt/install.py
@@ -73,7 +73,11 @@ def run(venv, **kwargs):
     install(browser, kwargs["component"], destination, channel)
 
 
-def install(name, component, destination, channel="nightly"):
+def install(name, component, destination, channel="nightly", logger=None):
+    if logger is None:
+        import logging
+        logger = logging.getLogger("install")
+
     if component == 'webdriver':
         method = 'install_webdriver'
     else:
@@ -81,6 +85,6 @@ def install(name, component, destination, channel="nightly"):
 
     subclass = getattr(browser, name.title())
     sys.stdout.write('Now installing %s %s...\n' % (name, component))
-    path = getattr(subclass(), method)(dest=destination, channel=channel)
+    path = getattr(subclass(logger), method)(dest=destination, channel=channel)
     if path:
         sys.stdout.write('Binary installed as %s\n' % (path,))

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -151,7 +151,7 @@ class BrowserSetup(object):
     browser_cls = None
 
     def __init__(self, venv, prompt=True, sub_product=None):
-        self.browser = self.browser_cls()
+        self.browser = self.browser_cls(logger)
         self.venv = venv
         self.prompt = prompt
         self.sub_product = sub_product
@@ -474,6 +474,7 @@ def setup_logging(kwargs, default_config=None):
         default_config = {default_formatter: sys.stdout}
     wptrunner.setup_logging(kwargs, default_config)
     logger = wptrunner.logger
+    return logger
 
 
 def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -1,11 +1,16 @@
 import mock
 import subprocess
+import logging
 
 from tools.wpt import browser
 
+
+logger = logging.getLogger()
+
+
 @mock.patch('subprocess.check_output')
 def test_safari_version(mocked_check_output):
-    safari = browser.Safari()
+    safari = browser.Safari(logger)
 
     # Safari
     mocked_check_output.return_value = 'Included with Safari 12.1 (14607.1.11)'
@@ -17,7 +22,7 @@ def test_safari_version(mocked_check_output):
 
 @mock.patch('subprocess.check_output')
 def test_safari_version_errors(mocked_check_output):
-    safari = browser.Safari()
+    safari = browser.Safari(logger)
 
     # No webdriver_binary
     assert safari.version() is None


### PR DESCRIPTION
To make logging in the browser class work better we explicitly pass in a logger,
rather than depending on a global variable.