### PR TITLE
Update MathML spec link

### DIFF
--- a/mathml/META.yml
+++ b/mathml/META.yml
@@ -1,3 +1,3 @@
-spec: https://w3c.github.io/mathml/
+spec: http://www.mathml-association.org/MathMLinHTML5/
 suggested_reviewers:
   - fred-wang


### PR DESCRIPTION
https://w3c.github.io/mathml/ is 404.