### PR TITLE
Unify the log level for wpt server

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -149,10 +149,6 @@ class TestEnvironment(object):
     def setup_server_logging(self):
         server_logger = get_default_logger(component="wptserve")
         assert server_logger is not None
-        log_filter = handlers.LogLevelFilter(lambda x:x, "info")
-        # Downgrade errors to warnings for the server
-        log_filter = LogLevelRewriter(log_filter, ["error"], "warning")
-        server_logger.component_filter = log_filter
 
         server_logger = proxy.QueuedProxyLogger(server_logger)
 

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -6,9 +6,8 @@ import socket
 import sys
 import time
 
-from mozlog import get_default_logger, handlers, proxy
+from mozlog import get_default_logger, proxy
 
-from wptlogging import LogLevelRewriter
 from wptserve.handlers import StringHandler
 
 here = os.path.split(__file__)[0]

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -157,9 +157,10 @@ class TestEnvironment(object):
         if not self.options.get("verify"):
             for key, value in six.iteritems(log_levels):
                 # Set the same log level for wpt server as the wpt runner.
-                if logger.handlers[0].formatter.level == value:
+                if hasattr(logger, "handlers") and logger.handlers[0].formatter.level == value:
                     server_log_level = key.lower()
-        self.options.pop("verify")
+        if "verify" in self.options:
+            self.options.pop("verify")
         log_filter = handlers.LogLevelFilter(lambda x:x, server_log_level)
         # Downgrade errors to warnings for the server
         log_filter = LogLevelRewriter(log_filter, ["error"], "warning")

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -154,10 +154,12 @@ class TestEnvironment(object):
         assert server_logger is not None
 
         server_log_level = "info"
-        for key, value in six.iteritems(log_levels):
-            # Set the same log level for wpt server as the wpt runner.
-            if logger.handlers[0].formatter.level == value:
-                server_log_level = key.lower()
+        if not self.options.get("verify"):
+            for key, value in six.iteritems(log_levels):
+                # Set the same log level for wpt server as the wpt runner.
+                if logger.handlers[0].formatter.level == value:
+                    server_log_level = key.lower()
+        self.options.pop("verify")
         log_filter = handlers.LogLevelFilter(lambda x:x, server_log_level)
         # Downgrade errors to warnings for the server
         log_filter = LogLevelRewriter(log_filter, ["error"], "warning")

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -186,6 +186,8 @@ def run_tests(config, test_paths, product, **kwargs):
 
         testharness_timeout_multipler = product.get_timeout_multiplier("testharness", run_info, **kwargs)
 
+        # For setting up the log level for test servers.
+        product.env_options['verify'] = kwargs['verify']
         with env.TestEnvironment(test_paths,
                                  testharness_timeout_multipler,
                                  kwargs["pause_after_test"],

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -187,7 +187,7 @@ def run_tests(config, test_paths, product, **kwargs):
         testharness_timeout_multipler = product.get_timeout_multiplier("testharness", run_info, **kwargs)
 
         # For setting up the log level for test servers.
-        product.env_options['verify'] = kwargs['verify']
+        product.env_options["verify"] = kwargs["verify"]
         with env.TestEnvironment(test_paths,
                                  testharness_timeout_multipler,
                                  kwargs["pause_after_test"],


### PR DESCRIPTION
When `--log-*-level` option is used in `./wpt run` command line to set
the log level, it should be applied to the wpt server as well.
Fixed: #10512