### PR TITLE
Claim to support testdriver in servodriver

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -177,6 +177,8 @@ def timeout_func(timeout):
 
 
 class ServoWebDriverTestharnessExecutor(TestharnessExecutor):
+    supports_testdriver = True
+
     def __init__(self, browser, server_config, timeout_multiplier=1,
                  close_after_done=True, capabilities=None, debug_info=None,
                  **kwargs):


### PR DESCRIPTION
This resolves an upstreaming attempt that failed due to an incompatibility between Servo's CI and WPT's CI in https://github.com/web-platform-tests/wpt/pull/14468.