### PR TITLE
WritableStream: fix two small coverage gaps

### DIFF
--- a/streams/writable-streams/aborting.any.js
+++ b/streams/writable-streams/aborting.any.js
@@ -1368,3 +1368,10 @@ promise_test(t => {
                               e => assert_equals(e, 'string argument', 'e should be \'string argument\''));
   });
 }, 'abort with a string argument should set the stored error to that argument');
+
+promise_test(t => {
+  const ws = new WritableStream();
+  const writer = ws.getWriter();
+  return promise_rejects(t, new TypeError(), ws.abort(), 'abort should reject')
+    .then(() => writer.ready);
+}, 'abort on a locked stream should reject');

--- a/streams/writable-streams/general.any.js
+++ b/streams/writable-streams/general.any.js
@@ -268,3 +268,10 @@ test(() => {
   assert_true(sub.extraFunction(),
               'extraFunction() should be present on Subclass object');
 }, 'Subclassing WritableStream should work');
+
+test(() => {
+  const ws = new WritableStream();
+  assert_false(ws.locked, 'stream should not be locked');
+  ws.getWriter();
+  assert_true(ws.locked, 'stream should be locked');
+}, 'the locked getter should return true if the stream has a writer');


### PR DESCRIPTION
Verify that stream.abort() fails if the stream is locked.
Verify that the .locked getter becomes true when a writer is acquired.