### PR TITLE
Make selectors/first-letter-punctuation-* tests more robust

### DIFF
--- a/css/CSS2/selectors/first-letter-punctuation-001-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-001-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-001.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-001.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-002-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-002-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-002.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-002.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-003-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-003-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-003.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-003.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-004-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-004-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-004.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-004.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-005-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-005-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-005.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-005.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-006-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-006-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-006.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-006.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-007-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-007-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-007.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-007.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-008-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-008-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-008.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-008.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-009-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-009-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-009.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-009.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-010-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-010-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-010.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-010.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-012-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-012-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-012.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-012.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-013-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-013-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-013.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-013.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-014-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-014-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-014.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-014.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-015-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-015-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-015.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-015.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-016-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-016-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-016.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-016.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-017-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-017-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-017.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-017.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-018-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-018-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-018.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-018.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-019-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-019-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-019.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-019.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-020-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-020-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-020.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-020.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-021-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-021-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-021.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-021.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-022-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-022-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-022.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-022.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-023-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-023-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-023.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-023.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-024-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-024-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-024.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-024.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-025-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-025-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-025.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-025.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-026-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-026-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-026.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-026.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-027-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-027-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-027.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-027.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-028-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-028-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-028.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-028.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-029-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-029-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-029.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-029.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-030-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-030-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-030.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-030.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-031-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-031-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-031.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-031.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-032-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-032-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-032.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-032.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-033-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-033-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-033.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-033.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-034-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-034-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-034.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-034.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-035-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-035-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-035.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-035.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-036-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-036-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-036.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-036.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-037-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-037-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-037.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-037.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-038-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-038-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-038.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-038.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-039-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-039-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-039.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-039.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-040-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-040-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-040.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-040.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-041-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-041-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-041.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-041.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-042-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-042-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-042.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-042.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-043-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-043-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-043.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-043.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-044-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-044-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-044.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-044.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-045-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-045-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-045.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-045.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-046-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-046-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-046.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-046.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-047-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-047-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-047.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-047.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-048-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-048-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-048.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-048.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-049-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-049-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-049.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-049.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-050-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-050-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-050.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-050.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-051-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-051-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-051.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-051.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-052-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-052-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-052.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-052.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-053-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-053-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-053.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-053.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-054-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-054-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-054.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-054.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-055-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-055-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-055.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-055.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-056-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-056-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-056.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-056.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-057-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-057-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-057.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-057.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-058-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-058-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-058.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-058.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-059-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-059-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-059.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-059.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-060-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-060-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-060.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-060.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-061-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-061-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-061.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-061.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-062-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-062-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-062.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-062.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-063-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-063-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-063.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-063.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-064-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-064-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-064.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-064.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-065-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-065-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-065.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-065.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-066-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-066-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-066.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-066.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-067-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-067-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-067.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-067.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-068-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-068-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-068.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-068.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-069-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-069-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-069.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-069.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-070-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-070-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-070.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-070.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-071-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-071-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-071.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-071.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-072-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-072-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-072.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-072.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-073-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-073-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-073.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-073.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-074-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-074-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-074.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-074.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-075-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-075-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-075.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-075.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-076-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-076-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-076.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-076.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-077-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-077-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-077.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-077.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-078-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-078-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-078.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-078.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-079-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-079-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-079.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-079.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-080-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-080-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-080.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-080.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-081-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-081-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-081.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-081.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-082-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-082-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-082.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-082.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-083-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-083-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-083.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-083.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-084-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-084-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-084.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-084.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-085-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-085-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-085.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-085.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-086-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-086-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-086.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-086.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-087-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-087-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-087.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-087.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-088-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-088-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-088.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-088.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-089-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-089-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-089.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-089.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-090-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-090-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-090.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-090.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-091-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-091-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-091.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-091.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-092-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-092-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-092.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-092.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-093-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-093-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-093.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-093.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-094-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-094-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-094.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-094.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-095-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-095-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-095.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-095.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-096-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-096-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-096.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-096.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-097-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-097-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-097.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-097.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-098-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-098-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-098.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-098.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-099-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-099-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-099.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-099.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-100-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-100-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-100.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-100.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-101-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-101-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-101.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-101.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-102-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-102-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-102.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-102.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-103-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-103-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-103.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-103.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-104-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-104-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-104.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-104.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-105-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-105-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-105.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-105.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-106-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-106-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-106.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-106.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-107-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-107-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-107.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-107.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-108-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-108-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-108.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-108.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-109-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-109-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-109.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-109.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-110-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-110-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-110.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-110.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-111-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-111-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-111.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-111.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-112-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-112-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-112.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-112.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-113-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-113-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-113.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-113.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-115-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-115-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-115.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-115.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-116-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-116-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-116.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-116.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-117-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-117-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-117.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-117.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-118-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-118-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-118.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-118.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-119-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-119-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-119.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-119.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-120-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-120-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-120.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-120.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-121-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-121-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-121.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-121.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-122-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-122-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-122.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-122.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-123-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-123-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-123.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-123.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-124-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-124-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-124.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-124.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-125-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-125-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-125.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-125.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-126-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-126-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-126.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-126.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-127-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-127-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-127.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-127.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-128-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-128-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-128.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-128.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-129-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-129-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-129.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-129.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-130-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-130-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-130.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-130.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-131-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-131-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-131.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-131.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-132-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-132-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-132.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-132.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-133-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-133-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-133.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-133.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-134-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-134-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-134.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-134.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-135-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-135-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-135.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-135.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-136-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-136-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-136.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-136.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-137-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-137-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-137.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-137.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-138-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-138-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-138.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-138.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-139-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-139-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-139.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-139.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-140-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-140-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-140.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-140.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-141-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-141-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-141.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-141.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-142-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-142-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-142.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-142.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-143-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-143-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-143.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-143.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-144-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-144-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-144.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-144.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-145-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-145-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-145.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-145.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-146-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-146-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-146.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-146.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-147-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-147-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-147.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-147.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-148-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-148-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-148.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-148.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-149-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-149-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-149.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-149.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-150-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-150-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-150.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-150.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-151-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-151-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-151.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-151.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-152-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-152-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-152.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-152.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-153-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-153-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-153.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-153.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-154-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-154-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-154.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-154.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-155-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-155-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-155.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-155.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-156-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-156-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-156.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-156.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-157-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-157-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-157.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-157.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-158-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-158-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-158.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-158.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-159-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-159-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-159.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-159.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-160-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-160-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-160.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-160.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-161-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-161-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-161.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-161.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-162-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-162-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-162.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-162.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-163-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-163-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-163.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-163.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-164-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-164-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-164.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-164.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-165-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-165-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-165.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-165.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-166-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-166-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-166.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-166.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-167-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-167-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-167.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-167.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-168-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-168-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-168.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-168.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-169-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-169-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-169.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-169.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-170-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-170-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-170.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-170.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-171-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-171-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-171.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-171.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-172-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-172-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-172.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-172.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-173-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-173-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-173.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-173.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-174-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-174-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-174.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-174.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-175-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-175-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-175.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-175.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-176-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-176-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-176.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-176.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-177-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-177-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-177.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-177.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-178-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-178-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-178.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-178.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-179-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-179-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-179.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-179.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-180-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-180-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-180.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-180.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-181-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-181-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-181.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-181.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-182-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-182-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-182.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-182.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-183-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-183-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-183.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-183.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-184-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-184-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-184.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-184.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-185-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-185-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-185.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-185.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-186-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-186-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-186.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-186.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-187-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-187-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-187.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-187.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-188-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-188-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-188.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-188.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-189-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-189-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-189.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-189.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-190-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-190-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-190.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-190.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-191-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-191-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-191.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-191.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-192-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-192-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-192.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-192.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-193-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-193-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-193.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-193.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-194-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-194-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-194.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-194.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-195-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-195-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-195.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-195.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-196-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-196-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-196.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-196.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-197-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-197-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-197.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-197.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-198-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-198-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-198.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-198.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-199-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-199-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-199.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-199.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-200-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-200-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-200.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-200.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-201-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-201-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-201.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-201.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-202-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-202-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-202.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-202.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-203-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-203-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-203.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-203.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-204-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-204-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-204.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-204.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-205-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-205-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-205.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-205.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-206-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-206-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-206.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-206.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-207-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-207-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-207.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-207.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-208-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-208-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-208.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-208.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-211-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-211-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-211.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-211.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-212-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-212-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-212.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-212.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-213-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-213-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-213.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-213.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-214-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-214-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-214.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-214.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-215-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-215-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-215.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-215.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-216-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-216-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-216.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-216.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-217-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-217-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-217.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-217.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-218-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-218-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-218.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-218.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-219-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-219-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-219.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-219.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-220-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-220-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-220.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-220.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-221-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-221-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-221.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-221.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-222-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-222-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-222.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-222.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-223-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-223-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-223.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-223.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-224-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-224-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-224.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-224.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-225-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-225-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-225.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-225.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-226-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-226-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-226.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-226.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-227-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-227-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-227.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-227.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-228-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-228-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-228.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-228.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-229-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-229-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-229.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-229.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-230-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-230-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-230.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-230.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-231-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-231-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-231.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-231.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-232-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-232-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-232.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-232.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-233-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-233-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-233.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-233.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-234-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-234-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-234.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-234.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-235-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-235-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-235.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-235.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-236-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-236-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-236.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-236.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-237-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-237-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-237.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-237.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-238-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-238-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-238.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-238.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-239-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-239-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-239.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-239.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-240-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-240-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-240.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-240.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-241-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-241-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-241.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-241.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-242-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-242-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-242.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-242.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-243-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-243-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-243.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-243.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-244-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-244-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-244.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-244.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-245-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-245-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-245.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-245.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-246-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-246-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-246.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-246.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-247-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-247-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-247.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-247.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-248-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-248-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-248.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-248.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-249-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-249-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-249.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-249.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-250-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-250-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-250.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-250.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-251-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-251-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-251.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-251.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-252-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-252-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-252.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-252.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-253-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-253-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-253.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-253.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-254-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-254-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-254.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-254.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-255-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-255-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-255.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-255.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-256-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-256-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-256.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-256.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-257-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-257-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-257.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-257.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-258-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-258-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-258.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-258.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-259-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-259-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-259.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-259.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-260-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-260-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-260.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-260.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-262-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-262-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-262.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-262.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-263-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-263-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-263.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-263.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-264-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-264-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-264.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-264.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-265-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-265-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-265.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-265.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-266-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-266-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-266.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-266.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-267-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-267-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-267.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-267.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-268-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-268-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-268.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-268.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-269-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-269-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-269.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-269.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-270-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-270-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-270.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-270.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-271-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-271-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-271.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-271.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-272-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-272-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-272.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-272.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-273-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-273-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-273.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-273.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-274-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-274-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-274.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-274.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-275-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-275-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-275.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-275.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-276-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-276-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-276.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-276.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-277-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-277-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-277.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-277.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-278-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-278-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-278.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-278.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-279-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-279-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-279.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-279.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-280-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-280-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-280.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-280.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-281-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-281-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-281.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-281.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-282-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-282-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-282.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-282.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-283-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-283-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-283.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-283.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-284-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-284-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-284.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-284.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-285-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-285-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-285.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-285.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-286-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-286-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-286.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-286.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-287-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-287-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-287.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-287.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-288-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-288-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-288.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-288.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-289-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-289-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-289.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-289.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-290-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-290-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-290.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-290.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-291-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-291-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-291.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-291.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-292-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-292-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-292.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-292.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-293-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-293-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-293.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-293.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-294-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-294-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-294.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-294.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-295-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-295-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-295.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-295.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-296-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-296-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-296.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-296.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-297-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-297-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-297.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-297.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-298-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-298-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-298.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-298.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-299-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-299-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-299.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-299.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-300-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-300-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-300.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-300.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-301-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-301-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-301.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-301.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-302-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-302-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-302.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-302.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-303-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-303-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-303.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-303.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-304-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-304-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-304.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-304.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-305-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-305-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-305.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-305.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-306-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-306-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-306.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-306.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-307-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-307-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-307.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-307.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-308-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-308-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-308.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-308.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-309-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-309-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-309.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-309.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-310-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-310-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-310.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-310.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-311-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-311-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-311.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-311.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-312-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-312-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-312.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-312.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-313-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-313-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-313.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-313.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-314-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-314-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-314.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-314.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-315-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-315-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-315.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-315.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-316-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-316-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-316.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-316.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-317-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-317-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-317.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-317.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-318-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-318-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-318.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-318.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-319-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-319-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-319.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-319.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-320-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-320-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-320.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-320.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-321-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-321-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-321.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-321.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-322-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-322-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-322.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-322.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-323-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-323-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-323.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-323.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-324-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-324-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-324.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-324.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-325-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-325-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-325.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-325.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-326-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-326-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-326.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-326.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-327-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-327-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-327.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-327.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-328-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-328-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-328.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-328.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-329-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-329-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-329.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-329.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-330-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-330-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-330.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-330.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-331-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-331-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-331.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-331.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-332-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-332-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-332.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-332.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-333-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-333-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-333.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-333.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-334-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-334-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-334.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-334.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-335-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-335-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-335.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-335.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-336-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-336-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-336.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-336.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-337-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-337-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-337.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-337.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-338-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-338-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-338.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-338.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-339-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-339-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-339.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-339.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-340-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-340-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-340.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-340.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-341-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-341-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-341.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-341.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-342-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-342-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-342.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-342.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-343-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-343-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-343.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-343.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-344-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-344-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-344.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-344.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-345-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-345-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-345.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-345.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-346-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-346-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-346.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-346.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-347-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-347-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-347.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-347.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-348-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-348-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-348.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-348.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-349-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-349-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-349.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-349.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-350-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-350-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-350.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-350.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-351-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-351-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-351.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-351.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-352-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-352-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-352.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-352.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-353-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-353-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-353.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-353.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-354-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-354-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-354.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-354.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-355-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-355-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-355.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-355.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-356-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-356-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-356.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-356.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-357-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-357-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-357.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-357.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-359-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-359-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-359.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-359.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-360-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-360-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-360.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-360.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-361-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-361-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-361.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-361.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-362-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-362-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-362.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-362.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-363-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-363-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-363.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-363.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-364-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-364-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-364.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-364.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-365-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-365-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-365.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-365.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-366-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-366-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-366.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-366.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-367-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-367-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-367.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-367.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-368-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-368-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-368.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-368.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-369-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-369-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-369.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-369.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-370-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-370-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-370.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-370.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-371-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-371-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-371.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-371.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-372-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-372-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-372.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-372.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-373-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-373-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-373.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-373.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-374-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-374-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-374.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-374.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-375-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-375-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-375.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-375.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-376-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-376-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-376.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-376.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-377-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-377-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-377.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-377.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-378-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-378-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-378.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-378.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-379-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-379-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-379.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-379.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-380-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-380-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-380.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-380.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-381-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-381-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-381.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-381.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-382-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-382-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-382.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-382.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-383-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-383-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-383.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-383.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-384-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-384-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-384.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-384.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-385-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-385-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-385.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-385.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-386-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-386-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-386.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-386.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-387-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-387-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-387.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-387.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-388-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-388-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-388.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-388.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-389-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-389-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-389.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-389.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-390-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-390-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-390.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-390.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-391-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-391-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-391.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-391.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-392-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-392-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-392.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-392.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-393-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-393-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-393.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-393.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-394-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-394-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-394.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-394.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-395-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-395-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-395.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-395.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-396-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-396-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-396.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-396.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-397-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-397-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-397.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-397.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-398-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-398-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-398.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-398.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-399-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-399-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-399.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-399.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-400-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-400-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-400.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-400.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-401-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-401-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-401.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-401.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-402-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-402-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-402.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-402.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-403-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-403-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-403.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-403.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-404-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-404-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-404.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-404.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-405-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-405-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-405.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-405.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-406-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-406-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-406.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-406.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-407-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-407-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-407.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-407.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-408-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-408-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-408.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-408.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-409-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-409-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-409.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-409.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-410-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-410-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-410.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-410.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-411-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-411-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-411.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-411.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-412-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-412-ref.xht
@@ -8,6 +8,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>

--- a/css/CSS2/selectors/first-letter-punctuation-412.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-412.xht
@@ -12,6 +12,7 @@
             {
                 color: green;
                 font-size: 36px;
+                line-height: 2;
             }
         </style>
     </head>


### PR DESCRIPTION
In Firefox, at least, we see a lot of spurious "failures" on these tests because the large initial letter may affect line positioning differently in the testcase vs the span-wrapped version in the reference file. For the tests using "unusual" (non-Latin, etc) punctuation characters where font fallback may come into play, it becomes particularly fragile; whether a specific test fails may depend on details of the line-spacing metrics of the fallback font that happens to be chosen.

This patch simply adds `line-height: 2` to all the files, resulting in a more stable positioning of the test and reference texts and giving us consistent results across multiple platforms and font configurations.