### PR TITLE
[css-font-loading] Handle a fontFace.loaded promise rejection in idlharness test

### DIFF
--- a/css/css-font-loading/idlharness.https.html
+++ b/css/css-font-loading/idlharness.https.html
@@ -14,10 +14,15 @@ idl_test(
   idl_array => {
     idl_array.add_objects({
       Document: ['document'],
-      FontFace: ['new FontFace("family", "src")'],
-      FontFaceSetLoadEvent: ['new FontFaceSetLoadEvent("type")'],
+      FontFace: ['fontFace'],
+      FontFaceSetLoadEvent: ['fontFaceSetLoadEvent'],
       FontFaceSet: ['document.fonts'],
     });
+    self.fontFace = new FontFace("family", "src");
+    // The `fontFace.loaded` promise will be rejected, so handle that to
+    // avoid an unhandled promise rejection manifesting as a harness error.
+    self.fontFace.loaded.catch(() => {});
+    self.fontFaceSetLoadEvent = new FontFaceSetLoadEvent("type");
   }
 );
 </script>


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/wpt/issues/14862.