### PR TITLE
Fix #12696: make property_order default to empty list

### DIFF
--- a/tools/wptrunner/wptrunner/update/metadata.py
+++ b/tools/wptrunner/wptrunner/update/metadata.py
@@ -11,7 +11,7 @@ class GetUpdatePropertyList(Step):
     def create(self, state):
         property_order, boolean_properties = products.load_product_update(
             state.config, state.product)
-        state.property_order = property_order + state.extra_properties
+        state.property_order = (property_order or []) + state.extra_properties
         state.boolean_properties = boolean_properties
 
 


### PR DESCRIPTION
IIRC, @jgraham didn't like this, but I can't find where he said why.

Fixes #12696.