### PR TITLE
Use CSS style to set color of text and background.

### DIFF
--- a/mathml/presentation-markup/fractions/frac-1.html
+++ b/mathml/presentation-markup/fractions/frac-1.html
@@ -83,44 +83,44 @@
     <math>
       <mo id="axis">−</mo>
       <mfrac id="frac0">
-        <mspace id="frac0num" width="15px" height="15px" mathbackground="blue"/>
-        <mspace id="frac0den" width="15px" height="15px" mathbackground="green"/>
+        <mspace id="frac0num" width="15px" height="15px" style="background: blue"/>
+        <mspace id="frac0den" width="15px" height="15px" style="background: green"/>
       </mfrac>
       <mfrac id="frac1">
-        <mspace id="frac1num" width="30px" height="15px" mathbackground="blue"/>
-        <mspace id="frac1den" width="15px" height="15px" mathbackground="green"/>
+        <mspace id="frac1num" width="30px" height="15px" style="background: blue"/>
+        <mspace id="frac1den" width="15px" height="15px" style="background: green"/>
       </mfrac>
       <mfrac id="frac2">
-        <mspace id="frac2num" width="15px" height="15px" mathbackground="blue"/>
-        <mspace id="frac2den" width="30px" height="15px" mathbackground="green"/>
+        <mspace id="frac2num" width="15px" height="15px" style="background: blue"/>
+        <mspace id="frac2den" width="30px" height="15px" style="background: green"/>
       </mfrac>
       <mfrac id="frac3">
-        <mspace id="frac3num" width="15px" height="30px" mathbackground="blue"/>
-        <mspace id="frac3den" width="15px" height="15px" mathbackground="green"/>
+        <mspace id="frac3num" width="15px" height="30px" style="background: blue"/>
+        <mspace id="frac3den" width="15px" height="15px" style="background: green"/>
       </mfrac>
       <mfrac id="frac4">
-        <mspace id="frac4num" width="15px" height="15px" mathbackground="blue"/>
-        <mspace id="frac4den" width="15px" height="30px" mathbackground="green"/>
+        <mspace id="frac4num" width="15px" height="15px" style="background: blue"/>
+        <mspace id="frac4den" width="15px" height="30px" style="background: green"/>
       </mfrac>
       <mfrac id="frac5" linethickness="0px">
-        <mspace id="frac5num" width="15px" height="15px" mathbackground="blue"/>
-        <mspace id="frac5den" width="15px" height="15px" mathbackground="green"/>
+        <mspace id="frac5num" width="15px" height="15px" style="background: blue"/>
+        <mspace id="frac5den" width="15px" height="15px" style="background: green"/>
       </mfrac>
       <mfrac id="frac6" linethickness="0px">
-        <mspace id="frac6num" width="30px" height="15px" mathbackground="blue"/>
-        <mspace id="frac6den" width="15px" height="15px" mathbackground="green"/>
+        <mspace id="frac6num" width="30px" height="15px" style="background: blue"/>
+        <mspace id="frac6den" width="15px" height="15px" style="background: green"/>
       </mfrac>
       <mfrac id="frac7" linethickness="0px">
-        <mspace id="frac7num" width="15px" height="15px" mathbackground="blue"/>
-        <mspace id="frac7den" width="30px" height="15px" mathbackground="green"/>
+        <mspace id="frac7num" width="15px" height="15px" style="background: blue"/>
+        <mspace id="frac7den" width="30px" height="15px" style="background: green"/>
       </mfrac>
       <mfrac id="frac8" linethickness="0px">
-        <mspace id="frac8num" width="15px" height="30px" mathbackground="blue"/>
-        <mspace id="frac8den" width="15px" height="15px" mathbackground="green"/>
+        <mspace id="frac8num" width="15px" height="30px" style="background: blue"/>
+        <mspace id="frac8den" width="15px" height="15px" style="background: green"/>
       </mfrac>
       <mfrac id="frac9" linethickness="0px">
-        <mspace id="frac9num" width="15px" height="15px" mathbackground="blue"/>
-        <mspace id="frac9den" width="15px" height="30px" mathbackground="green"/>
+        <mspace id="frac9num" width="15px" height="15px" style="background: blue"/>
+        <mspace id="frac9den" width="15px" height="30px" style="background: green"/>
       </mfrac>
     </math>
   </p>

--- a/mathml/presentation-markup/fractions/frac-parameters-1.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-1.html
@@ -135,9 +135,9 @@
 <body>
   <p>
     <math style="font-family: axisheight7000-rulethickness1000;">
-      <mspace id="ref0001" depth="1em" width="3em" mathbackground="green"/>
+      <mspace id="ref0001" depth="1em" width="3em" style="background: green"/>
       <mfrac>
-        <mspace width="3em" height="1em" id="num0001" mathbackground="blue"/>
+        <mspace width="3em" height="1em" id="num0001" style="background: blue"/>
         <mspace width="3em"/>
       </mfrac>
     </math>
@@ -146,20 +146,20 @@
   <p>
     <math display="block" style="font-family: denominatordisplaystylegapmin5000-rulethickness1000;">
       <mspace id="ref0002" width="3em"
-              height=".5em" depth=".5em" mathbackground="green"/>
+              height=".5em" depth=".5em" style="background: green"/>
       <mfrac>
         <mspace width="3em"/>
-        <mspace width="3em" height="1em" id="den0002" mathbackground="blue"/>
+        <mspace width="3em" height="1em" id="den0002" style="background: blue"/>
       </mfrac>
     </math>
   </p>
   <hr/>
   <p>
     <math display="block" style="font-family: denominatordisplaystyleshiftdown6000-rulethickness1000;">
-      <mspace id="ref0003" width="3em" height="1em" mathbackground="green"/>
+      <mspace id="ref0003" width="3em" height="1em" style="background: green"/>
       <mfrac>
         <mspace width="3em"/>
-        <mspace width="3em" depth="1em" id="den0003" mathbackground="blue"/>
+        <mspace width="3em" depth="1em" id="den0003" style="background: blue"/>
       </mfrac>
     </math>
   </p>
@@ -167,20 +167,20 @@
   <p>
     <math style="font-family: denominatorgapmin4000-rulethickness1000;">
       <mspace id="ref0004" width="3em"
-              height=".5em" depth=".5em" mathbackground="green"/>
+              height=".5em" depth=".5em" style="background: green"/>
       <mfrac>
         <mspace width="3em"/>
-        <mspace width="3em" height="1em" id="den0004" mathbackground="blue"/>
+        <mspace width="3em" height="1em" id="den0004" style="background: blue"/>
       </mfrac>
     </math>
   </p>
   <hr/>
   <p>
     <math style="font-family: denominatorshiftdown3000-rulethickness1000;">
-      <mspace id="ref0005" width="3em" height="1em" mathbackground="green"/>
+      <mspace id="ref0005" width="3em" height="1em" style="background: green"/>
       <mfrac>
         <mspace width="3em"/>
-        <mspace width="3em" depth="1em" id="den0005" mathbackground="blue"/>
+        <mspace width="3em" depth="1em" id="den0005" style="background: blue"/>
       </mfrac>
     </math>
   </p>
@@ -188,9 +188,9 @@
   <p>
     <math display="block" style="font-family: numeratordisplaystylegapmin8000-rulethickness1000;">
       <mspace id="ref0006" width="3em"
-              height=".5em" depth=".5em" mathbackground="green"/>
+              height=".5em" depth=".5em" style="background: green"/>
       <mfrac>
-        <mspace width="3em" depth="1em" id="num0006" mathbackground="blue"/>
+        <mspace width="3em" depth="1em" id="num0006" style="background: blue"/>
         <mspace width="3em"/>
       </mfrac>
     </math>
@@ -199,9 +199,9 @@
   <p>
     <math display="block" style="font-family: numeratordisplaystyleshiftup2000-rulethickness1000;">
       <mspace id="ref0007" width="3em"
-              depth="1em" mathbackground="green"/>
+              depth="1em" style="background: green"/>
       <mfrac>
-        <mspace width="3em" height="1em" id="num0007" mathbackground="blue"/>
+        <mspace width="3em" height="1em" id="num0007" style="background: blue"/>
         <mspace width="3em"/>
       </mfrac>
     </math>
@@ -210,9 +210,9 @@
   <p>
     <math style="font-family: numeratorgapmin9000-rulethickness1000;">
       <mspace id="ref0008" width="3em"
-              height=".5em" depth=".5em" mathbackground="green"/>
+              height=".5em" depth=".5em" style="background: green"/>
       <mfrac>
-        <mspace width="3em" depth="1em" id="num0008" mathbackground="blue"/>
+        <mspace width="3em" depth="1em" id="num0008" style="background: blue"/>
         <mspace width="3em"/>
       </mfrac>
     </math>
@@ -221,9 +221,9 @@
   <p>
     <math style="font-family: numeratorshiftup11000-rulethickness1000;">
       <mspace id="ref0009" width="3em"
-              depth="1em" mathbackground="green"/>
+              depth="1em" style="background: green"/>
       <mfrac>
-        <mspace width="3em" height="1em" id="num0009" mathbackground="blue"/>
+        <mspace width="3em" height="1em" id="num0009" style="background: blue"/>
         <mspace width="3em"/>
       </mfrac>
     </math>
@@ -232,8 +232,8 @@
   <p>
     <math style="font-family: rulethickness10000">
       <mfrac>
-        <mspace width="3em" height="1em" id="num0010" mathbackground="blue"/>
-        <mspace width="3em" depth="1em" id="den0010" mathbackground="green"/>
+        <mspace width="3em" height="1em" id="num0010" style="background: blue"/>
+        <mspace width="3em" depth="1em" id="den0010" style="background: green"/>
       </mfrac>
     </math>
   </p>

--- a/mathml/presentation-markup/fractions/frac-parameters-2.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-2.html
@@ -104,9 +104,9 @@
 <body>
   <p>
     <math style="font-family: axisheight7000;">
-      <mspace id="ref0001" depth="1em" width="3em" mathbackground="green"/>
+      <mspace id="ref0001" depth="1em" width="3em" style="background: green"/>
       <mfrac linethickness="0px">
-        <mspace width="3em" height="1em" id="num0001" mathbackground="blue"/>
+        <mspace width="3em" height="1em" id="num0001" style="background: blue"/>
         <mspace width="3em"/>
       </mfrac>
     </math>
@@ -114,20 +114,20 @@
   <hr/>
   <p>
     <math display="block" style="font-family: bottomdisplaystyleshiftdown5000;">
-      <mspace id="ref0002" width="3em" height="1em" mathbackground="green"/>
+      <mspace id="ref0002" width="3em" height="1em" style="background: green"/>
       <mfrac linethickness="0px">
         <mspace width="3em"/>
-        <mspace width="3em" depth="1em" id="den0002" mathbackground="blue"/>
+        <mspace width="3em" depth="1em" id="den0002" style="background: blue"/>
       </mfrac>
     </math>
   </p>
   <hr/>
   <p>
     <math style="font-family: bottomshiftdown6000;">
-      <mspace id="ref0003" width="3em" height="1em" mathbackground="green"/>
+      <mspace id="ref0003" width="3em" height="1em" style="background: green"/>
       <mfrac linethickness="0px">
         <mspace width="3em"/>
-        <mspace width="3em" depth="1em" id="den0003" mathbackground="blue"/>
+        <mspace width="3em" depth="1em" id="den0003" style="background: blue"/>
       </mfrac>
     </math>
   </p>
@@ -135,8 +135,8 @@
   <p>
     <math display="block" style="font-family: displaystylegapmin4000;">
       <mfrac linethickness="0px">
-        <mspace width="3em" height="1em" id="num0004" mathbackground="blue"/>
-        <mspace width="3em" depth="1em" id="den0004" mathbackground="green"/>
+        <mspace width="3em" height="1em" id="num0004" style="background: blue"/>
+        <mspace width="3em" depth="1em" id="den0004" style="background: green"/>
       </mfrac>
     </math>
   </p>
@@ -144,17 +144,17 @@
   <p>
     <math style="font-family: gapmin8000;">
       <mfrac linethickness="0px">
-        <mspace width="3em" height="1em" id="num0005" mathbackground="blue"/>
-        <mspace width="3em" depth="1em" id="den0005" mathbackground="green"/>
+        <mspace width="3em" height="1em" id="num0005" style="background: blue"/>
+        <mspace width="3em" depth="1em" id="den0005" style="background: green"/>
       </mfrac>
     </math>
   </p>
   <hr/>
   <p>
     <math display="block" style="font-family: topdisplaystyleshiftup3000;">
-      <mspace id="ref0006" width="3em" depth="1em" mathbackground="green"/>
+      <mspace id="ref0006" width="3em" depth="1em" style="background: green"/>
       <mfrac linethickness="0px">
-        <mspace width="3em" height="1em" id="num0006" mathbackground="blue"/>
+        <mspace width="3em" height="1em" id="num0006" style="background: blue"/>
         <mspace width="3em"/>
       </mfrac>
     </math>
@@ -162,9 +162,9 @@
   <hr/>
   <p>
     <math style="font-family: topshiftup9000;">
-      <mspace id="ref0007" width="3em" depth="1em" mathbackground="green"/>
+      <mspace id="ref0007" width="3em" depth="1em" style="background: green"/>
       <mfrac linethickness="0px">
-        <mspace width="3em" height="1em" id="num0007" mathbackground="blue"/>
+        <mspace width="3em" height="1em" id="num0007" style="background: blue"/>
         <mspace width="3em"/>
       </mfrac>
     </math>

--- a/mathml/presentation-markup/operators/mo-axis-height-1.html
+++ b/mathml/presentation-markup/operators/mo-axis-height-1.html
@@ -58,18 +58,18 @@
   <p>
     <math style="font-family: axisheight5000-verticalarrow14000;">
       <mrow>
-        <mspace id="baseline1" mathbackground="blue" width="50px" height="1px"/>
-        <mpadded voffset="50px"><mspace mathbackground="cyan" width="50px" height="1px"/></mpadded>
-        <mo id="mo1" symmetric="true" mathcolor="green">&#x21A8;</mo>
-        <mspace mathbackground="gray" width="10px" height="50px"/>
+        <mspace id="baseline1" style="background: blue" width="50px" height="1px"/>
+        <mpadded voffset="50px"><mspace style="background: cyan" width="50px" height="1px"/></mpadded>
+        <mo id="mo1" symmetric="true" style="color: green">&#x21A8;</mo>
+        <mspace style="background: gray" width="10px" height="50px"/>
       </mrow>
     </math>
     <math style="font-family: axisheight5000-verticalarrow14000;">
       <mrow>
-        <mspace id="baseline2" mathbackground="blue" width="50px" height="1px"/>
-        <mpadded voffset="50px"><mspace mathbackground="cyan" width="50px" height="1px"/></mpadded>
-        <mo id="mo2" symmetric="true" mathcolor="green">&#x21A8;</mo>
-        <mspace id="target2" mathbackground="gray" width="10px" height="200px"/>
+        <mspace id="baseline2" style="background: blue" width="50px" height="1px"/>
+        <mpadded voffset="50px"><mspace style="background: cyan" width="50px" height="1px"/></mpadded>
+        <mo id="mo2" symmetric="true" style="color: green">&#x21A8;</mo>
+        <mspace id="target2" style="background: gray" width="10px" height="200px"/>
       </mrow>
     </math>
   </p>

--- a/mathml/presentation-markup/radicals/root-parameters-1.html
+++ b/mathml/presentation-markup/radicals/root-parameters-1.html
@@ -131,10 +131,10 @@
 <body>
   <p>
     <math style="font-family: degreebottomraisepercent25-rulethickness1000;">
-      <mspace id="ref001" width="3em" depth="1em" mathbackground="green"/>
+      <mspace id="ref001" width="3em" depth="1em" style="background: green"/>
       <mroot>
-        <mspace id="base001" width="3em" height="10em" mathbackground="green"/>
-        <mspace id="index001" width="3em" height="1em" mathbackground="blue"/>
+        <mspace id="base001" width="3em" height="10em" style="background: green"/>
+        <mspace id="index001" width="3em" height="1em" style="background: blue"/>
       </mroot>
     </math>
   </p>
@@ -142,24 +142,24 @@
   <p>
     <math display="block"
           style="font-family: displaystyleverticalgap7000-rulethickness1000;">
-      <msqrt mathbackground="green" id="radical0021">
-        <mspace id="base0021" width="3em" height="1em" mathbackground="blue"/>
+      <msqrt style="background: green" id="radical0021">
+        <mspace id="base0021" width="3em" height="1em" style="background: blue"/>
       </msqrt>
-      <mroot mathbackground="green" id="radical0022">
-        <mspace id="base0022" width="3em" height="1em" mathbackground="blue"/>
-        <mspace width="3em" height="1em" mathbackground="black"/>
+      <mroot style="background: green" id="radical0022">
+        <mspace id="base0022" width="3em" height="1em" style="background: blue"/>
+        <mspace width="3em" height="1em" style="background: black"/>
       </mroot>
     </math>
   </p>
   <hr/>
   <p>
     <math style="font-family: extraascender3000-rulethickness1000;">
-      <msqrt mathbackground="green" id="radical0031">
-        <mspace id="base0031" width="3em" height="1em" mathbackground="blue"/>
+      <msqrt style="background: green" id="radical0031">
+        <mspace id="base0031" width="3em" height="1em" style="background: blue"/>
       </msqrt>
-      <mroot mathbackground="green" id="radical0032">
-        <mspace id="base0032" width="3em" height="1em" mathbackground="blue"/>
-        <mspace width="3em" height="1em" mathbackground="black"/>
+      <mroot style="background: green" id="radical0032">
+        <mspace id="base0032" width="3em" height="1em" style="background: blue"/>
+        <mspace width="3em" height="1em" style="background: black"/>
       </mroot>
     </math>
   </p>
@@ -167,40 +167,40 @@
   <p>
     <math style="font-family: kernafterdegreeminus5000-rulethickness1000;">
       <mroot>
-        <mspace id="base004" width="3em" height="2em"  mathbackground="blue"/>
-        <mspace id="index004" width="7em" height="1em" mathbackground="green"/>
+        <mspace id="base004" width="3em" height="2em"  style="background: blue"/>
+        <mspace id="index004" width="7em" height="1em" style="background: green"/>
       </mroot>
     </math>
   </p>
   <hr/>
   <p>
     <math style="font-family: kernbeforedegree4000-rulethickness1000;">
-      <mroot id="radical005" mathbackground="blue">
+      <mroot id="radical005" style="background: blue">
         <mspace width="3em" height="1em"/>
-        <mspace id="index005" width="3em" height="1em" mathbackground="green"/>
+        <mspace id="index005" width="3em" height="1em" style="background: green"/>
       </mroot>
     </math>
   </p>
   <hr/>
   <p>
     <math style="font-family: rulethickness8000;">
-      <msqrt mathbackground="green" id="radical0061">
-        <mspace id="base0061" width="3em" height="1em" mathbackground="blue"/>
+      <msqrt style="background: green" id="radical0061">
+        <mspace id="base0061" width="3em" height="1em" style="background: blue"/>
       </msqrt>
-      <mroot mathbackground="green" id="radical0062">
-        <mspace id="base0062" width="3em" height="1em" mathbackground="blue"/>
-        <mspace width="3em" height="1em" mathbackground="black"/>
+      <mroot style="background: green" id="radical0062">
+        <mspace id="base0062" width="3em" height="1em" style="background: blue"/>
+        <mspace width="3em" height="1em" style="background: black"/>
       </mroot>
     </math>
   </p>
   <p>
     <math style="font-family: verticalgap6000-rulethickness1000;">
-      <msqrt mathbackground="green" id="radical0071">
-        <mspace id="base0071" width="3em" height="1em" mathbackground="blue"/>
+      <msqrt style="background: green" id="radical0071">
+        <mspace id="base0071" width="3em" height="1em" style="background: blue"/>
       </msqrt>
-      <mroot mathbackground="green" id="radical0072">
-        <mspace id="base0072" width="3em" height="1em" mathbackground="blue"/>
-        <mspace width="3em" height="1em" mathbackground="black"/>
+      <mroot style="background: green" id="radical0072">
+        <mspace id="base0072" width="3em" height="1em" style="background: blue"/>
+        <mspace width="3em" height="1em" style="background: black"/>
       </mroot>
     </math>
   </p>

--- a/mathml/presentation-markup/scripts/subsup-1.html
+++ b/mathml/presentation-markup/scripts/subsup-1.html
@@ -83,19 +83,19 @@
 <body>
   <p>
     <math>
-      <mspace id="baseline" width="30px" height="2px" depth="0px" mathbackground="blue"/>
-      <msub id="msub" mathbackground="green">
-        <mspace id="msubBase" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="msubSub" width="10px" height="5px" depth="5px" mathbackground="black"/>
+      <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
+      <msub id="msub" style="background: green">
+        <mspace id="msubBase" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="msubSub" width="10px" height="5px" depth="5px" style="background: black"/>
       </msub>
-      <msup id="msup" mathbackground="blue">
-        <mspace id="msupBase" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="msupSup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+      <msup id="msup" style="background: blue">
+        <mspace id="msupBase" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="msupSup" width="10px" height="5px" depth="5px" style="background: black"/>
       </msup>
-      <msubsup id="msubsup" mathbackground="green">
-        <mspace id="msubsupBase" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="msubsupSub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="msubsupSup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+      <msubsup id="msubsup" style="background: green">
+        <mspace id="msubsupBase" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="msubsupSub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="msubsupSup" width="10px" height="5px" depth="5px" style="background: black"/>
       </msubsup>
     </math>
   </p>

--- a/mathml/presentation-markup/scripts/subsup-2.html
+++ b/mathml/presentation-markup/scripts/subsup-2.html
@@ -122,39 +122,39 @@
 <body>
   <p>
     <math>
-      <mspace id="baseline" width="30px" height="2px" depth="0px" mathbackground="blue"/>
-      <mmultiscripts id="msub" mathbackground="green">
-        <mspace id="msubBase" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="msubSub" width="10px" height="5px" depth="5px" mathbackground="black"/>
+      <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
+      <mmultiscripts id="msub" style="background: green">
+        <mspace id="msubBase" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="msubSub" width="10px" height="5px" depth="5px" style="background: black"/>
         <none/>
       </mmultiscripts>
-      <mmultiscripts id="msup" mathbackground="green">
-        <mspace id="msupBase" width="30px" height="15px" depth="15px" mathbackground="black"/>
+      <mmultiscripts id="msup" style="background: green">
+        <mspace id="msupBase" width="30px" height="15px" depth="15px" style="background: black"/>
         <none/>
-        <mspace id="msupSup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msupSup" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
-      <mmultiscripts id="msubsup" mathbackground="green">
-        <mspace id="msubsupBase" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="msubsupSub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="msubsupSup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+      <mmultiscripts id="msubsup" style="background: green">
+        <mspace id="msubsupBase" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="msubsupSub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="msubsupSup" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
-      <mmultiscripts id="premsub" mathbackground="green">
-        <mspace id="premsubBase" width="30px" height="15px" depth="15px" mathbackground="black"/>
+      <mmultiscripts id="premsub" style="background: green">
+        <mspace id="premsubBase" width="30px" height="15px" depth="15px" style="background: black"/>
         <mprescripts/>
-        <mspace id="premsubSub" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="premsubSub" width="10px" height="5px" depth="5px" style="background: black"/>
         <none/>
       </mmultiscripts>
-      <mmultiscripts id="premsup" mathbackground="green">
-        <mspace id="premsupBase" width="30px" height="15px" depth="15px" mathbackground="black"/>
+      <mmultiscripts id="premsup" style="background: green">
+        <mspace id="premsupBase" width="30px" height="15px" depth="15px" style="background: black"/>
         <mprescripts/>
         <none/>
-        <mspace id="premsupSup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="premsupSup" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
-      <mmultiscripts id="premsubsup" mathbackground="green">
-        <mspace id="premsubsupBase" width="30px" height="15px" depth="15px" mathbackground="black"/>
+      <mmultiscripts id="premsubsup" style="background: green">
+        <mspace id="premsubsupBase" width="30px" height="15px" depth="15px" style="background: black"/>
         <mprescripts/>
-        <mspace id="premsubsupSub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="premsubsupSup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="premsubsupSub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="premsubsupSup" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
     </math>
   </p>

--- a/mathml/presentation-markup/scripts/subsup-3.html
+++ b/mathml/presentation-markup/scripts/subsup-3.html
@@ -109,69 +109,69 @@
 <body>
   <p>
     <math>
-      <mspace id="baseline" width="30px" height="2px" depth="0px" mathbackground="blue"/>
-      <mmultiscripts id="multi0" mathbackground="green">
-        <mspace id="multi0base" width="30px" height="15px" depth="15px" mathbackground="black"/>
+      <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
+      <mmultiscripts id="multi0" style="background: green">
+        <mspace id="multi0base" width="30px" height="15px" depth="15px" style="background: black"/>
       </mmultiscripts>
-      <mmultiscripts id="multi1" mathbackground="green">
-        <mspace id="multi1base" width="30px" height="15px" depth="15px" mathbackground="black"/>
+      <mmultiscripts id="multi1" style="background: green">
+        <mspace id="multi1base" width="30px" height="15px" depth="15px" style="background: black"/>
         <mprescripts/>
       </mmultiscripts>
-      <mmultiscripts id="multi2" mathbackground="green">
-        <mspace id="multi2base" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="multi2postsub1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi2postsup1" width="10px" height="5px" depth="5px" mathbackground="black"/>
+      <mmultiscripts id="multi2" style="background: green">
+        <mspace id="multi2base" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="multi2postsub1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi2postsup1" width="10px" height="5px" depth="5px" style="background: black"/>
         <mprescripts/>
-        <mspace id="multi2presub1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi2presup1" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi2presub1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi2presup1" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
-      <mmultiscripts id="multi3" mathbackground="green">
-        <mspace id="multi3base" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="multi3postsub1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi3postsup1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi3postsub2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi3postsup2" width="10px" height="5px" depth="5px" mathbackground="black"/>
+      <mmultiscripts id="multi3" style="background: green">
+        <mspace id="multi3base" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="multi3postsub1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi3postsup1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi3postsub2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi3postsup2" width="10px" height="5px" depth="5px" style="background: black"/>
         <mprescripts/>
-        <mspace id="multi3presub1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi3presup1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi3presub2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi3presup2" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi3presub1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi3presup1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi3presub2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi3presup2" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
-      <mmultiscripts id="multi4" mathbackground="green">
-        <mspace id="multi4base" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="multi4postsub1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4postsup1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4postsub2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4postsup2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4postsub3" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4postsup3" width="10px" height="5px" depth="5px" mathbackground="black"/>
+      <mmultiscripts id="multi4" style="background: green">
+        <mspace id="multi4base" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="multi4postsub1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4postsup1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4postsub2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4postsup2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4postsub3" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4postsup3" width="10px" height="5px" depth="5px" style="background: black"/>
         <mprescripts/>
-        <mspace id="multi4presub1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4presup1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4presub2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4presup2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4presub3" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi4presup3" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi4presub1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4presup1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4presub2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4presup2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4presub3" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi4presup3" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
-      <mmultiscripts id="multi5" mathbackground="green">
-        <mspace id="multi5base" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="multi5postsub1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5postsup1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5postsub2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5postsup2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5postsub3" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5postsup3" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5postsub4" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5postsup4" width="10px" height="5px" depth="5px" mathbackground="black"/>
+      <mmultiscripts id="multi5" style="background: green">
+        <mspace id="multi5base" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="multi5postsub1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5postsup1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5postsub2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5postsup2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5postsub3" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5postsup3" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5postsub4" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5postsup4" width="10px" height="5px" depth="5px" style="background: black"/>
         <mprescripts/>
-        <mspace id="multi5presub1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5presup1" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5presub2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5presup2" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5presub3" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5presup3" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5presub4" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi5presup4" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi5presub1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5presup1" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5presub2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5presup2" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5presub3" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5presup3" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5presub4" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi5presup4" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
     </math>
   </p>

--- a/mathml/presentation-markup/scripts/subsup-4.html
+++ b/mathml/presentation-markup/scripts/subsup-4.html
@@ -53,69 +53,69 @@
 <body>
   <p>
     <math>
-      <mspace id="baseline" width="30px" height="2px" depth="0px" mathbackground="blue"/>
+      <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
       <msub id="msub50">
-        <mspace id="msub50base" width="30px" height="50px" depth="50px" mathbackground="black"/>
-        <mspace id="msub50sub" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msub50base" width="30px" height="50px" depth="50px" style="background: black"/>
+        <mspace id="msub50sub" width="10px" height="5px" depth="5px" style="background: black"/>
       </msub>
       <msup id="msup50">
-        <mspace id="msup50base" width="30px" height="50px" depth="50px" mathbackground="black"/>
-        <mspace id="msup50sup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msup50base" width="30px" height="50px" depth="50px" style="background: black"/>
+        <mspace id="msup50sup" width="10px" height="5px" depth="5px" style="background: black"/>
       </msup>
       <msubsup id="msubsup50">
-        <mspace id="msubsup50base" width="30px" height="50px" depth="50px" mathbackground="black"/>
-        <mspace id="msubsup50sub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="msubsup50sup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msubsup50base" width="30px" height="50px" depth="50px" style="background: black"/>
+        <mspace id="msubsup50sub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="msubsup50sup" width="10px" height="5px" depth="5px" style="background: black"/>
       </msubsup>
       <mmultiscripts id="multi50">
-        <mspace id="multi50base" width="30px" height="50px" depth="50px" mathbackground="black"/>
-        <mspace id="multi50postsub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi50postsup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi50base" width="30px" height="50px" depth="50px" style="background: black"/>
+        <mspace id="multi50postsub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi50postsup" width="10px" height="5px" depth="5px" style="background: black"/>
         <mprescripts/>
-        <mspace id="multi50presub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi50presup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi50presub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi50presup" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
       <msub id="msub75">
-        <mspace id="msub75base" width="30px" height="75px" depth="75px" mathbackground="black"/>
-        <mspace id="msub75sub" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msub75base" width="30px" height="75px" depth="75px" style="background: black"/>
+        <mspace id="msub75sub" width="10px" height="5px" depth="5px" style="background: black"/>
       </msub>
       <msup id="msup75">
-        <mspace id="msup75base" width="30px" height="75px" depth="75px" mathbackground="black"/>
-        <mspace id="msup75sup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msup75base" width="30px" height="75px" depth="75px" style="background: black"/>
+        <mspace id="msup75sup" width="10px" height="5px" depth="5px" style="background: black"/>
       </msup>
       <msubsup id="msubsup75">
-        <mspace id="msubsup75base" width="30px" height="75px" depth="75px" mathbackground="black"/>
-        <mspace id="msubsup75sub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="msubsup75sup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msubsup75base" width="30px" height="75px" depth="75px" style="background: black"/>
+        <mspace id="msubsup75sub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="msubsup75sup" width="10px" height="5px" depth="5px" style="background: black"/>
       </msubsup>
       <mmultiscripts id="multi75">
-        <mspace id="multi75base" width="30px" height="75px" depth="75px" mathbackground="black"/>
-        <mspace id="multi75postsub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi75postsup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi75base" width="30px" height="75px" depth="75px" style="background: black"/>
+        <mspace id="multi75postsub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi75postsup" width="10px" height="5px" depth="5px" style="background: black"/>
         <mprescripts/>
-        <mspace id="multi75presub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi75presub" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi75presub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi75presub" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
       <msub id="msub100">
-        <mspace id="msub100base" width="30px" height="100px" depth="100px" mathbackground="black"/>
-        <mspace id="msub100sub" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msub100base" width="30px" height="100px" depth="100px" style="background: black"/>
+        <mspace id="msub100sub" width="10px" height="5px" depth="5px" style="background: black"/>
       </msub>
       <msup id="msup100">
-        <mspace id="msup100base" width="30px" height="100px" depth="100px" mathbackground="black"/>
-        <mspace id="msup100sup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msup100base" width="30px" height="100px" depth="100px" style="background: black"/>
+        <mspace id="msup100sup" width="10px" height="5px" depth="5px" style="background: black"/>
       </msup>
       <msubsup id="msubsup100">
-        <mspace id="msubsup100base" width="30px" height="100px" depth="100px" mathbackground="black"/>
-        <mspace id="msubsup100sub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="msubsup100sup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="msubsup100base" width="30px" height="100px" depth="100px" style="background: black"/>
+        <mspace id="msubsup100sub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="msubsup100sup" width="10px" height="5px" depth="5px" style="background: black"/>
       </msubsup>
       <mmultiscripts id="multi100">
-        <mspace id="multi100base" width="30px" height="100px" depth="100px" mathbackground="black"/>
-        <mspace id="multi100postsub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi100postsup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi100base" width="30px" height="100px" depth="100px" style="background: black"/>
+        <mspace id="multi100postsub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi100postsup" width="10px" height="5px" depth="5px" style="background: black"/>
         <mprescripts/>
-        <mspace id="multi100presub" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="multi100presup" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="multi100presub" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="multi100presup" width="10px" height="5px" depth="5px" style="background: black"/>
       </mmultiscripts>
     </math>
   </p>

--- a/mathml/presentation-markup/scripts/subsup-5.html
+++ b/mathml/presentation-markup/scripts/subsup-5.html
@@ -61,27 +61,27 @@
 <body>
   <p>
     <math>
-      <mspace id="baseline" width="30px" height="2px" depth="0px" mathbackground="blue"/>
+      <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
       <msub id="msub">
-        <mspace id="msubbase" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="msubsub" width="10px" height="50px" depth="50px" mathbackground="black"/>
+        <mspace id="msubbase" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="msubsub" width="10px" height="50px" depth="50px" style="background: black"/>
       </msub>
       <msup id="msup">
-        <mspace id="msupbase" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="msupsup" width="10px" height="75px" depth="75px" mathbackground="black"/>
+        <mspace id="msupbase" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="msupsup" width="10px" height="75px" depth="75px" style="background: black"/>
       </msup>
       <msubsup id="msubsup">
-        <mspace id="msubsupbase" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="msubsupsub" width="10px" height="50px" depth="50px" mathbackground="black"/>
-        <mspace id="msubsupsup" width="10px" height="75px" depth="75px" mathbackground="black"/>
+        <mspace id="msubsupbase" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="msubsupsub" width="10px" height="50px" depth="50px" style="background: black"/>
+        <mspace id="msubsupsup" width="10px" height="75px" depth="75px" style="background: black"/>
       </msubsup>
       <mmultiscripts id="multi">
-        <mspace id="multibase" width="30px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="multipostsub" width="10px" height="50px" depth="50px" mathbackground="black"/>
-        <mspace id="multipostsup" width="10px" height="75px" depth="75px" mathbackground="black"/>
+        <mspace id="multibase" width="30px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="multipostsub" width="10px" height="50px" depth="50px" style="background: black"/>
+        <mspace id="multipostsup" width="10px" height="75px" depth="75px" style="background: black"/>
         <mprescripts/>
-        <mspace id="multipresub" width="10px" height="50px" depth="50px" mathbackground="black"/>
-        <mspace id="multipresup" width="10px" height="75px" depth="75px" mathbackground="black"/>
+        <mspace id="multipresub" width="10px" height="50px" depth="50px" style="background: black"/>
+        <mspace id="multipresup" width="10px" height="75px" depth="75px" style="background: black"/>
       </mmultiscripts>
     </math>
   </p>

--- a/mathml/presentation-markup/scripts/subsup-parameters-1.html
+++ b/mathml/presentation-markup/scripts/subsup-parameters-1.html
@@ -146,60 +146,60 @@
     <p>
       <math style="font-family: spaceafterscript3000;">
         <msub>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
-          <mspace id="sub001" height="1em" width="1em" mathbackground="red"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
+          <mspace id="sub001" height="1em" width="1em" style="background: red"/>
         </msub>
-        <mspace id="ref001" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="ref001" height="1em" width="1em" style="background: green"/>
       </math>
       <math style="font-family: spaceafterscript3000;">
         <msup>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
-          <mspace id="sup002" height="1em" width="1em" mathbackground="red"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
+          <mspace id="sup002" height="1em" width="1em" style="background: red"/>
         </msup>
-        <mspace id="ref002" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="ref002" height="1em" width="1em" style="background: green"/>
       </math>
       <math style="font-family: spaceafterscript3000;">
         <msubsup>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
           <mspace/>
-          <mspace id="sup003" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sup003" height="1em" width="1em" style="background: red"/>
         </msubsup>
-        <mspace id="ref003" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="ref003" height="1em" width="1em" style="background: green"/>
       </math>
       <math style="font-family: spaceafterscript3000;">
         <mmultiscripts>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
           <none/>
-          <mspace id="sup0041" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sup0041" height="1em" width="1em" style="background: red"/>
           <none/>
-          <mspace id="sup0042" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sup0042" height="1em" width="1em" style="background: red"/>
           <none/>
-          <mspace id="sup0043" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sup0043" height="1em" width="1em" style="background: red"/>
         </mmultiscripts>
-        <mspace id="ref004" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="ref004" height="1em" width="1em" style="background: green"/>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: superscriptshiftup7000;">
-        <mspace id="ref101" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="ref101" height="1em" width="1em" style="background: green"/>
         <msup>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
-          <mspace id="sup102" height="1em" width="1em" mathbackground="red"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
+          <mspace id="sup102" height="1em" width="1em" style="background: red"/>
         </msup>
         <msubsup>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
-          <mspace height="1em" width="1em" mathbackground="red"/>
-          <mspace id="sup103" height="1em" width="1em" mathbackground="red"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
+          <mspace height="1em" width="1em" style="background: red"/>
+          <mspace id="sup103" height="1em" width="1em" style="background: red"/>
         </msubsup>
         <mmultiscripts>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
           <none/>
-          <mspace id="sup1041" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sup1041" height="1em" width="1em" style="background: red"/>
           <none/>
-          <mspace id="sup1042" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sup1042" height="1em" width="1em" style="background: red"/>
           <none/>
-          <mspace id="sup1043" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sup1043" height="1em" width="1em" style="background: red"/>
         </mmultiscripts>
       </math>
     </p>
@@ -207,24 +207,24 @@
     <p>
       <math style="font-family: superscriptshiftupcramped5000;">
         <msqrt>
-          <mspace id="ref201" height="1em" width="1em" mathbackground="green"/>
+          <mspace id="ref201" height="1em" width="1em" style="background: green"/>
           <msup>
-            <mspace height="2em" width="2em" mathbackground="blue"/>
-            <mspace id="sup202" height="1em" width="1em" mathbackground="red"/>
+            <mspace height="2em" width="2em" style="background: blue"/>
+            <mspace id="sup202" height="1em" width="1em" style="background: red"/>
           </msup>
           <msubsup>
-            <mspace height="2em" width="2em" mathbackground="blue"/>
-            <mspace height="1em" width="1em" mathbackground="blue"/>
-            <mspace id="sup203" height="1em" width="1em" mathbackground="red"/>
+            <mspace height="2em" width="2em" style="background: blue"/>
+            <mspace height="1em" width="1em" style="background: blue"/>
+            <mspace id="sup203" height="1em" width="1em" style="background: red"/>
           </msubsup>
           <mmultiscripts>
-            <mspace height="2em" width="2em" mathbackground="blue"/>
+            <mspace height="2em" width="2em" style="background: blue"/>
             <none/>
-            <mspace id="sup2041" height="1em" width="1em" mathbackground="red"/>
+            <mspace id="sup2041" height="1em" width="1em" style="background: red"/>
             <none/>
-            <mspace id="sup2042" height="1em" width="1em" mathbackground="red"/>
+            <mspace id="sup2042" height="1em" width="1em" style="background: red"/>
             <none/>
-            <mspace id="sup2043" height="1em" width="1em" mathbackground="red"/>
+            <mspace id="sup2043" height="1em" width="1em" style="background: red"/>
           </mmultiscripts>
         </msqrt>
       </math>
@@ -232,21 +232,21 @@
     <hr/>
     <p>
       <math style="font-family: subscriptshiftdown6000;">
-        <mspace id="ref300" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="ref300" height="1em" width="1em" style="background: green"/>
         <msub>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
-          <mspace id="sub301" height="1em" width="1em" mathbackground="red"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
+          <mspace id="sub301" height="1em" width="1em" style="background: red"/>
         </msub>
         <msubsup>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
-          <mspace id="sub302" height="1em" width="1em" mathbackground="red"/>
-          <mspace height="1em" width="1em" mathbackground="blue"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
+          <mspace id="sub302" height="1em" width="1em" style="background: red"/>
+          <mspace height="1em" width="1em" style="background: blue"/>
         </msubsup>
         <mmultiscripts>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
-          <mspace id="sub303" height="1em" width="1em" mathbackground="red"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
+          <mspace id="sub303" height="1em" width="1em" style="background: red"/>
           <none/>
-          <mspace id="sub304" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sub304" height="1em" width="1em" style="background: red"/>
           <none/>
         </mmultiscripts>
       </math>
@@ -255,34 +255,34 @@
     <p>
       <math style="font-family: subsuperscriptgapmin11000;">
         <msubsup>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
-          <mspace id="sub4011" height="1em" width="1em" mathbackground="red"/>
-          <mspace id="sup4012" height="1em" width="1em" mathbackground="red"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
+          <mspace id="sub4011" height="1em" width="1em" style="background: red"/>
+          <mspace id="sup4012" height="1em" width="1em" style="background: red"/>
         </msubsup>
         <mmultiscripts>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
           <none/>
           <none/>
-          <mspace id="sub4021" height="1em" width="1em" mathbackground="red"/>
-          <mspace id="sup4022" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sub4021" height="1em" width="1em" style="background: red"/>
+          <mspace id="sup4022" height="1em" width="1em" style="background: red"/>
         </mmultiscripts>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: subsuperscriptgapmin11000superscriptbottommaxwithsubscript3000;">
-        <mspace id="ref500" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="ref500" height="1em" width="1em" style="background: green"/>
         <msubsup>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
-          <mspace id="sub501" height="1em" width="1em" mathbackground="red"/>
-          <mspace id="sup501" height="1em" width="1em" mathbackground="red"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
+          <mspace id="sub501" height="1em" width="1em" style="background: red"/>
+          <mspace id="sup501" height="1em" width="1em" style="background: red"/>
         </msubsup>
         <mmultiscripts>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
           <none/>
           <none/>
-          <mspace id="sub502" height="1em" width="1em" mathbackground="red"/>
-          <mspace id="sup502" height="1em" width="1em" mathbackground="red"/>
+          <mspace id="sub502" height="1em" width="1em" style="background: red"/>
+          <mspace id="sup502" height="1em" width="1em" style="background: red"/>
         </mmultiscripts>
       </math>
     </p>
@@ -290,11 +290,11 @@
     <p>
       <math style="font-family: subscripttopmax4000;">
         <mspace id="ref600" height="1em"
-                width="1em" mathbackground="green"/>
+                width="1em" style="background: green"/>
         <msub>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
           <mspace id="sub601" height="10em"
-                  width="1em" mathbackground="red"/>
+                  width="1em" style="background: red"/>
         </msub>
       </math>
     </p>
@@ -302,11 +302,11 @@
     <p>
       <math style="font-family: superscriptbottommin8000;">
         <mspace id="ref700" height="1em"
-                width="1em" mathbackground="green"/>
+                width="1em" style="background: green"/>
         <msup>
-          <mspace height="2em" width="2em" mathbackground="blue"/>
+          <mspace height="2em" width="2em" style="background: blue"/>
           <mspace id="sub701" depth="1em"
-                  width="1em" mathbackground="red"/>
+                  width="1em" style="background: red"/>
         </msup>
       </math>
     </p>
@@ -314,9 +314,9 @@
     <p>
       <math style="font-family: subscriptbaselinedropmin9000;">
         <msub>
-          <mspace id="base801" height="2em" width="2em" mathbackground="blue"/>
+          <mspace id="base801" height="2em" width="2em" style="background: blue"/>
           <mspace id="sub801" height="1em"
-                  width="1em" mathbackground="red"/>
+                  width="1em" style="background: red"/>
         </msub>
       </math>
     </p>
@@ -324,9 +324,9 @@
     <p>
       <math style="font-family: superscriptbaselinedropmax10000;">
         <msup>
-          <mspace id="base901" height="15em" width="2em" mathbackground="blue"/>
+          <mspace id="base901" height="15em" width="2em" style="background: blue"/>
           <mspace id="sup901" height="1em"
-                  width="1em" mathbackground="red"/>
+                  width="1em" style="background: red"/>
         </msup>
       </math>
     </p>

--- a/mathml/presentation-markup/scripts/subsup-parameters-2.html
+++ b/mathml/presentation-markup/scripts/subsup-parameters-2.html
@@ -69,30 +69,30 @@
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight5000;">
       <msub>
         <mo id="base001" lspace="0px" rspace="0px">&#x2AFF;</mo>
-        <mspace id="sub001" height="1em" width="1em" mathbackground="blue"/>
+        <mspace id="sub001" height="1em" width="1em" style="background: blue"/>
       </msub>
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight5000;">
       <msup>
         <mo id="base002" lspace="0px" rspace="0px">&#x2AFF;</mo>
-        <mspace id="sup002" height="1em" width="1em" mathbackground="blue"/>
+        <mspace id="sup002" height="1em" width="1em" style="background: blue"/>
       </msup>
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight5000;">
       <msubsup>
         <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
-        <mspace id="sub003" height="1em" width="1em" mathbackground="blue"/>
-        <mspace id="sup003" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="sub003" height="1em" width="1em" style="background: blue"/>
+        <mspace id="sup003" height="1em" width="1em" style="background: green"/>
       </msubsup>
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight5000;">
       <mmultiscripts>
         <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
-        <mspace id="sub004" height="1em" width="1em" mathbackground="blue"/>
-        <mspace id="sup004" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="sub004" height="1em" width="1em" style="background: blue"/>
+        <mspace id="sup004" height="1em" width="1em" style="background: green"/>
         <mprescripts/>
-        <mspace id="sub005" height="1em" width="1em" mathbackground="magenta"/>
-        <mspace id="sup005" height="1em" width="1em" mathbackground="cyan"/>
+        <mspace id="sub005" height="1em" width="1em" style="background: magenta"/>
+        <mspace id="sup005" height="1em" width="1em" style="background: cyan"/>
       </mmultiscripts>
     </math>
   </p>
@@ -101,30 +101,30 @@
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight2000-2AFF-italiccorrection3000;">
       <msub>
         <mo id="base011" lspace="0px" rspace="0px">&#x2AFF;</mo>
-        <mspace id="sub011" height="1em" width="1em" mathbackground="blue"/>
+        <mspace id="sub011" height="1em" width="1em" style="background: blue"/>
       </msub>
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight2000-2AFF-italiccorrection3000;">
       <msup>
         <mo id="base012" lspace="0px" rspace="0px">&#x2AFF;</mo>
-        <mspace id="sup012" height="1em" width="1em" mathbackground="blue"/>
+        <mspace id="sup012" height="1em" width="1em" style="background: blue"/>
       </msup>
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight2000-2AFF-italiccorrection3000;">
       <msubsup>
         <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
-        <mspace id="sub013" height="1em" width="1em" mathbackground="blue"/>
-        <mspace id="sup013" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="sub013" height="1em" width="1em" style="background: blue"/>
+        <mspace id="sup013" height="1em" width="1em" style="background: green"/>
       </msubsup>
     </math>
     <math displaystyle="true" style="font-family: largeop-displayoperatorminheight2000-2AFF-italiccorrection3000;">
       <mmultiscripts>
         <mo lspace="0px" rspace="0px">&#x2AFF;</mo>
-        <mspace id="sub014" height="1em" width="1em" mathbackground="blue"/>
-        <mspace id="sup014" height="1em" width="1em" mathbackground="green"/>
+        <mspace id="sub014" height="1em" width="1em" style="background: blue"/>
+        <mspace id="sup014" height="1em" width="1em" style="background: green"/>
         <mprescripts/>
-        <mspace id="sub015" height="1em" width="1em" mathbackground="magenta"/>
-        <mspace id="sup015" height="1em" width="1em" mathbackground="cyan"/>
+        <mspace id="sub015" height="1em" width="1em" style="background: magenta"/>
+        <mspace id="sup015" height="1em" width="1em" style="background: cyan"/>
       </mmultiscripts>
     </math>
   </p>

--- a/mathml/presentation-markup/scripts/underover-1.html
+++ b/mathml/presentation-markup/scripts/underover-1.html
@@ -91,68 +91,68 @@
 <body>
   <p>
     <math>
-      <mspace id="baseline" width="30px" height="2px" depth="0px" mathbackground="blue"/>
+      <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
       <munder id="under0">
-        <mspace id="under0base" width="30px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="under0under" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="under0base" width="30px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="under0under" width="10px" height="5px" depth="5px" style="background: black"/>
       </munder>
       <munder id="under1">
-        <mspace id="under1base" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="under1under" width="30px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="under1base" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="under1under" width="30px" height="5px" depth="5px" style="background: black"/>
       </munder>
       <munder id="under2">
-        <mspace id="under2base" width="10px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="under2under" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="under2base" width="10px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="under2under" width="10px" height="5px" depth="5px" style="background: black"/>
       </munder>
       <munder id="under3">
-        <mspace id="under3base" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="under3under" width="10px" height="15px" depth="15px" mathbackground="black"/>
+        <mspace id="under3base" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="under3under" width="10px" height="15px" depth="15px" style="background: black"/>
       </munder>
       <mover id="over0">
-        <mspace id="over0base" width="30px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="over0over" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="over0base" width="30px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="over0over" width="10px" height="5px" depth="5px" style="background: black"/>
       </mover>
       <mover id="over1">
-        <mspace id="over1base" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="over1over" width="30px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="over1base" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="over1over" width="30px" height="5px" depth="5px" style="background: black"/>
       </mover>
       <mover id="over2">
-        <mspace id="over2base" width="10px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="over2over" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="over2base" width="10px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="over2over" width="10px" height="5px" depth="5px" style="background: black"/>
       </mover>
       <mover id="over3">
-        <mspace id="over3base" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="over3over" width="10px" height="15px" depth="15px" mathbackground="black"/>
+        <mspace id="over3base" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="over3over" width="10px" height="15px" depth="15px" style="background: black"/>
       </mover>
       <munderover id="underover0">
-        <mspace id="underover0base" width="30px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover0under" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover0over" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="underover0base" width="30px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover0under" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover0over" width="10px" height="5px" depth="5px" style="background: black"/>
       </munderover>
       <munderover id="underover1">
-        <mspace id="underover1base" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover1under" width="30px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover1over" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="underover1base" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover1under" width="30px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover1over" width="10px" height="5px" depth="5px" style="background: black"/>
       </munderover>
       <munderover id="underover2">
-        <mspace id="underover2base" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover2under" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover2over" width="30px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="underover2base" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover2under" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover2over" width="30px" height="5px" depth="5px" style="background: black"/>
       </munderover>
       <munderover id="underover3">
-        <mspace id="underover3base" width="10px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="underover3under" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover3over" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="underover3base" width="10px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="underover3under" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover3over" width="10px" height="5px" depth="5px" style="background: black"/>
       </munderover>
       <munderover id="underover4">
-        <mspace id="underover4base" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover4under" width="10px" height="15px" depth="15px" mathbackground="black"/>
-        <mspace id="underover4over" width="10px" height="5px" depth="5px" mathbackground="black"/>
+        <mspace id="underover4base" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover4under" width="10px" height="15px" depth="15px" style="background: black"/>
+        <mspace id="underover4over" width="10px" height="5px" depth="5px" style="background: black"/>
       </munderover>
       <munderover id="underover5">
-        <mspace id="underover5base" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover5under" width="10px" height="5px" depth="5px" mathbackground="black"/>
-        <mspace id="underover5over" width="10px" height="15px" depth="15px" mathbackground="black"/>
+        <mspace id="underover5base" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover5under" width="10px" height="5px" depth="5px" style="background: black"/>
+        <mspace id="underover5over" width="10px" height="15px" depth="15px" style="background: black"/>
       </munderover>
     </math>
   </p>

--- a/mathml/presentation-markup/scripts/underover-parameters-1.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-1.html
@@ -82,60 +82,60 @@
 <body>
     <p>
       <math style="font-family: lowerlimitbaselinedropmin3000;">
-        <mspace id="ref0001" height="1em" width="3em" mathbackground="green"/>
+        <mspace id="ref0001" height="1em" width="3em" style="background: green"/>
         <munder>
           <mo movablelimits="false">&#x2211;</mo>
-          <mspace id="under00011" depth="1em" width="3em" mathbackground="blue"/>
+          <mspace id="under00011" depth="1em" width="3em" style="background: blue"/>
         </munder>
         <munderover>
           <mo movablelimits="false">&#x2211;</mo>
-          <mspace id="under00012" depth="1em" width="3em" mathbackground="blue"/>
-          <mspace height="1em" width="3em" mathbackground="black"/>
+          <mspace id="under00012" depth="1em" width="3em" style="background: blue"/>
+          <mspace height="1em" width="3em" style="background: black"/>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: lowerlimitgapmin11000;">
-        <mspace id="ref0002" height="1em" width="3em" mathbackground="green"/>
+        <mspace id="ref0002" height="1em" width="3em" style="background: green"/>
         <munder>
           <mo movablelimits="false">&#x2211;</mo>
-          <mspace id="under00021" depth="1em" width="3em" mathbackground="blue"/>
+          <mspace id="under00021" depth="1em" width="3em" style="background: blue"/>
         </munder>
         <munderover>
           <mo movablelimits="false">&#x2211;</mo>
-          <mspace id="under00022" depth="1em" width="3em" mathbackground="blue"/>
-          <mspace height="1em" width="3em" mathbackground="black"/>
+          <mspace id="under00022" depth="1em" width="3em" style="background: blue"/>
+          <mspace height="1em" width="3em" style="background: black"/>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: upperlimitbaselinerisemin5000;">
-        <mspace id="ref0003" height="1em" width="3em" mathbackground="green"/>
+        <mspace id="ref0003" height="1em" width="3em" style="background: green"/>
         <mover>
           <mo movablelimits="false">&#x2211;</mo>
-          <mspace id="over00031" height="1em" width="3em" mathbackground="blue"/>
+          <mspace id="over00031" height="1em" width="3em" style="background: blue"/>
         </mover>
         <munderover>
           <mo movablelimits="false">&#x2211;</mo>
-          <mspace height="1em" width="3em" mathbackground="black"/>
-          <mspace id="over00032" height="1em" width="3em" mathbackground="blue"/>
+          <mspace height="1em" width="3em" style="background: black"/>
+          <mspace id="over00032" height="1em" width="3em" style="background: blue"/>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: upperlimitgapmin7000;">
-        <mspace id="ref0004" height="1em" width="3em" mathbackground="green"/>
+        <mspace id="ref0004" height="1em" width="3em" style="background: green"/>
         <mover>
           <mo movablelimits="false">&#x2211;</mo>
-          <mspace id="over00041" depth="1em" width="3em" mathbackground="blue"/>
+          <mspace id="over00041" depth="1em" width="3em" style="background: blue"/>
         </mover>
         <munderover>
           <mo movablelimits="false">&#x2211;</mo>
-          <mspace height="1em" width="3em" mathbackground="black"/>
-          <mspace id="over00042" depth="1em" width="3em" mathbackground="blue"/>
+          <mspace height="1em" width="3em" style="background: black"/>
+          <mspace id="over00042" depth="1em" width="3em" style="background: blue"/>
         </munderover>
       </math>
     </p>

--- a/mathml/presentation-markup/scripts/underover-parameters-2.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-2.html
@@ -82,60 +82,60 @@
 <body>
     <p>
       <math style="font-family: bottomshiftdown3000;">
-        <mspace id="ref0001" height="1em" width="3em" mathbackground="green"/>
+        <mspace id="ref0001" height="1em" width="3em" style="background: green"/>
         <munder>
           <mo>&#x2192;</mo>
-          <mspace id="under00011" depth="1em" width="3em" mathbackground="blue"/>
+          <mspace id="under00011" depth="1em" width="3em" style="background: blue"/>
         </munder>
         <munderover>
           <mo>&#x2192;</mo>
-          <mspace id="under00012" depth="1em" width="3em" mathbackground="blue"/>
-          <mspace height="1em" width="3em" mathbackground="black"/>
+          <mspace id="under00012" depth="1em" width="3em" style="background: blue"/>
+          <mspace height="1em" width="3em" style="background: black"/>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: gapbelowmin11000;">
-        <mspace id="ref0002" height="1em" width="3em" mathbackground="green"/>
+        <mspace id="ref0002" height="1em" width="3em" style="background: green"/>
         <munder>
           <mo>&#x2192;</mo>
-          <mspace id="under00021" depth="1em" width="3em" mathbackground="blue"/>
+          <mspace id="under00021" depth="1em" width="3em" style="background: blue"/>
         </munder>
         <munderover>
           <mo>&#x2192;</mo>
-          <mspace id="under00022" depth="1em" width="3em" mathbackground="blue"/>
-          <mspace height="1em" width="3em" mathbackground="black"/>
+          <mspace id="under00022" depth="1em" width="3em" style="background: blue"/>
+          <mspace height="1em" width="3em" style="background: black"/>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: topshiftup5000;">
-        <mspace id="ref0003" height="1em" width="3em" mathbackground="green"/>
+        <mspace id="ref0003" height="1em" width="3em" style="background: green"/>
         <mover>
           <mo>&#x2192;</mo>
-          <mspace id="over00031" height="1em" width="3em" mathbackground="blue"/>
+          <mspace id="over00031" height="1em" width="3em" style="background: blue"/>
         </mover>
         <munderover>
           <mo>&#x2192;</mo>
-          <mspace height="1em" width="3em" mathbackground="black"/>
-          <mspace id="over00032" height="1em" width="3em" mathbackground="blue"/>
+          <mspace height="1em" width="3em" style="background: black"/>
+          <mspace id="over00032" height="1em" width="3em" style="background: blue"/>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: gapabovemin7000;">
-        <mspace id="ref0004" height="1em" width="3em" mathbackground="green"/>
+        <mspace id="ref0004" height="1em" width="3em" style="background: green"/>
         <mover>
           <mo>&#x2192;</mo>
-          <mspace id="over00041" depth="1em" width="3em" mathbackground="blue"/>
+          <mspace id="over00041" depth="1em" width="3em" style="background: blue"/>
         </mover>
         <munderover>
           <mo>&#x2192;</mo>
-          <mspace height="1em" width="3em" mathbackground="black"/>
-          <mspace id="over00042" depth="1em" width="3em" mathbackground="blue"/>
+          <mspace height="1em" width="3em" style="background: black"/>
+          <mspace id="over00042" depth="1em" width="3em" style="background: blue"/>
         </munderover>
       </math>
     </p>

--- a/mathml/presentation-markup/scripts/underover-parameters-3.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-3.html
@@ -189,132 +189,132 @@
 <body>
     <p>
       <math style="font-family: accentbaseheight4000underbarextradescender5000;">
-        <mspace id="ref001" height="1em" width="3em" mathbackground="green"/>
-        <munder mathbackground="cyan" id="el0011">
-          <mspace id="base0011" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0011" height="1em" width="3em" mathbackground="blue"/>
+        <mspace id="ref001" height="1em" width="3em" style="background: green"/>
+        <munder style="background: cyan" id="el0011">
+          <mspace id="base0011" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0011" height="1em" width="3em" style="background: blue"/>
         </munder>
-        <munder mathbackground="cyan" id="el0012" accentunder="true">
-          <mspace id="base0012" height="5em" width="1em" mathbackground="black"/>
-          <mspace id="under0012" height="1em" width="3em" mathbackground="blue"/>
+        <munder style="background: cyan" id="el0012" accentunder="true">
+          <mspace id="base0012" height="5em" width="1em" style="background: black"/>
+          <mspace id="under0012" height="1em" width="3em" style="background: blue"/>
         </munder>
-        <munder mathbackground="cyan" id="el0013" accentunder="true">
-          <mspace id="base0013" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0013" height="1em" width="3em" mathbackground="blue"/>
+        <munder style="background: cyan" id="el0013" accentunder="true">
+          <mspace id="base0013" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0013" height="1em" width="3em" style="background: blue"/>
         </munder>
-        <munderover mathbackground="cyan" id="el0014">
-          <mspace id="base0014" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0014" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0014" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0014">
+          <mspace id="base0014" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0014" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0014" height="1em" width="3em" style="background: red"/>
         </munderover>
-        <munderover mathbackground="cyan" id="el0015" accent="true">
-          <mspace id="base0015" height="5em" width="1em" mathbackground="black"/>
-          <mspace id="under0015" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0015" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0015" accent="true">
+          <mspace id="base0015" height="5em" width="1em" style="background: black"/>
+          <mspace id="under0015" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0015" height="1em" width="3em" style="background: red"/>
         </munderover>
-        <munderover mathbackground="cyan" id="el0016" accent="true">
-          <mspace id="base0016" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0016" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0016" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0016" accent="true">
+          <mspace id="base0016" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0016" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0016" height="1em" width="3em" style="background: red"/>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: accentbaseheight4000underbarverticalgap7000;">
-        <mspace id="ref002" height="1em" width="3em" mathbackground="green"/>
-        <munder mathbackground="cyan" id="el0021">
-          <mspace id="base0021" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0021" height="1em" width="3em" mathbackground="blue"/>
+        <mspace id="ref002" height="1em" width="3em" style="background: green"/>
+        <munder style="background: cyan" id="el0021">
+          <mspace id="base0021" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0021" height="1em" width="3em" style="background: blue"/>
         </munder>
-        <munder mathbackground="cyan" id="el0022" accentunder="true">
-          <mspace id="base0022" height="5em" width="1em" mathbackground="black"/>
-          <mspace id="under0022" height="1em" width="3em" mathbackground="blue"/>
+        <munder style="background: cyan" id="el0022" accentunder="true">
+          <mspace id="base0022" height="5em" width="1em" style="background: black"/>
+          <mspace id="under0022" height="1em" width="3em" style="background: blue"/>
         </munder>
-        <munder mathbackground="cyan" id="el0023" accentunder="true">
-          <mspace id="base0023" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0023" height="1em" width="3em" mathbackground="blue"/>
+        <munder style="background: cyan" id="el0023" accentunder="true">
+          <mspace id="base0023" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0023" height="1em" width="3em" style="background: blue"/>
         </munder>
-        <munderover mathbackground="cyan" id="el0024">
-          <mspace id="base0024" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0024" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0024" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0024">
+          <mspace id="base0024" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0024" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0024" height="1em" width="3em" style="background: red"/>
         </munderover>
-        <munderover mathbackground="cyan" id="el0025" accent="true">
-          <mspace id="base0025" height="5em" width="1em" mathbackground="black"/>
-          <mspace id="under0025" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0025" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0025" accent="true">
+          <mspace id="base0025" height="5em" width="1em" style="background: black"/>
+          <mspace id="under0025" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0025" height="1em" width="3em" style="background: red"/>
         </munderover>
-        <munderover mathbackground="cyan" id="el0026" accent="true">
-          <mspace id="base0026" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0026" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0026" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0026" accent="true">
+          <mspace id="base0026" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0026" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0026" height="1em" width="3em" style="background: red"/>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: accentbaseheight4000overbarextraascender3000;">
-        <mspace id="ref003" height="1em" width="3em" mathbackground="green"/>
-        <mover mathbackground="cyan" id="el0031">
-          <mspace id="base0031" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="over0031" height="1em" width="3em" mathbackground="red"/>
+        <mspace id="ref003" height="1em" width="3em" style="background: green"/>
+        <mover style="background: cyan" id="el0031">
+          <mspace id="base0031" height="3em" width="1em" style="background: black"/>
+          <mspace id="over0031" height="1em" width="3em" style="background: red"/>
         </mover>
-        <mover mathbackground="cyan" id="el0032" accent="true">
-          <mspace id="base0032" height="5em" width="1em" mathbackground="black"/>
-          <mspace id="over0032" height="1em" width="3em" mathbackground="red"/>
+        <mover style="background: cyan" id="el0032" accent="true">
+          <mspace id="base0032" height="5em" width="1em" style="background: black"/>
+          <mspace id="over0032" height="1em" width="3em" style="background: red"/>
         </mover>
-        <mover mathbackground="cyan" id="el0033" accent="true">
-          <mspace id="base0033" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="over0033" height="1em" width="3em" mathbackground="red"/>
+        <mover style="background: cyan" id="el0033" accent="true">
+          <mspace id="base0033" height="3em" width="1em" style="background: black"/>
+          <mspace id="over0033" height="1em" width="3em" style="background: red"/>
         </mover>
-        <munderover mathbackground="cyan" id="el0034">
-          <mspace id="base0034" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0034" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0034" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0034">
+          <mspace id="base0034" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0034" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0034" height="1em" width="3em" style="background: red"/>
         </munderover>
-        <munderover mathbackground="cyan" id="el0035" accent="true">
-          <mspace id="base0035" height="5em" width="1em" mathbackground="black"/>
-          <mspace id="under0035" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0035" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0035" accent="true">
+          <mspace id="base0035" height="5em" width="1em" style="background: black"/>
+          <mspace id="under0035" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0035" height="1em" width="3em" style="background: red"/>
         </munderover>
-        <munderover mathbackground="cyan" id="el0036" accent="true">
-          <mspace id="base0036" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0036" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0036" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0036" accent="true">
+          <mspace id="base0036" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0036" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0036" height="1em" width="3em" style="background: red"/>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: accentbaseheight4000overbarverticalgap11000;">
-        <mspace id="ref004" height="1em" width="3em" mathbackground="green"/>
-        <mover mathbackground="cyan" id="el0041">
-          <mspace id="base0041" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="over0041" height="1em" width="3em" mathbackground="red"/>
+        <mspace id="ref004" height="1em" width="3em" style="background: green"/>
+        <mover style="background: cyan" id="el0041">
+          <mspace id="base0041" height="3em" width="1em" style="background: black"/>
+          <mspace id="over0041" height="1em" width="3em" style="background: red"/>
         </mover>
-        <mover mathbackground="cyan" id="el0042" accent="true">
-          <mspace id="base0042" height="5em" width="1em" mathbackground="black"/>
-          <mspace id="over0042" height="1em" width="3em" mathbackground="red"/>
+        <mover style="background: cyan" id="el0042" accent="true">
+          <mspace id="base0042" height="5em" width="1em" style="background: black"/>
+          <mspace id="over0042" height="1em" width="3em" style="background: red"/>
         </mover>
-        <mover mathbackground="cyan" id="el0043" accent="true">
-          <mspace id="base0043" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="over0043" height="1em" width="3em" mathbackground="red"/>
+        <mover style="background: cyan" id="el0043" accent="true">
+          <mspace id="base0043" height="3em" width="1em" style="background: black"/>
+          <mspace id="over0043" height="1em" width="3em" style="background: red"/>
         </mover>
-        <munderover mathbackground="cyan" id="el0044">
-          <mspace id="base0044" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0044" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0044" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0044">
+          <mspace id="base0044" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0044" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0044" height="1em" width="3em" style="background: red"/>
         </munderover>
-        <munderover mathbackground="cyan" id="el0045" accent="true">
-          <mspace id="base0045" height="5em" width="1em" mathbackground="black"/>
-          <mspace id="under0045" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0045" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0045" accent="true">
+          <mspace id="base0045" height="5em" width="1em" style="background: black"/>
+          <mspace id="under0045" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0045" height="1em" width="3em" style="background: red"/>
         </munderover>
-        <munderover mathbackground="cyan" id="el0046" accent="true">
-          <mspace id="base0046" height="3em" width="1em" mathbackground="black"/>
-          <mspace id="under0046" height="1em" width="3em" mathbackground="blue"/>
-          <mspace id="over0046" height="1em" width="3em" mathbackground="red"/>
+        <munderover style="background: cyan" id="el0046" accent="true">
+          <mspace id="base0046" height="3em" width="1em" style="background: black"/>
+          <mspace id="under0046" height="1em" width="3em" style="background: blue"/>
+          <mspace id="over0046" height="1em" width="3em" style="background: red"/>
         </munderover>
       </math>
     </p>

--- a/mathml/presentation-markup/scripts/underover-parameters-4.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-4.html
@@ -189,132 +189,132 @@
 <body>
     <p>
       <math style="font-family: accentbaseheight4000underbarextradescender5000;">
-        <mspace id="ref001" height="1em" width="3em" mathbackground="green"/>
-        <munder mathbackground="cyan" id="el0011">
-          <mspace id="base0011" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0011" mathcolor="blue">&#xB0;</mo>
+        <mspace id="ref001" height="1em" width="3em" style="background: green"/>
+        <munder style="background: cyan" id="el0011">
+          <mspace id="base0011" height="3em" width="1em" style="background: black"/>
+          <mo id="under0011" style="color: blue">&#xB0;</mo>
         </munder>
-        <munder mathbackground="cyan" id="el0012">
-          <mspace id="base0012" height="5em" width="1em" mathbackground="black"/>
-          <mo id="under0012" mathcolor="blue">&#x2D8;</mo>
+        <munder style="background: cyan" id="el0012">
+          <mspace id="base0012" height="5em" width="1em" style="background: black"/>
+          <mo id="under0012" style="color: blue">&#x2D8;</mo>
         </munder>
-        <munder mathbackground="cyan" id="el0013">
-          <mspace id="base0013" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0013" mathcolor="blue">&#x2D8;</mo>
+        <munder style="background: cyan" id="el0013">
+          <mspace id="base0013" height="3em" width="1em" style="background: black"/>
+          <mo id="under0013" style="color: blue">&#x2D8;</mo>
         </munder>
-        <munderover mathbackground="cyan" id="el0014">
-          <mspace id="base0014" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0014" mathcolor="blue">&#xB0;</mo>
-          <mo id="over0014" mathcolor="red">&#xB0;</mo>
+        <munderover style="background: cyan" id="el0014">
+          <mspace id="base0014" height="3em" width="1em" style="background: black"/>
+          <mo id="under0014" style="color: blue">&#xB0;</mo>
+          <mo id="over0014" style="color: red">&#xB0;</mo>
         </munderover>
-        <munderover mathbackground="cyan" id="el0015" accent="true">
-          <mspace id="base0015" height="5em" width="1em" mathbackground="black"/>
-          <mo id="under0015" mathcolor="blue">&#x2D8;</mo>
-          <mo id="over0015" mathcolor="red">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0015" accent="true">
+          <mspace id="base0015" height="5em" width="1em" style="background: black"/>
+          <mo id="under0015" style="color: blue">&#x2D8;</mo>
+          <mo id="over0015" style="color: red">&#x2D8;</mo>
         </munderover>
-        <munderover mathbackground="cyan" id="el0016" accent="true">
-          <mspace id="base0016" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0016" mathcolor="blue">&#x2D8;</mo>
-          <mo id="over0016" mathcolor="red">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0016" accent="true">
+          <mspace id="base0016" height="3em" width="1em" style="background: black"/>
+          <mo id="under0016" style="color: blue">&#x2D8;</mo>
+          <mo id="over0016" style="color: red">&#x2D8;</mo>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: accentbaseheight4000underbarverticalgap7000;">
-        <mspace id="ref002" height="1em" width="3em" mathbackground="green"/>
-        <munder mathbackground="cyan" id="el0021" accentunder="false">
-          <mspace id="base0021" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0021" mathcolor="blue">&#x2D8;</mo>
+        <mspace id="ref002" height="1em" width="3em" style="background: green"/>
+        <munder style="background: cyan" id="el0021" accentunder="false">
+          <mspace id="base0021" height="3em" width="1em" style="background: black"/>
+          <mo id="under0021" style="color: blue">&#x2D8;</mo>
         </munder>
-        <munder mathbackground="cyan" id="el0022">
-          <mspace id="base0022" height="5em" width="1em" mathbackground="black"/>
-          <mo id="under0022" mathcolor="blue" accent="true">&#x2D8;</mo>
+        <munder style="background: cyan" id="el0022">
+          <mspace id="base0022" height="5em" width="1em" style="background: black"/>
+          <mo id="under0022" style="color: blue" accent="true">&#x2D8;</mo>
         </munder>
-        <munder mathbackground="cyan" id="el0023">
-          <mspace id="base0023" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0023" mathcolor="blue" accent="true">&#xB0;</mo>
+        <munder style="background: cyan" id="el0023">
+          <mspace id="base0023" height="3em" width="1em" style="background: black"/>
+          <mo id="under0023" style="color: blue" accent="true">&#xB0;</mo>
         </munder>
-        <munderover mathbackground="cyan" id="el0024">
-          <mspace id="base0024" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0024" mathcolor="blue" accent="false">&#x2D8;</mo>
-          <mo id="over0024" mathcolor="red" accent="false">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0024">
+          <mspace id="base0024" height="3em" width="1em" style="background: black"/>
+          <mo id="under0024" style="color: blue" accent="false">&#x2D8;</mo>
+          <mo id="over0024" style="color: red" accent="false">&#x2D8;</mo>
         </munderover>
-        <munderover mathbackground="cyan" id="el0025">
-          <mspace id="base0025" height="5em" width="1em" mathbackground="black"/>
-          <mo id="under0025" mathcolor="blue" accent="false">&#x2D8;</mo>
-          <mo id="over0025" mathcolor="red">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0025">
+          <mspace id="base0025" height="5em" width="1em" style="background: black"/>
+          <mo id="under0025" style="color: blue" accent="false">&#x2D8;</mo>
+          <mo id="over0025" style="color: red">&#x2D8;</mo>
         </munderover>
-        <munderover mathbackground="cyan" id="el0026">
-          <mspace id="base0026" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0026" mathcolor="blue" accent="false">&#x2D8;</mo>
-          <mo id="over0026" mathcolor="red">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0026">
+          <mspace id="base0026" height="3em" width="1em" style="background: black"/>
+          <mo id="under0026" style="color: blue" accent="false">&#x2D8;</mo>
+          <mo id="over0026" style="color: red">&#x2D8;</mo>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: accentbaseheight4000overbarextraascender3000;">
-        <mspace id="ref003" height="1em" width="3em" mathbackground="green"/>
-        <mover mathbackground="cyan" id="el0031">
-          <mspace id="base0031" height="3em" width="1em" mathbackground="black"/>
-          <mo id="over0031" mathcolor="red">&#xB0;</mo>
+        <mspace id="ref003" height="1em" width="3em" style="background: green"/>
+        <mover style="background: cyan" id="el0031">
+          <mspace id="base0031" height="3em" width="1em" style="background: black"/>
+          <mo id="over0031" style="color: red">&#xB0;</mo>
         </mover>
-        <mover mathbackground="cyan" id="el0032" accent="true">
-          <mspace id="base0032" height="5em" width="1em" mathbackground="black"/>
-          <mo id="over0032" mathcolor="red">&#xB0;</mo>
+        <mover style="background: cyan" id="el0032" accent="true">
+          <mspace id="base0032" height="5em" width="1em" style="background: black"/>
+          <mo id="over0032" style="color: red">&#xB0;</mo>
         </mover>
-        <mover mathbackground="cyan" id="el0033">
-          <mspace id="base0033" height="3em" width="1em" mathbackground="black"/>
-          <mo id="over0033" mathcolor="red">&#x2D8;</mo>
+        <mover style="background: cyan" id="el0033">
+          <mspace id="base0033" height="3em" width="1em" style="background: black"/>
+          <mo id="over0033" style="color: red">&#x2D8;</mo>
         </mover>
-        <munderover mathbackground="cyan" id="el0034">
-          <mspace id="base0034" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0034" mathcolor="blue">&#xB0;</mo>
-          <mo id="over0034" mathcolor="red" accent="false">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0034">
+          <mspace id="base0034" height="3em" width="1em" style="background: black"/>
+          <mo id="under0034" style="color: blue">&#xB0;</mo>
+          <mo id="over0034" style="color: red" accent="false">&#x2D8;</mo>
         </munderover>
-        <munderover mathbackground="cyan" id="el0035" accent="true">
-          <mspace id="base0035" height="5em" width="1em" mathbackground="black"/>
-          <mo id="under0035" mathcolor="blue">&#x2D8;</mo>
-          <mo id="over0035" mathcolor="red">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0035" accent="true">
+          <mspace id="base0035" height="5em" width="1em" style="background: black"/>
+          <mo id="under0035" style="color: blue">&#x2D8;</mo>
+          <mo id="over0035" style="color: red">&#x2D8;</mo>
         </munderover>
-        <munderover mathbackground="cyan" id="el0036" accent="true">
-          <mspace id="base0036" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0036" mathcolor="blue">&#x2D8;</mo>
-          <mo id="over0036" mathcolor="red">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0036" accent="true">
+          <mspace id="base0036" height="3em" width="1em" style="background: black"/>
+          <mo id="under0036" style="color: blue">&#x2D8;</mo>
+          <mo id="over0036" style="color: red">&#x2D8;</mo>
         </munderover>
       </math>
     </p>
     <hr/>
     <p>
       <math style="font-family: accentbaseheight4000overbarverticalgap11000;">
-        <mspace id="ref004" height="1em" width="3em" mathbackground="green"/>
-        <mover mathbackground="cyan" id="el0041">
-          <mspace id="base0041" height="3em" width="1em" mathbackground="black"/>
-          <mo id="over0041" mathcolor="red">&#xB0;</mo>
+        <mspace id="ref004" height="1em" width="3em" style="background: green"/>
+        <mover style="background: cyan" id="el0041">
+          <mspace id="base0041" height="3em" width="1em" style="background: black"/>
+          <mo id="over0041" style="color: red">&#xB0;</mo>
         </mover>
-        <mover mathbackground="cyan" id="el0042" accent="true">
-          <mspace id="base0042" height="5em" width="1em" mathbackground="black"/>
-          <mo id="over0042" mathcolor="red">&#xB0;</mo>
+        <mover style="background: cyan" id="el0042" accent="true">
+          <mspace id="base0042" height="5em" width="1em" style="background: black"/>
+          <mo id="over0042" style="color: red">&#xB0;</mo>
         </mover>
-        <mover mathbackground="cyan" id="el0043">
-          <mspace id="base0043" height="3em" width="1em" mathbackground="black"/>
-          <mo id="over0043" mathcolor="red">&#x2D8;</mo>
+        <mover style="background: cyan" id="el0043">
+          <mspace id="base0043" height="3em" width="1em" style="background: black"/>
+          <mo id="over0043" style="color: red">&#x2D8;</mo>
         </mover>
-        <munderover mathbackground="cyan" id="el0044">
-          <mspace id="base0044" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0044" mathcolor="blue">&#xB0;</mo>
-          <mo id="over0044" mathcolor="red" accent="false">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0044">
+          <mspace id="base0044" height="3em" width="1em" style="background: black"/>
+          <mo id="under0044" style="color: blue">&#xB0;</mo>
+          <mo id="over0044" style="color: red" accent="false">&#x2D8;</mo>
         </munderover>
-        <munderover mathbackground="cyan" id="el0045" accent="true">
-          <mspace id="base0045" height="5em" width="1em" mathbackground="black"/>
-          <mo id="under0045" mathcolor="blue">&#x2D8;</mo>
-          <mo id="over0045" mathcolor="red">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0045" accent="true">
+          <mspace id="base0045" height="5em" width="1em" style="background: black"/>
+          <mo id="under0045" style="color: blue">&#x2D8;</mo>
+          <mo id="over0045" style="color: red">&#x2D8;</mo>
         </munderover>
-        <munderover mathbackground="cyan" id="el0046" accent="true">
-          <mspace id="base0046" height="3em" width="1em" mathbackground="black"/>
-          <mo id="under0046" mathcolor="blue">&#x2D8;</mo>
-          <mo id="over0046" mathcolor="red">&#x2D8;</mo>
+        <munderover style="background: cyan" id="el0046" accent="true">
+          <mspace id="base0046" height="3em" width="1em" style="background: black"/>
+          <mo id="under0046" style="color: blue">&#x2D8;</mo>
+          <mo id="over0046" style="color: red">&#x2D8;</mo>
         </munderover>
       </math>
     </p>

--- a/mathml/presentation-markup/spaces/space-1.html
+++ b/mathml/presentation-markup/spaces/space-1.html
@@ -81,9 +81,9 @@
       <mspace id="depth0" depth="25px"/>
       <mspace id="depth1" depth="50px"/>
       <mspace id="depth2" depth="75px"/>
-      <mspace id="mspace0" width="25px" height="50px" depth="75px" mathbackground="green"/>
-      <mspace id="mspace1" width="50px" height="75px" depth="25px" mathbackground="blue"/>
-      <mspace id="mspace2" width="75px" height="25px" depth="50px" mathbackground="green"/>
+      <mspace id="mspace0" width="25px" height="50px" depth="75px" style="background: green"/>
+      <mspace id="mspace1" width="50px" height="75px" depth="25px" style="background: blue"/>
+      <mspace id="mspace2" width="75px" height="25px" depth="50px" style="background: green"/>
     </math>
   </p>
   <hr/>

--- a/mathml/presentation-markup/spaces/space-2.html
+++ b/mathml/presentation-markup/spaces/space-2.html
@@ -14,17 +14,17 @@
     <div style="position: absolute; top: 0px; left: 0px;
                 width: 200px; height: 200px;">
       <math style="position: absolute; top: 0px; left: 0px">
-        <mspace width="50px" height="100px" depth="100px" mathbackground="green"/>
-        <mspace width="50px" height="100px" depth="100px" mathbackground="green"/>
-        <mspace width="25px" depth="100px" mathbackground="green"/>
-        <mspace width="25px" depth="100px" mathbackground="green"/>
-        <mspace width="25px" height="100px" mathbackground="green"/>
-        <mspace width="25px" height="100px" mathbackground="green"/>
+        <mspace width="50px" height="100px" depth="100px" style="background: green"/>
+        <mspace width="50px" height="100px" depth="100px" style="background: green"/>
+        <mspace width="25px" depth="100px" style="background: green"/>
+        <mspace width="25px" depth="100px" style="background: green"/>
+        <mspace width="25px" height="100px" style="background: green"/>
+        <mspace width="25px" height="100px" style="background: green"/>
       </math>
       <math style="position: absolute; top: 0px; left: 0px">
-        <mspace width="100px" height="20px" depth="20px" mathbackground="red"/>
-        <mspace width="50px" height="100px" mathbackground="red"/>
-        <mspace width="50px" depth="100px" mathbackground="red"/>
+        <mspace width="100px" height="20px" depth="20px" style="background: red"/>
+        <mspace width="50px" height="100px" style="background: red"/>
+        <mspace width="50px" depth="100px" style="background: red"/>
       </math>
     </div>
     <!-- These green divs should cover the red mspace elements -->

--- a/mathml/presentation-markup/tables/table-axis-height.html
+++ b/mathml/presentation-markup/tables/table-axis-height.html
@@ -45,8 +45,8 @@
 <body>
   <p>
     <math style="font-family: axisheight5000-verticalarrow14000">
-      <mspace id="baseline" mathbackground="green" width="50px" height="1px"/>
-      <mtable id="table" mathbackground="blue"><mtr><mtd><mspace width="100px" height="1px"/></mtd></mtr></mtable>
+      <mspace id="baseline" style="background: green" width="50px" height="1px"/>
+      <mtable id="table" style="background: blue"><mtr><mtd><mspace width="100px" height="1px"/></mtd></mtr></mtable>
     </math>
   </p>
 </body>

--- a/mathml/relations/css-styling/display-1.html
+++ b/mathml/relations/css-styling/display-1.html
@@ -10,7 +10,7 @@
 <body>
   <p>Test passes if you see a green square.</p>
   <div style="background: green; color: red; width: 200px; height: 200px;">
-    <math style="display: none;"><mspace width="200px" height="200px" mathbackground="red"/></math>
+    <math style="display: none;"><mspace width="200px" height="200px" style="background: red"/></math>
   </div>
 </body>
 </html>

--- a/mathml/relations/html5-tree/href-click-1.html
+++ b/mathml/relations/html5-tree/href-click-1.html
@@ -22,12 +22,12 @@
   <div style="width: 150px; height: 150px; overflow: hidden">
     <math>
       <mrow id="link" href="#target">
-        <mspace id="space" width="150px" height="150px" mathbackground="red"/>
+        <mspace id="space" width="150px" height="150px" style="background: red"/>
       </mrow>
     </math>
     <div style="height: 500px;"></div>
     <math id="target">
-      <mspace width="150px" height="150px" mathbackground="green"/>
+      <mspace width="150px" height="150px" style="background: green"/>
     </math>
   </div>
 

--- a/mathml/relations/html5-tree/href-click-2.html
+++ b/mathml/relations/html5-tree/href-click-2.html
@@ -24,14 +24,14 @@
       <mrow href="#target">
         <mrow>
           <mrow>
-            <mspace id="space" width="150px" height="150px" mathbackground="red"/>
+            <mspace id="space" width="150px" height="150px" style="background: red"/>
           </mrow>
         </mrow>
       </mrow>
     </math>
     <div style="height: 500px;"></div>
     <math id="target">
-      <mspace width="150px" height="150px" mathbackground="green"/>
+      <mspace width="150px" height="150px" style="background: green"/>
     </math>
   </div>
 


### PR DESCRIPTION
Currently, many tests unnecessarily rely on the MathML mathcolor/mathbackground
attributes to be implemented. This commit use the equivalent CSS color and background properties instead, except for the test that actually checks support for the MathML color attributes (relations/html5-tree/color-attributes-1.html).