### PR TITLE
Add firefox buildid and source changeset to wptreport.json

### DIFF
--- a/tools/wptrunner/requirements_firefox.txt
+++ b/tools/wptrunner/requirements_firefox.txt
@@ -6,4 +6,4 @@ mozrunner==7.2.0
 mozleak==0.2
 mozinstall==1.16.0
 mozdownload==1.25
-
+mozversion==1.5

--- a/tools/wptrunner/wptrunner/browsers/fennec.py
+++ b/tools/wptrunner/wptrunner/browsers/fennec.py
@@ -13,7 +13,11 @@ from .base import (get_free_port,
                    browser_command)
 from ..executors.executormarionette import (MarionetteTestharnessExecutor,  # noqa: F401
                                             MarionetteRefTestExecutor)  # noqa: F401
-from .firefox import (get_timeout_multiplier, update_properties, executor_kwargs, FirefoxBrowser)  # noqa: F401
+from .firefox import (get_timeout_multiplier,  # noqa: F401
+                      run_info_browser_version,
+                      update_properties,  # noqa: F401
+                      executor_kwargs,  # noqa: F401
+                      FirefoxBrowser)  # noqa: F401
 
 
 __wptrunner__ = {"product": "fennec",
@@ -64,9 +68,11 @@ def env_extras(**kwargs):
 
 
 def run_info_extras(**kwargs):
-    return {"e10s": False,
-            "headless": False,
-            "sw-e10s": False}
+    rv = {"e10s": False,
+          "headless": False,
+          "sw-e10s": False}
+    rv.update(run_info_browser_version(kwargs["binary"]))
+    return rv
 
 
 def env_options():

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -7,6 +7,7 @@ import sys
 
 import mozinfo
 import mozleak
+import mozversion
 from mozprocess import ProcessHandler
 from mozprofile import FirefoxProfile, Preferences
 from mozrunner import FirefoxRunner
@@ -151,11 +152,21 @@ def run_info_extras(**kwargs):
                 return value.lower() in ('true', '1')
         return False
 
-    return {"e10s": kwargs["gecko_e10s"],
-            "wasm": kwargs.get("wasm", True),
-            "verify": kwargs["verify"],
-            "headless": "MOZ_HEADLESS" in os.environ,
-            "sw-e10s": get_bool_pref("dom.serviceWorkers.parent_intercept"),}
+    rv = {"e10s": kwargs["gecko_e10s"],
+          "wasm": kwargs.get("wasm", True),
+          "verify": kwargs["verify"],
+          "headless": "MOZ_HEADLESS" in os.environ,
+          "sw-e10s": get_bool_pref("dom.serviceWorkers.parent_intercept")}
+    rv.update(run_info_browser_version(kwargs["binary"]))
+    return rv
+
+
+def run_info_browser_version(binary):
+    version_info = mozversion.get_version(binary)
+    if version_info:
+        return {"browser_build_id": version_info.get("application_buildid", None),
+                "browser_changeset": version_info.get("application_changeset", None)}
+    return {}
 
 
 def update_properties():


### PR DESCRIPTION
This adds two keys to the run_info dict for Firefox; browser_build_id containing a build id
and browser_changeset containing the SHA1 of the source commit from which the browser was built.