### PR TITLE
ReadableStream @@asyncIterator

### DIFF
--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -83,7 +83,7 @@ promise_test(async () => {
 
   await Promise.race([
     loop(),
-    delay(500)
+    flushAsyncEvents()
   ]);
 }, 'Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function');
 

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -140,8 +140,5 @@ test(() => {
     },
   });
   const it = s.getIterator();
-  try {
-    s.getIterator();
-    assert_unreached();
-  } catch (e) {}
+  assert_throws(new TypeError(), () => s.getIterator(), 'getIterator() should throw');
 }, 'getIterator throws if there\'s already a lock');

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -132,7 +132,7 @@ promise_test(async () => {
   const it = s[Symbol.asyncIterator]();
   const next = await it.next();
   assert_equals(Object.getPrototypeOf(next), Object.prototype);
-  assert_array_equals(Object.keys(next), ['value', 'done']);
+  assert_array_equals(Object.getOwnPropertyNames(next).sort(), ['done', 'value']);
 }, 'next()\'s fulfillment value has the right shape');
 
 test(() => {

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -170,6 +170,15 @@ promise_test(async () => {
   assert_array_equals(Object.getOwnPropertyNames(next).sort(), ['done', 'value']);
 }, 'next()\'s fulfillment value has the right shape');
 
+promise_test(async t => {
+  const s = recordingReadableStream();
+  const it = s[Symbol.asyncIterator]();
+  it.next();
+
+  await promise_rejects(t, new TypeError(), it.return(), 'return() should reject');
+  assert_array_equals(s.events, ['pull']);
+}, 'calling return() while there are pending reads rejects');
+
 test(() => {
   const s = new ReadableStream({
     start(c) {

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -113,6 +113,28 @@ promise_test(async () => {
 }, 'Cancellation behavior');
 
 promise_test(async () => {
+  const test = async (preventCancel) => {
+    const s = recordingReadableStream({
+      start(c) {
+        c.enqueue(0);
+      }
+    });
+
+    const it = s.getIterator({ preventCancel });
+    await it.return();
+
+    if (preventCancel) {
+      assert_array_equals(s.events, [], `cancel() should not be called when preventCancel is true`);
+    } else {
+      assert_array_equals(s.events, ['cancel', undefined], `cancel() should be called when preventCancel is false`);
+    }
+  };
+
+  await test(true);
+  await test(false);
+}, 'Cancellation behavior when manually calling return()');
+
+promise_test(async () => {
   const s = new ReadableStream();
   const it = s[Symbol.asyncIterator]();
   await it.return();

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -22,7 +22,7 @@ promise_test(async () => {
     chunks.push(chunk);
   }
   assert_array_equals(chunks, [1, 2, 3]);
-}, 'async iterator push source');
+}, 'Async-iterating a push source');
 
 promise_test(async () => {
   let i = 1;
@@ -41,7 +41,7 @@ promise_test(async () => {
     chunks.push(chunk);
   }
   assert_array_equals(chunks, [1, 2, 3]);
-}, 'async iterator pull source');
+}, 'Async-iterating a pull source');
 
 promise_test(async () => {
   const s = new ReadableStream({
@@ -105,7 +105,7 @@ promise_test(async () => {
     await test(t, true);
     await test(t, false);
   }
-}, 'cancellation behavior');
+}, 'Cancellation behavior');
 
 promise_test(async () => {
   const s = new ReadableStream();
@@ -139,4 +139,4 @@ test(() => {
   });
   const it = s.getIterator();
   assert_throws(new TypeError(), () => s.getIterator(), 'getIterator() should throw');
-}, 'getIterator throws if there\'s already a lock');
+}, 'getIterator() throws if there\'s already a lock');

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -108,26 +108,26 @@ promise_test(async () => {
 }, 'cancellation behavior');
 
 promise_test(async () => {
-    const s = new ReadableStream();
-    const it = s[Symbol.asyncIterator]();
+  const s = new ReadableStream();
+  const it = s[Symbol.asyncIterator]();
+  await it.return();
+  try {
     await it.return();
-    try {
-      await it.return();
-      assert_unreached();
-    } catch (e) {}
+    assert_unreached();
+  } catch (e) {}
 }, 'Calling return() twice rejects');
 
 promise_test(async () => {
-    const s = new ReadableStream({
-      start(c) {
-        c.enqueue(0);
-        c.close();
-      },
-    });
-    const it = s[Symbol.asyncIterator]();
-    const next = await it.next();
-    assert_equals(Object.getPrototypeOf(next), Object.prototype);
-    assert_array_equals(Object.keys(next), ['value', 'done']);
+  const s = new ReadableStream({
+    start(c) {
+      c.enqueue(0);
+      c.close();
+    },
+  });
+  const it = s[Symbol.asyncIterator]();
+  const next = await it.next();
+  assert_equals(Object.getPrototypeOf(next), Object.prototype);
+  assert_array_equals(Object.keys(next), ['value', 'done']);
 }, 'next()\'s fulfillment value has the right shape');
 
 test(() => {

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -1,0 +1,147 @@
+// META: global=worker,jsshell
+// META: script=../resources/rs-utils.js
+// META: script=../resources/recording-streams.js
+'use strict';
+
+test(() => {
+  assert_equals(ReadableStream.prototype[Symbol.asyncIterator], ReadableStream.prototype.getIterator);
+}, '@@asyncIterator() method is === to getIterator() method');
+
+promise_test(async () => {
+  const s = new ReadableStream({
+    start(c) {
+      c.enqueue(1);
+      c.enqueue(2);
+      c.enqueue(3);
+      c.close();
+    },
+  });
+
+  const chunks = [];
+  for await (const chunk of s) {
+    chunks.push(chunk);
+  }
+  assert_array_equals(chunks, [1, 2, 3]);
+}, 'async iterator push source');
+
+promise_test(async () => {
+  let i = 1;
+  const s = new ReadableStream({
+    pull(c) {
+      c.enqueue(i);
+      if (i >= 3) {
+        c.close();
+      }
+      i += 1;
+    },
+  });
+
+  const chunks = [];
+  for await (const chunk of s) {
+    chunks.push(chunk);
+  }
+  assert_array_equals(chunks, [1, 2, 3]);
+}, 'async iterator pull source');
+
+promise_test(async () => {
+  const s = new ReadableStream({
+    start(c) {
+      c.error('e');
+    },
+  });
+
+  try {
+    for await (const chunk of s) {}
+    assert_unreached();
+  } catch (e) {
+    assert_equals(e, 'e');
+  }
+}, 'Async-iterating an errored stream throws');
+
+promise_test(async () => {
+  const s = new ReadableStream({
+    start(c) {
+      c.close();
+    }
+  });
+
+  for await (const chunk of s) {
+    assert_unreached();
+  }
+}, 'Async-iterating a closed stream never executes the loop body, but works fine');
+
+promise_test(async () => {
+
+}, 'Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function');
+
+promise_test(async () => {
+  const test = async (type, preventCancel) => {
+    const s = recordingReadableStream({
+      start(c) {
+        c.enqueue(0);
+      }
+    });
+
+    await (async () => {
+      for await (const c of s.getIterator({ preventCancel })) {
+        if (type === 'throw') {
+          throw new Error();
+        } else if (type === 'break') {
+          break;
+        } else if (type === 'return') {
+          return;
+        }
+      }
+    })().catch(() => 0);
+
+    if (preventCancel) {
+      assert_array_equals(s.events, ['pull'], `cancel() should not be called when type = '${type}' and preventCancel is true`);
+    } else {
+      assert_array_equals(s.events, ['pull', 'cancel', undefined], `cancel() should be called when type = '${type}' and preventCancel is false`);
+    }
+  };
+
+  for (const t of ['throw', 'break', 'return']) {
+    await test(t, true);
+    await test(t, false);
+  }
+}, 'cancellation behavior');
+
+promise_test(async () => {
+  {
+    const s = new ReadableStream();
+    const it = s[Symbol.asyncIterator]();
+    await it.return();
+    try {
+      await it.return();
+      assert_unreached();
+    } catch (e) {}
+  }
+
+  {
+    const s = new ReadableStream({
+      start(c) {
+        c.enqueue(0);
+        c.close();
+      },
+    });
+    const it = s[Symbol.asyncIterator]();
+    const next = await it.next();
+    assert_equals(Object.getPrototypeOf(next), Object.prototype);
+    assert_array_equals(Object.keys(next), ['value', 'done']);
+  }
+}, 'manual manipulation');
+
+test(() => {
+  const s = new ReadableStream({
+    start(c) {
+      c.enqueue(0);
+      c.close();
+    },
+  });
+  const it = s.getIterator();
+  try {
+    s.getIterator();
+    assert_unreached();
+  } catch (e) {}
+}, 'getIterator throws if there\'s already a lock');

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -223,6 +223,26 @@ promise_test(async () => {
     },
   });
 
+  const chunks = [];
+  for await (const chunk of s) {
+    chunks.push(chunk);
+  }
+  assert_array_equals(chunks, [1, 2, 3]);
+
+  const reader = s.getReader();
+  await reader.closed;
+}, 'Acquiring a reader after exhaustively async-iterating a stream');
+
+promise_test(async () => {
+  const s = new ReadableStream({
+    start(c) {
+      c.enqueue(1);
+      c.enqueue(2);
+      c.enqueue(3);
+      c.close();
+    },
+  });
+
   // read the first two chunks, then cancel
   const chunks = [];
   for await (const chunk of s) {

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -110,8 +110,9 @@ promise_test(async () => {
   assert_array_equals(chunks, [2, 3]);
 }, 'Async-iterating a partially consumed stream');
 
-promise_test(async () => {
-  const test = async (type, preventCancel) => {
+for (const type of ['throw', 'break', 'return']) {
+  for (const preventCancel of [false, true]) {
+    promise_test(async () => {
     const s = recordingReadableStream({
       start(c) {
         c.enqueue(0);
@@ -140,16 +141,12 @@ promise_test(async () => {
     } else {
       assert_array_equals(s.events, ['pull', 'cancel', undefined], `cancel() should be called when type = '${type}' and preventCancel is false`);
     }
-  };
-
-  for (const t of ['throw', 'break', 'return']) {
-    await test(t, true);
-    await test(t, false);
+    }, `Cancellation behavior when ${type}ing inside loop body; preventCancel = ${preventCancel}`);
   }
-}, 'Cancellation behavior');
+}
 
-promise_test(async () => {
-  const test = async (preventCancel) => {
+for (const preventCancel of [false, true]) {
+  promise_test(async () => {
     const s = recordingReadableStream({
       start(c) {
         c.enqueue(0);
@@ -164,11 +161,8 @@ promise_test(async () => {
     } else {
       assert_array_equals(s.events, ['cancel', undefined], `cancel() should be called when preventCancel is false`);
     }
-  };
-
-  await test(true);
-  await test(false);
-}, 'Cancellation behavior when manually calling return()');
+  }, `Cancellation behavior when manually calling return(); preventCancel = ${preventCancel}`);
+}
 
 promise_test(async () => {
   const s = new ReadableStream();

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -1,5 +1,6 @@
 // META: global=worker,jsshell
 // META: script=../resources/rs-utils.js
+// META: script=../resources/test-utils.js
 // META: script=../resources/recording-streams.js
 'use strict';
 
@@ -71,7 +72,19 @@ promise_test(async () => {
 }, 'Async-iterating a closed stream never executes the loop body, but works fine');
 
 promise_test(async () => {
+  const s = new ReadableStream();
 
+  const loop = async () => {
+    for await (const chunk of s) {
+      assert_unreached();
+    }
+    assert_unreached();
+  };
+
+  await Promise.race([
+    loop(),
+    delay(500)
+  ]);
 }, 'Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function');
 
 promise_test(async () => {

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -137,9 +137,9 @@ for (const type of ['throw', 'break', 'return']) {
       } catch (e) {}
 
       if (preventCancel) {
-        assert_array_equals(s.events, ['pull'], `cancel() should not be called when type = '${type}' and preventCancel is true`);
+        assert_array_equals(s.events, ['pull'], `cancel() should not be called`);
       } else {
-        assert_array_equals(s.events, ['pull', 'cancel', undefined], `cancel() should be called when type = '${type}' and preventCancel is false`);
+        assert_array_equals(s.events, ['pull', 'cancel', undefined], `cancel() should be called`);
       }
     }, `Cancellation behavior when ${type}ing inside loop body; preventCancel = ${preventCancel}`);
   }
@@ -157,9 +157,9 @@ for (const preventCancel of [false, true]) {
     await it.return();
 
     if (preventCancel) {
-      assert_array_equals(s.events, [], `cancel() should not be called when preventCancel is true`);
+      assert_array_equals(s.events, [], `cancel() should not be called`);
     } else {
-      assert_array_equals(s.events, ['cancel', undefined], `cancel() should be called when preventCancel is false`);
+      assert_array_equals(s.events, ['cancel', undefined], `cancel() should be called`);
     }
   }, `Cancellation behavior when manually calling return(); preventCancel = ${preventCancel}`);
 }

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -108,7 +108,6 @@ promise_test(async () => {
 }, 'cancellation behavior');
 
 promise_test(async () => {
-  {
     const s = new ReadableStream();
     const it = s[Symbol.asyncIterator]();
     await it.return();
@@ -116,9 +115,9 @@ promise_test(async () => {
       await it.return();
       assert_unreached();
     } catch (e) {}
-  }
+}, 'Calling return() twice rejects');
 
-  {
+promise_test(async () => {
     const s = new ReadableStream({
       start(c) {
         c.enqueue(0);
@@ -129,8 +128,7 @@ promise_test(async () => {
     const next = await it.next();
     assert_equals(Object.getPrototypeOf(next), Object.prototype);
     assert_array_equals(Object.keys(next), ['value', 'done']);
-  }
-}, 'manual manipulation');
+}, 'next()\'s fulfillment value has the right shape');
 
 test(() => {
   const s = new ReadableStream({

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -82,7 +82,8 @@ promise_test(async () => {
       }
     });
 
-    await (async () => {
+    // use a separate function for the loop body so return does not stop the test
+    const loop = async () => {
       for await (const c of s.getIterator({ preventCancel })) {
         if (type === 'throw') {
           throw new Error();
@@ -92,7 +93,11 @@ promise_test(async () => {
           return;
         }
       }
-    })().catch(() => 0);
+    };
+
+    try {
+      await loop();
+    } catch (e) {}
 
     if (preventCancel) {
       assert_array_equals(s.events, ['pull'], `cancel() should not be called when type = '${type}' and preventCancel is true`);

--- a/streams/readable-streams/brand-checks.any.js
+++ b/streams/readable-streams/brand-checks.any.js
@@ -4,6 +4,7 @@
 
 let ReadableStreamDefaultReader;
 let ReadableStreamDefaultController;
+let ReadableStreamAsyncIteratorPrototype;
 
 test(() => {
 
@@ -22,6 +23,13 @@ test(() => {
   });
 
 }, 'Can get the ReadableStreamDefaultController constructor indirectly');
+
+test(() => {
+
+  const rs = new ReadableStream();
+  ReadableStreamAsyncIteratorPrototype = Object.getPrototypeOf(rs.getIterator());
+
+}, 'Can get ReadableStreamAsyncIteratorPrototype object indirectly');
 
 function fakeRS() {
   return Object.setPrototypeOf({
@@ -66,6 +74,13 @@ function realRSDefaultController() {
     }
   });
   return controller;
+}
+
+function fakeRSAsyncIterator() {
+  return Object.setPrototypeOf({
+    next() { },
+    return(value = undefined) { }
+  }, ReadableStreamAsyncIteratorPrototype);
 }
 
 promise_test(t => {
@@ -157,3 +172,17 @@ test(() => {
                      [fakeRSDefaultController(), realRS(), realRSDefaultReader(), undefined, null]);
 
 }, 'ReadableStreamDefaultController.prototype.error enforces a brand check');
+
+promise_test(t => {
+
+  return methodRejectsForAll(t, ReadableStreamAsyncIteratorPrototype, 'next',
+                             [fakeRSAsyncIterator(), realRS(), realRSDefaultReader(), undefined, null]);
+
+}, 'ReadableStreamAsyncIteratorPrototype.next enforces a brand check');
+
+promise_test(t => {
+
+  return methodRejectsForAll(t, ReadableStreamAsyncIteratorPrototype, 'return',
+                             [fakeRSAsyncIterator(), realRS(), realRSDefaultReader(), undefined, null]);
+
+}, 'ReadableStreamAsyncIteratorPrototype.return enforces a brand check');

--- a/streams/readable-streams/general.any.js
+++ b/streams/readable-streams/general.any.js
@@ -41,11 +41,13 @@ test(() => {
 
   const methods = ['cancel', 'constructor', 'getReader', 'pipeThrough', 'pipeTo', 'tee', 'getIterator'];
   const properties = methods.concat(['locked']).sort();
+  const symbols = [Symbol.asyncIterator];
 
   const rs = new ReadableStream();
   const proto = Object.getPrototypeOf(rs);
 
-  assert_array_equals(Object.getOwnPropertyNames(proto).sort(), properties, 'should have all the correct methods');
+  assert_array_equals(Object.getOwnPropertyNames(proto).sort(), properties, 'should have all the correct properties');
+  assert_array_equals(Object.getOwnPropertySymbols(proto).sort(), symbols, 'should have all the correct symbols');
 
   for (const m of methods) {
     const propDesc = Object.getOwnPropertyDescriptor(proto, m);
@@ -71,6 +73,14 @@ test(() => {
   assert_equals(rs.pipeTo.length, 1, 'pipeTo should have 1 parameter');
   assert_equals(rs.tee.length, 0, 'tee should have no parameters');
   assert_equals(rs.getIterator.length, 0, 'getIterator should have no required parameters');
+  assert_equals(rs[Symbol.asyncIterator].length, 0, '@@asyncIterator should have no required parameters');
+
+  const asyncIteratorPropDesc = Object.getOwnPropertyDescriptor(proto, Symbol.asyncIterator);
+  assert_false(asyncIteratorPropDesc.enumerable, '@@asyncIterator should be non-enumerable');
+  assert_true(asyncIteratorPropDesc.configurable, '@@asyncIterator should be configurable');
+  assert_true(asyncIteratorPropDesc.writable, '@@asyncIterator should be writable');
+  assert_equals(typeof rs[Symbol.asyncIterator], 'function', '@@asyncIterator should be a function');
+  assert_equals(rs[Symbol.asyncIterator].name, 'getIterator', '@@asyncIterator should have the correct name');
 
 }, 'ReadableStream instances should have the correct list of properties');
 

--- a/streams/readable-streams/general.any.js
+++ b/streams/readable-streams/general.any.js
@@ -39,7 +39,7 @@ test(() => {
 
 test(() => {
 
-  const methods = ['cancel', 'constructor', 'getReader', 'pipeThrough', 'pipeTo', 'tee'];
+  const methods = ['cancel', 'constructor', 'getReader', 'pipeThrough', 'pipeTo', 'tee', 'getIterator'];
   const properties = methods.concat(['locked']).sort();
 
   const rs = new ReadableStream();
@@ -70,6 +70,7 @@ test(() => {
   assert_equals(rs.pipeThrough.length, 1, 'pipeThrough should have 1 parameters');
   assert_equals(rs.pipeTo.length, 1, 'pipeTo should have 1 parameter');
   assert_equals(rs.tee.length, 0, 'tee should have no parameters');
+  assert_equals(rs.getIterator.length, 0, 'getIterator should have no required parameters');
 
 }, 'ReadableStream instances should have the correct list of properties');
 

--- a/streams/readable-streams/patched-global.any.js
+++ b/streams/readable-streams/patched-global.any.js
@@ -57,3 +57,53 @@ test(t => {
   assert_true(isReadableStream(branch1), 'branch1 should be a ReadableStream');
   assert_true(isReadableStream(branch2), 'branch2 should be a ReadableStream');
 }, 'ReadableStream tee() should not call the global ReadableStream');
+
+promise_test(async t => {
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue(1);
+      c.enqueue(2);
+      c.enqueue(3);
+      c.close();
+    }
+  });
+
+  const oldReadableStreamGetReader = ReadableStream.prototype.getReader;
+
+  const ReadableStreamDefaultReader = (new ReadableStream()).getReader().constructor;
+  const oldDefaultReaderRead = ReadableStreamDefaultReader.prototype.read;
+  const oldDefaultReaderCancel = ReadableStreamDefaultReader.prototype.cancel;
+  const oldDefaultReaderReleaseLock = ReadableStreamDefaultReader.prototype.releaseLock;
+
+  self.ReadableStream.prototype.getReader = function() {
+    throw new Error('patched getReader() called');
+  };
+
+  ReadableStreamDefaultReader.prototype.read = function() {
+    throw new Error('patched read() called');
+  };
+  ReadableStreamDefaultReader.prototype.cancel = function() {
+    throw new Error('patched cancel() called');
+  };
+  ReadableStreamDefaultReader.prototype.releaseLock = function() {
+    throw new Error('patched releaseLock() called');
+  };
+
+  t.add_cleanup(() => {
+    self.ReadableStream.prototype.getReader = oldReadableStreamGetReader;
+
+    ReadableStreamDefaultReader.prototype.read = oldDefaultReaderRead;
+    ReadableStreamDefaultReader.prototype.cancel = oldDefaultReaderCancel;
+    ReadableStreamDefaultReader.prototype.releaseLock = oldDefaultReaderReleaseLock;
+  });
+
+  // read the first chunk, then cancel
+  for await (const chunk of rs) {
+    break;
+  }
+
+  // should be able to acquire a new reader
+  const reader = oldReadableStreamGetReader.call(rs);
+  // stream should be cancelled
+  await reader.closed;
+}, 'ReadableStream getIterator() should use the original values of getReader() and ReadableStreamDefaultReader methods');


### PR DESCRIPTION
Add tests for async-iterating a `ReadableStream`. See whatwg/streams#980 for the accompanying spec change.

This PR continues from @devsnek's work in #13362.

The tests are based on [Domenic's comment](https://github.com/whatwg/streams/pull/954#issuecomment-421107013) in whatwg/streams#954. So far, the following tests have been implemented:

* [x] Basic test of a stream with a few chunks that closes
  * [x] Using a "push" underlying source (calls `c.enqueue()` in `start`) that enqueues all at once
  * [x] Using a "push" underlying source  where you call `c.enqueue()` "just in time" (i.e. inside the loop body)
  * [x] Using a "pull" underlying source (calls `c.enqueue()` in `pull`) using recordingReadableStream to verify the correct underlying source method calls
* [x] Degenerate streams
  * [x] Async-iterating an errored stream throws
  * [x] Async-iterating a closed stream never executes the loop body, but works fine
  * [x] Async-iterating an empty but not closed/errored stream never executes the loop body and stalls the async function (end the test if 50 ms pass without the promise resolving)
* [x] `@@asyncIterator()` method is `===` to `getIterator()` method
* [x] Cancellation behavior (use recordingReadableStream)
  * [x] Manually calling `return()` causes a cancel
  * [x] `throw`ing inside the loop body causes a cancel
  * [x] `break`ing inside the loop body causes a cancel
  * [x] `return`ing inside the loop body causes a cancel
  * [x] All of the above, but with `preventCancel: true` and the pass conditions reversed
* [x] Manual manipulation
  * [x] double-return rejects ([#954 (comment)](https://github.com/whatwg/streams/pull/954#discussion_r216237031))
  * [x] next()'s fulfillment values have exactly the right shape (Object.prototype, only two properties, correct property descriptors)
  * [x] throw method does not exist
  * [x] Calling next() or return() on non-ReadableStreamDefaultReaderAsyncIterator instances rejects with TypeError (there are existing brand check tests you can add to)
  * [x] Calling return() while there are pending reads (i.e. unsettled promises returned by next()) rejects the return Promise ([#950 (comment)](https://github.com/whatwg/streams/pull/950#issuecomment-417393457))
* [x] Interaction with existing infrastructure
  * [x] getIterator/@@asyncIterator throw if there's already a lock
  * [x] Monkey-patch getReader and default reader's prototype methods and ensure this does not interfere with async iteration (e.g. using one of the basic test cases)
  * [x] Basic test with a few chunks but you've already consumed one or two via a normal reader (which you then released)
* [x] Auto-release
  * [x] You can still acquire a reader and successfully use its `.closed` promise after exhausting the async iterator via for-await-of
  * [x] You can still acquire a reader and successfully use its `.closed` promise after `return()`ing from the async iterator (either manually or via `break`; take your pick)
