### PR TITLE
Replicating "Alt" key workaround for IE WebDriver tests

### DIFF
--- a/webdriver/tests/perform_actions/key_events.py
+++ b/webdriver/tests/perform_actions/key_events.py
@@ -31,7 +31,7 @@ def test_modifier_key_sends_correct_events(session, key_reporter, key_chain, key
     code = ALL_EVENTS[event]["code"]
     value = ALL_EVENTS[event]["key"]
 
-    if (session.capabilities["browserName"] == 'internet explorer'):
+    if session.capabilities["browserName"] == "internet explorer":
         key_reporter.click()
         session.execute_script("resetEvents();")
     key_chain \
@@ -180,7 +180,7 @@ def test_special_key_sends_keydown(session, key_reporter, key_chain, name, expec
             document.body.addEventListener("keydown",
                     function(e) { e.preventDefault() });
         """)
-    if (session.capabilities["browserName"] == 'internet explorer'):
+    if session.capabilities["browserName"] == "internet explorer":
         key_reporter.click()
         session.execute_script("resetEvents();")
     key_chain.key_down(getattr(Keys, name)).perform()

--- a/webdriver/tests/perform_actions/key_events.py
+++ b/webdriver/tests/perform_actions/key_events.py
@@ -31,6 +31,9 @@ def test_modifier_key_sends_correct_events(session, key_reporter, key_chain, key
     code = ALL_EVENTS[event]["code"]
     value = ALL_EVENTS[event]["key"]
 
+    if (session.capabilities["browserName"] == 'internet explorer'):
+        key_reporter.click()
+        session.execute_script("resetEvents();")
     key_chain \
         .key_down(key) \
         .key_up(key) \


### PR DESCRIPTION
When the Alt key is pressed on Windows, it activates the menu bar for
the focused application. This means that subsequent operations must
first dismiss the menu before being able to carry on. This commit
for Internet Explorer duplicates the workaround for Alt keys from
the test_special_key_sends_keydown subtest in key_events.py to the
test_modifier_key_sends_correct_events subtest.