### PR TITLE
Improve `EventListener::handleEvent()` coverage

### DIFF
--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -47,4 +47,21 @@ test(function(t) {
     target.dispatchEvent(new Event(type));
     assert_equals(thrownError, uncaughtError);
 }, "rethrows errors when getting `handleEvent`");
+
+test(function(t) {
+    var type = "foo";
+    var target = document.getElementById("target");
+    var uncaughtError;
+
+    window.addEventListener("error", function(event) {
+        uncaughtError = event.error;
+    });
+
+    target.addEventListener(type, {
+        handleEvent: null,
+    });
+
+    target.dispatchEvent(new Event(type));
+    assert_true(uncaughtError instanceof TypeError);
+}, "throws if `handleEvent` is not callable");
 </script>

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -51,6 +51,24 @@ test(function(t) {
 test(function(t) {
     var type = "foo";
     var target = document.getElementById("target");
+    var calls = 0;
+
+    target.addEventListener(type, {
+        get handleEvent() {
+            calls++;
+            return function() {};
+        },
+    });
+
+    assert_equals(calls, 0);
+    target.dispatchEvent(new Event(type));
+    target.dispatchEvent(new Event(type));
+    assert_equals(calls, 2);
+}, "performs `Get` every time event is dispatched");
+
+test(function(t) {
+    var type = "foo";
+    var target = document.getElementById("target");
     var uncaughtError;
 
     window.addEventListener("error", function(event) {

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -3,6 +3,7 @@
 <title>EventListener::handleEvent()</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">
 <div id=log></div>
 <div id=target></div>
 <script>

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -7,6 +7,8 @@
 <div id=log></div>
 <div id=target></div>
 <script>
+setup({ allow_uncaught_exception: true });
+
 test(function(t) {
     var type = "foo";
     var target = document.getElementById("target");
@@ -26,4 +28,23 @@ test(function(t) {
     target.dispatchEvent(new Event(type));
 }, "calls `handleEvent` method of `EventListener`");
 
+test(function(t) {
+    var type = "foo";
+    var target = document.getElementById("target");
+    var thrownError = new Error();
+    var uncaughtError;
+
+    window.addEventListener("error", function(event) {
+        uncaughtError = event.error;
+    });
+
+    target.addEventListener(type, {
+        get handleEvent() {
+            throw thrownError;
+        },
+    });
+
+    target.dispatchEvent(new Event(type));
+    assert_equals(thrownError, uncaughtError);
+}, "rethrows errors when getting `handleEvent`");
 </script>

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -4,39 +4,25 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<table id="table" border="1" style="display: none">
-    <tbody id="table-body">
-    <tr id="table-row">
-        <td id="table-cell">Shady Grove</td>
-        <td>Aeolian</td>
-    </tr>
-    <tr id="parent">
-        <td id="target">Over the river, Charlie</td>
-        <td>Dorian</td>
-    </tr>
-    </tbody>
-</table>
+<div id=target></div>
 <script>
 test(function(t) {
-    var event = "foo";
+    var type = "foo";
     var target = document.getElementById("target");
-
-    var event_listener = {
-        "handleEvent": function(evt) {
+    var eventListener = {
+        handleEvent: function(evt) {
             var that = this;
             t.step(function() {
-                assert_equals(evt.type, event);
+                assert_equals(evt.type, type);
                 assert_equals(evt.target, target);
                 assert_equals(evt.srcElement, target);
-                assert_equals(that, event_listener);
+                assert_equals(that, eventListener);
             });
-        }
+        },
     };
 
-    var evt = document.createEvent("Event");
-    evt.initEvent(event, true, true);
+    target.addEventListener(type, eventListener);
+    target.dispatchEvent(new Event(type));
+}, "calls `handleEvent` method of `EventListener`");
 
-    target.addEventListener(event, event_listener, true);
-    target.dispatchEvent(evt);
-});
 </script>


### PR DESCRIPTION
Came to my attention because of [this tweet](https://twitter.com/roman01la/status/1088845282757001219): Chrome and Safari seem to ignore non-callable `handleEvent` method, while Firefox follows [the spec](https://heycam.github.io/webidl/#call-a-user-objects-operation) (step 10.4).