### PR TITLE
Fix first arg of assert_throws

### DIFF
--- a/css/css-syntax/escaped-eof.html
+++ b/css/css-syntax/escaped-eof.html
@@ -15,7 +15,7 @@
 
 <script>
 test(()=>{
-    assert_throws(new SyntaxError, ()=>{document.querySelector("#123");}, "numeric hash token is invalid in a selector");
+    assert_throws("SyntaxError", ()=>{document.querySelector("#123");}, "numeric hash token is invalid in a selector");
     document.querySelector("#foo\\"); // escaped-EOF in a hash token is valid in a selector
 }, "Escaped EOF turns into a U+FFFD in a hash token, makes it 'ID' type.");
 


### PR DESCRIPTION
Apparently you should specifically use the string form of the first `assert_throws` argument to catch DOMExceptions.