### PR TITLE
Stop running coverage by default in tox

### DIFF
--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -9,7 +9,7 @@ deps =
   mock
   hypothesis
 
-commands = pytest --cov {posargs}
+commands = pytest {posargs}
 
 passenv =
   HYPOTHESIS_PROFILE

--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -13,4 +13,4 @@ deps =
   -r{toxinidir}/../wptrunner/requirements_firefox.txt
 
 commands =
-  pytest --cov {posargs}
+  pytest {posargs}

--- a/tools/wptrunner/tox.ini
+++ b/tools/wptrunner/tox.ini
@@ -20,6 +20,6 @@ deps =
      sauce: -r{toxinidir}/requirements_sauce.txt
      servo: -r{toxinidir}/requirements_servo.txt
 
-commands = pytest {posargs:--cov}
+commands = pytest {posargs}
 
 setenv = CURRENT_TOX_ENV = {envname}


### PR DESCRIPTION
This doesn't re-enable it on CI because of #8613.