### PR TITLE
[manifest] Make sure deleted tests are removed from manifest

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -79,6 +79,8 @@ class TypeData(object):
         return rv
 
     def __delitem__(self, key):
+        # First access the index to ensure it is loaded.
+        self[key]
         del self.data[key]
 
     def __setitem__(self, key, value):
@@ -279,6 +281,10 @@ class Manifest(object):
                     if old_hash != file_hash:
                         new_type, manifest_items = source_file.manifest_items()
                         hash_changed = True
+                        try:
+                            del self._data[old_type][rel_path]
+                        except KeyError:
+                            pass
                     else:
                         new_type, manifest_items = old_type, self._data[old_type][rel_path]
                     if old_type in reftest_types and new_type != old_type:
@@ -306,10 +312,7 @@ class Manifest(object):
                     _, old_type = self._path_hash[rel_path]
                     if old_type in reftest_types:
                         reftest_changes = True
-                    try:
-                        del self._path_hash[rel_path]
-                    except KeyError:
-                        pass
+                    del self._path_hash[rel_path]
                     try:
                         del self._data[old_type][rel_path]
                     except KeyError:

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -79,9 +79,12 @@ class TypeData(object):
         return rv
 
     def __delitem__(self, key):
-        # First access the index to ensure it is loaded.
-        self[key]
-        del self.data[key]
+        if key in self.data:
+            del self.data[key]
+        elif self.json_data is not None:
+            del self.json_data[from_os_path(key)]
+        else:
+            raise KeyError
 
     def __setitem__(self, key, value):
         self.data[key] = value

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -284,10 +284,11 @@ class Manifest(object):
                     if old_hash != file_hash:
                         new_type, manifest_items = source_file.manifest_items()
                         hash_changed = True
-                        try:
-                            del self._data[old_type][rel_path]
-                        except KeyError:
-                            pass
+                        if new_type != old_type:
+                            try:
+                                del self._data[old_type][rel_path]
+                            except KeyError:
+                                pass
                     else:
                         new_type, manifest_items = old_type, self._data[old_type][rel_path]
                     if old_type in reftest_types and new_type != old_type:

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -353,13 +353,13 @@ def test_no_update():
     assert list(m) == [("testharness", test1.path, {test1}),
                        ("testharness", test2.path, {test2})]
 
-    s1_1 = SourceFileWithTest("test1", "1"*40, item.TestharnessTest)
+    s1_1 = SourceFileWithTest("test1", "1"*40, item.ManualTest)
 
-    m.update([(s1, True), (s2.rel_path, False)])
+    m.update([(s1_1, True), (s2.rel_path, False)])
 
     test1_1 = s1_1.manifest_items()[1][0]
 
-    assert list(m) == [("testharness", test1_1.path, {test1_1}),
+    assert list(m) == [("manual", test1_1.path, {test1_1}),
                        ("testharness", test2.path, {test2})]
 
 
@@ -371,10 +371,28 @@ def test_no_update_delete():
 
     m.update([(s1, True), (s2, True)])
 
-    s1_1 = SourceFileWithTest("test1", "1"*40, item.TestharnessTest)
+    test1 = s1.manifest_items()[1][0]
+
+    s1_1 = SourceFileWithTest("test1", "1"*40, item.ManualTest)
+
+    m.update([(s1_1.rel_path, False)])
+
+    assert list(m) == [("testharness", test1.path, {test1})]
+
+
+def test_update_from_json():
+    m = manifest.Manifest()
+
+    s1 = SourceFileWithTest("test1", "0"*40, item.TestharnessTest)
+    s2 = SourceFileWithTest("test2", "0"*40, item.TestharnessTest)
+
+    m.update([(s1, True), (s2, True)])
+
+    json_str = m.to_json()
+    m = manifest.Manifest.from_json("/", json_str)
 
     m.update([(s1, True)])
 
-    test1_1 = s1_1.manifest_items()[1][0]
+    test1 = s1.manifest_items()[1][0]
 
-    assert list(m) == [("testharness", test1_1.path, {test1_1})]
+    assert list(m) == [("testharness", test1.path, {test1})]


### PR DESCRIPTION
This fix is developed in a TDD style. The first commit tweaks two existing test cases to make them more meaningful and cover case 1, and adds a new test case for case 2. The second commit fixes the two edge cases and passes the tests.

Fixes #14568 .