### PR TITLE
Make webrtc-stats idlharness.js test depend on webrtc

### DIFF
--- a/webrtc-stats/idlharness.window.js
+++ b/webrtc-stats/idlharness.window.js
@@ -7,7 +7,7 @@
 
 idl_test(
   ['webrtc-stats'],
-  [], // No deps
+  ['webrtc'],
   idl_array => {
     // No interfaces to test
   }


### PR DESCRIPTION
Required for https://github.com/web-platform-tests/wpt/pull/14960.