### PR TITLE
Prevent webdriver client Session.close() exception

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -566,7 +566,7 @@ class Session(object):
     @command
     def close(self):
         handles = self.send_session_command("DELETE", "window")
-        if len(handles) == 0:
+        if handles is not None and len(handles) == 0:
             # With no more open top-level browsing contexts, the session is closed.
             self.session_id = None
 


### PR DESCRIPTION
This change adds handling for the case when the call to `self.send_session_command("DELETE", "window")` in `Session.close()` in `tools/webdriver/webdriver/client.py` returns None.

Otherwise without this change, the code ends up checking `len()` on the return value of `self.send_session_command("DELETE", "window")`, which can result in a _"TypeError: object of type 'NoneType' has no len()"_ exception.

Fixes https://github.com/web-platform-tests/wpt/issues/14714

---

If the code in this patch isn’t the right/best way (or the most idiomatic way in Python) to deal with the problem in #14714, then let’s use this PR branch to update the patch to fix it the right way.