### PR TITLE
python3 de-linting

### DIFF
--- a/encoding/resources/single-byte-raw.py
+++ b/encoding/resources/single-byte-raw.py
@@ -1,3 +1,3 @@
 def main(request, response):
   response.headers.set("Content-Type", "text/plain;charset=" + request.GET.first("label"))
-  response.content = "".join(chr(byte) for byte in xrange(255))
+  response.content = "".join(chr(byte) for byte in range(255))


### PR DESCRIPTION
xrange give a very very slight memory (premature?) optimization in python2, **but** is incompatible with python3

Refs: https://docs.python.org/3/whatsnew/3.0.html#views-and-iterators-instead-of-lists