### PR TITLE
[css-text][css2] Add refs and update links

### DIFF
--- a/css/CSS2/bidi-005.xht
+++ b/css/CSS2/bidi-005.xht
@@ -10,6 +10,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
+  <link rel="match" href="reference/bidi-005-ref.xht" />
   <style type="text/css">
    div p { white-space: pre; margin: 1em; padding: 0.75em; background: black; color: yellow; font: 2em/1 serif; letter-spacing: 1em; }
    .one, .c, .j, .e { color: aqua; }

--- a/css/CSS2/bidi-006.xht
+++ b/css/CSS2/bidi-006.xht
@@ -10,6 +10,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
+  <link rel="match" href="reference/bidi-005-ref.xht" />
   <style type="text/css">
    div p { white-space: nowrap; margin: 1em; padding: 0.75em; background: black; color: yellow; font: 2em/1 serif; letter-spacing: 1em; }
    .one, .c, .j, .e { color: aqua; }

--- a/css/CSS2/bidi-007.xht
+++ b/css/CSS2/bidi-007.xht
@@ -10,6 +10,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
+  <link rel="match" href="reference/bidi-007-ref.xht" />
   <style type="text/css">
    div p { float: left; clear: left; margin: 0.5em 1em; padding: 0.75em; background: black; color: yellow; font: 2em/1 serif; letter-spacing: 1em; }
    .one, .c, .j, .e { color: aqua; }

--- a/css/CSS2/bidi-008.xht
+++ b/css/CSS2/bidi-008.xht
@@ -10,6 +10,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
+  <link rel="match" href="reference/bidi-007-ref.xht" />
   <style type="text/css">
    div p { display: table; margin: 1em; padding: 0.75em; background: black; color: yellow; font: 2em/1 serif; letter-spacing: 1em; }
    .one, .c, .j, .e { color: aqua; }

--- a/css/CSS2/bidi-009.xht
+++ b/css/CSS2/bidi-009.xht
@@ -10,6 +10,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
+  <link rel="match" href="reference/bidi-005-ref.xht" />
   <style type="text/css">
    div { margin: 1em; padding: 0.75em; background: black; color: yellow;
          letter-spacing: 1em; font: 2em/1 serif; }

--- a/css/CSS2/bidi-010.xht
+++ b/css/CSS2/bidi-010.xht
@@ -10,6 +10,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
+  <link rel="match" href="reference/bidi-007-ref.xht" />
   <style type="text/css">
    div { position: relative; }
    .reference { top: -.5em; }

--- a/css/CSS2/bidi-text/bidi-002.xht
+++ b/css/CSS2/bidi-text/bidi-002.xht
@@ -13,6 +13,7 @@
 
   <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-processing"/>
 
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>

--- a/css/CSS2/bidi-text/bidi-005a.xht
+++ b/css/CSS2/bidi-text/bidi-005a.xht
@@ -8,6 +8,8 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/005.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-005a-ref.xht" />
 

--- a/css/CSS2/bidi-text/bidi-005b.xht
+++ b/css/CSS2/bidi-text/bidi-005b.xht
@@ -9,6 +9,9 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-text-3/#letter-spacing-property"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="match" href="bidi-005b-ref.xht" />
 
   <style type="text/css">

--- a/css/CSS2/bidi-text/bidi-006a.xht
+++ b/css/CSS2/bidi-text/bidi-006a.xht
@@ -8,6 +8,8 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/006.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-005a-ref.xht" />
 

--- a/css/CSS2/bidi-text/bidi-006b.xht
+++ b/css/CSS2/bidi-text/bidi-006b.xht
@@ -8,6 +8,9 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/006.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-text-3/#letter-spacing-property"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-005b-ref.xht" />
 

--- a/css/CSS2/bidi-text/bidi-007a.xht
+++ b/css/CSS2/bidi-text/bidi-007a.xht
@@ -8,6 +8,8 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/007.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-007a-ref.xht" />
 

--- a/css/CSS2/bidi-text/bidi-007b.xht
+++ b/css/CSS2/bidi-text/bidi-007b.xht
@@ -8,6 +8,9 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/007.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-text-3/#letter-spacing-property"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-007b-ref.xht" />
 

--- a/css/CSS2/bidi-text/bidi-008a.xht
+++ b/css/CSS2/bidi-text/bidi-008a.xht
@@ -8,6 +8,8 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/008.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-008a-ref.xht" />
 

--- a/css/CSS2/bidi-text/bidi-008b.xht
+++ b/css/CSS2/bidi-text/bidi-008b.xht
@@ -8,6 +8,9 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/008.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-text-3/#letter-spacing-property"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-008b-ref.xht" />
 

--- a/css/CSS2/bidi-text/bidi-009a.xht
+++ b/css/CSS2/bidi-text/bidi-009a.xht
@@ -8,6 +8,8 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/009.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-005a-ref.xht" />
 

--- a/css/CSS2/bidi-text/bidi-010a.xht
+++ b/css/CSS2/bidi-text/bidi-010a.xht
@@ -8,6 +8,8 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/010.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-007a-ref.xht" />
 

--- a/css/CSS2/bidi-text/bidi-010b.xht
+++ b/css/CSS2/bidi-text/bidi-010b.xht
@@ -8,6 +8,9 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/box/inline/bidi/010.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#bidi-box-model"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+  <link rel="help" href="http://www.w3.org/TR/css-text-3/#letter-spacing-property"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-box-model"/>
+  <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes"/>
   <link rel="help" href="http://unicode.org/reports/tr9/"/>
   <link rel="match" href="bidi-007b-ref.xht" />
 

--- a/css/CSS2/bidi-text/line-breaking-bidi-001.xht
+++ b/css/CSS2/bidi-text/line-breaking-bidi-001.xht
@@ -7,6 +7,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-03-14 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/line-breaking/bidi/001.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-processing" />
   <link rel="match" href="line-breaking-bidi-001-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/bidi-text/line-breaking-bidi-002.xht
+++ b/css/CSS2/bidi-text/line-breaking-bidi-002.xht
@@ -7,6 +7,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-03-14 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/line-breaking/bidi/002.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-processing" />
   <link rel="match" href="line-breaking-bidi-002-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/bidi-text/line-breaking-bidi-003.xht
+++ b/css/CSS2/bidi-text/line-breaking-bidi-003.xht
@@ -7,6 +7,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-03-14 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/line-breaking/bidi/003.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-processing" />
   <link rel="match" href="line-breaking-bidi-003-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/css1/c562-white-sp-000.xht
+++ b/css/CSS2/css1/c562-white-sp-000.xht
@@ -16,6 +16,7 @@
    .three {white-space: normal;}
   ]]></style>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" title="16.6 Whitespace: the 'white-space' property"/>
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property"/>
  </head>
  <body>
   <p>There should be a single green block below.</p>

--- a/css/CSS2/reference/bidi-005-ref.xht
+++ b/css/CSS2/reference/bidi-005-ref.xht
@@ -1,0 +1,24 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+ <head>
+  <title>CSS Test reference</title>
+  <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net"/>
+  <style type="text/css">
+   div p { white-space: pre; margin: 1em; padding: 0.75em; background: black; color: yellow; font: 2em/1 serif; letter-spacing: 1em; }
+   .one, .c, .j, .e { color: aqua; }
+   .two, .i, .d, .k, .b { color: fuchsia; }
+   .one, .two { border: solid; padding: 0.1em 0 0.1em 0; margin: 0 0.5em 0 0.5em; }
+   .c, .b { border-style: solid none solid solid; padding: 0.1em 0 0.1em 0; margin: 0 0 0 0.5em; }
+   .j, .k { border-style: solid solid solid none; padding: 0.1em 0 0.1em 0; margin: 0 0.5em 0 0; }
+   .e, .i, .d { border-style: solid none solid none; padding: 0.1em 0 0.1em 0; margin: 0 0 0 0; }
+  </style>
+ </head>
+ <body>
+  <p> The following two blocks should be identical, including overflow. (Force bidi: &#x05D0;) </p>
+  <div>
+   <p class="reference"><span class="a">a</span><span class="b">b</span><span class="c">c</span><span class="d">d</span><span class="e">e</span><span class="f">f</span><span class="g">g</span><span class="h">h</span><span class="i">i</span><span class="j">j</span><span class="k">k</span><span class="l">l</span><span class="m">m</span></p>
+   <p class="reference"><span class="a">a</span><span class="b">b</span><span class="c">c</span><span class="d">d</span><span class="e">e</span><span class="f">f</span><span class="g">g</span><span class="h">h</span><span class="i">i</span><span class="j">j</span><span class="k">k</span><span class="l">l</span><span class="m">m</span></p>
+  </div>
+ </body>
+</html>

--- a/css/CSS2/reference/bidi-007-ref.xht
+++ b/css/CSS2/reference/bidi-007-ref.xht
@@ -1,0 +1,24 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+ <head>
+  <title>CSS Test: The bidi algorithm and inlines in CSS: embed levels and float: left; </title>
+  <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net"/>
+  <style type="text/css">
+   div p { float: left; clear: left; margin: 0.5em 1em; padding: 0.75em; background: black; color: yellow; font: 2em/1 serif; letter-spacing: 1em; }
+   .one, .c, .j, .e { color: aqua; }
+   .two, .i, .d, .k, .b { color: fuchsia; }
+   .one, .two { border: solid; padding: 0.1em 0 0.1em 0; margin: 0 0.5em 0 0.5em; }
+   .c, .b { border-style: solid none solid solid; padding: 0.1em 0 0.1em 0; margin: 0 0 0 0.5em; }
+   .j, .k { border-style: solid solid solid none; padding: 0.1em 0 0.1em 0; margin: 0 0.5em 0 0; }
+   .e, .i, .d { border-style: solid none solid none; padding: 0.1em 0 0.1em 0; margin: 0 0 0 0; }
+  </style>
+ </head>
+ <body>
+  <p> The following two blocks should be identical, including overflow. (Force bidi: &#x05D0;) </p>
+  <div>
+   <p class="reference"><span class="a">a</span><span class="b">b</span><span class="c">c</span><span class="d">d</span><span class="e">e</span><span class="f">f</span><span class="g">g</span><span class="h">h</span><span class="i">i</span><span class="j">j</span><span class="k">k</span><span class="l">l</span><span class="m">m</span></p>
+   <p class="reference"><span class="a">a</span><span class="b">b</span><span class="c">c</span><span class="d">d</span><span class="e">e</span><span class="f">f</span><span class="g">g</span><span class="h">h</span><span class="i">i</span><span class="j">j</span><span class="k">k</span><span class="l">l</span><span class="m">m</span></p>
+  </div>
+ </body>
+</html>

--- a/css/CSS2/text/text-align-white-space-001.xht
+++ b/css/CSS2/text/text-align-white-space-001.xht
@@ -7,8 +7,9 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
 		<link rel="match" href="text-align-white-space-001-ref.xht" />
 
-        <meta name="flags" content="ahem" />
+        <meta name="flags" content="ahem may" /> <!-- "may" because level 3 makes it no longer mandatory -->
         <meta name="assert" content="Setting 'text-align' to 'justify' and 'white-space' to 'pre', text-align is computed to its initial value." />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#text-align-property" />
         <style type="text/css">
             div
             {

--- a/css/CSS2/text/text-align-white-space-003.xht
+++ b/css/CSS2/text/text-align-white-space-003.xht
@@ -7,7 +7,8 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
 		<link rel="match" href="text-align-white-space-002-ref.xht" />
 
-        <meta name="flags" content="ahem" />
+	<meta name="flags" content="ahem may" /> <!-- "may" because level 3 makes it no longer mandatory -->
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#text-align-property" />
         <meta name="assert" content="Setting 'text-align' to 'justify' and 'white-space' to 'pre-wrap', text-align is computed to its initial value." />
         <style type="text/css">
             div

--- a/css/CSS2/text/text-align-white-space-005.xht
+++ b/css/CSS2/text/text-align-white-space-005.xht
@@ -7,7 +7,8 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
 		<link rel="match" href="text-align-white-space-005-ref.xht" />
 
-        <meta name="flags" content="ahem" />
+	<meta name="flags" content="ahem may" /> <!-- "may" because level 3 makes it no longer mandatory -->
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#text-align-property" />
         <meta name="assert" content="Setting 'text-align' to 'justify' and 'white-space' to 'pre', text-align is computed to its initial value." />
         <style type="text/css">
             div

--- a/css/CSS2/text/text-align-white-space-007.xht
+++ b/css/CSS2/text/text-align-white-space-007.xht
@@ -7,7 +7,8 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#alignment-prop" />
 		<link rel="match" href="text-align-white-space-002-ref.xht" />
 
-        <meta name="flags" content="ahem" />
+	<meta name="flags" content="ahem may" /> <!-- "may" because level 3 makes it no longer mandatory -->
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#text-align-property" />
         <meta name="assert" content="Setting 'text-align' to 'justify' and 'white-space' to 'pre-wrap', text-align is computed to its initial value." />
         <style type="text/css">
             div

--- a/css/CSS2/text/white-space-001-ref.xht
+++ b/css/CSS2/text/white-space-001-ref.xht
@@ -1,0 +1,42 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <meta name="flags" content="ahem" />
+
+        <style type="text/css">
+            div
+            {
+                font: 1em Ahem;
+                line-height: 1em;
+            }
+            #reference
+            {
+                height: 1em;
+                width: 5em;
+            }
+            #div1, #div3
+            {
+                background: black;
+            }
+            #div1, #div2, #div3
+            {
+                display: inline-block;
+                height: 1em;
+                width: 2em;
+            }
+            #div2
+            {
+                height: 1em;
+                width: 1em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there are 2 filled black squares.</p>
+        <div id="reference"><div id="div1"></div><div id="div2"></div><div id="div3"></div></div>
+        <div id="reference"><div id="div1"></div><div id="div2"></div><div id="div3"></div></div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-001.xht
+++ b/css/CSS2/text/white-space-001.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'normal' removes extra spacing when more than one space is next to another." />
 

--- a/css/CSS2/text/white-space-002-ref.xht
+++ b/css/CSS2/text/white-space-002-ref.xht
@@ -1,0 +1,41 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <meta name="flags" content="ahem" />
+        <style type="text/css">
+            div
+            {
+                font: 1em Ahem;
+                line-height: 1em;
+            }
+            #reference
+            {
+                height: 1em;
+                width: 7em;
+            }
+            #div1, #div3
+            {
+                background: black;
+            }
+            #div1, #div2, #div3
+            {
+                display: inline-block;
+                height: 1em;
+                width: 2em;
+            }
+            #div2
+            {
+                height: 1em;
+                width: 3em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there are two black squares on the page.</p>
+        <div id="reference"><div id="div1"></div><div id="div2"></div><div id="div3"></div></div>
+        <div id="reference"><div id="div1"></div><div id="div2"></div><div id="div3"></div></div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-002.xht
+++ b/css/CSS2/text/white-space-002.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'pre' does not remove extra spacing when more than one space is next to another." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-003.xht
+++ b/css/CSS2/text/white-space-003.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'nowrap' removes extra spacing when more than one space is next to another. And the text does not wrap when width is constrained." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-004-ref.xht
+++ b/css/CSS2/text/white-space-004-ref.xht
@@ -1,0 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <meta name="flags" content="ahem" />
+        <style type="text/css">
+            div
+            {
+                font: 20px/1em Ahem;
+                margin: 0;
+                padding: 0;
+            }
+            #reference
+            {
+                background: blue;
+                display: inline-block;
+                height: 1em;
+                width: 2em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a single black box above a blue box (there can be white space between the boxes) and the black box has the same width as the blue box.</p>
+	<div>XX<br />XX</div>
+        <div id="reference"></div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-004.xht
+++ b/css/CSS2/text/white-space-004.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-004-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'pre-wrap' does not remove extra spacing when two spaces are next to each other and introduces line breaking opportunities." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-005.xht
+++ b/css/CSS2/text/white-space-005.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'pre-line' does remove extra spacing when two spaces are next to each other and breaks at new lines." />
         <style type="text/css">
@@ -40,7 +42,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are two black squares on the page.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="test">XX   XX</div>
         <div id="reference"><div id="div1"></div><div id="div2"></div><div id="div3"></div></div>
     </body>

--- a/css/CSS2/text/white-space-006.xht
+++ b/css/CSS2/text/white-space-006.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'inherit' causes the element to use its parent's white-space value." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-007-ref.xht
+++ b/css/CSS2/text/white-space-007-ref.xht
@@ -1,0 +1,41 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+ <head>
+
+  <title>CSS Test reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <link rel="author" title="James Hopkins" href="http://idreamincode.co.uk/css21testsuite" />
+  <link rel="author" title="Justin Boss" href="http://www.bosspro.org/contactus/" />
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+
+  <style type="text/css"><![CDATA[
+  div#test
+  {
+  background-color: orange;
+  height: 100px;
+  width: 500px;
+  }
+
+  div#control
+  {
+  background-color: blue;
+  height: 100px;
+  width: 500px;
+  }
+  ]]></style>
+
+ </head>
+
+ <body>
+
+  <p>Test passes if the wide orange and blue rectangles are the <strong>same width</strong> and the <strong>same height</strong>.</p>
+
+  <div id="test">&nbsp;</div>
+
+  <div id="control">&nbsp;</div>
+
+ </body>
+</html>

--- a/css/CSS2/text/white-space-007.xht
+++ b/css/CSS2/text/white-space-007.xht
@@ -12,6 +12,8 @@
   <link rel="help" title="C.5.76 Section 16.6.1 The 'white-space' processing model" href="https://www.w3.org/TR/CSS21/changes.html#q21.363" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+  <link rel="match" href="white-space-007-ref.xht" />
   <meta name="flags" content="ahem" />
   <meta name="assert" content="'white-space: normal' and 'white-space: nowrap' should collapse sequences of white space. Regarding wrapping, line breaking opportunities are determined on the text prior to white space collapsing steps." />
 

--- a/css/CSS2/text/white-space-008-ref.xht
+++ b/css/CSS2/text/white-space-008-ref.xht
@@ -1,0 +1,32 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+ <head>
+
+  <title>CSS Test reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <link rel="author" title="Bruno Fassino" href="fassino[at]gmail.com" />
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+  <meta content="" name="flags" />
+
+  <style type="text/css"><![CDATA[
+  #test-overlapping-green
+  {
+  background-color: lime;
+  }
+
+  ]]></style>
+
+ </head>
+
+ <body>
+
+  <p>Test passes if there is a wide bright green rectangle below with one "X" in it and if there is no red.</p>
+
+  <div id="test-overlapping-green"><br/><br/>X</div>
+
+
+ </body>
+</html>

--- a/css/CSS2/text/white-space-008.xht
+++ b/css/CSS2/text/white-space-008.xht
@@ -7,6 +7,8 @@
   <title>CSS Test: white-space - pre and newlines in source</title>
 
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-transform" />
+  <link rel="match" href="white-space-008-ref.xht" />
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
   <link rel="author" title="Bruno Fassino" href="fassino[at]gmail.com" />
   <meta content="Newlines in source must be preserved with 'white-space: pre'" name="assert" />

--- a/css/CSS2/text/white-space-applies-to-001.xht
+++ b/css/CSS2/text/white-space-applies-to-001.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: inline' elements." />
         <style type="text/css">
@@ -31,7 +33,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div>
             <div id="div1">XX   XX</div>
         </div>

--- a/css/CSS2/text/white-space-applies-to-002.xht
+++ b/css/CSS2/text/white-space-applies-to-002.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: block' elements." />
         <style type="text/css">
@@ -31,7 +32,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div>
             <span>XX   XX</span>
         </div>

--- a/css/CSS2/text/white-space-applies-to-003-ref.xht
+++ b/css/CSS2/text/white-space-applies-to-003-ref.xht
@@ -1,0 +1,39 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <meta name="flags" content="ahem" />
+        <style type="text/css">
+            body
+            {
+                margin-left: 2em;
+            }
+            div
+            {
+                font: 16px/1em Ahem;
+            }
+            #test
+            {
+                display: list-item;
+            }
+            #ref1, #ref2
+            {
+                background: black;
+                display: inline-block;
+                height: 1em;
+                width: 2em;
+            }
+            #ref2
+            {
+                margin-left: 3em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there are two squares below and the left most square has a marker bullet on the left-hand side.</p>
+        <div id="test">XX&nbsp;&nbsp;&nbsp;XX</div>
+        <div id="ref1"></div><div id="ref2"></div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-applies-to-003.xht
+++ b/css/CSS2/text/white-space-applies-to-003.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-applies-to-003-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to display: list-item elements." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-applies-to-005.xht
+++ b/css/CSS2/text/white-space-applies-to-005.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: inline-block' elements." />
         <style type="text/css">
@@ -31,7 +32,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div>
             <span>XX   XX</span>
         </div>

--- a/css/CSS2/text/white-space-applies-to-006.xht
+++ b/css/CSS2/text/white-space-applies-to-006.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: table' elements." />
         <style type="text/css">
@@ -39,7 +40,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div id="table">
             <div id="row">
                 <div id="cell">XX   XX</div>

--- a/css/CSS2/text/white-space-applies-to-007.xht
+++ b/css/CSS2/text/white-space-applies-to-007.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: inline-table' elements." />
         <style type="text/css">
@@ -39,7 +40,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div>
             <div id="table">
                 <div id="row">

--- a/css/CSS2/text/white-space-applies-to-008.xht
+++ b/css/CSS2/text/white-space-applies-to-008.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: table-row-group' elements." />
         <style type="text/css">
@@ -44,7 +45,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div id="table">
             <div id="test">
                 <div id="row">

--- a/css/CSS2/text/white-space-applies-to-009.xht
+++ b/css/CSS2/text/white-space-applies-to-009.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: table-header-group' elements." />
         <style type="text/css">
@@ -44,7 +45,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div id="table">
             <div id="test">
                 <div id="row">

--- a/css/CSS2/text/white-space-applies-to-010.xht
+++ b/css/CSS2/text/white-space-applies-to-010.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: table-footer-group' elements." />
         <style type="text/css">
@@ -44,7 +45,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div id="table">
             <div id="test">
                 <div id="row">

--- a/css/CSS2/text/white-space-applies-to-011.xht
+++ b/css/CSS2/text/white-space-applies-to-011.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display:  table-row' elements." />
         <style type="text/css">
@@ -39,7 +40,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div>
             <div id="table">
                 <div id="row">

--- a/css/CSS2/text/white-space-applies-to-012.xht
+++ b/css/CSS2/text/white-space-applies-to-012.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property is not applied to 'display: table-column-group' elements." />
         <style type="text/css">
@@ -43,7 +44,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="table">
             <div id="test"></div>
             <div id="row">

--- a/css/CSS2/text/white-space-applies-to-013.xht
+++ b/css/CSS2/text/white-space-applies-to-013.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property is not applied to 'display: table-column' elements." />
         <style type="text/css">
@@ -43,7 +44,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="table">
             <div id="test"></div>
             <div id="row">

--- a/css/CSS2/text/white-space-applies-to-014.xht
+++ b/css/CSS2/text/white-space-applies-to-014.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: table-cell' elements." />
         <style type="text/css">
@@ -39,7 +40,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div id="table">
             <div id="row">
                 <div id="cell">XX   XX</div>

--- a/css/CSS2/text/white-space-applies-to-015.xht
+++ b/css/CSS2/text/white-space-applies-to-015.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#propdef-white-space" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property applies to 'display: table-caption' elements." />
         <style type="text/css">
@@ -43,7 +44,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div id="table">
             <div id="caption">XX   XX</div>
             <div id="row">

--- a/css/CSS2/text/white-space-bidirectionality-001-ref.xht
+++ b/css/CSS2/text/white-space-bidirectionality-001-ref.xht
@@ -1,0 +1,14 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+    </head>
+    <body>
+        <p>Test passes if the following text is below "A  BC" (there can be two spaces between letters 'A' and 'B').</p>
+        <div>
+            <bdo>A&nbsp;&nbsp;BC</bdo>
+        </div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-bidirectionality-001.xht
+++ b/css/CSS2/text/white-space-bidirectionality-001.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space and bidirectionality (example from spec)</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-bidirectionality-001-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The white space processing model does not take bidi into account for the first half of the processing model but does for the second half." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-collapsing-001.xht
+++ b/css/CSS2/text/white-space-collapsing-001.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-28 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/collapsing/001.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
   <link rel="match" href="white-space-collapsing-001-ref.xht" />
 
   <meta name="flags" content="ahem"/>

--- a/css/CSS2/text/white-space-collapsing-002.xht
+++ b/css/CSS2/text/white-space-collapsing-002.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-28 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/collapsing/002.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
   <link rel="match" href="white-space-collapsing-001-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-collapsing-003-ref.xht
+++ b/css/CSS2/text/white-space-collapsing-003-ref.xht
@@ -1,0 +1,22 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Test reference</title>
+  <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net"/>
+  <style type="text/css">
+   .test { margin: 0.25em; border: 0.25em solid navy; padding: 0.1em; background: blue; color: yellow; text-decoration: underline; width: 7em; text-align: center; font: 2em Ahem, monospace; }
+  </style>
+ </head>
+ <body>
+  <p>The following lines should all look identical:</p>
+  <div class="test">XXXX</div>
+  <div class="test">XXXX</div>
+  <div class="test">XXXX</div>
+  <div class="test">XXXX</div>
+  <div class="test"><span>XXXX</span></div>
+  <div class="test"><span>XXXX</span></div>
+  <div class="test"><span>XXXX</span></div>
+  <div class="test"><span>XXXX</span></div>
+ </body>
+</html>

--- a/css/CSS2/text/white-space-collapsing-003.xht
+++ b/css/CSS2/text/white-space-collapsing-003.xht
@@ -5,6 +5,8 @@
   <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/collapsing/003.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+  <link rel="match" href="white-space-collapsing-003-ref.xht" />
   <style type="text/css">
    .test { margin: 0.25em; border: 0.25em solid navy; padding: 0.1em; background: blue; color: yellow; text-decoration: underline; width: 7em; text-align: center; font: 2em Ahem, monospace; }
   </style>

--- a/css/CSS2/text/white-space-collapsing-004.xht
+++ b/css/CSS2/text/white-space-collapsing-004.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-28 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/collapsing/none/001.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
   <link rel="match" href="white-space-collapsing-004-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-collapsing-005.xht
+++ b/css/CSS2/text/white-space-collapsing-005.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-28 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/collapsing/none/002.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
   <link rel="match" href="white-space-collapsing-004-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-collapsing-bidi-001.xht
+++ b/css/CSS2/text/white-space-collapsing-bidi-001.xht
@@ -6,6 +6,9 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/collapsing/bidi/001.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#egbidiwscollapse" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#bidi-box-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
   <link rel="match" href="white-space-collapsing-bidi-001-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-collapsing-bidi-002.xht
+++ b/css/CSS2/text/white-space-collapsing-bidi-002.xht
@@ -6,6 +6,9 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/collapsing/bidi/002.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#egbidiwscollapse" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#bidi-box-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
   <link rel="match" href="white-space-collapsing-bidi-001-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-collapsing-bidi-003.xht
+++ b/css/CSS2/text/white-space-collapsing-bidi-003.xht
@@ -6,6 +6,9 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/collapsing/bidi/003.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#bidi-control-codes" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#bidi-box-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
   <link rel="match" href="white-space-collapsing-bidi-003-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-collapsing-breaks-001-ref.xht
+++ b/css/CSS2/text/white-space-collapsing-breaks-001-ref.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Test reference</title>
+  <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/"/>
+  <link rel="author" title="Florian Rivoal" href="https:/florian.rivoal.net"/>
+  <style type="text/css">
+    div {
+      height: 2em;
+      background: green;
+    }
+  </style>
+
+ </head>
+ <body>
+  <p>There must be a green box below and no red.</p>
+  <div></div>
+ </body>
+</html>

--- a/css/CSS2/text/white-space-collapsing-breaks-001.xht
+++ b/css/CSS2/text/white-space-collapsing-breaks-001.xht
@@ -4,6 +4,8 @@
   <title>CSS Test: Line Breaking in Collapsed White Space</title>
   <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model"/>
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1"/>
+  <link rel="match" href="white-space-collapsing-breaks-001-ref.xht"/>
   <meta name="assert" content="Line break opportunities are determined before
     white space collapsing."/>
   <style type="text/css">

--- a/css/CSS2/text/white-space-generated-content-before-001-ref.xht
+++ b/css/CSS2/text/white-space-generated-content-before-001-ref.xht
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test Reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/" />
+        <style type="text/css">
+        </style>
+    </head>
+    <body>
+        <p>Test passes if the two lines below have the exact same spacing.</p>
+        <div>The spacing on these two sentences need to be the same!</div>
+        <div>The spacing on these two sentences need to be the same!</div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-generated-content-before-001.xht
+++ b/css/CSS2/text/white-space-generated-content-before-001.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-line' vs. ':before' assignment</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-line" />
+        <link rel="match" href="white-space-generated-content-before-001-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The ':before' assignment and 'white-space: pre-line' assignment behave the same way with respect to white space." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-mixed-001.xht
+++ b/css/CSS2/text/white-space-mixed-001.xht
@@ -11,6 +11,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/mixed/001.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property" />
   <link rel="match" href="white-space-mixed-001-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-mixed-002.xht
+++ b/css/CSS2/text/white-space-mixed-002.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/mixed/002.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-mixed-002-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-mixed-003.xht
+++ b/css/CSS2/text/white-space-mixed-003.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/mixed/003.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property" />
   <link rel="match" href="white-space-mixed-003-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-normal-001.xht
+++ b/css/CSS2/text/white-space-normal-001.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/001.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
   <link rel="match" href="white-space-normal-001-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-normal-002.xht
+++ b/css/CSS2/text/white-space-normal-002.xht
@@ -6,6 +6,8 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/002.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
   <link rel="match" href="white-space-normal-001-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-normal-003.xht
+++ b/css/CSS2/text/white-space-normal-003.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/003.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-003-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-normal-004.xht
+++ b/css/CSS2/text/white-space-normal-004.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/004.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-003-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-normal-005.xht
+++ b/css/CSS2/text/white-space-normal-005.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/005.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-005-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-normal-006.xht
+++ b/css/CSS2/text/white-space-normal-006.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/006.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-005-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-normal-007.xht
+++ b/css/CSS2/text/white-space-normal-007.xht
@@ -9,6 +9,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/007.html" type="text/html" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-007-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-normal-008.xht
+++ b/css/CSS2/text/white-space-normal-008.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/008.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-008-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-normal-009.xht
+++ b/css/CSS2/text/white-space-normal-009.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/normal/009.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property" />
   <link rel="match" href="white-space-normal-009-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-nowrap-001.xht
+++ b/css/CSS2/text/white-space-nowrap-001.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/nowrap/001.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property" />
   <link rel="match" href="white-space-nowrap-001-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-nowrap-005.xht
+++ b/css/CSS2/text/white-space-nowrap-005.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/nowrap/005.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-005-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-nowrap-006.xht
+++ b/css/CSS2/text/white-space-nowrap-006.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/nowrap/006.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-005-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-nowrap-attribute-001.xht
+++ b/css/CSS2/text/white-space-nowrap-attribute-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: White-space 'nowrap' vs. 'nowrap' attribute</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-generated-content-before-001-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'nowrap' attribute and 'white-space: nowrap' assignment behave the same way with respect to white space." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-p-element-001.xht
+++ b/css/CSS2/text/white-space-p-element-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: White-space 'normal' vs. 'p' element</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-generated-content-before-001-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'p' element and 'white-space: normal' assignment behave the same way with respect to white space." />
         <style type="text/css">
@@ -11,6 +12,7 @@
             {
                 white-space: normal;
             }
+	    div + p { margin: 0; }
        </style>
     </head>
     <body>

--- a/css/CSS2/text/white-space-pre-001.xht
+++ b/css/CSS2/text/white-space-pre-001.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/pre/001.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property" />
   <link rel="match" href="white-space-pre-001-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-pre-005.xht
+++ b/css/CSS2/text/white-space-pre-005.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/pre/005.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-005-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-pre-006.xht
+++ b/css/CSS2/text/white-space-pre-006.xht
@@ -6,6 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-29 -->
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/text/white-space/pre/006.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
   <link rel="match" href="white-space-normal-005-ref.xht" />
 
   <meta name="flags" content="ahem" />

--- a/css/CSS2/text/white-space-pre-element-001-ref.xht
+++ b/css/CSS2/text/white-space-pre-element-001-ref.xht
@@ -1,0 +1,24 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <style type="text/css">
+            pre, div
+            {
+                font-family: monospace;
+                font-size: 10pt;
+            }
+            div
+            {
+                white-space: pre;
+            }
+       </style>
+    </head>
+    <body>
+        <p>Test passes if the next two lines have the exact same spacing.</p>
+        <div> The   spacing  on      these         two  sentences need to be the    same!  </div>
+        <div> The   spacing  on      these         two  sentences need to be the    same!  </div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-pre-element-001.xht
+++ b/css/CSS2/text/white-space-pre-element-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: White-space 'pre' vs. 'pre' element</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-prop" />
+        <link rel="match" href="white-space-pre-element-001-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'pre' element and 'white-space: pre' assignment behave the same way with respect to white space." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-001.xht
+++ b/css/CSS2/text/white-space-processing-001.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Block level elements with text and white space</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Text within a block element is treated like an anonymous inline element for white space processing model." />
         <style type="text/css">
@@ -25,7 +27,7 @@
        </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div>XX   XX</div>
         <div id="div1"></div><div id="div2"></div>
      </body>

--- a/css/CSS2/text/white-space-processing-002-ref.xht
+++ b/css/CSS2/text/white-space-processing-002-ref.xht
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/" />
+        <style type="text/css">
+            div
+            {
+                height: 1em;
+                margin-bottom: 3px;
+            }
+            #div1
+            {
+                background-color: black;
+                width: 2em;
+            }
+            #div2
+            {
+                background-color: blue;
+                width: 3em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if the black box below is shorter than the blue box.</p>
+        <div id="div1"></div>
+        <div id="div2"></div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-002.xht
+++ b/css/CSS2/text/white-space-processing-002.xht
@@ -4,8 +4,10 @@
         <title>CSS Test: White-space 'normal' with tab adjoining linefeed</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
-        <meta name="flags" content="ahem may" />
-        <meta name="assert" content="A tab before a linefeed is removed if 'white-space' is set to 'normal'. The linefeed may be rendered as a space or not rendered." />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-processing-002-ref.xht" />
+        <meta name="flags" content="ahem" />
+        <meta name="assert" content="A tab before a linefeed is removed if 'white-space' is set to 'normal'." />
         <style type="text/css">
             div
             {
@@ -25,7 +27,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the black box below is the same width, or shorter, than the blue box.</p>
+        <p>Test passes if the black box below is shorter than the blue box.</p>
         <div id="div1">XX&#09;&#10;</div>
         <div id="div2"></div>
     </body>

--- a/css/CSS2/text/white-space-processing-003.xht
+++ b/css/CSS2/text/white-space-processing-003.xht
@@ -4,8 +4,10 @@
         <title>CSS Test: White-space 'nowrap' with tab adjoining linefeed</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
-        <meta name="flags" content="ahem may" />
-        <meta name="assert" content="A tab before a linefeed is removed if 'white-space' is set to 'nowrap'. The linefeed may be rendered as a space or not rendered." />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-processing-002-ref.xht" />
+        <meta name="flags" content="ahem" />
+        <meta name="assert" content="A tab before a linefeed is removed if 'white-space' is set to 'nowrap'." />
         <style type="text/css">
             div
             {
@@ -25,7 +27,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the black box below is the same width, or shorter, than the blue box.</p>
+        <p>Test passes if the black box below is shorter than the blue box.</p>
         <div id="div1">XX&#09;&#10;</div>
         <div id="div2"></div>
     </body>

--- a/css/CSS2/text/white-space-processing-004.xht
+++ b/css/CSS2/text/white-space-processing-004.xht
@@ -4,8 +4,10 @@
         <title>CSS Test: White-space 'pre-line' with tab adjoining linefeed</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
-        <meta name="flags" content="ahem may" />
-        <meta name="assert" content="A tab before a linefeed is removed if 'white-space' is set to 'pre-line'. The linefeed may be rendered as a space or not rendered." />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-processing-002-ref.xht" />
+        <meta name="flags" content="ahem" />
+        <meta name="assert" content="A tab before a linefeed is removed if 'white-space' is set to 'pre-line'." />
         <style type="text/css">
             div
             {
@@ -25,7 +27,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the black box below is the same width, or shorter, than the blue box.</p>
+        <p>Test passes if the black box below is shorter than the blue box.</p>
         <div id="div1">XX&#09;&#10;</div>
         <div id="div2"></div>
     </body>

--- a/css/CSS2/text/white-space-processing-008.xht
+++ b/css/CSS2/text/white-space-processing-008.xht
@@ -4,8 +4,10 @@
         <title>CSS Test: White-space 'normal' with space adjoining linefeed</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
-        <meta name="flags" content="ahem may" />
-        <meta name="assert" content="A space before a linefeed is removed if 'white-space' is set to 'normal'. The linefeed may be rendered as a space or not rendered." />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-processing-002-ref.xht" />
+        <meta name="flags" content="ahem" />
+        <meta name="assert" content="A space before a linefeed is removed if 'white-space' is set to 'normal'." />
         <style type="text/css">
             div
             {
@@ -16,7 +18,7 @@
             }
             #div1
             {
-                white-space: normal;
+                white-space: pre;
             }
             #div2
             {
@@ -25,7 +27,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the black box below is the same width, or shorter, than the blue box.</p>
+        <p>Test passes if the black box below is shorter than the blue box.</p>
         <div id="div1">XX&#32;&#10;</div>
         <div id="div2"></div>
     </body>

--- a/css/CSS2/text/white-space-processing-009.xht
+++ b/css/CSS2/text/white-space-processing-009.xht
@@ -4,8 +4,10 @@
         <title>CSS Test: White-space 'nowrap' with space adjoining linefeed</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
-        <meta name="flags" content="ahem may" />
-        <meta name="assert" content="A space before a linefeed is removed if 'white-space' is set to 'nowrap'. The linefeed may be rendered as a space or not rendered." />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-processing-002-ref.xht" />
+        <meta name="flags" content="ahem" />
+        <meta name="assert" content="A space before a linefeed is removed if 'white-space' is set to 'nowrap'." />
         <style type="text/css">
             div
             {
@@ -25,7 +27,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the black box below is the same width, or shorter, than the blue box.</p>
+        <p>Test passes if the black box below is shorter than the blue box.</p>
         <div id="div1">XX&#32;&#10;</div>
         <div id="div2"></div>
     </body>

--- a/css/CSS2/text/white-space-processing-010.xht
+++ b/css/CSS2/text/white-space-processing-010.xht
@@ -4,8 +4,10 @@
         <title>CSS Test: White-space 'pre-line' with space adjoining linefeed</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
-        <meta name="flags" content="ahem may" />
-        <meta name="assert" content="A space before a linefeed is removed if 'white-space' is set to 'pre-line'. The linefeed may be rendered as a space or not rendered." />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-processing-002-ref.xht" />
+        <meta name="flags" content="ahem" />
+        <meta name="assert" content="A space before a linefeed is removed if 'white-space' is set to 'pre-line'." />
         <style type="text/css">
             div
             {
@@ -25,7 +27,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the black box below is the same width, or shorter, than the blue box.</p>
+        <p>Test passes if the black box below is shorter than the blue box.</p>
         <div id="div1">XX&#32;&#10;</div>
         <div id="div2"></div>
     </body>

--- a/css/CSS2/text/white-space-processing-011.xht
+++ b/css/CSS2/text/white-space-processing-011.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre' with sequence of spaces</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="A sequence of spaces are not collapsed when 'white-space' is set to 'pre'." />
         <style type="text/css">
@@ -29,7 +31,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div id="div1">XX&#32;&#32;&#32;XX</div>
         <div id="div2"></div><div id="div3"></div>
     </body>

--- a/css/CSS2/text/white-space-processing-012.xht
+++ b/css/CSS2/text/white-space-processing-012.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-wrap' with sequence of spaces</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-002-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Sequence of spaces are not collapsed when 'white-space' is set to 'pre-wrap'." />
         <style type="text/css">
@@ -29,7 +31,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are two black squares on the page.</p>
         <div id="div1">XX&#32;&#32;&#32;XX</div>
         <div id="div2"></div><div id="div3"></div>
     </body>

--- a/css/CSS2/text/white-space-processing-013-ref.xht
+++ b/css/CSS2/text/white-space-processing-013-ref.xht
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/" />
+        <meta name="flags" content="ahem" />
+        <style type="text/css">
+            div
+            {
+                font-family: Ahem;
+                line-height: 1em;
+                width: 5em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is one box below.</p>
+	<div>XX<br />XX</div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-013.xht
+++ b/css/CSS2/text/white-space-processing-013.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-wrap' and line opportunity with sequence of spaces</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-processing-013-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="A line breaking opportunity is introduced at the end of a sequence of spaces when 'white-space' is set to 'pre-wrap'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-016-ref.xht
+++ b/css/CSS2/text/white-space-processing-016-ref.xht
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <meta name="flags" content="ahem" />
+        <style type="text/css">
+            span
+            {
+                background-color: black;
+                font-family: Ahem;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there are two boxes below, one above the other.</p>
+        <div>
+	    <span>XX<br />XX</span>
+        </div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-016.xht
+++ b/css/CSS2/text/white-space-processing-016.xht
@@ -4,6 +4,9 @@
         <title>CSS Test: White-space 'pre' and linefeed characters</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-transform" />
+        <link rel="match" href="white-space-processing-016-ref.xht" />
+
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Linefeed characters are not transformed when 'white-space' is set to 'pre'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-017.xht
+++ b/css/CSS2/text/white-space-processing-017.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-line' and linefeed characters</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-transform" />
+        <link rel="match" href="white-space-processing-016-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Linefeed characters are not transformed when 'white-space' is set to 'pre-line'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-018.xht
+++ b/css/CSS2/text/white-space-processing-018.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-wrap' and linefeed characters</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#line-break-transform" />
+        <link rel="match" href="white-space-processing-016-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Linefeed characters are not transformed when 'white-space' is set to 'pre-wrap'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-019.xht
+++ b/css/CSS2/text/white-space-processing-019.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'normal' and tabs</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Tabs are converted to spaces when 'white-space' is set to 'normal'." />
         <style type="text/css">
@@ -20,7 +22,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -29,8 +31,8 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
-        <div id="div1">X&#09;X</div>
+        <p>Test passes if there are 2 filled black squares.</p>
+        <div id="div1">XX&#09;XX</div>
         <div id="div2"></div><div id="div3"></div>
     </body>
 </html>

--- a/css/CSS2/text/white-space-processing-020.xht
+++ b/css/CSS2/text/white-space-processing-020.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'nowrap' and tabs</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Tabs are converted to spaces when 'white-space' is set to 'nowrap'." />
         <style type="text/css">
@@ -20,7 +22,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -29,8 +31,8 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
-        <div id="div1">X&#09;X</div>
+        <p>Test passes if there are 2 filled black squares.</p>
+        <div id="div1">XX&#09;XX</div>
         <div id="div2"></div><div id="div3"></div>
     </body>
 </html>

--- a/css/CSS2/text/white-space-processing-021.xht
+++ b/css/CSS2/text/white-space-processing-021.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-line' and tabs</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Tabs are converted to spaces when 'white-space' is set to 'pre-line'." />
         <style type="text/css">
@@ -20,7 +22,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -29,8 +31,8 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
-        <div id="div1">X&#09;X</div>
+        <p>Test passes if there are 2 filled black squares.</p>
+        <div id="div1">XX&#09;XX</div>
         <div id="div2"></div><div id="div3"></div>
     </body>
 </html>

--- a/css/CSS2/text/white-space-processing-022.xht
+++ b/css/CSS2/text/white-space-processing-022.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White space processing model with 'space' characters</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'normal' adjoining a space with 'white-space' set to 'normal' collapse into one space." />
         <style type="text/css">
@@ -20,7 +22,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -29,8 +31,8 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
-        <div id="div1">X&#32;&#32;&#32;X</div>
+        <p>Test passes if there are 2 filled black squares.</p>
+        <div id="div1">XX&#32;&#32;&#32;XX</div>
         <div id="div2"></div><div id="div3"></div>
     </body>
 </html>

--- a/css/CSS2/text/white-space-processing-023.xht
+++ b/css/CSS2/text/white-space-processing-023.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'normal'/'nowrap'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'normal' adjoining a space with 'white-space' set to 'nowrap' collapse into one space." />
         <style type="text/css">
@@ -24,7 +26,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -33,10 +35,9 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">XX&#32;</span><span id="span2">&#32;XX</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-024.xht
+++ b/css/CSS2/text/white-space-processing-024.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'normal'/'pre-line'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'normal' adjoining a space with 'white-space' set to 'pre-line' collapse into one space." />
         <style type="text/css">
@@ -24,7 +26,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -33,10 +35,9 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">XX&#32;</span><span id="span2">&#32;XX</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-025.xht
+++ b/css/CSS2/text/white-space-processing-025.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'nowrap'/'normal'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'nowrap' adjoining a space with 'white-space' set to 'normal' collapse into one space." />
         <style type="text/css">
@@ -24,7 +26,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -33,10 +35,9 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">XX&#32;</span><span id="span2">&#32;XX</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-026.xht
+++ b/css/CSS2/text/white-space-processing-026.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'nowrap'/'nowrap'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'nowrap' adjoining a space with 'white-space' set to 'nowrap' collapse into one space." />
         <style type="text/css">
@@ -24,7 +26,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -33,10 +35,9 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">XX&#32;</span><span id="span2">&#32;XX</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-027.xht
+++ b/css/CSS2/text/white-space-processing-027.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'nowrap'/'pre-line'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'nowrap' adjoining a space with 'white-space' set to 'pre-line' collapse into one space." />
         <style type="text/css">
@@ -24,7 +26,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -33,10 +35,9 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">XX&#32;</span><span id="span2">&#32;XX</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-028.xht
+++ b/css/CSS2/text/white-space-processing-028.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'pre-line'/'normal'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'pre-line' adjoining a space with 'white-space' set to 'normal' collapse into one space." />
         <style type="text/css">
@@ -24,7 +26,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -33,10 +35,9 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">XX&#32;</span><span id="span2">&#32;XX</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-029.xht
+++ b/css/CSS2/text/white-space-processing-029.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'pre-line'/'nowrap'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'pre-line' adjoining a space with 'white-space' set to 'nowrap' collapse into one space." />
         <style type="text/css">
@@ -24,7 +26,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -33,10 +35,9 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">XX&#32;</span><span id="span2">&#32;XX</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-030.xht
+++ b/css/CSS2/text/white-space-processing-030.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'pre-line'/'pre-line'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'pre-line' adjoining a space with 'white-space' set to 'pre-line' collapse into one space." />
         <style type="text/css">
@@ -24,7 +26,7 @@
                 background: black;
                 display: inline-block;
                 height: 1em;
-                width: 1em;
+                width: 2em;
             }
             #div3
             {
@@ -33,10 +35,9 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">XX&#32;</span><span id="span2">&#32;XX</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-031-ref.xht
+++ b/css/CSS2/text/white-space-processing-031-ref.xht
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <style type="text/css">
+            div
+            {
+                height: 1em;
+            }
+            #div2, #div3
+            {
+                background: black;
+                display: inline-block;
+                height: 1em;
+                width: 1em;
+            }
+            #div3
+            {
+                margin-left: 2em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there are only two boxes below.</p>
+            <div>
+                <div id="div2"></div><div id="div3"></div>
+            </div>
+            <div>
+                <div id="div2"></div><div id="div3"></div>
+            </div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-031.xht
+++ b/css/CSS2/text/white-space-processing-031.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'normal'/'pre'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+	<link rel="match" href="white-space-processing-031-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'normal' adjoining a space with 'white-space' set to 'pre' remain two spaces." />
         <style type="text/css">
@@ -35,8 +37,7 @@
     <body>
         <p>Test passes if there are only two boxes below.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">X&#32;</span><span id="span2">&#32;X</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-032.xht
+++ b/css/CSS2/text/white-space-processing-032.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'normal'/'pre-wrap'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+	<link rel="match" href="white-space-processing-031-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'normal' adjoining a space with 'white-space' set to 'pre-wrap' remain two spaces." />
         <style type="text/css">
@@ -35,8 +37,7 @@
     <body>
         <p>Test passes if there are only two boxes below.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">X&#32;</span><span id="span2">&#32;X</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-033.xht
+++ b/css/CSS2/text/white-space-processing-033.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'nowrap'/'pre'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+	<link rel="match" href="white-space-processing-031-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'nowrap' adjoining a space with 'white-space' set to 'pre' remain two spaces." />
         <style type="text/css">
@@ -35,8 +37,7 @@
     <body>
         <p>Test passes if there are only two boxes below.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">X&#32;</span><span id="span2">&#32;X</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-034.xht
+++ b/css/CSS2/text/white-space-processing-034.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'nowrap'/'pre-wrap'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+	<link rel="match" href="white-space-processing-031-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'nowrap' adjoining a space with 'white-space' set to 'pre-wrap' remain two spaces." />
         <style type="text/css">
@@ -35,8 +37,7 @@
     <body>
         <p>Test passes if there are only two boxes below.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">X&#32;</span><span id="span2">&#32;X</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-035.xht
+++ b/css/CSS2/text/white-space-processing-035.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'pre-line'/'pre'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+	<link rel="match" href="white-space-processing-031-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'pre-line' adjoining a space with 'white-space' set to 'pre' retain two spaces." />
         <style type="text/css">
@@ -35,8 +37,7 @@
     <body>
         <p>Test passes if there are only two boxes below.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">X&#32;</span><span id="span2">&#32;X</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-036.xht
+++ b/css/CSS2/text/white-space-processing-036.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Two spaces adjoining with 'white-space' 'pre-line'/'pre-wrap'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+	<link rel="match" href="white-space-processing-031-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="One space with 'white-space' set to 'pre-line' adjoining a space with 'white-space' set to 'pre-wrap' retain two spaces." />
         <style type="text/css">
@@ -35,8 +37,7 @@
     <body>
         <p>Test passes if there are only two boxes below.</p>
         <div id="div1">
-            <span id="span1">X&#32;</span>
-            <span id="span2">&#32;X</span>
+            <span id="span1">X&#32;</span><span id="span2">&#32;X</span>
             <div>
                 <div id="div2"></div><div id="div3"></div>
             </div>

--- a/css/CSS2/text/white-space-processing-037-ref.xht
+++ b/css/CSS2/text/white-space-processing-037-ref.xht
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: White-space 'normal' and space at beginning of line</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <style type="text/css">
+            div
+            {
+                background: black;
+                height: 1em;
+                width: 1em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is only one box below.</p>
+        <div></div>
+        <div></div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-037.xht
+++ b/css/CSS2/text/white-space-processing-037.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'normal' and space at beginning of line</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-037-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Space at beginning of line is removed when 'white-space' is set to 'normal'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-039.xht
+++ b/css/CSS2/text/white-space-processing-039.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-line' and space at beginning of line</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-037-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Space at beginning of line is removed when 'white-space' is set to 'pre-line'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-040.xht
+++ b/css/CSS2/text/white-space-processing-040.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-wrap' and space at beginning of line</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-037-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Space at beginning of line is not removed when 'white-space' is set to 'pre-wrap'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-041.xht
+++ b/css/CSS2/text/white-space-processing-041.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre' and space at beginning of line</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-037-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Space at beginning of line is not removed when 'white-space' is set to 'pre'." />
         <style type="text/css">
@@ -14,12 +16,12 @@
             #div1
             {
                 white-space: pre;
+                margin-left: -1em;
             }
             #div2
             {
                 background: black;
                 height: 1em;
-                margin-left: 1em;
                 width: 1em;
             }
         </style>

--- a/css/CSS2/text/white-space-processing-042-ref.xht
+++ b/css/CSS2/text/white-space-processing-042-ref.xht
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivol" href="https://florian.rivoal.net" />
+        <style type="text/css">
+            div
+            {
+                height: 1em;
+            }
+            #div2, #div3
+            {
+                background: black;
+                display: inline-block;
+                height: 1em;
+                width: 2em;
+            }
+            #div3
+            {
+                margin-left: 6em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there are only two boxes below.</p>
+        <div>
+            <div id="div2"></div><div id="div3"></div>
+        </div>
+        <div>
+            <div id="div2"></div><div id="div3"></div>
+        </div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-042.xht
+++ b/css/CSS2/text/white-space-processing-042.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: Tab width</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-042-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Tabs (when rendered) render spaces at 8 character stops. That is, within a line, split the line into 8 character lengths. The tab would continue until the end of the next length. So if there are already 3 characters in a line, the tab would be rendered as 5 spaces." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-043-ref.xht
+++ b/css/CSS2/text/white-space-processing-043-ref.xht
@@ -1,0 +1,22 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <meta name="flags" content="ahem" />
+        <style type="text/css">
+            span
+            {
+                font: 1.25em/1 Ahem;
+                white-space: normal;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is <strong>no red</strong>.</p>
+        <div>
+            <span>X</span>
+        </div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-043.xht
+++ b/css/CSS2/text/white-space-processing-043.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-08-11 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-043-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Space is removed at the end of the line when 'white-space' is set to 'normal'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-044.xht
+++ b/css/CSS2/text/white-space-processing-044.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-08-11 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-043-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Space is removed at the end of the line when 'white-space' is set to 'nowrap'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-045.xht
+++ b/css/CSS2/text/white-space-processing-045.xht
@@ -5,6 +5,8 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-08-11 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-043-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Space is removed at the end of the line when 'white-space' is set to 'pre-line'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-046-ref.xht
+++ b/css/CSS2/text/white-space-processing-046-ref.xht
@@ -1,0 +1,23 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoa.net" />
+        <meta name="flags" content="ahem" />
+        <style type="text/css">
+            span
+            {
+                background-color:black;
+                font-family: Ahem;
+                white-space: pre;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a box below.</p>
+        <div>
+            <span>&nbsp;</span>
+        </div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-046.xht
+++ b/css/CSS2/text/white-space-processing-046.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre' and space at end of line</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-046-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Space is not removed at the end of the line when 'white-space' is set to 'pre'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-047.xht
+++ b/css/CSS2/text/white-space-processing-047.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-wrap' and space at end of line</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2" />
+        <link rel="match" href="white-space-processing-046-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="Space is not removed at the end of the line when 'white-space' is set to 'pre-wrap'." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-050.xht
+++ b/css/CSS2/text/white-space-processing-050.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'normal' on a 'pre' element</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'normal' removes extra spacing when two spaces are next to each other when set on 'pre' element." />
         <style type="text/css">
@@ -35,7 +37,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <pre id="pre1">XX   XX</pre>
         <pre id="pre2"></pre><pre id="pre3"></pre>
     </body>

--- a/css/CSS2/text/white-space-processing-051.xht
+++ b/css/CSS2/text/white-space-processing-051.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'nowrap' on a 'pre' element</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-001-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'nowrap' does not remove extra spacing when two spaces are next to each other." />
         <style type="text/css">
@@ -32,7 +34,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are only two boxes below.</p>
+        <p>Test passes if there are 2 filled black squares.</p>
         <pre id="pre1">XX   XX</pre>
         <pre id="pre2"></pre><pre id="pre3"></pre>
     </body>

--- a/css/CSS2/text/white-space-processing-052-ref.xht
+++ b/css/CSS2/text/white-space-processing-052-ref.xht
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <meta name="flags" content="ahem" />
+        <style type="text/css">
+            pre
+            {
+                font: 16px/1em Ahem;
+                margin: 0;
+                padding: 0;
+            }
+            #pre1
+            {
+                white-space: pre-wrap;
+                width: 5em;
+            }
+            #pre2
+            {
+                background: black;
+                display: inline-block;
+                height: 1em;
+                width: 2em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is one box below.</p>
+	<pre id="pre1">XX<br />XX</pre>
+        <pre id="pre2"></pre>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-052.xht
+++ b/css/CSS2/text/white-space-processing-052.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-wrap' on a 'pre' element</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-processing-052-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'pre-wrap' does not remove extra spacing when two spaces are next to each other and introduces line breaking opportunities when set on a 'pre' element." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-053.xht
+++ b/css/CSS2/text/white-space-processing-053.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White-space 'pre-line' on a 'pre' element</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-1" />
+        <link rel="match" href="white-space-processing-052-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'white-space' property set to 'pre-line' does remove extra spacing when two spaces are next to each other and breaks at new lines when set on a 'pre' element." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-054-ref.xht
+++ b/css/CSS2/text/white-space-processing-054-ref.xht
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/" />
+        <style type="text/css">
+            div
+            {
+                height: 1em;
+            }
+            #div2, #div3
+            {
+                background: black;
+                display: inline-block;
+                height: 1em;
+                width: 2em;
+            }
+            #div3
+            {
+                margin-left: 1.5em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there are only two boxes below.</p>
+	<div><div id="div2"></div><div id="div3"></div></div>
+	<div><div id="div2"></div><div id="div3"></div></div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-054.xht
+++ b/css/CSS2/text/white-space-processing-054.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White space processing model with 'en quad' characters</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
+        <link rel="match" href="white-space-processing-054-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="An 'en quad' characters is not collapsed by the white space processing model." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-055-ref.xht
+++ b/css/CSS2/text/white-space-processing-055-ref.xht
@@ -1,0 +1,22 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <style type="text/css">
+            div
+            {
+                font: 16px/1em Ahem;
+                background: black;
+                display: inline-block;
+                height: 2em;
+                width: 4em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is only one box below.</p>
+        <div></div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-055.xht
+++ b/css/CSS2/text/white-space-processing-055.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White space processing model with 'zero width no break space' character</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
+        <link rel="match" href="white-space-processing-055-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="A 'zero width no break space' character is not collapsed by the white space processing model." />
         <style type="text/css">

--- a/css/CSS2/text/white-space-processing-056-ref.xht
+++ b/css/CSS2/text/white-space-processing-056-ref.xht
@@ -1,0 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test reference</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net" />
+        <style type="text/css">
+            div
+            {
+                font-size: 1.25em;
+            }
+            #div2, #div3
+            {
+                background: black;
+                display: inline-block;
+                height: 2em;
+                width: 2em;
+            }
+            #div3
+            {
+                margin-left: 3em;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there are 2 small filled black squares.</p>
+        <div id="div2"></div><div id="div3"></div>
+    </body>
+</html>

--- a/css/CSS2/text/white-space-processing-056.xht
+++ b/css/CSS2/text/white-space-processing-056.xht
@@ -4,6 +4,8 @@
         <title>CSS Test: White space processing model with 'ideographic space' character</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/text.html#white-space-model" />
+        <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules" />
+        <link rel="match" href="white-space-processing-056-ref.xht" />
 
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'ideographic space' character is not collapsed by the white space processing model." />


### PR DESCRIPTION
A number of test from css 2 are still relevant to the css-text-3 spec,
so I tagged them with the appropriate link rel=help. Along the way, I
added refs to those that didn't have one, making a few tweaks to
harmonize some tests in order to minimize the number of refs needed.

This should cover all the tests for the white-space property,
plus a handful of others.