### PR TITLE
Set a viewport meta tag to a intersection observer test

### DIFF
--- a/intersection-observer/root-margin.html
+++ b/intersection-observer/root-margin.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="./resources/intersection-observer-test-utils.js"></script>


### PR DESCRIPTION
To avoid the content is zoomed out and to avoid expanding the layout viewport
to the minimum-scale size.

On mobile without specifying the viewport meta tag, the target element,
positioned at the center of the contents, is initially visible because the
content is zoomed out to some extent.  But the test supposes that the target
element is scrolled out of view in the first place and is moved into the
root margin after setting scrollLeft to 100 in step0().  Thus all subsequent
test cases don't work as expected.