### PR TITLE
[Azure Pipelines] Use `brew cask install --force`

### DIFF
--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -1,6 +1,6 @@
 steps:
 - script: |
-    HOMEBREW_NO_AUTO_UPDATE=1 brew cask install Homebrew/homebrew-cask-versions/safari-technology-preview
+    HOMEBREW_NO_AUTO_UPDATE=1 brew cask install --force Homebrew/homebrew-cask-versions/safari-technology-preview
     # https://web-platform-tests.org/running-tests/safari.html
     sudo "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable
     defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1


### PR DESCRIPTION
Due to caching at some level, Safari TP on Azure Pipelines is still 
release 70, although it should now be 72:
https://github.com/Homebrew/homebrew-cask-versions/pull/6747