### PR TITLE
Clarify that object arg to assert_throws is for non-DOMExceptions

### DIFF
--- a/docs/_writing-tests/testharness-api.md
+++ b/docs/_writing-tests/testharness-api.md
@@ -776,11 +776,14 @@ assert that property `property_name` on object is readonly
 ### `assert_throws(code, func, description)`
 `code` - the expected exception. This can take several forms:
 
-  * string - the thrown exception must be a DOMException with the given
-             name, e.g., "TimeoutError" (for compatibility with existing
-             tests, a constant is also supported, e.g., "TIMEOUT_ERR")
-  * object - the thrown exception must have a property called "name" that
-             matches code.name
+  * string - asserts that the thrown exception must be a DOMException
+             with the given name, e.g., "TimeoutError". (For
+             compatibility with existing tests, the name of a
+             DOMException constant can also be given, e.g.,
+             "TIMEOUT_ERR")
+  * object - asserts that the thrown exception must be any other kind
+             of exception, with a property called "name" that matches
+             `code.name`.
 
 `func` - a function that should throw
 


### PR DESCRIPTION
Previous text made it seem like passing any object with the correct "name" property would be fine, but in reality, if you're specifically expecting a DOMException, you should be passing a string. (per @Ms2ger feedback)

Preserved the original wording as much as possible otherwise.

(Probably `assert_throws` itself should check the error type if called with an object, and verify that it's *not* a DOMException. But that's a separate cleanup project.)