### PR TITLE
Use get-host-info to run fetch/abort test in CI

### DIFF
--- a/fetch/api/abort/general.any.js
+++ b/fetch/api/abort/general.any.js
@@ -1,5 +1,6 @@
 // META: global=window,worker
 // META: script=/common/utils.js
+// META: script=/common/get-host-info.sub.js
 // META: script=../request/request-error.js
 
 const BODY_METHODS = ['arrayBuffer', 'blob', 'formData', 'json', 'text'];
@@ -15,6 +16,9 @@ function abortRequests() {
     keys.map(key => fetch(`../resources/stash-put.py?key=${key}&value=close`))
   );
 }
+
+const hostInfo = get_host_info();
+const urlHostname = hostInfo.REMOTE_HOST;
 
 promise_test(async t => {
   const controller = new AbortController();
@@ -32,7 +36,7 @@ promise_test(async t => {
   controller.abort();
 
   const url = new URL('../resources/data.json', location);
-  url.hostname = 'www1.' + url.hostname;
+  url.hostname = urlHostname;
 
   const fetchPromise = fetch(url, {
     signal,
@@ -315,7 +319,7 @@ promise_test(async t => {
   requestAbortKeys.push(abortKey);
 
   const url = new URL(`../resources/infinite-slow-response.py?stateKey=${stateKey}&abortKey=${abortKey}`, location);
-  url.hostname = 'www1.' + url.hostname;
+  url.hostname = urlHostname;
 
   await fetch(url, {
     signal,
@@ -323,7 +327,7 @@ promise_test(async t => {
   });
 
   const stashTakeURL = new URL(`../resources/stash-take.py?key=${stateKey}`, location);
-  stashTakeURL.hostname = 'www1.' + stashTakeURL.hostname;
+  stashTakeURL.hostname = urlHostname;
 
   const beforeAbortResult = await fetch(stashTakeURL).then(r => r.json());
   assert_equals(beforeAbortResult, "open", "Connection is open");
@@ -441,7 +445,7 @@ promise_test(async t => {
   const controller = new AbortController();
   const signal = controller.signal;
 
-  const response = await fetch(`../resources/empty.txt`, { signal });
+  const response = await fetch(`../resources/method.py`, { signal });
 
   // Read whole response to ensure close signal has sent.
   await response.clone().text();


### PR DESCRIPTION
 Use method.py to get a response without any body