### PR TITLE
Fix Mojo detection in bluetooth-helpers.js

### DIFF
--- a/bluetooth/resources/bluetooth-helpers.js
+++ b/bluetooth/resources/bluetooth-helpers.js
@@ -18,8 +18,8 @@ function loadScripts(paths) {
 }
 
 function performChromiumSetup() {
-  // Make sure we are actually on Chromium.
-  if (!Mojo) {
+  // Make sure we are actually on Chromium with Mojo enabled.
+  if (typeof Mojo === 'undefined') {
     return;
   }
 


### PR DESCRIPTION
Avoid throwing a reference error when Mojo is not defined.