### PR TITLE
Enabling older browsers values for KeyboardEvent.key in WebDriver tests

### DIFF
--- a/webdriver/tests/perform_actions/key_events.py
+++ b/webdriver/tests/perform_actions/key_events.py
@@ -1,8 +1,9 @@
 # META: timeout=long
 
 import pytest
+import copy
 
-from tests.perform_actions.support.keys import ALL_EVENTS, Keys
+from tests.perform_actions.support.keys import ALL_EVENTS, Keys, ALTERNATIVE_KEY_NAMES
 from tests.perform_actions.support.refine import filter_dict, get_events, get_keys
 
 
@@ -72,16 +73,24 @@ def test_non_printable_key_sends_events(session, key_reporter, key_chain, key, e
         {"code": code, "key": value, "type": "keyup"},
     ]
 
+    # Make a copy for alternate key property values
+    # Note: only keydown and keyup are affected by alternate key names
+    alt_expected = copy.deepcopy(expected)
+    if (event in ALTERNATIVE_KEY_NAMES):
+        alt_expected[0]["key"] = ALTERNATIVE_KEY_NAMES[event]
+        alt_expected[2]["key"] = ALTERNATIVE_KEY_NAMES[event]
+
     events = [filter_dict(e, expected[0]) for e in all_events]
     if len(events) > 0 and events[0]["code"] is None:
         # Remove 'code' entry if browser doesn't support it
         expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
+        alt_expected = [filter_dict(e, {"key": "", "type": ""}) for e in alt_expected]
         events = [filter_dict(e, expected[0]) for e in events]
     if len(events) == 2:
         # most browsers don't send a keypress for non-printable keys
-        assert events == [expected[0], expected[2]]
+        assert events == [expected[0], expected[2]] or events == [alt_expected[0], alt_expected[2]]
     else:
-        assert events == expected
+        assert events == expected or events == alt_expected
 
     assert len(get_keys(key_reporter)) == 0
 
@@ -166,7 +175,6 @@ def test_sequence_of_keydown_printable_characters_sends_events(session, key_repo
 
     assert get_keys(key_reporter) == "ef"
 
-
 @pytest.mark.parametrize("name,expected", ALL_EVENTS.items())
 def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expected):
     if name.startswith("F"):
@@ -189,6 +197,11 @@ def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expec
 
     del expected["value"]
 
+    # make another copy for alternative key names
+    alt_expected = copy.deepcopy(expected)
+    if (name in ALTERNATIVE_KEY_NAMES):
+        alt_expected["key"] = ALTERNATIVE_KEY_NAMES[name]
+
     # check and remove keys that aren't in expected
     assert first_event["type"] == "keydown"
     assert first_event["repeat"] is False
@@ -196,7 +209,8 @@ def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expec
     if first_event["code"] is None:
         del first_event["code"]
         del expected["code"]
-    assert first_event == expected
+        del alt_expected["code"]
+    assert first_event == expected or first_event == alt_expected
     # only printable characters should be recorded in input field
     entered_keys = get_keys(key_reporter)
     if len(expected["key"]) == 1:

--- a/webdriver/tests/perform_actions/key_events.py
+++ b/webdriver/tests/perform_actions/key_events.py
@@ -76,7 +76,7 @@ def test_non_printable_key_sends_events(session, key_reporter, key_chain, key, e
     # Make a copy for alternate key property values
     # Note: only keydown and keyup are affected by alternate key names
     alt_expected = copy.deepcopy(expected)
-    if (event in ALTERNATIVE_KEY_NAMES):
+    if event in ALTERNATIVE_KEY_NAMES:
         alt_expected[0]["key"] = ALTERNATIVE_KEY_NAMES[event]
         alt_expected[2]["key"] = ALTERNATIVE_KEY_NAMES[event]
 
@@ -199,7 +199,7 @@ def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expec
 
     # make another copy for alternative key names
     alt_expected = copy.deepcopy(expected)
-    if (name in ALTERNATIVE_KEY_NAMES):
+    if name in ALTERNATIVE_KEY_NAMES:
         alt_expected["key"] = ALTERNATIVE_KEY_NAMES[name]
 
     # check and remove keys that aren't in expected

--- a/webdriver/tests/perform_actions/key_events.py
+++ b/webdriver/tests/perform_actions/key_events.py
@@ -175,6 +175,7 @@ def test_sequence_of_keydown_printable_characters_sends_events(session, key_repo
 
     assert get_keys(key_reporter) == "ef"
 
+
 @pytest.mark.parametrize("name,expected", ALL_EVENTS.items())
 def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expected):
     if name.startswith("F"):

--- a/webdriver/tests/perform_actions/pointer.py
+++ b/webdriver/tests/perform_actions/pointer.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 import pytest
 
 from webdriver.error import NoSuchWindowException

--- a/webdriver/tests/perform_actions/support/keys.py
+++ b/webdriver/tests/perform_actions/support/keys.py
@@ -740,6 +740,27 @@ ALL_EVENTS = {
     }
 }
 
+ALTERNATIVE_KEY_NAMES = {
+    "ADD": "Add",
+    "DECIMAL": "Decimal",
+    "DELETE": "Del",
+    "DIVIDE": "Divide",
+    "DOWN": "Down",
+    "ESCAPE": "Esc",
+    "LEFT": "Left",
+    "MULTIPLY": "Multiply",
+    "R_ARROWDOWN": "Down",
+    "R_ARROWLEFT": "Left",
+    "R_ARROWRIGHT": "Right",
+    "R_ARROWUP": "Up",
+    "R_DELETE": "Del",
+    "RIGHT": "Right",
+    "SEPARATOR": "Separator",
+    "SPACE": "Spacebar",
+    "SUBTRACT": "Subtract",
+    "UP": "Up",
+}
+
 if sys.platform == "darwin":
     MODIFIER_KEY = Keys.META
 else:


### PR DESCRIPTION
When propagating keyboard events, older browsers use different strings
for the "key" property of the KeyboardEvent object. This commit enables
the ability of the WebDriver tests for keyboard events to validate the
comparison to these older values in addition to the values used by
modern browsers. See the footnotes in the sections of the following:

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values