### PR TITLE
[wasm] use DOMString in JS-API: Module.customSections

### DIFF
--- a/wasm/jsapi/module/customSections.any.js
+++ b/wasm/jsapi/module/customSections.any.js
@@ -156,9 +156,7 @@ test(() => {
   assert_sections(WebAssembly.Module.customSections(module, "na\uFFFDme"), [
     bytes,
   ]);
-  assert_sections(WebAssembly.Module.customSections(module, "na\uDC01me"), [
-    bytes,
-  ]);
+  assert_sections(WebAssembly.Module.customSections(module, "na\uDC01me"), []);
 }, "Custom sections with U+FFFD");
 
 test(() => {


### PR DESCRIPTION
See https://github.com/WebAssembly/spec/pull/947. cc @Ms2ger 

`interfaces/wasm-js-api.idl`'s customSections already uses a DOMString, that said I don't know if it needs to be updated.