### PR TITLE
Correct the order of owner and repo args in tag_master.py

### DIFF
--- a/tools/ci/tag_master.py
+++ b/tools/ci/tag_master.py
@@ -17,9 +17,9 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def get_pr(repo, owner, sha):
+def get_pr(owner, repo, sha):
     url = ("https://api.github.com/search/issues?q=type:pr+is:merged+repo:%s/%s+sha:%s" %
-           (repo, owner, sha))
+           (owner, repo, sha))
     try:
         resp = urllib2.urlopen(url)
         body = resp.read()

--- a/tools/ci/tag_master.py
+++ b/tools/ci/tag_master.py
@@ -51,11 +51,11 @@ def get_pr(repo, owner, sha):
     return pr["number"]
 
 
-def tag(repo, owner, sha, tag):
+def tag(owner, repo, sha, tag):
     data = json.dumps({"ref": "refs/tags/%s" % tag,
                        "sha": sha})
     try:
-        url = "https://api.github.com/repos/%s/%s/git/refs" % (repo, owner)
+        url = "https://api.github.com/repos/%s/%s/git/refs" % (owner, repo)
         req = urllib2.Request(url, data=data)
 
         base64string = base64.b64encode(os.environ["GH_TOKEN"])


### PR DESCRIPTION
This was harmless because the order was reversed both in the arguments
and where used, but did cause me confusion when comparing to docs:
https://developer.github.com/v3/git/refs/#create-a-reference