### PR TITLE
[resource-timing] test_resource_timing.html to pass also when run in HTTPS

### DIFF
--- a/resource-timing/test_resource_timing.https.html
+++ b/resource-timing/test_resource_timing.https.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>window.performance Resource Timing Entries exist</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="https://w3c.github.io/web-performance/specs/ResourceTiming/Overview.html"/>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="test_resource_timing.js"></script>
+    </head>
+    <body>
+        <h1>Description</h1>
+        <p>
+           NOTE: Due to caching behavior in the browser, it is possible that when revisiting this page, some resources
+           may not have to be fetched from the network.  As a result, the performance timeline will not contain entries
+           for these resources. This test will fail if any entries are missing to ensure that all resources are fetched
+           from the network and entries for these resources exist in the Performance Timeline.  If revisiting this page,
+           please either perform a full reload of the page or clear the cache between visits.
+        </p>
+
+        <div id="log"></div>
+    </body>
+</html>

--- a/resource-timing/test_resource_timing.js
+++ b/resource-timing/test_resource_timing.js
@@ -186,6 +186,11 @@ function resource_load(expected)
         const entries = window.performance.getEntriesByName(expected.name);
         assert_equals(entries.length, 1, 'There should be a single matching entry');
         const actual = entries[0];
+        if (window.location.protocol == "http:") {
+            assert_equals(actual.secureConnectionStart, 0, 'secureConnectionStart should be 0 in http');
+        } else {
+            assert_greater_than(actual.secureConnectionStart, 0, 'secureConnectionStart should not be 0 in https');
+        }
 
         assert_equals(actual.redirectStart, 0, 'redirectStart should be 0');
         assert_equals(actual.redirectEnd, 0, 'redirectEnd should be 0');

--- a/resource-timing/test_resource_timing.js
+++ b/resource-timing/test_resource_timing.js
@@ -187,21 +187,15 @@ function resource_load(expected)
         assert_equals(entries.length, 1, 'There should be a single matching entry');
         const actual = entries[0];
 
-        // Debugging bug 1263428
-        // Feel free to remove/overwrite this piece of code
-        if (actual.connectStart < actual.domainLookupEnd) {
-            assert_true(false, "actual: "+JSON.stringify(actual));
-        }
-
         assert_equals(actual.redirectStart, 0, 'redirectStart should be 0');
         assert_equals(actual.redirectEnd, 0, 'redirectEnd should be 0');
-        assert_true(actual.secureConnectionStart == undefined ||
-                    actual.secureConnectionStart == 0, 'secureConnectionStart should be 0 or undefined');
         assert_equals(actual.fetchStart, actual.startTime, 'fetchStart is equal to startTime');
         assert_greater_than_equal(actual.domainLookupStart, actual.fetchStart, 'domainLookupStart after fetchStart');
         assert_greater_than_equal(actual.domainLookupEnd, actual.domainLookupStart, 'domainLookupEnd after domainLookupStart');
         assert_greater_than_equal(actual.connectStart, actual.domainLookupEnd, 'connectStart after domainLookupEnd');
         assert_greater_than_equal(actual.connectEnd, actual.connectStart, 'connectEnd after connectStart');
+        assert_true(actual.secureConnectionStart == 0 || actual.secureConnectionStart <= actual.requestStart,
+            "secureConnectionStart should be either 0 or smaller than/equals to requestStart")
         assert_greater_than_equal(actual.requestStart, actual.connectEnd, 'requestStart after connectEnd');
         assert_greater_than_equal(actual.responseStart, actual.requestStart, 'responseStart after requestStart');
         assert_greater_than_equal(actual.responseEnd, actual.responseStart, 'responseEnd after responseStart');


### PR DESCRIPTION
I spotted a recent [regression](https://staging.wpt.fyi/results/resource-timing/test_resource_timing.html?sha=cf8b055289) on wpt.fyi where test_resource_timing.html fails in experimental. I suspected it may be related to this test running in HTTPS, but I'm less sure that's the case.

Regardless, when I looked into it, it became clear that this test was never meant to pass under HTTPS, so fixing that here.