### PR TITLE
[css-flexbox] Inheritance, initial values

### DIFF
--- a/css/css-flexbox/inheritance.html
+++ b/css/css-flexbox/inheritance.html
@@ -4,31 +4,33 @@
 <meta charset="utf-8">
 <title>Inheritance of CSS Flexible Box Layout properties</title>
 <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#property-index">
-<meta name="assert" content="Properties inherit or not according to the spec.">
+<link rel="help" href="https://drafts.csswg.org/css-align/#property-index">
+<meta name="assert" content="Properties do not inherit, according to the spec.">
 <meta name="assert" content="Properties have initial values according to the spec.">
+<meta name="assert" content="align-content, align-items, justify-content have initial value 'normal' as specified in CSS Box Alignment.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/inheritance-testcommon.js"></script>
-</head>
-<body>
-<div id="container">
-  <div id="target"></div>
-</div>
 <style>
   #container, #target {
     display: flex;
   }
 </style>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
 <script>
-assert_not_inherited('align-content', 'stretch', 'center'); // expected "stretch" but got "normal"
-assert_not_inherited('align-items', 'stretch', 'center'); // expected "stretch" but got "normal"
+assert_not_inherited('align-content', 'normal', 'center'); // initial value was "stretch" in flexbox-1
+assert_not_inherited('align-items', 'normal', 'center'); // initial value was "stretch" in flexbox-1
 assert_not_inherited('align-self', 'auto', 'stretch');
 assert_not_inherited('flex-basis', 'auto', '10px');
 assert_not_inherited('flex-direction', 'row', 'column');
 assert_not_inherited('flex-grow', '0', '2');
 assert_not_inherited('flex-shrink', '1', '3');
 assert_not_inherited('flex-wrap', 'nowrap', 'wrap-reverse');
-assert_not_inherited('justify-content', 'flex-start', 'center'); // expected "flex-start" but got "normal"
+assert_not_inherited('justify-content', 'normal', 'center'); // initial value was "flex-start" in flexbox-1
 assert_not_inherited('order', '0', '2');
 </script>
 </body>

--- a/css/css-flexbox/inheritance.html
+++ b/css/css-flexbox/inheritance.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Flexible Box Layout properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#property-index">
+<meta name="assert" content="Properties inherit or not according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<style>
+  #container, #target {
+    display: flex;
+  }
+</style>
+<script>
+assert_not_inherited('align-content', 'stretch', 'center'); // expected "stretch" but got "normal"
+assert_not_inherited('align-items', 'stretch', 'center'); // expected "stretch" but got "normal"
+assert_not_inherited('align-self', 'auto', 'stretch');
+assert_not_inherited('flex-basis', 'auto', '10px');
+assert_not_inherited('flex-direction', 'row', 'column');
+assert_not_inherited('flex-grow', '0', '2');
+assert_not_inherited('flex-shrink', '1', '3');
+assert_not_inherited('flex-wrap', 'nowrap', 'wrap-reverse');
+assert_not_inherited('justify-content', 'flex-start', 'center'); // expected "flex-start" but got "normal"
+assert_not_inherited('order', '0', '2');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Test that properties do not inherit.
Test that they have the expected initial values.
https://drafts.csswg.org/css-flexbox-1/#property-index