### PR TITLE
Updating WebDriver new window command tests to switch window

### DIFF
--- a/webdriver/tests/new_window/new_tab.py
+++ b/webdriver/tests/new_window/new_tab.py
@@ -26,11 +26,8 @@ def test_new_tab_opens_about_blank(session):
     value = assert_success(response)
     assert value["type"] == "tab"
 
-    original_handle = session.window_handle
     session.window_handle = value["handle"]
-    new_window_url = session.url
-    session.window_handle = original_handle
-    assert new_window_url == "about:blank"
+    assert session.url == "about:blank"
 
 
 def test_new_tab_sets_no_window_name(session):
@@ -38,11 +35,8 @@ def test_new_tab_sets_no_window_name(session):
     value = assert_success(response)
     assert value["type"] == "tab"
 
-    original_handle = session.window_handle
     session.window_handle = value["handle"]
-    new_window_name = window_name(session)
-    session.window_handle = original_handle
-    assert new_window_name == ""
+    assert window_name(session) == ""
 
 
 def test_new_tab_sets_no_opener(session):
@@ -50,8 +44,5 @@ def test_new_tab_sets_no_opener(session):
     value = assert_success(response)
     assert value["type"] == "tab"
 
-    original_handle = session.window_handle
     session.window_handle = value["handle"]
-    new_window_opener = opener(session)
-    session.window_handle = original_handle
-    assert new_window_opener is None
+    assert opener(session) is None

--- a/webdriver/tests/new_window/new_tab.py
+++ b/webdriver/tests/new_window/new_tab.py
@@ -26,8 +26,11 @@ def test_new_tab_opens_about_blank(session):
     value = assert_success(response)
     assert value["type"] == "tab"
 
-    session.handle = value["handle"]
-    assert session.url == "about:blank"
+    original_handle = session.window_handle
+    session.window_handle = value["handle"]
+    new_window_url = session.url
+    session.window_handle = original_handle
+    assert new_window_url == "about:blank"
 
 
 def test_new_tab_sets_no_window_name(session):
@@ -35,8 +38,11 @@ def test_new_tab_sets_no_window_name(session):
     value = assert_success(response)
     assert value["type"] == "tab"
 
-    session.handle = value["handle"]
-    assert window_name(session) == ""
+    original_handle = session.window_handle
+    session.window_handle = value["handle"]
+    new_window_name = window_name(session)
+    session.window_handle = original_handle
+    assert new_window_name == ""
 
 
 def test_new_tab_sets_no_opener(session):
@@ -44,5 +50,8 @@ def test_new_tab_sets_no_opener(session):
     value = assert_success(response)
     assert value["type"] == "tab"
 
-    session.handle = value["handle"]
-    assert opener(session) is None
+    original_handle = session.window_handle
+    session.window_handle = value["handle"]
+    new_window_opener = opener(session)
+    session.window_handle = original_handle
+    assert new_window_opener is None

--- a/webdriver/tests/new_window/new_window.py
+++ b/webdriver/tests/new_window/new_window.py
@@ -26,11 +26,8 @@ def test_new_window_opens_about_blank(session):
     value = assert_success(response)
     assert value["type"] == "window"
 
-    original_handle = session.window_handle
     session.window_handle = value["handle"]
-    new_window_url = session.url
-    session.window_handle = original_handle
-    assert new_window_url == "about:blank"
+    assert session.url == "about:blank"
 
 
 def test_new_window_sets_no_window_name(session):
@@ -38,11 +35,8 @@ def test_new_window_sets_no_window_name(session):
     value = assert_success(response)
     assert value["type"] == "window"
 
-    original_handle = session.window_handle
     session.window_handle = value["handle"]
-    new_window_name = window_name(session)
-    session.window_handle = original_handle
-    assert new_window_name == ""
+    assert window_name(session) == ""
 
 
 def test_new_window_sets_no_opener(session):
@@ -50,8 +44,5 @@ def test_new_window_sets_no_opener(session):
     value = assert_success(response)
     assert value["type"] == "window"
 
-    original_handle = session.window_handle
     session.window_handle = value["handle"]
-    new_window_opener = opener(session)
-    session.window_handle = original_handle
-    assert new_window_opener is None
+    assert opener(session) is None

--- a/webdriver/tests/new_window/new_window.py
+++ b/webdriver/tests/new_window/new_window.py
@@ -26,8 +26,11 @@ def test_new_window_opens_about_blank(session):
     value = assert_success(response)
     assert value["type"] == "window"
 
-    session.handle = value["handle"]
-    assert session.url == "about:blank"
+    original_handle = session.window_handle
+    session.window_handle = value["handle"]
+    new_window_url = session.url
+    session.window_handle = original_handle
+    assert new_window_url == "about:blank"
 
 
 def test_new_window_sets_no_window_name(session):
@@ -35,8 +38,11 @@ def test_new_window_sets_no_window_name(session):
     value = assert_success(response)
     assert value["type"] == "window"
 
-    session.handle = value["handle"]
-    assert window_name(session) == ""
+    original_handle = session.window_handle
+    session.window_handle = value["handle"]
+    new_window_name = window_name(session)
+    session.window_handle = original_handle
+    assert new_window_name == ""
 
 
 def test_new_window_sets_no_opener(session):
@@ -44,5 +50,8 @@ def test_new_window_sets_no_opener(session):
     value = assert_success(response)
     assert value["type"] == "window"
 
-    session.handle = value["handle"]
-    assert opener(session) is None
+    original_handle = session.window_handle
+    session.window_handle = value["handle"]
+    new_window_opener = opener(session)
+    session.window_handle = original_handle
+    assert new_window_opener is None


### PR DESCRIPTION
As originally implemented, the tests set the `handle` property of
the session instead of the `window_handle` property. Moreover, the
tests did not switch to the new window context before checking the
url, opener, and name. This commit fixes both issues.