### PR TITLE
[Resource-Timing] Flakiness reduction

### DIFF
--- a/resource-timing/buffer-full-add-after-full-event.html
+++ b/resource-timing/buffer-full-add-after-full-event.html
@@ -74,7 +74,7 @@ promise_test(async () => {
     await clearAndAddAnotherEntryToBuffer();
     // Since we have no strict guarantees when an entry will be added to the
     // buffer, waiting till next task to try to avoid flakiness.
-    await waitTillNextTask();
+    await waitForNextTask();
     await testThatEntryWasAdded();
 }, "Test that entry was added to the buffer after a buffer full event");
 </script>

--- a/resource-timing/buffer-full-add-after-full-event.html
+++ b/resource-timing/buffer-full-add-after-full-event.html
@@ -72,6 +72,9 @@ promise_test(async () => {
     await loadRandomResource();
     await waitForEventToFire();
     await clearAndAddAnotherEntryToBuffer();
+    // Since we have no strict guarantees when an entry will be added to the
+    // buffer, waiting till next task to try to avoid flakiness.
+    await waitTillNextTask();
     await testThatEntryWasAdded();
 }, "Test that entry was added to the buffer after a buffer full event");
 </script>

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -30,8 +30,6 @@ var timingAttributes = [
     'unloadEventStart'
 ];
 
-var namespace_check = false;
-
 //
 // All test() functions in the WebPerf test suite should use wp_test() instead.
 //
@@ -41,19 +39,6 @@ var namespace_check = false;
 
 function wp_test(func, msg, properties)
 {
-    // only run the namespace check once
-    if (!namespace_check)
-    {
-        namespace_check = true;
-
-        if (performanceNamespace === undefined || performanceNamespace == null)
-        {
-            // show a single error that window.performance is undefined
-            // The window.performance attribute provides a hosting area for performance related attributes.
-            test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.");
-        }
-    }
-
     test(func, msg, properties);
 }
 

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -133,7 +133,9 @@ function test_true(value, msg, properties)
 
 function test_equals(value, equals, msg, properties)
 {
-    wp_test(function () { msg += " " + value + " " + equals + "."; assert_equals(value, equals, msg); }, msg, properties);
+    let localValue = value;
+    let localEquals = equals;
+    wp_test(function () { assert_equals(localValue, localEquals, msg); }, msg, properties);
 }
 
 function test_greater_than(value, greater_than, msg, properties)

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -133,7 +133,7 @@ function test_true(value, msg, properties)
 
 function test_equals(value, equals, msg, properties)
 {
-    test(function () { assert_equals(value, equals, msg); }, msg, properties);
+    wp_test(function () { assert_equals(value, equals, msg); }, msg, properties);
 }
 
 function test_greater_than(value, greater_than, msg, properties)

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -133,7 +133,7 @@ function test_true(value, msg, properties)
 
 function test_equals(value, equals, msg, properties)
 {
-    test(function () { assert_equals(value, equals, msg); }, msg, properties);
+    test(function () { assert_equals(value, equals, msg); return value + " " + equals }, msg, properties);
 }
 
 function test_greater_than(value, greater_than, msg, properties)

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -133,7 +133,7 @@ function test_true(value, msg, properties)
 
 function test_equals(value, equals, msg, properties)
 {
-    test(function () { assert_equals(value, equals, msg); return value + " " + equals }, msg, properties);
+    test(function () { assert_equals(value, equals, msg); }, msg, properties);
 }
 
 function test_greater_than(value, greater_than, msg, properties)

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -30,6 +30,8 @@ var timingAttributes = [
     'unloadEventStart'
 ];
 
+var namespace_check = false;
+
 //
 // All test() functions in the WebPerf test suite should use wp_test() instead.
 //
@@ -39,6 +41,19 @@ var timingAttributes = [
 
 function wp_test(func, msg, properties)
 {
+    // only run the namespace check once
+    if (!namespace_check)
+    {
+        namespace_check = true;
+
+        if (performanceNamespace === undefined || performanceNamespace == null)
+        {
+            // show a single error that window.performance is undefined
+            // The window.performance attribute provides a hosting area for performance related attributes.
+            test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.");
+        }
+    }
+
     test(func, msg, properties);
 }
 
@@ -118,7 +133,7 @@ function test_true(value, msg, properties)
 
 function test_equals(value, equals, msg, properties)
 {
-    wp_test(function () { assert_equals(value, equals, msg); }, msg, properties);
+    wp_test(function () { msg += " " + value + " " + equals + "."; assert_equals(value, equals, msg); }, msg, properties);
 }
 
 function test_greater_than(value, greater_than, msg, properties)

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -133,9 +133,7 @@ function test_true(value, msg, properties)
 
 function test_equals(value, equals, msg, properties)
 {
-    msg += " " + value + " " + equals;
-    wp_test(function () { assert_equals(value, equals, msg); }, msg, properties);
-    console.log(value + " " + equals);
+    test(function () { assert_equals(value, equals, msg); }, msg, properties);
 }
 
 function test_greater_than(value, greater_than, msg, properties)

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -133,9 +133,9 @@ function test_true(value, msg, properties)
 
 function test_equals(value, equals, msg, properties)
 {
-    let localValue = value;
-    let localEquals = equals;
-    wp_test(function () { assert_equals(localValue, localEquals, msg); }, msg, properties);
+    msg += " " + value + " " + equals;
+    wp_test(function () { assert_equals(value, equals, msg); }, msg, properties);
+    console.log(value + " " + equals);
 }
 
 function test_greater_than(value, greater_than, msg, properties)

--- a/resource-timing/resources/webperftestharnessextension.js
+++ b/resource-timing/resources/webperftestharnessextension.js
@@ -49,45 +49,48 @@ function test_fail(msg, properties)
 
 function test_resource_entries(entries, expected_entries)
 {
-    // This is slightly convoluted so that we can sort the output.
-    var actual_entries = {};
-    var origin = window.location.protocol + "//" + window.location.host;
+    test(function() {
+        // This is slightly convoluted so that we can sort the output.
+        var actual_entries = {};
+        var origin = window.location.protocol + "//" + window.location.host;
 
-    for (var i = 0; i < entries.length; ++i) {
-        var entry = entries[i];
-        var found = false;
-        for (var expected_entry in expected_entries) {
-            if (entry.name == origin + expected_entry) {
-                found = true;
-                if (expected_entry in actual_entries) {
-                    test_fail(expected_entry + ' is not expected to have duplicate entries');
+        for (var i = 0; i < entries.length; ++i) {
+            var entry = entries[i];
+            var found = false;
+            for (var expected_entry in expected_entries) {
+                if (entry.name == origin + expected_entry) {
+                    found = true;
+                    if (expected_entry in actual_entries) {
+                        assert_unreached(expected_entry + ' is not expected to have duplicate entries');
+                    }
+                    actual_entries[expected_entry] = entry;
+                    break;
                 }
-                actual_entries[expected_entry] = entry;
-                break;
+            }
+            if (!found) {
+                assert_unreached(entries[i].name + ' is not expected to be in the Resource Timing buffer');
             }
         }
-        if (!found) {
-            test_fail(entries[i].name + ' is not expected to be in the Resource Timing buffer');
-        }
-    }
 
-    sorted_urls = [];
-    for (var i in actual_entries) {
-        sorted_urls.push(i);
-    }
-    sorted_urls.sort();
-    for (var i in sorted_urls) {
-        var url = sorted_urls[i];
-        test_equals(actual_entries[url].initiatorType,
-                    expected_entries[url],
-                    origin + url + ' is expected to have initiatorType ' + expected_entries[url]);
-    }
-    for (var j in expected_entries) {
-        if (!(j in actual_entries)) {
-            test_fail(origin + j + ' is expected to be in the Resource Timing buffer');
+        sorted_urls = [];
+        for (var i in actual_entries) {
+            sorted_urls.push(i);
         }
-    }
+        sorted_urls.sort();
+        for (var i in sorted_urls) {
+            var url = sorted_urls[i];
+            assert_equals(actual_entries[url].initiatorType,
+                        expected_entries[url],
+                        origin + url + ' is expected to have initiatorType ' + expected_entries[url]);
+        }
+        for (var j in expected_entries) {
+            if (!(j in actual_entries)) {
+                assert_unreached(origin + j + ' is expected to be in the Resource Timing buffer');
+            }
+        }
+    }, "Testing resource entries");
 }
+
 function performance_entrylist_checker(type)
 {
     var entryType = type;


### PR DESCRIPTION
Alternative approach to #14616
Closes w3c/resource-timing#182 and #14433

Reducing RT test flakiness by:

* Adding an extra task before actual testing in buffer-full-add-after-full-event.html, as the timing of when entries are added to the buffer is not really well-defined at the moment.
* Remove use of `test_equals` in resource_initiator_types.html