### PR TITLE
Fix useless test in dataset-delete.html.

### DIFF
--- a/html/dom/elements/global-attributes/dataset-delete.html
+++ b/html/dom/elements/global-attributes/dataset-delete.html
@@ -32,8 +32,15 @@
         "Deleting element.dataset['-'] should also remove an attribute with name 'data--' should it exist.");
       test(function() { assert_true(testDelete('data--foo', 'Foo')); },
         "Deleting element.dataset['Foo'] should also remove an attribute with name 'data--foo' should it exist.");
-      test(function() { assert_true(testDeleteNoAdd('data--foo', '-foo')); },
-        "Deleting element.dataset['-foo'] should also remove an attribute with name 'data--foo' should it exist.");
+      test(function() {
+        var d = document.createElement("div");
+        d.setAttribute('data--foo', "value");
+        assert_equals(d.dataset['-foo'], undefined);
+        assert_false('-foo' in d.dataset);
+        delete d.dataset['-foo'];
+        assert_true(d.hasAttribute('data--foo'));
+        assert_equals(d.getAttribute('data--foo'), "value");
+      }, "Deleting element.dataset['-foo'] should not remove an attribute with name 'data--foo' should it exist.");
       test(function() { assert_true(testDelete('data---foo', '-Foo')); },
         "Deleting element.dataset['-Foo'] should also remove an attribute with name 'data---foo' should it exist.");
       test(function() { assert_true(testDelete('data-', '')); },


### PR DESCRIPTION
This is not currently testing anything useful, and hasn't been since I
introduced this subtest in d5a8cbe61b61c7fa9891f380bdfe1e0c142fbc84 back in
2012.

However, the test I meant to write was not correct either, since the steps to
delete an existing named property in HTML are only run if the property is
exposed on the object, which isn't the case here.