### PR TITLE
[css-scroll-snap] scroll-snap-type computed value

### DIFF
--- a/css/css-scroll-snap/parsing/scroll-margin-block-computed.html
+++ b/css/css-scroll-snap/parsing/scroll-margin-block-computed.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Scroll Snap: getComputedValue().scrollMarginBlock</title>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block">
+<meta name="assert" content="scroll-margin-block computed value is absolute length.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+<script>
+test_computed_value("scroll-margin-block-start", "10px");
+test_computed_value("scroll-margin-block-start", "calc(10px - 0.5em)", "-10px");
+
+
+test_computed_value("scroll-margin-block-end", "10px");
+test_computed_value("scroll-margin-block-end", "calc(10px - 0.5em)", "-10px");
+
+
+test_computed_value("scroll-margin-block", "10px");
+test_computed_value("scroll-margin-block", "calc(10px - 0.5em)", "-10px");
+
+test_computed_value("scroll-margin-block", "1px 2px");
+</script>
+</body>
+</html>

--- a/css/css-scroll-snap/parsing/scroll-margin-computed.html
+++ b/css/css-scroll-snap/parsing/scroll-margin-computed.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Scroll Snap: getComputedValue().scrollMargin</title>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin">
+<meta name="assert" content="scroll-margin computed value is absolute length.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+<script>
+test_computed_value("scroll-margin-top", "10px");
+test_computed_value("scroll-margin-top", "calc(10px - 0.5em)", "-10px");
+
+
+test_computed_value("scroll-margin-right", "10px");
+test_computed_value("scroll-margin-right", "calc(10px - 0.5em)", "-10px");
+
+
+test_computed_value("scroll-margin-bottom", "10px");
+test_computed_value("scroll-margin-bottom", "calc(10px - 0.5em)", "-10px");
+
+
+test_computed_value("scroll-margin-left", "10px");
+test_computed_value("scroll-margin-left", "calc(10px - 0.5em)", "-10px");
+
+
+test_computed_value("scroll-margin", "10px");
+test_computed_value("scroll-margin", "calc(10px - 0.5em)", "-10px");
+
+test_computed_value("scroll-margin", "1px 2px");
+</script>
+</body>
+</html>

--- a/css/css-scroll-snap/parsing/scroll-margin-inline-computed.html
+++ b/css/css-scroll-snap/parsing/scroll-margin-inline-computed.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Scroll Snap: getComputedValue().scrollMarginInline</title>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline">
+<meta name="assert" content="scroll-margin-inline computed value is absolute length.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+<script>
+test_computed_value("scroll-margin-inline-start", "10px");
+test_computed_value("scroll-margin-inline-start", "calc(10px - 0.5em)", "-10px");
+
+
+test_computed_value("scroll-margin-inline-end", "10px");
+test_computed_value("scroll-margin-inline-end", "calc(10px - 0.5em)", "-10px");
+
+
+test_computed_value("scroll-margin-inline", "10px");
+test_computed_value("scroll-margin-inline", "calc(10px - 0.5em)", "-10px");
+
+test_computed_value("scroll-margin-inline", "1px 2px");
+</script>
+</body>
+</html>

--- a/css/css-scroll-snap/parsing/scroll-snap-align-computed.html
+++ b/css/css-scroll-snap/parsing/scroll-snap-align-computed.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Scroll Snap: getComputedValue().scrollSnapAlign</title>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-align">
+<meta name="assert" content="scroll-snap-align computed value is as specified.">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("scroll-snap-align", "none");
+test_computed_value("scroll-snap-align", "start");
+test_computed_value("scroll-snap-align", "end");
+test_computed_value("scroll-snap-align", "center");
+
+test_computed_value("scroll-snap-align", "start none");
+test_computed_value("scroll-snap-align", "center end");
+</script>
+</body>
+</html>

--- a/css/css-scroll-snap/parsing/scroll-snap-align-computed.html
+++ b/css/css-scroll-snap/parsing/scroll-snap-align-computed.html
@@ -20,6 +20,7 @@ test_computed_value("scroll-snap-align", "center");
 
 test_computed_value("scroll-snap-align", "start none");
 test_computed_value("scroll-snap-align", "center end");
+test_computed_value("scroll-snap-align", "start start", "start");
 </script>
 </body>
 </html>

--- a/css/css-scroll-snap/parsing/scroll-snap-stop-computed.html
+++ b/css/css-scroll-snap/parsing/scroll-snap-stop-computed.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Scroll Snap: getComputedValue().scrollSnapStop</title>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-stop">
+<meta name="assert" content="scroll-snap-stop computed value is as specified.">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("scroll-snap-stop", "normal");
+test_computed_value("scroll-snap-stop", "always");
+</script>
+</body>
+</html>

--- a/css/css-scroll-snap/parsing/scroll-snap-type-computed.html
+++ b/css/css-scroll-snap/parsing/scroll-snap-type-computed.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Scroll Snap: getComputedValue().scrollSnapType</title>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-type">
+<meta name="assert" content="scroll-snap-type computed value is as specified.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("scroll-snap-type", "none");
+
+test_computed_value("scroll-snap-type", "x");
+test_computed_value("scroll-snap-type", "y");
+test_computed_value("scroll-snap-type", "block");
+test_computed_value("scroll-snap-type", "inline");
+test_computed_value("scroll-snap-type", "both");
+
+test_computed_value("scroll-snap-type", "y mandatory");
+test_computed_value("scroll-snap-type", "inline proximity", "inline");
+</script>
+</body>
+</html>


### PR DESCRIPTION
Spec: https://drafts.csswg.org/css-scroll-snap-1/

Blink/Safari fail by reporting the scroll-snap-type computed value
as "x proximity" instead of "x".