### PR TITLE
correct calc-unit-analysis test (see issue 13713)

### DIFF
--- a/css/css-values/calc-unit-analysis.html
+++ b/css/css-values/calc-unit-analysis.html
@@ -10,7 +10,7 @@
   <script src="/resources/testharnessreport.js"></script>
 <style id="style"></style>
 </head>
-<body onload="run()">
+<body>
 <div id=log></div>
 <div id="test"></div>
 <script>


### PR DESCRIPTION
Removing the onload handler and keeping the run() at the end of the script tag fixes the problem. Credits and thanks to @qiuzhong 

Fixes https://github.com/web-platform-tests/wpt/issues/13713