### PR TITLE
Sync Mozilla CSS tests as of 2019-01-17

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-width-table-auto-1-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-width-table-auto-1-ref.html
@@ -16,6 +16,11 @@
 </table>
 <table border>
   <tr>
+    <td style="width: 50%">x</td>
+    <td style="width: 100px">y</td>
+</table>
+<table border>
+  <tr>
     <td>x</td>
     <td style="width: 100px">y</td>
 </table>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-width-table-auto-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-width-table-auto-1.html
@@ -13,6 +13,11 @@
 </table>
 <table border>
   <tr>
+    <td style="width: calc(50% + 1px)">x</td>
+    <td style="width: 100px">y</td>
+</table>
+<table border>
+  <tr>
     <td style="width: calc(50%)">x</td>
     <td style="width: 100px">y</td>
 </table>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-width-table-fixed-1-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-width-table-fixed-1-ref.html
@@ -21,6 +21,11 @@ table { table-layout: fixed; width: 500px; border-spacing: 0 }
 </table>
 <table border>
   <tr>
+    <td style="width: 50%">x</td>
+    <td style="width: 100px">y</td>
+</table>
+<table border>
+  <tr>
     <td>x</td>
     <td style="width: 100px">y</td>
 </table>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-width-table-fixed-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/values3/calc-width-table-fixed-1.html
@@ -18,6 +18,11 @@ table { table-layout: fixed; width: 500px; border-spacing: 0 }
 </table>
 <table border>
   <tr>
+    <td style="width: calc(50% + 1px)">x</td>
+    <td style="width: 100px">y</td>
+</table>
+<table border>
+  <tr>
     <td style="width: calc(50%)">x</td>
     <td style="width: 100px">y</td>
 </table>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/1bbec154fb73b0fa3756a9ed417815c87fc82b4e .

This contains changes from [bug 957915](https://bugzilla.mozilla.org/show_bug.cgi?id=957915) by @emilio, reviewed by @MatsPalmgren.