### PR TITLE
[css-transforms] backface-visibility parsing

### DIFF
--- a/css/css-transforms/parsing/backface-visibility-computed.html
+++ b/css/css-transforms/parsing/backface-visibility-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transform Module Level 2: getComputedValue().backfaceVisibility</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#backface-visibility-property">
+<meta name="assert" content="backface-visibility computed value is as specified.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("backface-visibility", "visible");
+test_computed_value("backface-visibility", "hidden");
+</script>
+</body>
+</html>

--- a/css/css-transforms/parsing/backface-visibility-invalid.html
+++ b/css/css-transforms/parsing/backface-visibility-invalid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transform Module Level 2: parsing backface-visibility with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#backface-visibility-property">
+<meta name="assert" content="backface-visibility supports only the grammar 'visible | hidden'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("backface-visibility", "auto");
+test_invalid_value("backface-visibility", "visible hidden");
+</script>
+</body>
+</html>

--- a/css/css-transforms/parsing/backface-visibility-valid.html
+++ b/css/css-transforms/parsing/backface-visibility-valid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transform Module Level 2: parsing backface-visibility with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#backface-visibility-property">
+<meta name="assert" content="backface-visibility supports the full grammar 'visible | hidden'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("backface-visibility", "visible");
+test_valid_value("backface-visibility", "hidden");
+</script>
+</body>
+</html>


### PR DESCRIPTION
Test that backface-visibility accepts the grammar
'visible | hidden', with computed values as specified.
https://drafts.csswg.org/css-transforms-2/#backface-visibility-property