### PR TITLE
Convert css/ idlharness.js tests to use idl_test

### DIFF
--- a/css/css-conditional/idlharness.html
+++ b/css/css-conditional/idlharness.html
@@ -9,6 +9,16 @@
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
   <script src="/resources/idlharness.js"></script>
+  <!-- used to provide objects -->
+  <style>
+    div { display: block; }
+  </style>
+  <style>
+    @media print { }
+  </style>
+  <style>
+    @supports (display: block) { }
+  </style>
 </head>
 
 <body>
@@ -20,7 +30,14 @@
       ['css-conditional'],
       ['cssom', 'dom'],
       idl_array => {
-        // No objects
+        idl_array.add_objects({
+          CSSRule: ['cssRule'],
+          CSSMediaRule: ['cssMediaRule'],
+          CSSSupportsRule: ['cssSupportsRule'],
+        });
+        self.cssRule = document.styleSheets[0].cssRules[0];
+        self.cssMediaRule = document.styleSheets[1].cssRules[0];
+        self.cssSupportsRule = document.styleSheets[2].cssRules[0];
       }
     );
   </script>

--- a/css/css-conditional/idlharness.html
+++ b/css/css-conditional/idlharness.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>css-conditional IDL tests</title>
+  <title>CSS Conditional Rules IDL tests</title>
   <link rel="help" href="https://drafts.csswg.org/css-conditional/">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
@@ -16,16 +16,13 @@
 
   <script>
     'use strict';
-    promise_test(async () => {
-      const idl = await fetch('/interfaces/css-conditional.idl').then(r => r.text());
-      const cssom = await fetch('/interfaces/cssom.idl').then(r => r.text());
-      const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
-      const idl_array = new IdlArray();
-      idl_array.add_idls(idl);
-      idl_array.add_dependency_idls(cssom);
-      idl_array.add_dependency_idls(dom);
-      idl_array.test();
-    }, 'Test css-conditional IDL implementation');
+    idl_test(
+      ['css-conditional'],
+      ['cssom', 'dom'],
+      idl_array => {
+        // No objects
+      }
+    );
   </script>
 
 </body>

--- a/css/css-fonts/idlharness.html
+++ b/css/css-fonts/idlharness.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>css-fonts IDL tests</title>
+<title>CSS Fonts IDL tests</title>
 <link rel="help" href="https://drafts.csswg.org/css-fonts-4/">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -8,12 +8,11 @@
 <script>
   "use strict";
 
-  promise_test(async () => {
-    const idl_array = new IdlArray();
-    const idl = await fetch("/interfaces/css-fonts.idl").then(r => r.text());
-    const cssom = await fetch("/interfaces/cssom.idl").then(r => r.text());
-    idl_array.add_idls(idl);
-    idl_array.add_dependency_idls(cssom);
-    idl_array.test();
-  }, "Test IDL implementation of css-fonts API");
+  idl_test(
+    ["css-fonts"],
+    ["cssom"],
+    idl_array => {
+      // No objects
+    }
+  );
 </script>

--- a/css/css-fonts/idlharness.html
+++ b/css/css-fonts/idlharness.html
@@ -5,6 +5,17 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
+
+<style>
+  div { display: block; }
+</style>
+<style>
+  @font-face {
+    font-family: fwf;
+    src: url(support/fonts/FontWithFancyFeatures.otf);
+  }
+</style>
+
 <script>
   "use strict";
 
@@ -12,7 +23,12 @@
     ["css-fonts"],
     ["cssom"],
     idl_array => {
-      // No objects
+      idl_array.add_objects({
+        CSSRule: ['cssRule'],
+        CSSFontFaceRule: ['cssFontFaceRule'],
+      });
+      self.cssRule = document.styleSheets[0].cssRules[0];
+      self.cssFontFaceRule = document.styleSheets[1].cssRules[0];
     }
   );
 </script>

--- a/css/css-paint-api/idlharness.html
+++ b/css/css-paint-api/idlharness.html
@@ -10,9 +10,7 @@
 
   idl_test(
     ["css-paint-api"],
-    ["cssom", "html", "worklets"],
-    idl_array => {
-      // No objects
-    }
+    ["cssom", "html", "worklets"]
+    // No objects in Window global
   );
 </script>

--- a/css/css-paint-api/idlharness.html
+++ b/css/css-paint-api/idlharness.html
@@ -8,19 +8,11 @@
 <script>
   "use strict";
 
-  promise_test(async () => {
-    const idl_array = new IdlArray();
-    const idl = await fetch("/interfaces/css-paint-api.idl").then(r => r.text());
-    const cssom = await fetch("/interfaces/cssom.idl").then(r => r.text());
-    const html = await fetch("/interfaces/html.idl").then(r => r.text());
-    idl_array.add_idls(idl);
-    idl_array.add_dependency_idls(cssom);
-    idl_array.add_dependency_idls(html);
-    idl_array.add_untested_idls(`
-      [Exposed=Worklet]
-      interface WorkletGlobalScope {
-          attribute Console console;
-      };`);
-    idl_array.test();
-  }, "Test IDL implementation of CSS Painting API");
+  idl_test(
+    ["css-paint-api"],
+    ["cssom", "html", "worklets"],
+    idl_array => {
+      // No objects
+    }
+  );
 </script>

--- a/css/css-properties-values-api/idlharness.html
+++ b/css/css-properties-values-api/idlharness.html
@@ -8,13 +8,11 @@
 <script>
   "use strict";
 
-  promise_test(async () => {
-    const idl = await fetch("/interfaces/css-properties-values-api.idl").then(r => r.text());
-    const cssom = await fetch("/interfaces/cssom.idl").then(r => r.text());
-
-    const idl_array = new IdlArray();
-    idl_array.add_idls(idl);
-    idl_array.add_dependency_idls(cssom);
-    idl_array.test();
-  }, "Test IDL implementation of CSS Properties Values API");
+  idl_test(
+    ["css-properties-values-api"],
+    ["cssom"],
+    idl_array => {
+      // No objects
+    }
+  );
 </script>

--- a/css/css-properties-values-api/idlharness.html
+++ b/css/css-properties-values-api/idlharness.html
@@ -10,9 +10,7 @@
 
   idl_test(
     ["css-properties-values-api"],
-    ["cssom"],
-    idl_array => {
-      // No objects
-    }
+    ["cssom"]
+    // No objects
   );
 </script>


### PR DESCRIPTION
This is to make all loads of cssom.idl go through the same code
path which will make it possible to add a workaround for
https://github.com/web-platform-tests/wpt/issues/12515 in idl_test.