### PR TITLE
Add tentative WPT to assert download has / has not happened in sandbox

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_anchor_download_allow_downloads_without_user_activation.sub.tentative.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_anchor_download_allow_downloads_without_user_activation.sub.tentative.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>&lt;a download&gt; triggered download in sandbox is allowed by allow-downloads-without-user-activation.</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-iframe-sandbox">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-iframe-element">
+<script src="/resources/testharness.js"></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src="support/iframe_sandbox_download_helper.js"></script>
+<body>
+<script>
+"use strict";
+
+async_test(t => {
+    const token = "{{$id:uuid()}}";
+    var frame_onload_triggered = false;
+    var iframe = document.createElement("iframe");
+    iframe.src = "support/iframe_sandbox_download.html";
+    iframe.sandbox = "allow-same-origin allow-downloads-without-user-activation";
+    iframe.onload = t.step_func(function () {
+        assert_false(frame_onload_triggered, "Unexpected navigation.");
+        frame_onload_triggered = true;
+        var doc = iframe.contentDocument;
+        var anchor = doc.getElementById('link_id');
+        anchor.href += "?token=" + token;
+        anchor.download = "tmp.txt";
+        anchor.click();
+        VerifyDownload(t, token, true, DownloadVerifyDelay());
+    });
+
+    document.body.appendChild(iframe);
+}, "<a download> triggered download in sandbox is allowed by allow-downloads-without-user-activation.");
+</script>
+</body>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_anchor_download_block_downloads_without_user_activation.sub.tentative.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_anchor_download_block_downloads_without_user_activation.sub.tentative.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>&lt;a download&gt; triggered download in sandbox is blocked.</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-iframe-sandbox">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-iframe-element">
+<script src="/resources/testharness.js"></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src="support/iframe_sandbox_download_helper.js"></script>
+<body>
+<script>
+"use strict";
+
+async_test(t => {
+    const token = "{{$id:uuid()}}";
+    var frame_onload_triggered = false;
+    var iframe = document.createElement("iframe");
+    iframe.src = "support/iframe_sandbox_download.html";
+    iframe.sandbox = "allow-same-origin";
+    iframe.onload = t.step_func(function () {
+        assert_false(frame_onload_triggered, "Unexpected navigation.");
+        frame_onload_triggered = true;
+        var doc = iframe.contentDocument;
+        var anchor = doc.getElementById('link_id');
+        anchor.href += "?token=" + token;
+        anchor.download = "tmp.txt";
+        anchor.click();
+        VerifyDownload(t, token, false, DownloadVerifyDelay());
+    });
+
+    document.body.appendChild(iframe);
+}, "<a download> triggered download in sandbox is blocked.");
+</script>
+</body>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigation_download_allow_downloads_without_user_activation.sub.tentative.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigation_download_allow_downloads_without_user_activation.sub.tentative.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Navigation resulted download in sandbox is allowed by allow-downloads-without-user-activation.</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-iframe-sandbox">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-iframe-element">
+<script src="/resources/testharness.js"></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src="support/iframe_sandbox_download_helper.js"></script>
+<body>
+<script>
+"use strict";
+
+async_test(t => {
+    const token = "{{$id:uuid()}}";
+    var frame_onload_triggered = false;
+    var iframe = document.createElement("iframe");
+    iframe.src = "support/iframe_sandbox_download.html";
+    iframe.sandbox = "allow-same-origin allow-downloads-without-user-activation";
+    iframe.onload = t.step_func(function () {
+        assert_false(frame_onload_triggered, "Unexpected navigation.");
+        frame_onload_triggered = true;
+        var doc = iframe.contentDocument;
+        var anchor = doc.getElementById('link_id');
+        anchor.href += "?token=" + token;
+        // Set |finish-delay| to let the server stream a response over a
+        // period of time, so it's able to catch potential download
+        // cancellation by detecting a socket close.
+        anchor.href += "&finish-delay=" + StreamDownloadFinishDelay();
+        anchor.click();
+        VerifyDownload(t, token, true, StreamDownloadFinishDelay() + DownloadVerifyDelay());
+    });
+
+    document.body.appendChild(iframe);
+}, "Navigation resulted download in sandbox is allowed by allow-downloads-without-user-activation.");
+</script>
+</body>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigation_download_block_downloads_without_user_activation.sub.tentative.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_navigation_download_block_downloads_without_user_activation.sub.tentative.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Navigation resulted download in sandbox is blocked.</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-iframe-sandbox">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-iframe-element">
+<script src="/resources/testharness.js"></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src="support/iframe_sandbox_download_helper.js"></script>
+<body>
+<script>
+"use strict";
+
+async_test(t => {
+    const token = "{{$id:uuid()}}";
+    var frame_onload_triggered = false;
+    var iframe = document.createElement("iframe");
+    iframe.src = "support/iframe_sandbox_download.html";
+    iframe.sandbox = "allow-same-origin";
+    iframe.onload = t.step_func(function () {
+        assert_false(frame_onload_triggered, "Unexpected navigation.");
+        frame_onload_triggered = true;
+        var doc = iframe.contentDocument;
+        var anchor = doc.getElementById('link_id');
+        anchor.href += "?token=" + token;
+        // Set |finish-delay| to let the server stream a response over a
+        // period of time, so it's able to catch potential download
+        // cancellation by detecting a socket close.
+        anchor.href += "&finish-delay=" + StreamDownloadFinishDelay();
+        anchor.click();
+        VerifyDownload(t, token, false, StreamDownloadFinishDelay() + DownloadVerifyDelay());
+    });
+
+    document.body.appendChild(iframe);
+}, "Navigation resulted download in sandbox is blocked.");
+</script>
+</body>

--- a/html/semantics/embedded-content/the-iframe-element/support/download_stash.py
+++ b/html/semantics/embedded-content/the-iframe-element/support/download_stash.py
@@ -1,0 +1,28 @@
+import time
+
+def main(request, response):
+    token = request.GET["token"]
+    response.status = 200
+    response.headers.append("Content-Type", "text/html")
+    if "verify-token" in request.GET:
+      if request.server.stash.take(token):
+        return 'TOKEN_SET'
+      return 'TOKEN_NOT_SET'
+
+    if "finish-delay" not in request.GET:
+      # <a download>
+      request.server.stash.put(token, True)
+      return
+
+    # navigation to download
+    response.headers.append("Content-Disposition", "attachment")
+    response.write_status_headers()
+    finish_delay = float(request.GET["finish-delay"]) / 1E3
+    count = 10
+    single_delay = finish_delay / count
+    for i in range(count):
+        time.sleep(single_delay)
+        response.writer.write_content("DOWNLOAD_CONTENT\n")
+        if not response.writer.flush():
+          return
+    request.server.stash.put(token, True)

--- a/html/semantics/embedded-content/the-iframe-element/support/iframe_sandbox_download.html
+++ b/html/semantics/embedded-content/the-iframe-element/support/iframe_sandbox_download.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<a id="link_id" href="download_stash.py">Click me</a>

--- a/html/semantics/embedded-content/the-iframe-element/support/iframe_sandbox_download_helper.js
+++ b/html/semantics/embedded-content/the-iframe-element/support/iframe_sandbox_download_helper.js
@@ -1,0 +1,24 @@
+function StreamDownloadFinishDelay() {
+    return 1000;
+}
+
+function DownloadVerifyDelay() {
+    return 1000;
+}
+
+function VerifyDownload(test_obj, token, expect_download, timeout) {
+    var verify_token = test_obj.step_func(function () {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'support/download_stash.py?verify-token&token=' + token);
+        xhr.onload = test_obj.step_func(function(e) {
+            if (expect_download) {
+              assert_equals(xhr.response, "TOKEN_SET", "Expect download to happen, but got nothing.");
+            } else {
+              assert_equals(xhr.response, "TOKEN_NOT_SET", "Expect no download to happen, but got one.");
+            }
+            test_obj.done();
+        });
+        xhr.send();
+    });
+    test_obj.step_timeout(verify_token, timeout);
+}


### PR DESCRIPTION
The plan is to implement "blocking download in sandbox without user gesture", unless user opt-in.
 
The issue was discussed https://github.com/whatwg/html/issues/3236
Pull request for the spec: https://github.com/whatwg/html/pull/4293

General testing idea:
For a network request, we store a token in stash. And after a fixed period of time sufficient for the download to finish, if there are any, we validate the token in the stash to see if the network request was issued and finished successfully.
- In the case of `<a download>` where the decision of download can be made before resource fetching, the server sets the token immediately.
- In the case of navigation to a download, the server will stream a response over 1 seconds and set the token at the end only when the socket has been connected. So it is able to detect any download cancellation while fetching the resource.

