### PR TITLE
xhr: Check if entry lists associated to new FormData instance and formData attribute are not identical.

### DIFF
--- a/xhr/formdata.htm
+++ b/xhr/formdata.htm
@@ -61,6 +61,9 @@
     assert_not_equals(formData, formDataInEvent,
                       '"formData" attribute should be different from the ' +
                       'FromData object created by "new"');
+
+    formDataInEvent.append('later-key', 'later-value');
+    assert_false(formData.has('later-key'));
   }, 'Newly created FormData contains entries added to "formData" IDL ' +
      'attribute of FormDataEvent.');
 


### PR DESCRIPTION
This is a test for https://github.com/whatwg/html/pull/4283