### PR TITLE
[Azure Pipelines] Only publish `./wpt run` results if all succeeded

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -151,7 +151,6 @@ jobs:
     displayName: 'Publish results'
     inputs:
       artifactName: 'results'
-    condition: succeededOrFailed()
 
 # The InvokeRESTAPI task can only run in a server job.
 - job: all_post


### PR DESCRIPTION
Publishing on failure was originally added to aid debugging, but it
also means that partial results may be published, and the wpt.fyi
results receiver would have to notice this.

If debugging is needed, better perhaps to publish TBPL logs
unconditionally, and separately from the reports.