### PR TITLE
Add an id="log" container at the top of the page for MathML testharne…

### DIFF
--- a/mathml/presentation-markup/fractions/frac-1.html
+++ b/mathml/presentation-markup/fractions/frac-1.html
@@ -79,6 +79,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math>
       <mo id="axis">−</mo>
@@ -124,6 +125,5 @@
       </mfrac>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-parameters-1.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-1.html
@@ -133,6 +133,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math style="font-family: axisheight7000-rulethickness1000;">
       <mspace id="ref0001" depth="1em" width="3em" style="background: green"/>
@@ -237,6 +238,5 @@
       </mfrac>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-parameters-2.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-2.html
@@ -102,6 +102,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math style="font-family: axisheight7000;">
       <mspace id="ref0001" depth="1em" width="3em" style="background: green"/>
@@ -169,6 +170,5 @@
       </mfrac>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/operators/mo-axis-height-1.html
+++ b/mathml/presentation-markup/operators/mo-axis-height-1.html
@@ -55,6 +55,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math style="font-family: axisheight5000-verticalarrow14000;">
       <mrow>
@@ -72,6 +73,5 @@
         <mspace id="target2" style="background: gray" width="10px" height="200px"/>
       </mrow>
     </math>
-  </p>
 </body>
 </html>

--- a/mathml/presentation-markup/radicals/root-parameters-1.html
+++ b/mathml/presentation-markup/radicals/root-parameters-1.html
@@ -129,6 +129,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math style="font-family: degreebottomraisepercent25-rulethickness1000;">
       <mspace id="ref001" width="3em" depth="1em" style="background: green"/>
@@ -204,6 +205,5 @@
       </mroot>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/subsup-1.html
+++ b/mathml/presentation-markup/scripts/subsup-1.html
@@ -81,6 +81,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math>
       <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
@@ -99,6 +100,5 @@
       </msubsup>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/subsup-2.html
+++ b/mathml/presentation-markup/scripts/subsup-2.html
@@ -120,6 +120,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math>
       <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
@@ -158,6 +159,5 @@
       </mmultiscripts>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/subsup-3.html
+++ b/mathml/presentation-markup/scripts/subsup-3.html
@@ -107,6 +107,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math>
       <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
@@ -175,6 +176,5 @@
       </mmultiscripts>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/subsup-4.html
+++ b/mathml/presentation-markup/scripts/subsup-4.html
@@ -51,6 +51,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math>
       <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
@@ -119,6 +120,5 @@
       </mmultiscripts>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/subsup-5.html
+++ b/mathml/presentation-markup/scripts/subsup-5.html
@@ -59,6 +59,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math>
       <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
@@ -85,6 +86,5 @@
       </mmultiscripts>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/subsup-parameters-1.html
+++ b/mathml/presentation-markup/scripts/subsup-parameters-1.html
@@ -143,6 +143,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
     <p>
       <math style="font-family: spaceafterscript3000;">
         <msub>
@@ -330,6 +331,5 @@
         </msup>
       </math>
     </p>
-    <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/underover-1.html
+++ b/mathml/presentation-markup/scripts/underover-1.html
@@ -89,6 +89,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math>
       <mspace id="baseline" width="30px" height="2px" depth="0px" style="background: blue"/>
@@ -156,6 +157,5 @@
       </munderover>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/underover-parameters-1.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-1.html
@@ -80,6 +80,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
     <p>
       <math style="font-family: lowerlimitbaselinedropmin3000;">
         <mspace id="ref0001" height="1em" width="3em" style="background: green"/>
@@ -139,6 +140,5 @@
         </munderover>
       </math>
     </p>
-    <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/underover-parameters-2.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-2.html
@@ -80,6 +80,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
     <p>
       <math style="font-family: bottomshiftdown3000;">
         <mspace id="ref0001" height="1em" width="3em" style="background: green"/>
@@ -139,6 +140,5 @@
         </munderover>
       </math>
     </p>
-    <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/underover-parameters-3.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-3.html
@@ -187,6 +187,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
     <p>
       <math style="font-family: accentbaseheight4000underbarextradescender5000;">
         <mspace id="ref001" height="1em" width="3em" style="background: green"/>
@@ -318,6 +319,5 @@
         </munderover>
       </math>
     </p>
-    <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/scripts/underover-parameters-4.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-4.html
@@ -187,6 +187,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
     <p>
       <math style="font-family: accentbaseheight4000underbarextradescender5000;">
         <mspace id="ref001" height="1em" width="3em" style="background: green"/>
@@ -318,6 +319,5 @@
         </munderover>
       </math>
     </p>
-    <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/spaces/space-1.html
+++ b/mathml/presentation-markup/spaces/space-1.html
@@ -68,6 +68,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <span id="baseline" style="display: inline-block; width: 30px; height: 5px; background: blue"></span>
     <math>
@@ -86,6 +87,5 @@
       <mspace id="mspace2" width="75px" height="25px" depth="50px" style="background: green"/>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/presentation-markup/tables/table-axis-height.html
+++ b/mathml/presentation-markup/tables/table-axis-height.html
@@ -43,6 +43,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math style="font-family: axisheight5000-verticalarrow14000">
       <mspace id="baseline" style="background: green" width="50px" height="1px"/>

--- a/mathml/relations/css-styling/displaystyle-1.html
+++ b/mathml/relations/css-styling/displaystyle-1.html
@@ -92,6 +92,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <math><mo id="math_default">&#x2AFF;</mo></math>
   <math display="inline"><mo id="math_inline">&#x2AFF;</mo></math>
   <math display="block"><mo id="math_block">&#x2AFF;</mo></math>

--- a/mathml/relations/css-styling/lengths-3.html
+++ b/mathml/relations/css-styling/lengths-3.html
@@ -93,6 +93,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <p>
     <math>
       <mspace id="unitCm" width="2.54cm"/>
@@ -154,6 +155,5 @@
       <mpadded voffset="-012.345em"><mspace id="N10"/></mpadded>
     </math>
   </p>
-  <hr/>
 </body>
 </html>

--- a/mathml/relations/html5-tree/class-2.html
+++ b/mathml/relations/html5-tree/class-2.html
@@ -13,7 +13,7 @@
     var mtext = document.getElementsByClassName("cl");
     test(function() {
       assert_equals(mtext.length, 3);
-      var mtext_ref = document.body.firstElementChild.firstElementChild;
+      var mtext_ref = document.body.lastElementChild.firstElementChild;
       mtext_ref = mtext_ref.nextElementSibling.nextElementSibling
       assert_equals(mtext[0], mtext_ref);
       mtext_ref = mtext_ref.nextElementSibling.nextElementSibling;
@@ -26,6 +26,7 @@
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <math>
     <mtext class="cl_"></mtext>
     <mtext class="c"></mtext>

--- a/mathml/relations/html5-tree/display-1.html
+++ b/mathml/relations/html5-tree/display-1.html
@@ -70,6 +70,7 @@
 </style>
 </head>
 <body>
+  <div id="log"></div>
   <div id="content">
     <span id="before_block" class="square"></span>
     <math display="block"><mspace id="mspace_block" width="50px" height="50px"/></math>

--- a/mathml/relations/html5-tree/unique-identifier-2.html
+++ b/mathml/relations/html5-tree/unique-identifier-2.html
@@ -12,13 +12,14 @@
   window.addEventListener("DOMContentLoaded", function() {
     var mtext = document.getElementById("MTEXT");
     test(function() {
-      assert_equals(mtext, document.body.firstElementChild.lastElementChild);
+      assert_equals(mtext, document.body.lastElementChild.lastElementChild);
     }, "getElementById()");
     done();
   });
 </script>
 </head>
 <body>
+  <div id="log"></div>
   <math>
     <mtext id="MTEXT_"></mtext>
     <mtext id="MTEX"></mtext>


### PR DESCRIPTION
…ss tests.

Currently the test summary is appended at the end of the page, sometimes after
a lot of MathML formulae. Adding an id="log" container allows to display the
summary at the top of the page.