### PR TITLE
HTML: window.open() can set opener of a nested browsing context

### DIFF
--- a/html/browsers/windows/embedded-opener-a-form.html
+++ b/html/browsers/windows/embedded-opener-a-form.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>opener and embedded documents; using a and form</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<iframe name=matchesastring></iframe>
+<a href=/common/blank.html target=matchesastring>&lt;a></a>
+<form action=/common/blank.html target=matchesastring><input type=submit value="<form>"></form>
+<script>
+async_test(t => {
+  const frame = document.querySelector("iframe");
+  let counter = 0;
+  frame.onload = t.step_func(() => {
+    // Firefox and Chrome/Safari load differently
+    if (frame.contentWindow.location.href === "about:blank") {
+      return;
+    }
+
+    // Test bits
+    assert_equals(frame.contentWindow.opener, null);
+    if (counter === 0) {
+      document.querySelector("input").click();
+    } else {
+      t.done();
+    }
+    counter++;
+  });
+  document.querySelector("a").click();
+});
+</script>

--- a/html/browsers/windows/embedded-opener.html
+++ b/html/browsers/windows/embedded-opener.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<title>opener and embedded documents; using window.open()</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<iframe name=matchesastring></iframe>
+<script>
+async_test(t => {
+  const frame = document.querySelector("iframe");
+  frame.onload = t.step_func(() => {
+    // Firefox and Chrome/Safari load differently
+    if (frame.contentWindow.location.href === "about:blank") {
+      return;
+    }
+
+    // Test bits
+    assert_equals(frame.contentWindow.opener, window, "opener before setting it to null");
+
+    const openerDesc = Object.getOwnPropertyDescriptor(frame.contentWindow, "opener"),
+          openerGet = openerDesc.get;
+
+    assert_equals(openerGet(), window, "opener before setting it to null via directly invoking the getter");
+    frame.contentWindow.opener = null;
+    frame.contentWindow.opener = "immaterial";
+    assert_equals(openerGet(), null, "opener after setting it to null via directly invoking the getter");
+    assert_equals(frame.contentWindow.opener, "immaterial");
+
+    t.done();
+  });
+  window.open("/common/blank.html", "matchesastring");
+});
+</script>


### PR DESCRIPTION
Needed for https://github.com/whatwg/html/pull/4284.