### PR TITLE
Use gPV/sP, as that's slightly more well-supported

### DIFF
--- a/css/css-syntax/urange-parsing.html
+++ b/css/css-syntax/urange-parsing.html
@@ -21,17 +21,17 @@
 function testUrange(input, expected) {
     test(()=>{
         const rule = document.styleSheets[0].cssRules[0];
-        rule.style.unicodeRange = "U+1357";
-        rule.style.unicodeRange = input;
-        assert_equals(rule.style.unicodeRange.toUpperCase(), expected.toUpperCase());
+        rule.style.setProperty("unicode-range", "U+1357");
+        rule.style.setProperty("unicode-range", input);
+        assert_equals(rule.style.getPropertyValue("unicode-range").toUpperCase(), expected.toUpperCase());
     }, `"${input}" => "${expected}"`)
 }
 function testInvalidUrange(input) {
     test(()=>{
         const rule = document.styleSheets[0].cssRules[0];
-        rule.style.unicodeRange = "U+1357";
-        rule.style.unicodeRange = input;
-        assert_equals(rule.style.unicodeRange.toUpperCase(), "U+1357");
+        rule.style.setProperty("unicode-range", "U+1357");
+        rule.style.setProperty("unicode-range", input);
+        assert_equals(rule.style.getPropertyValue("unicode-range").toUpperCase(), "U+1357");
     }, `"${input}" is invalid`);
 }
 


### PR DESCRIPTION
Requested by @emilio in <https://github.com/w3c/csswg-drafts/issues/3588#issuecomment-460019494>