### PR TITLE
Stop explicitly listing hosts in chrome_android.md

### DIFF
--- a/docs/_running-tests/chrome_android.md
+++ b/docs/_running-tests/chrome_android.md
@@ -10,16 +10,7 @@ connect to the device.
 ## Hosts
 
 Until we find a better way, we need to root the Android device and update the
-/etc/hosts file to include
-
-```
-127.0.0.1   web-platform.test
-127.0.0.1   www.web-platform.test
-127.0.0.1   www1.web-platform.test
-127.0.0.1   www2.web-platform.test
-127.0.0.1   xn--n8j6ds53lwwkrqhv28a.web-platform.test
-127.0.0.1   xn--lve-6lad.web-platform.test
-```
+/etc/hosts file to include the entries printed by `./wpt make-hosts-file`.
 
 ## CA certificate
 


### PR DESCRIPTION
Point to `wpt make-hosts-file` instead.

Part of #14772