### PR TITLE
Encoding: align encodeInto() test with reality

### DIFF
--- a/encoding/encodeInto.any.js
+++ b/encoding/encodeInto.any.js
@@ -142,8 +142,8 @@ test(() => {
   new MessageChannel().port1.postMessage(buffer, [buffer]);
   ({ read, written } = new TextEncoder().encodeInto("", view));
   assert_equals(read, 0);
-  assert_equalss(written, 0);
+  assert_equals(written, 0);
   ({ read, written } = new TextEncoder().encodeInto("test", view));
   assert_equals(read, 0);
-  assert_equalss(written, 0);
+  assert_equals(written, 0);
 }, "encodeInto() and a detached output buffer");

--- a/encoding/encodeInto.any.js
+++ b/encoding/encodeInto.any.js
@@ -136,14 +136,14 @@ test(() => {
 test(() => {
   const buffer = new ArrayBuffer(10),
         view = new Uint8Array(buffer);
-  const { read, written } = new TextEncoder().encodeInto("", view);
+  let { read, written } = new TextEncoder().encodeInto("", view);
   assert_equals(read, 0);
   assert_equals(written, 0);
-  self.postMessage(buffer, "/", [buffer]);
-  const { read2, written2 } = new TextEncoder().encodeInto("", view);
-  assert_equals(read2, 0);
-  assert_equalss(written2, 0);
-  const { read3, written3 } = new TextEncoder().encodeInto("test", view);
-  assert_equals(read3, 0);
-  assert_equalss(written3, 0);
+  new MessageChannel().port1.postMessage(buffer, [buffer]);
+  ({ read, written } = new TextEncoder().encodeInto("", view));
+  assert_equals(read, 0);
+  assert_equalss(written, 0);
+  ({ read, written } = new TextEncoder().encodeInto("test", view));
+  assert_equals(read, 0);
+  assert_equalss(written, 0);
 }, "encodeInto() and a detached output buffer");

--- a/encoding/encodeInto.any.js
+++ b/encoding/encodeInto.any.js
@@ -140,5 +140,10 @@ test(() => {
   assert_equals(read, 0);
   assert_equals(written, 0);
   self.postMessage(buffer, "/", [buffer]);
-  assert_throws(new TypeError(), () => new TextEncoder().encodeInto("", view));
-}, "encodeInto() cannot operate on a detached buffer");
+  const { read2, written2 } = new TextEncoder().encodeInto("", view);
+  assert_equals(read2, 0);
+  assert_equalss(written2, 0);
+  const { read3, written3 } = new TextEncoder().encodeInto("test", view);
+  assert_equals(read3, 0);
+  assert_equalss(written3, 0);
+}, "encodeInto() and a detached output buffer");


### PR DESCRIPTION
While IDL said this should throw, that was in error: https://github.com/heycam/webidl/pull/605.