### PR TITLE
Complement basic-card with ApplePay

### DIFF
--- a/payment-request/MerchantValidationEvent/constructor.https.html
+++ b/payment-request/MerchantValidationEvent/constructor.https.html
@@ -8,6 +8,13 @@
 <script>
 const applePay = Object.freeze({
   supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
 });
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const defaultMethods = Object.freeze([basicCard, applePay]);

--- a/payment-request/PaymentRequestUpdateEvent/constructor.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/constructor.https.html
@@ -6,8 +6,18 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
-const defaultMethods = Object.freeze([basicCard]);
+const defaultMethods = Object.freeze([basicCard, applePay]);
 const defaultDetails = Object.freeze({
   total: {
     label: "Total",

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-call-immediate-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-call-immediate-manual.https.html
@@ -9,8 +9,18 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ explicit_done: true, explicit_timeout: true });
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const validMethod = Object.freeze({ supportedMethods: "basic-card" });
-const validMethods = Object.freeze([validMethod]);
+const validMethods = Object.freeze([validMethod, applePay]);
 const validAmount = Object.freeze({ currency: "USD", value: "5.00" });
 const validTotal = Object.freeze({
   label: "label",

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html
@@ -8,9 +8,18 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ explicit_done: true, explicit_timeout: true });
-
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const validMethod = Object.freeze({ supportedMethods: "basic-card" });
-const validMethods = [validMethod];
+const validMethods = [validMethod, applePay];
 const validAmount = Object.freeze({
   currency: "USD",
   value: "5.00",

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-incremental-update-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-incremental-update-manual.https.html
@@ -14,6 +14,15 @@ setup({
 
 const methods = [{
   supportedMethods: "basic-card",
+}, {
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
 }];
 
 const options = {

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-method-abort-update-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-method-abort-update-manual.https.html
@@ -18,8 +18,19 @@ const validMethodBasicCard = Object.freeze({
   supportedMethods: "basic-card",
 });
 
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
+
 // Methods
-const validMethods = Object.freeze([validMethodBasicCard, validMethod]);
+const validMethods = Object.freeze([validMethodBasicCard, validMethod, applePay]);
 
 // Amounts
 const validAmount = Object.freeze({

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-state-checks-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-state-checks-manual.https.html
@@ -6,8 +6,18 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ explicit_done: true, explicit_timeout: true });
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const validMethod = Object.freeze({ supportedMethods: "basic-card" });
-const validMethods = Object.freeze([validMethod]);
+const validMethods = Object.freeze([validMethod, applePay]);
 const validAmount = Object.freeze({ currency: "USD", value: "5.00" });
 const validTotal = Object.freeze({
   label: "label",

--- a/payment-request/PaymentRequestUpdateEvent/updatewith-method.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updatewith-method.https.html
@@ -6,8 +6,18 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
-const defaultMethods = Object.freeze([basicCard]);
+const defaultMethods = Object.freeze([basicCard, applePay]);
 const defaultDetails = Object.freeze({
   total: {
     label: "Total",

--- a/payment-request/algorithms-manual.https.html
+++ b/payment-request/algorithms-manual.https.html
@@ -15,6 +15,16 @@ const methods = [
   {
     supportedMethods: "basic-card",
   },
+  {
+    supportedMethods: "https://apple.com/apple-pay",
+    data: {
+      version: 3,
+      merchantIdentifier: "merchant.com.example",
+      countryCode: "US",
+      merchantCapabilities: ["supports3DS"],
+      supportedNetworks: ["visa"],
+    },
+  }
 ];
 const shippingOptions = {
   shippingOptions: [

--- a/payment-request/billing-address-changed-manual.https.html
+++ b/payment-request/billing-address-changed-manual.https.html
@@ -10,7 +10,16 @@
 
   const methods = [
     { supportedMethods: "basic-card" },
-    { supportedMethods: "https://apple.com/apple-pay" },
+    {
+      supportedMethods: "https://apple.com/apple-pay",
+      data: {
+        version: 3,
+        merchantIdentifier: "merchant.com.example",
+        countryCode: "US",
+        merchantCapabilities: ["supports3DS"],
+        supportedNetworks: ["visa"],
+      },
+    },
   ];
 
   const details = {

--- a/payment-request/change-shipping-option-manual.https.html
+++ b/payment-request/change-shipping-option-manual.https.html
@@ -9,7 +9,17 @@
 <script>
 setup({ explicit_done: true, explicit_timeout: true });
 const validMethod = Object.freeze({ supportedMethods: "basic-card" });
-const validMethods = Object.freeze([validMethod]);
+const applePayMethod = {
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  },
+};
+const validMethods = Object.freeze([validMethod, applePayMethod]);
 const validAmount = Object.freeze({ currency: "USD", value: "5.00" });
 const validTotal = Object.freeze({
   label: "label",

--- a/payment-request/change-shipping-option-select-last-manual.https.html
+++ b/payment-request/change-shipping-option-select-last-manual.https.html
@@ -8,7 +8,16 @@
 setup({ explicit_done: true, explicit_timeout: true });
 const validMethods = Object.freeze([
   { supportedMethods: "basic-card" },
-  { supportedMethods: "https://apple.com/apple-pay" },
+  {
+    supportedMethods: "https://apple.com/apple-pay",
+    data: {
+      version: 3,
+      merchantIdentifier: "merchant.com.example",
+      countryCode: "US",
+      merchantCapabilities: ["supports3DS"],
+      supportedNetworks: ["visa"],
+    },
+  },
 ]);
 const validAmount = Object.freeze({ currency: "USD", value: "5.00" });
 const validTotal = Object.freeze({

--- a/payment-request/onmerchantvalidation-attribute.https.html
+++ b/payment-request/onmerchantvalidation-attribute.https.html
@@ -7,7 +7,16 @@
 <script>
 "use strict";
 const testMethod = Object.freeze({ supportedMethods: "not-a-real-method" });
-const applePay = Object.freeze({ supportedMethods: "https://apple.com/apple-pay" });
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  },
+});
 const defaultMethods = Object.freeze([testMethod, applePay]);
 const defaultDetails = Object.freeze({
   total: {

--- a/payment-request/onpaymentmenthodchange-attribute.https.html
+++ b/payment-request/onpaymentmenthodchange-attribute.https.html
@@ -7,7 +7,16 @@
 <script>
 "use strict";
 const testMethod = Object.freeze({ supportedMethods: "not-a-real-method" });
-const applePay = Object.freeze({ supportedMethods: "https://apple.com/apple-pay" });
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const defaultMethods = Object.freeze([testMethod, applePay]);
 const defaultDetails = Object.freeze({
   total: {

--- a/payment-request/payment-request-abort-method.https.html
+++ b/payment-request/payment-request-abort-method.https.html
@@ -17,6 +17,13 @@ setup({
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const applePay = Object.freeze({
   supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
 });
 const defaultMethods = Object.freeze([basicCard, applePay]);
 const defaultDetails = Object.freeze({

--- a/payment-request/payment-request-canmakepayment-method-protection.https.html
+++ b/payment-request/payment-request-canmakepayment-method-protection.https.html
@@ -8,7 +8,16 @@
 <script src="/resources/testdriver.js"></script>
 <script>
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
-const applePay = Object.freeze({ supportedMethods: "https://apple.com/apple-pay" });
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const defaultMethods = Object.freeze([basicCard, applePay]);
 const defaultDetails = Object.freeze({
   total: {

--- a/payment-request/payment-request-canmakepayment-method.https.html
+++ b/payment-request/payment-request-canmakepayment-method.https.html
@@ -10,6 +10,13 @@
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const applePay = Object.freeze({
   supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
 });
 const defaultMethods = Object.freeze([basicCard, applePay]);
 const defaultDetails = Object.freeze({

--- a/payment-request/payment-request-constructor-crash.https.html
+++ b/payment-request/payment-request-constructor-crash.https.html
@@ -28,6 +28,17 @@
 "use strict";
 const ABUSIVE_AMOUNT = 100000;
 
+const applePay = {
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+};
+
 const basicCard = Object.freeze({
   supportedMethods: "basic-card",
 });
@@ -42,7 +53,7 @@ const evilAmount = Object.freeze({
   value: "1".repeat(ABUSIVE_AMOUNT),
 });
 
-const defaultMethods = Object.freeze([basicCard]);
+const defaultMethods = Object.freeze([basicCard, applePay]);
 
 const defaultTotal = Object.freeze({
   label: "label",

--- a/payment-request/payment-request-onshippingaddresschange-attribute.https.html
+++ b/payment-request/payment-request-onshippingaddresschange-attribute.https.html
@@ -7,8 +7,18 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 "use strict";
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
-const defaultMethods = Object.freeze([basicCard]);
+const defaultMethods = Object.freeze([basicCard, applePay]);
 const defaultDetails = Object.freeze({
   total: {
     label: "Total",

--- a/payment-request/payment-request-onshippingoptionchange-attribute.https.html
+++ b/payment-request/payment-request-onshippingoptionchange-attribute.https.html
@@ -7,8 +7,18 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 "use strict";
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
-const defaultMethods = Object.freeze([basicCard]);
+const defaultMethods = Object.freeze([basicCard, applePay]);
 const defaultDetails = Object.freeze({
   total: {
     label: "Total",

--- a/payment-request/payment-request-shippingType-attribute.https.html
+++ b/payment-request/payment-request-shippingType-attribute.https.html
@@ -8,8 +8,18 @@
 <script>
 "use strict";
 const paymentShipingTypes = Object.freeze(["delivery", "pickup", "shipping"]);
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const basicCard = Object.freeze({ supportedMethods: "basic-card" });
-const defaultMethods = Object.freeze([basicCard]);
+const defaultMethods = Object.freeze([basicCard, applePay]);
 const defaultDetails = Object.freeze({
   total: {
     label: "",

--- a/payment-request/payment-request-show-method.https.html
+++ b/payment-request/payment-request-show-method.https.html
@@ -10,7 +10,16 @@
 "use strict";
 const defaultMethods = Object.freeze([
   { supportedMethods: "basic-card" },
-  { supportedMethods: "https://apple.com/apple-pay" },
+  {
+    supportedMethods: "https://apple.com/apple-pay",
+    data: {
+      version: 3,
+      merchantIdentifier: "merchant.com.example",
+      countryCode: "US",
+      merchantCapabilities: ["supports3DS"],
+      supportedNetworks: ["visa"],
+    }
+  },
 ]);
 
 const defaultDetails = Object.freeze({

--- a/payment-request/payment-response/helpers.js
+++ b/payment-request/payment-response/helpers.js
@@ -1,10 +1,21 @@
 setup({ explicit_done: true, explicit_timeout: true });
 
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
+
 const validMethod = Object.freeze({
   supportedMethods: "basic-card",
 });
 
-const validMethods = Object.freeze([validMethod]);
+const validMethods = Object.freeze([validMethod, applePay]);
 
 const validAmount = Object.freeze({
   currency: "USD",

--- a/payment-request/payment-response/rejects_if_not_active-manual.https.html
+++ b/payment-request/payment-response/rejects_if_not_active-manual.https.html
@@ -11,7 +11,17 @@ setup({ explicit_done: true, explicit_timeout: true });
 const validMethod = Object.freeze({
   supportedMethods: "basic-card",
 });
-const validMethods = Object.freeze([validMethod]);
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
+const validMethods = Object.freeze([validMethod, applePay]);
 const validAmount = Object.freeze({
   currency: "USD",
   value: "5.00",

--- a/payment-request/rejects_if_not_active.https.html
+++ b/payment-request/rejects_if_not_active.https.html
@@ -9,10 +9,20 @@
 <link rel="help" href="https://w3c.github.io/payment-request/#dom-paymentrequest-show()">
 <body>
 <script>
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const validMethod = Object.freeze({
   supportedMethods: "basic-card",
 });
-const validMethods = Object.freeze([validMethod]);
+const validMethods = Object.freeze([validMethod, applePay]);
 const validAmount = Object.freeze({
   currency: "USD",
   value: "5.00",

--- a/payment-request/shipping-address-changed-manual.https.html
+++ b/payment-request/shipping-address-changed-manual.https.html
@@ -8,8 +8,18 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ explicit_done: true, explicit_timeout: true });
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const validMethod = Object.freeze({ supportedMethods: "basic-card" });
-const validMethods = Object.freeze([validMethod]);
+const validMethods = Object.freeze([validMethod, applePay]);
 const validAmount = Object.freeze({ currency: "USD", value: "5.00" });
 const validTotal = Object.freeze({
   label: "label",

--- a/payment-request/show-method-optional-promise-rejects-manual.https.html
+++ b/payment-request/show-method-optional-promise-rejects-manual.https.html
@@ -24,6 +24,13 @@
 
   const validMethodApplePay = Object.freeze({
     supportedMethods: "https://apple.com/apple-pay",
+    data: {
+      version: 3,
+      merchantIdentifier: "merchant.com.example",
+      countryCode: "US",
+      merchantCapabilities: ["supports3DS"],
+      supportedNetworks: ["visa"],
+    }
   });
 
   // Methods

--- a/payment-request/show-method-optional-promise-resolves-manual.https.html
+++ b/payment-request/show-method-optional-promise-resolves-manual.https.html
@@ -23,6 +23,13 @@ const validMethods = Object.freeze([
   },
   {
     supportedMethods: "https://apple.com/apple-pay",
+    data: {
+      version: 3,
+      merchantIdentifier: "merchant.com.example",
+      countryCode: "US",
+      merchantCapabilities: ["supports3DS"],
+      supportedNetworks: ["visa"],
+    }
   },
 ]);
 

--- a/payment-request/show-method-postmessage-iframe.html
+++ b/payment-request/show-method-postmessage-iframe.html
@@ -3,7 +3,16 @@
 "use strict";
 const defaultMethods = Object.freeze([
   { supportedMethods: "basic-card" },
-  { supportedMethods: "https://apple.com/apple-pay" },
+  {
+    supportedMethods: "https://apple.com/apple-pay",
+    data: {
+      version: 3,
+      merchantIdentifier: "merchant.com.example",
+      countryCode: "US",
+      merchantCapabilities: ["supports3DS"],
+      supportedNetworks: ["visa"],
+    }
+  },
 ]);
 
 const defaultDetails = Object.freeze({

--- a/payment-request/show-method-postmessage-manual.https.html
+++ b/payment-request/show-method-postmessage-manual.https.html
@@ -14,7 +14,16 @@ setup({
 
 const defaultMethods = Object.freeze([
   { supportedMethods: "basic-card" },
-  { supportedMethods: "https://apple.com/apple-pay" },
+  {
+    supportedMethods: "https://apple.com/apple-pay",
+    data: {
+      version: 3,
+      merchantIdentifier: "merchant.com.example",
+      countryCode: "US",
+      merchantCapabilities: ["supports3DS"],
+      supportedNetworks: ["visa"],
+    }
+  },
 ]);
 
 const defaultDetails = Object.freeze({

--- a/payment-request/updateWith-method-pmi-handling-manual.https.html
+++ b/payment-request/updateWith-method-pmi-handling-manual.https.html
@@ -8,11 +8,21 @@
 <script>
 "use strict";
 setup({ explicit_done: true, explicit_timeout: true });
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const validMethod = Object.freeze({
   supportedMethods: "https://:@wpt.fyi:443/payment-request",
 });
 
-const validMethods = Object.freeze([validMethod]);
+const validMethods = Object.freeze([validMethod, applePay]);
 
 const validAmount = Object.freeze({
   currency: "USD",

--- a/payment-request/user-abort-algorithm-manual.https.html
+++ b/payment-request/user-abort-algorithm-manual.https.html
@@ -17,10 +17,20 @@ const validTotal = Object.freeze({
   label: "Total due",
   amount: validAmount,
 });
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const validMethod = Object.freeze({
   supportedMethods: "basic-card",
 });
-const validMethods = Object.freeze([validMethod]);
+const validMethods = Object.freeze([validMethod, applePay]);
 const validDetails = Object.freeze({
   total: validTotal,
 });

--- a/payment-request/user-accepts-payment-request-algo-manual.https.html
+++ b/payment-request/user-accepts-payment-request-algo-manual.https.html
@@ -8,13 +8,23 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 setup({ explicit_done: true, explicit_timeout: true });
+const applePay = Object.freeze({
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  }
+});
 const basicCardMethod = Object.freeze({
   supportedMethods: "basic-card",
 });
 const validMethod = Object.freeze({
   supportedMethods: "this-is-just-for-testings-will-never-match",
 });
-const methods = Object.freeze([basicCardMethod, validMethod]);
+const methods = Object.freeze([basicCardMethod, validMethod, applePay]);
 const validAmount = Object.freeze({
   currency: "USD",
   value: "5.00",


### PR DESCRIPTION
Add the required "data" members to conform with Apple Pay. 

@aestes, wdyt? :) In some cases, it won't have any effect. But at least at least the payment method is now always valid. 