### PR TITLE
[Azure Pipelines] Use raw URL with `brew cask install`

### DIFF
--- a/tools/ci/azure/install_chrome.yml
+++ b/tools/ci/azure/install_chrome.yml
@@ -1,3 +1,5 @@
 steps:
-- script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install Homebrew/homebrew-cask-versions/google-chrome-dev
+# This is equivalent to `Homebrew/homebrew-cask-versions/google-chrome-dev`,
+# but the raw URL is used to bypass caching.
+- script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/google-chrome-dev.rb
   displayName: 'Install Chrome Dev'

--- a/tools/ci/azure/install_firefox.yml
+++ b/tools/ci/azure/install_firefox.yml
@@ -1,3 +1,5 @@
 steps:
-- script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install Homebrew/homebrew-cask-versions/firefox-nightly
+# This is equivalent to `Homebrew/homebrew-cask-versions/firefox-nightly`,
+# but the raw URL is used to bypass caching.
+- script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/firefox-nightly.rb
   displayName: 'Install Firefox Nightly'

--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -1,6 +1,8 @@
 steps:
 - script: |
-    HOMEBREW_NO_AUTO_UPDATE=1 brew cask install Homebrew/homebrew-cask-versions/safari-technology-preview
+    # This is equivalent to `Homebrew/homebrew-cask-versions/safari-technology-preview`,
+    # but the raw URL is used to bypass caching.
+    HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/safari-technology-preview.rb
     # https://web-platform-tests.org/running-tests/safari.html
     sudo "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable
     defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1


### PR DESCRIPTION
Due to caching at some level, Safari TP on Azure Pipelines is still 
release 70, although it should now be 72:
https://github.com/Homebrew/homebrew-cask-versions/pull/6747