### PR TITLE
Fix resource-timing.html document.domain test - take 2

### DIFF
--- a/common/sleep.py
+++ b/common/sleep.py
@@ -1,0 +1,8 @@
+import time
+
+# sleep can be lower than requested value in some platforms: https://bugs.python.org/issue31539
+# We add padding here to compensate for that.
+sleep_padding = 15.0
+
+def sleep_at_least(sleep_in_ms):
+    time.sleep((sleep_in_ms + sleep_padding) / 1E3);

--- a/resource-timing/SyntheticResponse.py
+++ b/resource-timing/SyntheticResponse.py
@@ -1,5 +1,7 @@
 import urllib
-import time
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), "../common/"))
+import sleep
 
 def main(request, response):
     index = request.request_path.index("?")
@@ -11,7 +13,7 @@ def main(request, response):
         if arg.startswith("ignored"):
             continue
         elif arg.endswith("ms"):
-            time.sleep(float(arg[0:-2]) / 1E3);
+            sleep.sleep_at_least(float(arg[0:-2]))
         elif arg.startswith("redirect:"):
             return (302, "WEBPERF MARKETING"), [("Location", urllib.unquote(arg[9:]))], "TEST"
         elif arg.startswith("mime:"):

--- a/resource-timing/document-domain-no-impact-loader.sub.html
+++ b/resource-timing/document-domain-no-impact-loader.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+    const t = async_test("Finite resource timing entries buffer size");
+    addEventListener("message", t.step_func_done(e => {
+        assert_equals(e.data, "PASS", "Document domain had no impact on the timing-allow check");
+    }));
+window.open("//{{domains[www]}}:{{ports[http][1]}}/resource-timing/resources/document-domain-no-impact.sub.html");
+</script>

--- a/resource-timing/resource-timing-level1.js
+++ b/resource-timing/resource-timing-level1.js
@@ -60,13 +60,13 @@ window.onload =
                         initiateFetch(
                             test,
                             "iframe",
-                            canonicalize("iframe-setdomain.sub.html"),
+                            canonicalize("resources/iframe-setdomain.sub.html"),
                             function (initiator, entry) {
                                 // Ensure that the script inside the IFrame has successfully changed the IFrame's domain.
                                 assert_throws(
-                                    null,
+                                    "SecurityError",
                                     function () {
-                                        assert_not_equals(frame.contentWindow.document, null);
+                                        assert_not_equals(initiator.contentWindow.document, null);
                                     },
                                     "Test Error: IFrame is not recognized as cross-domain.");
 
@@ -74,7 +74,7 @@ window.onload =
                                 // verify that the following non-zero properties return their value.
                                 ["domainLookupStart", "domainLookupEnd", "connectStart", "connectEnd"]
                                     .forEach(function(property) {
-                                        assert_greater_than(entry.connectEnd, 0,
+                                        assert_greater_than(entry[property], 0,
                                             "Property should be non-zero because timing allow check ignores 'document.domain'.");
                                     });
                                 test.done();
@@ -324,7 +324,7 @@ window.onload =
             // Multiple browsers seem to cheat a bit and race img.onLoad and setting responseEnd.  Microsoft https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/2379187
             // Yield for 100ms to workaround a suspected race where window.onload fires before
             //     script visible side-effects from the wininet/urlmon thread have finished.
-            window.setTimeout(
+            test.step_timeout(
                 test.step_func(
                     function () {
                         performance
@@ -468,7 +468,7 @@ window.onload =
             when invoked. */
         function createOnloadCallbackFn(test, initiator, url, onloadCallback) {
             // Remember the number of entries on the timeline prior to initiating the fetch:
-            var beforeEntryCount = performance.getEntries().length;
+            var beforeEntryCount = performance.getEntriesByType("resource").length;
 
             return test.step_func(
                 function() {
@@ -480,7 +480,7 @@ window.onload =
                         }
                     }
 
-                    var entries = performance.getEntries();
+                    var entries = performance.getEntriesByType("resource");
                     var candidateEntry = entries[entries.length - 1];
 
                     switch (entries.length - beforeEntryCount)

--- a/resource-timing/resource-timing-level1.js
+++ b/resource-timing/resource-timing-level1.js
@@ -53,34 +53,6 @@ window.onload =
                             "'Src' of new <iframe> must be 'about:blank'.");
                     }
             },
-            {
-                description: "Setting 'document.domain' does not effect same-origin checks",
-                test:
-                    function (test) {
-                        initiateFetch(
-                            test,
-                            "iframe",
-                            canonicalize("resources/iframe-setdomain.sub.html"),
-                            function (initiator, entry) {
-                                // Ensure that the script inside the IFrame has successfully changed the IFrame's domain.
-                                assert_throws(
-                                    "SecurityError",
-                                    function () {
-                                        assert_not_equals(initiator.contentWindow.document, null);
-                                    },
-                                    "Test Error: IFrame is not recognized as cross-domain.");
-
-                                // To verify that setting 'document.domain' did not change the results of the timing allow check,
-                                // verify that the following non-zero properties return their value.
-                                ["domainLookupStart", "domainLookupEnd", "connectStart", "connectEnd"]
-                                    .forEach(function(property) {
-                                        assert_greater_than(entry[property], 0,
-                                            "Property should be non-zero because timing allow check ignores 'document.domain'.");
-                                    });
-                                test.done();
-                            });
-                    }
-            }
         ];
 
         // Create cached/uncached tests from the following array of templates.  For each template entry,

--- a/resource-timing/resource-timing-level1.sub.html
+++ b/resource-timing/resource-timing-level1.sub.html
@@ -14,6 +14,13 @@
 <body>
   <div id="log"></div>
   <pre id="output"></pre>
-  <script src="resource-timing.js"></script>
+  <script>
+      if (window.location.hostname != "{{domains[www]}}") {
+          let url = new URL(window.location.href);
+          url.hostname = "{{domains[www]}}";
+          window.location = url.href;
+      }
+  </script>
+  <script src="resource-timing-level1.js"></script>
 </body>
 </html>

--- a/resource-timing/resource-timing-level1.sub.html
+++ b/resource-timing/resource-timing-level1.sub.html
@@ -14,13 +14,6 @@
 <body>
   <div id="log"></div>
   <pre id="output"></pre>
-  <script>
-      if (window.location.hostname != "{{domains[www]}}") {
-          let url = new URL(window.location.href);
-          url.hostname = "{{domains[www]}}";
-          window.location = url.href;
-      }
-  </script>
   <script src="resource-timing-level1.js"></script>
 </body>
 </html>

--- a/resource-timing/resources/document-domain-no-impact.sub.html
+++ b/resource-timing/resources/document-domain-no-impact.sub.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<iframe id="frame" src="//{{domains[www]}}:{{ports[http][1]}}/resource-timing/resources/iframe-setdomain.sub.html"></iframe>
+<script>
+    let opener = window.opener;
+    window.addEventListener("load", () => {
+        try {
+            let frameDoc = document.getElementById("frame").contentWindow.document;
+            opener.postMessage("FAIL - iframe document.domain was not set", "*");
+            return;
+        } catch(error) {
+            if (error.name != "SecurityError") {
+                opener.postMessage("FAIL - error is " + error.name, "*");
+                return;
+            }
+            let entry = performance.getEntriesByName(window.location.protocol + "//{{domains[www]}}:{{ports[http][1]}}/resource-timing/resources/iframe-setdomain.sub.html");
+            // To verify that setting 'document.domain' did not change the results of the timing allow check,
+            // verify that the following non-zero properties return their value.
+            ["domainLookupStart", "domainLookupEnd", "connectStart", "connectEnd"].forEach(property => {
+                if (entry[property] == 0) {
+                    opener.postMessage("FAIL - " + property + " is 0 but timing allow check should ignore document.domain", "*");
+                }
+            });
+            opener.postMessage("PASS", "*");
+        }
+        opener.postMessage("FAIL - unknown", "*");
+    });
+</script>
+
+
+

--- a/resource-timing/resources/iframe-setdomain.sub.html
+++ b/resource-timing/resources/iframe-setdomain.sub.html
@@ -1,14 +1,14 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-  <title>domain: {{domains[www]}}</title>
+  <title>domain: {{domains[]}}</title>
 </head>
 <body>
   <script>
     // The purpose of this IFrame is to change the 'document.domain'
-    document.domain = "{{domains[www]}}";
+    document.domain = "{{domains[]}}";
   </script>
-  The resource-timings.html test loads this document into an IFrame to vet that setting
+  The resource-timings-level1.sub.html test loads this document into an IFrame to vet that setting
   'document.domain' does not effect the timing allowed.
 </body>
 </html>


### PR DESCRIPTION
Replaces https://github.com/web-platform-tests/wpt/pull/14636
Because [we can't make sure a test loads onto the right domain](https://github.com/web-platform-tests/wpt/pull/14636#discussion_r243443726), I extracted the document.domain tests from the larger file and only loaded that test on the right domain, as an external document.