### PR TITLE
WIP Add basic 'text-anchor' tests.

### DIFF
--- a/svg/text/reftests/text-text-anchor-001-ref.svg
+++ b/svg/text/reftests/text-text-anchor-001-ref.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 001</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <g id="test-body-reference" style="font-size:16px">
+    <g transform="translate(0,0)">
+      <text x="80" y="114.8">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</text>
+    </g>
+    <g transform="translate(0,60)">
+      <text x="48" y="114.8">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</text>
+    </g>
+    <g transform="translate(0,120)">
+      <text x="16" y="114.8">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-001.svg
+++ b/svg/text/reftests/text-text-anchor-001.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 001</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+    <html:link rel="help"
+          href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+    <html:link rel="match"  href="text-text-anchor-001-ref.svg" />
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <!-- TEMP -->
+  <g id="test-body-reference" style="font-size:16px;fill:red">
+    <g transform="translate(0,0)">
+      <circle cx="80" cy="114.8" r="2" style="fill:red"/>
+      <text x="80" y="114.8">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</text>
+    </g>
+    <g transform="translate(0,60)">
+      <circle cx="240" cy="114.8" r="2" style="fill:red"/>
+      <text x="48" y="114.8">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</text>
+    </g>
+    <g transform="translate(0,120)">
+      <circle cx="400" cy="114.8" r="2" style="fill:red"/>
+      <text x="17" y="114.8">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</text>
+    </g>
+  </g>
+
+  <g id="test-body-content" style="font-size:16px">
+    <g transform="translate(0,0)">
+      <text x="80" y="114.8" style="text-anchor:start">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</text>
+    </g>
+    <g transform="translate(0,60)">
+      <text x="240" y="114.8" style="text-anchor:middle">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</text>
+    </g>
+    <g transform="translate(0,120)">
+      <text x="400" y="114.8" style="text-anchor:end">Lorem ipsum dolor sit amet, consectetur adipisicing elit,</text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-002-ref.svg
+++ b/svg/text/reftests/text-text-anchor-002-ref.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 002</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <g id="test-body-reference" style="font-size:16px">
+    <g transform="translate(0,0)">
+      <text transform="translate(250,10) rotate(90)">
+        <tspan x="90" y="114.8">Lorem ipsum dolor sit amet,</tspan>
+      </text>
+    </g>
+    <g transform="translate(80,0)">
+      <text transform="translate(250,-40) rotate(90)" style="text-anchor:middle">
+        <tspan x="240" y="114.8">Lorem ipsum dolor sit amet,</tspan>
+      </text>
+    </g>
+    <g transform="translate(160,0)">
+      <text transform="translate(250,-90) rotate(90)" style="text-anchor:end">
+        <tspan x="390" y="114.8">Lorem ipsum dolor sit amet,</tspan>
+      </text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-002.svg
+++ b/svg/text/reftests/text-text-anchor-002.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 002</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+    <html:link rel="help"
+          href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+    <html:link rel="match"  href="text-text-anchor-002-ref.svg" />
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <g id="test-body-reference" style="font-size:16px;fill:red">
+    <g transform="translate(0,0)">
+      <circle cx="140" cy="100" r="2" style="fill:red"/>
+      <text transform="translate(250,10) rotate(90)">
+        <tspan x="90" y="114.8">Lorem ipsum dolor sit amet,</tspan>
+      </text>
+    </g>
+    <g transform="translate(80,0)">
+      <circle cx="140" cy="200" r="2" style="fill:red"/>
+      <text transform="translate(250,-40) rotate(90)" style="text-anchor:middle">
+        <tspan x="240" y="114.8">Lorem ipsum dolor sit amet,</tspan>
+      </text>
+    </g>
+    <g transform="translate(160,0)">
+      <circle cx="140" cy="300" r="2" style="fill:red"/>
+      <text transform="translate(250,-90) rotate(90)" style="text-anchor:end">
+        <tspan x="390" y="114.8">Lorem ipsum dolor sit amet,</tspan>
+      </text>
+    </g>
+  </g>
+
+  <g id="test-body-content" style="font-size:16px;writing-mode:tb-rl">
+    <g transform="translate(0,0)">
+      <text x="140" y="100" style="text-anchor:start">Lorem ipsum dolor sit amet,</text>
+    </g>
+    <g transform="translate(80,0)">
+      <text x="140" y="200" style="text-anchor:middle">Lorem ipsum dolor sit amet,</text>
+    </g>
+    <g transform="translate(160,0)">
+      <text x="140" y="300" style="text-anchor:end">Lorem ipsum dolor sit amet,</text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-003-ref.svg
+++ b/svg/text/reftests/text-text-anchor-003-ref.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 003</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <g id="test-body-reference" style="font-size:16px">
+    <g transform="translate(0,0)">
+      <text style="text-anchor:end">
+        <tspan x="400" y="114.8">لكن لا بد أن أوضح لك أن كل هذه الأفكار</tspan>
+      </text>
+    </g>
+    <g transform="translate(0,60)">
+      <text style="text-anchor:middle">
+        <tspan x="240" y="114.8">لكن لا بد أن أوضح لك أن كل هذه الأفكار</tspan>
+      </text>
+    </g>
+    <g transform="translate(0,120)">
+      <text>
+        <tspan x="80" y="114.8">لكن لا بد أن أوضح لك أن كل هذه الأفكار</tspan>
+      </text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-003.svg
+++ b/svg/text/reftests/text-text-anchor-003.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 003</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+    <html:link rel="help"
+          href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+    <html:link rel="match"  href="text-text-anchor-003-ref.svg" />
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <!-- TEMP -->
+  <g id="test-body-reference" style="font-size:16px;fill:red">
+    <g transform="translate(0,0)">
+      <circle cx="400" cy="114.8" r="2" style="fill:red"/>
+      <text style="text-anchor:end">
+        <tspan x="400" y="114.8">لكن لا بد أن أوضح لك أن كل هذه الأفكار</tspan>
+      </text>
+    </g>
+    <g transform="translate(0,60)">
+      <circle cx="240" cy="114.8" r="2" style="fill:red"/>
+      <text style="text-anchor:middle">
+        <tspan x="240" y="114.8">لكن لا بد أن أوضح لك أن كل هذه الأفكار</tspan>
+      </text>
+    </g>
+    <g transform="translate(0,120)">
+      <circle cx="80" cy="114.8" r="2" style="fill:red"/>
+      <text>
+        <tspan x="80" y="114.8">لكن لا بد أن أوضح لك أن كل هذه الأفكار</tspan>
+      </text>
+    </g>
+  </g>
+
+  <g id="test-body-content" style="font-size:16px;direction:rtl">
+    <g transform="translate(0,0)">
+      <text x="400" y="114.8" style="text-anchor:start">لكن لا بد أن أوضح لك أن كل هذه الأفكار</text>
+    </g>
+    <g transform="translate(0,60)">
+      <text x="240" y="114.8" style="text-anchor:middle">لكن لا بد أن أوضح لك أن كل هذه الأفكار</text>
+    </g>
+    <g transform="translate(0,120)">
+      <text x="80" y="114.8" style="text-anchor:end">لكن لا بد أن أوضح لك أن كل هذه الأفكار</text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-102-ref.svg
+++ b/svg/text/reftests/text-text-anchor-102-ref.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 102</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: IPAMincho;
+      src: url("fonts/IPAMincho.woff") format("woff"),
+           local("IPAMincho");
+    }
+    text { font-family: IPAMincho, sans-serif }
+  </style>
+
+  <g id="test-body-reference" style="font-size:16px">
+    <g transform="translate(0,0)">
+      <text x="132 132 132 132 132 132 132" y="114 130 146 162 178 194 210 ">千利奴流乎和加</text>
+    </g>
+    <g transform="translate(80,0)">
+      <text x="140" y="144" style="writing-mode:tb-rl">千利奴流乎和加</text>
+    </g>
+    <g transform="translate(160,0)">
+      <text x="140" y="188" style="writing-mode:tb-rl">千利奴流乎和加</text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-102.svg
+++ b/svg/text/reftests/text-text-anchor-102.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 102</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+    <html:link rel="help"
+          href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+    <html:link rel="match"  href="text-text-anchor-102-ref.svg" />
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: IPAMincho;
+      src: url("fonts/IPaMincho.woff") format("woff"),
+           local("IPAMincho");
+    }
+    text { font-family: IPAMincho, sans-serif }
+  </style>
+
+  <g id="test-body-reference" style="font-size:16px;fill:red">
+    <g transform="translate(0,0)">
+      <circle cx="140" cy="100" r="2" style="fill:red"/>
+      <text x="132 132 132 132 132 132 132" y="114 130 146 162 178 194 210 ">千利奴流乎和加</text>
+    </g>
+    <g transform="translate(80,0)">
+      <circle cx="140" cy="200" r="2" style="fill:red"/>
+      <text x="140" y="144" style="writing-mode:tb-rl">千利奴流乎和加</text>
+    </g>
+    <g transform="translate(160,0)">
+      <circle cx="140" cy="300" r="2" style="fill:red"/>
+      <text x="140" y="188" style="writing-mode:tb-rl">千利奴流乎和加</text>
+    </g>
+  </g>
+
+  <g id="test-body-content" style="font-size:16px;writing-mode:tb-rl">
+    <g transform="translate(0,0)">
+      <text x="140" y="100" style="text-anchor:start">千利奴流乎和加</text>
+    </g>
+    <g transform="translate(80,0)">
+      <text x="140" y="200" style="text-anchor:middle">千利奴流乎和加</text>
+    </g>
+    <g transform="translate(160,0)">
+      <text x="140" y="300" style="text-anchor:end">千利奴流乎和加</text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-201-ref.svg
+++ b/svg/text/reftests/text-text-anchor-201-ref.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 201</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <g id="test-body-reference" style="font-size:16px">
+    <g transform="translate(0,0)">
+      <text x="200" y="114.8">Lorem ipsum dolor</text>
+    </g>
+    <g transform="translate(0,60)">
+      <text x="200" y="114.8" style="text-anchor:middle">sit amet, consectetur</text>
+    </g>
+    <g transform="translate(0,120)">
+      <text x="200" y="114.8" style="text-anchor:end">adipisicing elit,</text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-201.svg
+++ b/svg/text/reftests/text-text-anchor-201.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 201</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+    <html:link rel="help"
+          href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+    <html:link rel="match"  href="text-text-anchor-201-ref.svg" />
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <!-- TEMP -->
+  <g id="test-body-reference" style="font-size:16px;fill:red">
+    <g transform="translate(0,0)">
+      <circle cx="200" cy="114.8" r="2" style="fill:red"/>
+      <text x="200" y="114.8">Lorem ipsum dolor</text>
+    </g>
+    <g transform="translate(0,60)">
+      <circle cx="200" cy="114.8" r="2" style="fill:red"/>
+      <text x="200" y="114.8" style="text-anchor:middle">sit amet, consectetur</text>
+    </g>
+    <g transform="translate(0,120)">
+      <circle cx="200" cy="114.8" r="2" style="fill:red"/>
+      <text x="200" y="114.8" style="text-anchor:end">adipisicing elit,</text>
+    </g>
+  </g>
+
+  <g id="test-body-content" style="font-size:16px">
+      <text>
+        <tspan x="200" y="114.8" style="text-anchor:start">Lorem ipsum dolor</tspan>
+        <tspan x="200" y="174.8" style="text-anchor:middle">sit amet, consectetur</tspan>
+        <tspan x="200" y="234.8" style="text-anchor:end">adipisicing elit,</tspan>
+      </text>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-202-ref.svg
+++ b/svg/text/reftests/text-text-anchor-202-ref.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 202</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <g id="test-body-reference" style="font-size:16px;writing-mode:tb-rl">
+    <g transform="translate(0,0)">
+      <text x="140" y="200">Lorem ipsum dolor</text>
+    </g>
+    <g transform="translate(80,0)">
+      <text x="140" y="200" style="text-anchor:middle">sit amet, consectetur</text>
+    </g>
+    <g transform="translate(160,0)">
+      <text x="140" y="200" style="text-anchor:end">adipisicing elit,</text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-202.svg
+++ b/svg/text/reftests/text-text-anchor-202.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 202</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+    <html:link rel="help"
+          href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+    <html:link rel="match"  href="text-text-anchor-202-ref.svg" />
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <!-- TEMP -->
+  <g id="test-body-reference" style="font-size:16px;writing-mode:tb-rl;fill:red">
+    <g transform="translate(0,0)">
+      <circle cx="140" cy="200" r="2" style="fill:red"/>
+      <text x="140" y="200">Lorem ipsum dolor</text>
+    </g>
+    <g transform="translate(80,0)">
+      <circle cx="140" cy="200" r="2" style="fill:red"/>
+      <text x="140" y="200" style="text-anchor:middle">sit amet, consectetur</text>
+    </g>
+    <g transform="translate(160,0)">
+      <circle cx="140" cy="200" r="2" style="fill:red"/>
+      <text x="140" y="200" style="text-anchor:end">adipisicing elit,</text>
+    </g>
+  </g>
+
+  <g id="test-body-content" style="font-size:16px;writing-mode:tb-rl">
+      <text>
+        <tspan x="140" y="200" style="text-anchor:start">Lorem ipsum dolor</tspan>
+        <tspan x="220" y="200" style="text-anchor:middle">sit amet, consectetur</tspan>
+        <tspan x="300" y="200" style="text-anchor:end">adipisicing elit,</tspan>
+      </text>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-203-ref.svg
+++ b/svg/text/reftests/text-text-anchor-203-ref.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 203</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <g id="test-body-reference" style="font-size:16px">
+    <g transform="translate(0,0)">
+      <text style="text-anchor:end">
+        <tspan x="200" y="114.8">لكن لا بد أن</tspan>
+      </text>
+    </g>
+    <g transform="translate(0,60)">
+      <text style="text-anchor:middle">
+        <tspan x="200" y="114.8" style="text-anchor:middle">أوضح لك أن</tspan>
+      </text>
+    </g>
+    <g transform="translate(0,120)">
+      <text>
+        <tspan x="200" y="114.8" style="text-anchor:start">كل هذه الأفكار</tspan>
+      </text>
+    </g>
+  </g>
+
+</svg>

--- a/svg/text/reftests/text-text-anchor-203.svg
+++ b/svg/text/reftests/text-text-anchor-203.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="svg-root"
+  width="100%" height="100%" viewBox="0 0 480 360"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Text: Text Anchor — 203</title>
+    <html:link rel="author"
+          title="Tavmjong Bah"
+          href="mailto:tavmjong@free.fr"/>
+    <html:link rel="help"
+          href="https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties"/>
+    <html:link rel="match"  href="text-text-anchor-003-ref.svg" />
+  </g>
+
+  <style id="test-font" type="text/css">
+    /* Standard Font (if needed). */
+    @font-face {
+      font-family: FreeSans;
+      src: url("fonts/FreeSans.woff") format("woff"),
+           local("FreeSans");
+    }
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <style id="test-style" type="text/css">
+    /* Style that is being tested (if needed). */
+    text { font-family: FreeSans, sans-serif }
+  </style>
+
+  <!-- TEMP -->
+  <g id="test-body-reference" style="font-size:16px;fill:red">
+    <g transform="translate(0,0)">
+      <circle cx="200" cy="114.8" r="2" style="fill:red"/>
+      <text style="text-anchor:end">
+        <tspan x="200" y="114.8">لكن لا بد أن</tspan>
+      </text>
+    </g>
+    <g transform="translate(0,60)">
+      <circle cx="200" cy="114.8" r="2" style="fill:red"/>
+      <text style="text-anchor:middle">
+        <tspan x="200" y="114.8" style="text-anchor:middle">أوضح لك أن</tspan>
+      </text>
+    </g>
+    <g transform="translate(0,120)">
+      <circle cx="200" cy="114.8" r="2" style="fill:red"/>
+      <text>
+        <tspan x="200" y="114.8" style="text-anchor:start">كل هذه الأفكار</tspan>
+      </text>
+    </g>
+  </g>
+
+  <g id="test-body-content" style="font-size:16px;direction:rtl">
+    <text>
+      <tspan x="200" y="114.8" style="text-anchor:start">لكن لا بد أن</tspan>
+      <tspan x="200" y="174.8" style="text-anchor:middle">أوضح لك أن</tspan>
+      <tspan x="200" y="234.8" style="text-anchor:end">كل هذه الأفكار</tspan>
+    </text>
+  </g>
+
+</svg>


### PR DESCRIPTION
Basic SVG 'text-anchor' tests.
001 LTR Latin
002 Vertical Latin
003 RTL Arabic
102 Vertical Kanji
201 LTR Latin 'tspan'
202 Vertical Latin 'tspan'
203 RTL Arabic 'tspan'

Temporarily, tests include the expected rendering in red below the test along with a red circle to indicate anchor point. Due to how the reference is created, there may be a pixel or so difference in rendering on one or two tests.

Firefox 64 passes all tests except small errors when 'text-anchor is 'mid' on a 'tspan'. (both Firefox and Chrome appear to incorrectly include a space following the tspan in calculating the tspan position).

Chrome 71 passes all except 002, 202, 203.

Inkscape passes all except those using 'tspan'.
