### PR TITLE
Update dynamic import tests now HTML event handler functions do not have [[ScriptOrModule]] set

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/Function.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/Function.js
@@ -1,1 +1,2 @@
+// import()s in a dynamically created function are resolved relative to the script.
 Function(`import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`)();

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/eval.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/eval.js
@@ -1,1 +1,2 @@
+// import()s in eval are resolved relative to the script.
 eval(`import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`);

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/inline-event-handlers-UA-code.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/inline-event-handlers-UA-code.js
@@ -1,2 +1,3 @@
-window.dummyDiv.setAttribute("onclick", `import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`);
+// import()s in an event handler are resolved relative to the document base.
+window.dummyDiv.setAttribute("onclick", `import('../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`);
 window.dummyDiv.click(); // different from **on**click()

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/reflected-inline-event-handlers.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/reflected-inline-event-handlers.js
@@ -1,2 +1,3 @@
-window.dummyDiv.setAttribute("onclick", `import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`);
+// import()s in an event handler are resolved relative to the document base.
+window.dummyDiv.setAttribute("onclick", `import('../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`);
 window.dummyDiv.onclick();

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/setTimeout.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/setTimeout.js
@@ -1,1 +1,2 @@
+// import()s in a timeout handler are resolved relative to the script.
 setTimeout(`import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`, 0);

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
@@ -37,7 +37,7 @@ function assertSuccessful(module) {
 promise_test(t => {
   const promise = createTestPromise(t);
 
-  setTimeout(`import('../imports-a.js?label=setTimeout').then(window.unreached, window.continueTest)`, 0);
+  setTimeout(`import('../imports-a.js?label=setTimeout').then(window.continueTest, window.errorTest)`, 0);
 
   return promise.then(assertSuccessful);
 }, "setTimeout must inherit the nonce from the triggering script, thus execute");
@@ -81,8 +81,8 @@ promise_test(t => {
   );
   dummyDiv.onclick();
 
-  return promise.then(assertSuccessful);
-}, "reflected inline event handlers must inherit the nonce from the triggering script, thus execute");
+  return promise_rejects(t, new TypeError(), promise);
+}, "reflected inline event handlers must not inherit the nonce from the triggering script, thus fail");
 
 promise_test(t => {
   t.add_cleanup(() => {
@@ -99,6 +99,6 @@ promise_test(t => {
   assert_equals(typeof dummyDiv.onclick, "function", "the browser must be able to parse a string containing the import() syntax into a function");
   dummyDiv.click(); // different from **on**click()
 
-  return promise.then(assertSuccessful);
-}, "inline event handlers triggered via UA code must inherit the nonce from the triggering script, thus execute");
+  return promise_rejects(t, new TypeError(), promise);
+}, "inline event handlers triggered via UA code must not inherit the nonce from the triggering script, thus fail");
 </script>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
@@ -36,7 +36,7 @@ function assertSuccessful(module) {
 promise_test(t => {
   const promise = createTestPromise(t);
 
-  setTimeout(`import('../imports-a.js?label=setTimeout').then(window.unreached, window.continueTest)`, 0);
+  setTimeout(`import('../imports-a.js?label=setTimeout').then(window.continueTest, window.errorTest)`, 0);
 
   return promise.then(assertSuccessful);
 }, "setTimeout must inherit the nonce from the triggering script, thus execute");
@@ -80,8 +80,8 @@ promise_test(t => {
   );
   dummyDiv.onclick();
 
-  return promise.then(assertSuccessful);
-}, "reflected inline event handlers must inherit the nonce from the triggering script, thus execute");
+  return promise_rejects(t, new TypeError(), promise);
+}, "reflected inline event handlers must not inherit the nonce from the triggering script, thus fail");
 
 promise_test(t => {
   t.add_cleanup(() => {
@@ -98,6 +98,6 @@ promise_test(t => {
   assert_equals(typeof dummyDiv.onclick, 'function', "the browser must be able to parse a string containing the import() syntax into a function");
   dummyDiv.click(); // different from **on**click()
 
-  return promise.then(assertSuccessful);
-}, "inline event handlers triggered via UA code must inherit the nonce from the triggering script, thus execute");
+  return promise_rejects(t, new TypeError(), promise);
+}, "inline event handlers triggered via UA code must not inherit the nonce from the triggering script, thus fail");
 </script>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-other-document.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-other-document.html
@@ -26,14 +26,6 @@ function startTest() {
     "the Function constructor"(x) {
       otherWindow.Function(x)();
     },
-    "reflected inline event handlers"(x) {
-      otherDiv.setAttribute("onclick", x);
-      otherDiv.onclick();
-    },
-    "inline event handlers triggered by JS"(x) {
-      otherDiv.setAttribute("onclick", x);
-      otherDiv.click(); // different from .**on**click()
-    }
   };
 
   for (const [label, evaluator] of Object.entries(evaluators)) {
@@ -46,6 +38,35 @@ function startTest() {
       const promise = createTestPromise();
 
       evaluator(`import('../imports-a.js?label=${label}').then(window.continueTest, window.errorTest);`);
+
+      return promise.then(module => {
+        assert_true(otherWindow.evaluated_imports_a, "The module must have been evaluated");
+        assert_equals(module.A.from, "imports-a.js", "The module namespace object must be correct");
+      });
+    }, label + " should successfully import");
+  };
+
+  const eventHandlerEvaluators = {
+    "reflected inline event handlers"(x) {
+      otherDiv.setAttribute("onclick", x);
+      otherDiv.onclick();
+    },
+    "inline event handlers triggered by JS"(x) {
+      otherDiv.setAttribute("onclick", x);
+      otherDiv.click(); // different from .**on**click()
+    }
+  };
+
+  for (const [label, evaluator] of Object.entries(eventHandlerEvaluators)) {
+    promise_test(t => {
+      t.add_cleanup(() => {
+        otherDiv.removeAttribute("onclick");
+        delete otherWindow.evaluated_imports_a;
+      });
+
+      const promise = createTestPromise();
+
+      evaluator(`import('../../imports-a.js?label=${label}').then(window.continueTest, window.errorTest);`);
 
       return promise.then(module => {
         assert_true(otherWindow.evaluated_imports_a, "The module must have been evaluated");


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/wpt/issues/15183

This updates paths/expected nonce behaviour now some methods of loading are not based off the current script.

cc @domenic 