### PR TITLE
[html] Restore coverage for query encoding

### DIFF
--- a/html/infrastructure/urls/resolving-urls/query-encoding/attributes.sub.html
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/attributes.sub.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset={{GET[encoding]}}> <!-- ends up as <meta charset> by default which is windows-1252 -->
+<meta name=variant content="?encoding=windows-1252">
 <meta name=variant content="?encoding=x-cp1251">
 <meta name=variant content="?encoding=utf8">
 <script src=/resources/testharness.js></script>

--- a/html/infrastructure/urls/resolving-urls/query-encoding/location.sub.html
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/location.sub.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset={{GET[encoding]}}> <!-- ends up as <meta charset> by default which is windows-1252 -->
+<meta name=variant content="?encoding=windows-1252">
 <meta name=variant content="?encoding=x-cp1251">
 <meta name=variant content="?encoding=utf8">
 <script src=/resources/testharness.js></script>

--- a/html/infrastructure/urls/resolving-urls/query-encoding/navigation.sub.html
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/navigation.sub.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset={{GET[encoding]}}> <!-- ends up as <meta charset> by default which is windows-1252 -->
+<meta name=variant content="?encoding=windows-1252">
 <meta name=variant content="?encoding=x-cp1251">
 <meta name=variant content="?encoding=utf8">
 <script src=/resources/testharness.js></script>


### PR DESCRIPTION
When the query encoding navigation tests were refactored to use WPT's
"variant" feature [1], the new structure omitted one of the encodings
which was previously tested. Although the encoding will be used when a
variant is not specified, the automation tooling only uses variants
which are explicitly specified. This can be observed through the
`--list-tests` flag of the `wpt run` command:

    $ ./wpt run --list-tests firefox html/infrastructure/urls/resolving-urls/query-encoding/navigation.sub.html
    /html/infrastructure/urls/resolving-urls/query-encoding/navigation.sub.html?encoding=utf8
    /html/infrastructure/urls/resolving-urls/query-encoding/navigation.sub.html?encoding=x-cp1251

Explicitly declare the default variant, restoring the original test
coverage.

[1] https://github.com/web-platform-tests/wpt/pull/11300