### PR TITLE
Align legacy callback interface tests

### DIFF
--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -69,6 +69,19 @@ test(function(t) {
 test(function(t) {
     var type = "foo";
     var target = document.getElementById("target");
+
+    var eventListener = function() {};
+    eventListener.handleEvent = function() {
+        assert_unreached("`handleEvent` method should not be called on functions");
+    };
+
+    target.addEventListener(type, eventListener);
+    target.dispatchEvent(new Event(type));
+}, "doesn't call `handleEvent` method on callable `EventListener`");
+
+test(function(t) {
+    var type = "foo";
+    var target = document.getElementById("target");
     var uncaughtError;
 
     window.addEventListener("error", function(event) {

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -73,12 +73,13 @@ test(function(t) {
 test(function(t) {
     var type = "foo";
     var target = document.getElementById("target");
-
-    var eventListener = function() {};
+    var calls = 0;
+    var eventListener = function() { calls++; };
     eventListener.handleEvent = t.unreached_func("`handleEvent` method should not be called on functions");
 
     target.addEventListener(type, eventListener);
     target.dispatchEvent(new Event(type));
+    assert_equals(calls, 1);
 }, "doesn't call `handleEvent` method on callable `EventListener`");
 
 test(function(t) {

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -5,13 +5,12 @@
 <script src="/resources/testharnessreport.js"></script>
 <link rel="help" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">
 <div id=log></div>
-<div id=target></div>
 <script>
 setup({ allow_uncaught_exception: true });
 
 test(function(t) {
     var type = "foo";
-    var target = document.getElementById("target");
+    var target = document.createElement("div");
     var eventListener = {
         handleEvent: function(evt) {
             var that = this;
@@ -30,7 +29,7 @@ test(function(t) {
 
 test(function(t) {
     var type = "foo";
-    var target = document.getElementById("target");
+    var target = document.createElement("div");
     var thrownError = { name: "test" };
     var uncaughtError;
     var errorHandler = function(event) {
@@ -54,7 +53,7 @@ test(function(t) {
 
 test(function(t) {
     var type = "foo";
-    var target = document.getElementById("target");
+    var target = document.createElement("div");
     var calls = 0;
 
     target.addEventListener(type, {
@@ -72,7 +71,7 @@ test(function(t) {
 
 test(function(t) {
     var type = "foo";
-    var target = document.getElementById("target");
+    var target = document.createElement("div");
     var calls = 0;
     var eventListener = function() { calls++; };
     eventListener.handleEvent = t.unreached_func("`handleEvent` method should not be called on functions");
@@ -84,7 +83,7 @@ test(function(t) {
 
 test(function(t) {
     var type = "foo";
-    var target = document.getElementById("target");
+    var target = document.createElement("div");
     var uncaughtError;
     var errorHandler = function(event) {
         uncaughtError = event.error;
@@ -105,7 +104,7 @@ test(function(t) {
 
 test(function(t) {
     var type = "foo";
-    var target = document.getElementById("target");
+    var target = document.createElement("div");
     var uncaughtError;
     var errorHandler = function(event) {
         uncaughtError = event.error;

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -94,5 +94,22 @@ test(function(t) {
 
     target.dispatchEvent(new Event(type));
     assert_true(uncaughtError instanceof TypeError);
-}, "throws if `handleEvent` is not callable");
+}, "throws if `handleEvent` is falsy and not callable");
+
+test(function(t) {
+    var type = "foo";
+    var target = document.getElementById("target");
+    var uncaughtError;
+
+    window.addEventListener("error", function(event) {
+        uncaughtError = event.error;
+    });
+
+    target.addEventListener(type, {
+        handleEvent: 1,
+    });
+
+    target.dispatchEvent(new Event(type));
+    assert_true(uncaughtError instanceof TypeError);
+}, "throws if `handleEvent` is thruthy and not callable");
 </script>

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -75,9 +75,7 @@ test(function(t) {
     var target = document.getElementById("target");
 
     var eventListener = function() {};
-    eventListener.handleEvent = function() {
-        assert_unreached("`handleEvent` method should not be called on functions");
-    };
+    eventListener.handleEvent = t.unreached_func("`handleEvent` method should not be called on functions");
 
     target.addEventListener(type, eventListener);
     target.dispatchEvent(new Event(type));

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -33,9 +33,13 @@ test(function(t) {
     var target = document.getElementById("target");
     var thrownError = { name: "test" };
     var uncaughtError;
-
-    window.addEventListener("error", function(event) {
+    var errorHandler = function(event) {
         uncaughtError = event.error;
+    };
+
+    window.addEventListener("error", errorHandler);
+    t.add_cleanup(function() {
+        window.removeEventListener("error", errorHandler);
     });
 
     target.addEventListener(type, {
@@ -83,9 +87,13 @@ test(function(t) {
     var type = "foo";
     var target = document.getElementById("target");
     var uncaughtError;
-
-    window.addEventListener("error", function(event) {
+    var errorHandler = function(event) {
         uncaughtError = event.error;
+    };
+
+    window.addEventListener("error", errorHandler);
+    t.add_cleanup(function() {
+        window.removeEventListener("error", errorHandler);
     });
 
     target.addEventListener(type, {
@@ -100,9 +108,13 @@ test(function(t) {
     var type = "foo";
     var target = document.getElementById("target");
     var uncaughtError;
-
-    window.addEventListener("error", function(event) {
+    var errorHandler = function(event) {
         uncaughtError = event.error;
+    };
+
+    window.addEventListener("error", errorHandler);
+    t.add_cleanup(function() {
+        window.removeEventListener("error", errorHandler);
     });
 
     target.addEventListener(type, {

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -31,7 +31,7 @@ test(function(t) {
 test(function(t) {
     var type = "foo";
     var target = document.getElementById("target");
-    var thrownError = new Error();
+    var thrownError = { name: "test" };
     var uncaughtError;
 
     window.addEventListener("error", function(event) {

--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -124,6 +124,20 @@ test(function()
     assert_node(walker.currentNode, { type: Element, id: 'root' });
 }, 'Testing with filter function that throws');
 
+test(function() {
+    var testError = new Error();
+    var filter = {
+        get acceptNode() {
+            throw testError;
+        },
+    };
+
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
+    assert_throws(testError, function() { walker.firstChild(); });
+    assert_node(walker.currentNode, { type: Element, id: 'root' });
+    assert_throws(testError, function() { walker.nextNode(); });
+    assert_node(walker.currentNode, { type: Element, id: 'root' });
+}, "rethrows errors when getting `acceptNode`");
 test(function()
 {
     var test_error = { name: "test" };

--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -138,6 +138,24 @@ test(function() {
     assert_throws(testError, function() { walker.nextNode(); });
     assert_node(walker.currentNode, { type: Element, id: 'root' });
 }, "rethrows errors when getting `acceptNode`");
+
+test(function() {
+    var calls = 0;
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, {
+        get acceptNode() {
+            calls++;
+            return function() {
+                return NodeFilter.FILTER_ACCEPT;
+            };
+        },
+    });
+
+    assert_equals(calls, 0);
+    walker.nextNode();
+    walker.nextNode();
+    assert_equals(calls, 2);
+}, "performs `Get` on every traverse");
+
 test(function()
 {
     var test_error = { name: "test" };

--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -113,17 +113,6 @@ test(function()
 
 test(function()
 {
-    var filter = {
-        acceptNode: function(node) {
-            return NodeFilter.FILTER_ACCEPT;
-        }
-    };
-    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
-    assert_node(walker.firstChild(), { type: Element, id: 'A1' });
-}, 'Testing acceptNode callee');
-
-test(function()
-{
     var test_error = { name: "test" };
     var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT,
                                            function(node) {

--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -125,7 +125,7 @@ test(function()
 }, 'Testing with filter function that throws');
 
 test(function() {
-    var testError = new Error();
+    var testError = { name: "test" };
     var filter = {
         get acceptNode() {
             throw testError;

--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -8,6 +8,7 @@ Test adapted from https://dxr.mozilla.org/chromium/source/src/third_party/WebKit
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="traversal-support.js"></script>
+<link rel="help" href="https://dom.spec.whatwg.org/#callbackdef-nodefilter">
 <div id=log></div>
 </head>
 <body>

--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -102,10 +102,10 @@ test(function()
     assert_node(walker.currentNode, { type: Element, id: 'root' });
 }, 'Testing with object with non-function acceptNode property');
 
-test(function()
+test(function(t)
 {
     var filter = function() { return NodeFilter.FILTER_ACCEPT; };
-    filter.acceptNode = function(node) { return NodeFilter.FILTER_SKIP; };
+    filter.acceptNode = t.unreached_func("`acceptNode` method should not be called on functions");
     var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.nextNode(), { type: Element, id: 'B1' });


### PR DESCRIPTION
Follow-up of #15105. Safari seem to swallow an exception from `acceptNode` getter and throw `TypeError` instead. I will make bug reports shortly.