### PR TITLE
Remove pytest-catchlog dependency

### DIFF
--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -8,7 +8,6 @@ deps =
   pytest-cov
   mock
   hypothesis
-  pytest-catchlog
 
 commands = pytest --cov {posargs}
 


### PR DESCRIPTION
Running the tests currently shows this warning:
> PytestWarning: pytest-catchlog plugin has been merged into the core, please remove it from your requirements.