### PR TITLE
Enabling older browsers values for KeyboardEvent.key in WebDriver tests

### DIFF
--- a/webdriver/tests/perform_actions/key_events.py
+++ b/webdriver/tests/perform_actions/key_events.py
@@ -5,7 +5,7 @@ import pytest
 from tests.perform_actions.support.keys import ALL_EVENTS, Keys, ALTERNATIVE_KEY_NAMES
 from tests.perform_actions.support.refine import filter_dict, get_events, get_keys
 
-'''
+
 def test_keyup_only_sends_no_events(session, key_reporter, key_chain):
     key_chain.key_up("a").perform()
 
@@ -50,7 +50,7 @@ def test_modifier_key_sends_correct_events(session, key_reporter, key_chain, key
     assert events == expected
 
     assert len(get_keys(key_reporter)) == 0
-'''
+
 
 @pytest.mark.parametrize("key,event", [
     (Keys.ESCAPE, "ESCAPE"),
@@ -92,7 +92,7 @@ def test_non_printable_key_sends_events(session, key_reporter, key_chain, key, e
 
     assert len(get_keys(key_reporter)) == 0
 
-'''
+
 @pytest.mark.parametrize("value,code", [
     (u"a", "KeyA",),
     ("a", "KeyA",),
@@ -216,4 +216,3 @@ def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expec
         assert entered_keys == expected["key"]
     else:
         assert len(entered_keys) == 0
-'''

--- a/webdriver/tests/perform_actions/key_events.py
+++ b/webdriver/tests/perform_actions/key_events.py
@@ -5,7 +5,7 @@ import pytest
 from tests.perform_actions.support.keys import ALL_EVENTS, Keys, ALTERNATIVE_KEY_NAMES
 from tests.perform_actions.support.refine import filter_dict, get_events, get_keys
 
-
+'''
 def test_keyup_only_sends_no_events(session, key_reporter, key_chain):
     key_chain.key_up("a").perform()
 
@@ -50,7 +50,7 @@ def test_modifier_key_sends_correct_events(session, key_reporter, key_chain, key
     assert events == expected
 
     assert len(get_keys(key_reporter)) == 0
-
+'''
 
 @pytest.mark.parametrize("key,event", [
     (Keys.ESCAPE, "ESCAPE"),
@@ -72,20 +72,27 @@ def test_non_printable_key_sends_events(session, key_reporter, key_chain, key, e
         {"code": code, "key": value, "type": "keyup"},
     ]
 
+    # Make a copy for alternate key property values
+    alt_expected = list(expected)
+    if (event in ALTERNATIVE_KEY_NAMES):
+        for e in alt_expected:
+            e["key"] = ALTERNATIVE_KEY_NAMES[event]
+
     events = [filter_dict(e, expected[0]) for e in all_events]
     if len(events) > 0 and events[0]["code"] is None:
         # Remove 'code' entry if browser doesn't support it
         expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
+        alt_expected = [filter_dict(e, {"key": "", "type": ""}) for e in alt_expected]
         events = [filter_dict(e, expected[0]) for e in events]
     if len(events) == 2:
         # most browsers don't send a keypress for non-printable keys
-        assert events == [expected[0], expected[2]]
+        assert events == [expected[0], expected[2]] or events == [alt_expected[0], alt_expected[2]]
     else:
-        assert events == expected
+        assert events == expected or events == alt_expected
 
     assert len(get_keys(key_reporter)) == 0
 
-
+'''
 @pytest.mark.parametrize("value,code", [
     (u"a", "KeyA",),
     ("a", "KeyA",),
@@ -209,3 +216,4 @@ def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expec
         assert entered_keys == expected["key"]
     else:
         assert len(entered_keys) == 0
+'''

--- a/webdriver/tests/perform_actions/key_events.py
+++ b/webdriver/tests/perform_actions/key_events.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.perform_actions.support.keys import ALL_EVENTS, Keys
+from tests.perform_actions.support.keys import ALL_EVENTS, Keys, ALTERNATIVE_KEY_NAMES
 from tests.perform_actions.support.refine import filter_dict, get_events, get_keys
 
 
@@ -189,6 +189,11 @@ def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expec
 
     del expected["value"]
 
+    # make another copy for alternative key names
+    alt_expected = dict(expected)
+    if (name in ALTERNATIVE_KEY_NAMES):
+        alt_expected["key"] = ALTERNATIVE_KEY_NAMES[name]
+
     # check and remove keys that aren't in expected
     assert first_event["type"] == "keydown"
     assert first_event["repeat"] is False
@@ -196,7 +201,8 @@ def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expec
     if first_event["code"] is None:
         del first_event["code"]
         del expected["code"]
-    assert first_event == expected
+        del alt_expected["code"]
+    assert first_event == expected or first_event == alt_expected
     # only printable characters should be recorded in input field
     entered_keys = get_keys(key_reporter)
     if len(expected["key"]) == 1:

--- a/webdriver/tests/perform_actions/support/keys.py
+++ b/webdriver/tests/perform_actions/support/keys.py
@@ -740,6 +740,27 @@ ALL_EVENTS = {
     }
 }
 
+ALTERNATIVE_KEY_NAMES = {
+    "ADD": "Add",
+    "DECIMAL": "Decimal",
+    "DELETE": "Del",
+    "DIVIDE": "Divide",
+    "DOWN": "Down",
+    "ESCAPE": "Esc",
+    "LEFT": "Left",
+    "MULTIPLY": "Multiply",
+    "R_ARROWDOWN": "Down",
+    "R_ARROWLEFT": "Left",
+    "R_ARROWRIGHT": "Right",
+    "R_ARROWUP": "Up",
+    "R_DELETE": "Del",
+    "RIGHT": "Right",
+    "SEPARATOR": "Separator",
+    "SPACE": "Spacebar",
+    "SUBTRACT": "Subtract",
+    "UP": "Up",
+}
+
 if sys.platform == "darwin":
     MODIFIER_KEY = Keys.META
 else:


### PR DESCRIPTION
When propagating keyboard events, older browsers use different strings
for the "key" property of the KeyboardEvent object. This commit enables
the ability of the WebDriver tests for keyboard events to validate the
comparison to these older values in addition to the values used by
modern browsers. See the footnotes in the sections of the following:

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values