### PR TITLE
Add a web platform test checking documentElement clientWidth is `Initial Containing Block` size even if there is visible overlow:hidden region due to minimum-scale.

### DIFF
--- a/css/css-device-adapt/documentElement-clientWidth-on-minimum-scale-size.tentative.html
+++ b/css/css-device-adapt/documentElement-clientWidth-on-minimum-scale-size.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width minimum-scale=0.5">
+<link rel="help" href="https://drafts.csswg.org/css-device-adapt/">
+<style>
+html {
+  overflow: hidden;
+}
+body {
+  margin: 0;
+}
+div {
+  height: 200%;
+  position: absolute;
+}
+</style>
+<title></title>
+<div style="width: 200%;"></div>
+<div id="reference" style="width: 100%;"></div>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+'use strict';
+test(() => {
+  assert_equals(document.documentElement.clientWidth, reference.clientWidth,
+    'documentElement clientWidth should be 100%');
+}, 'documentElement clientWidth should be equal to device-width even if ' +
+   'overflow:hidden region is visible');
+</script>


### PR DESCRIPTION
Differential Revision: https://phabricator.services.mozilla.com/D15344

bugzilla-url: https://bugzilla.mozilla.org/show_bug.cgi?id=1423013
gecko-commit: db57901030e954ada2c5ba75a3c6bd0160e6b7e2
gecko-integration-branch: central
gecko-reviewers: botond