### PR TITLE
Fix #14894: Disable Python hypothesis deadlines on CI

### DIFF
--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -6,8 +6,10 @@ from hypothesis import settings, HealthCheck
 impl = platform.python_implementation()
 
 settings.register_profile("ci", settings(max_examples=1000,
+                                         deadline=None,
                                          suppress_health_check=[HealthCheck.too_slow]))
-settings.register_profile("pypy", settings(suppress_health_check=[HealthCheck.too_slow]))
+settings.register_profile("pypy", settings(deadline=None,
+                                           suppress_health_check=[HealthCheck.too_slow]))
 
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE",
                                 "default" if impl != "PyPy" else "pypy"))


### PR DESCRIPTION
This is causing flakiness on Travis, presumably due to the VM being pre-empted. Fixes #14894.