### PR TITLE
Use fluxbox as window manager for xvfb in CI (14938)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -61,7 +61,7 @@ tasks:
               owner: ${event.pusher.email}
               source: ${event.repository.url}
             payload:
-              image: harjgam/web-platform-tests:0.25
+              image: harjgam/web-platform-tests:0.26
               maxRunTime: 7200
               artifacts:
                 public/results:
@@ -136,7 +136,7 @@ tasks:
                 owner: ${event.pull_request.user.login}@users.noreply.github.com
                 source: ${event.repository.url}
               payload:
-                image: harjgam/web-platform-tests:0.25
+                image: harjgam/web-platform-tests:0.26
                 maxRunTime: 7200
                 artifacts:
                   public/results:

--- a/tools/ci/start.sh
+++ b/tools/ci/start.sh
@@ -28,3 +28,4 @@ then
 fi
 
 sudo Xvfb $DISPLAY -screen 0 ${SCREEN_WIDTH}x${SCREEN_HEIGHT}x${SCREEN_DEPTH} &
+sudo fluxbox -display $DISPLAY &

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -qqy update \
     ca-certificates \
     dbus-x11 \
     earlyoom \
+    fluxbox \
     gdebi \
     git \
     locales \


### PR DESCRIPTION
This is an attempt to fix issue #14938 by trying to use fluxbox as window manager. As is it might fail because the package is most likely not installed in the docker image by default. 