### PR TITLE
[compositing] Computed value tests

### DIFF
--- a/css/compositing/META.yml
+++ b/css/compositing/META.yml
@@ -1,4 +1,5 @@
 spec: https://drafts.fxtf.org/compositing/
 suggested_reviewers:
+  - chrishtr
   - plinss
   - nikosandronikos

--- a/css/compositing/parsing/background-blend-mode-computed.html
+++ b/css/compositing/parsing/background-blend-mode-computed.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Compositing and Blending Level 1: getComputedValue().backgroundBlendMode</title>
+<link rel="help" href="https://drafts.fxtf.org/compositing-1/#propdef-background-blend-mode">
+<meta name="assert" content="background-blend-mode computed value is as specified.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("background-blend-mode", "normal");
+test_computed_value("background-blend-mode", "multiply");
+test_computed_value("background-blend-mode", "screen");
+test_computed_value("background-blend-mode", "overlay");
+test_computed_value("background-blend-mode", "darken");
+test_computed_value("background-blend-mode", "lighten");
+test_computed_value("background-blend-mode", "color-dodge");
+test_computed_value("background-blend-mode", "color-burn");
+test_computed_value("background-blend-mode", "hard-light");
+test_computed_value("background-blend-mode", "soft-light");
+test_computed_value("background-blend-mode", "difference");
+test_computed_value("background-blend-mode", "exclusion");
+test_computed_value("background-blend-mode", "hue");
+test_computed_value("background-blend-mode", "saturation");
+test_computed_value("background-blend-mode", "color");
+test_computed_value("background-blend-mode", "luminosity");
+
+test_computed_value("background-blend-mode", "normal, luminosity");
+test_computed_value("background-blend-mode", "screen, overlay");
+test_computed_value("background-blend-mode", "color, saturation");
+</script>
+</body>
+</html>

--- a/css/compositing/parsing/isolation-computed.html
+++ b/css/compositing/parsing/isolation-computed.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Compositing and Blending Level 1: getComputedValue().isolation</title>
+<link rel="help" href="https://drafts.fxtf.org/compositing-1/#propdef-isolation">
+<meta name="assert" content="isolation computed value is as specified.">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("isolation", "auto");
+test_computed_value("isolation", "isolate");
+</script>
+</body>
+</html>

--- a/css/compositing/parsing/mix-blend-mode-computed.html
+++ b/css/compositing/parsing/mix-blend-mode-computed.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Compositing and Blending Level 1: getComputedValue().mixBlendMode</title>
+<link rel="help" href="https://drafts.fxtf.org/compositing-1/#propdef-mix-blend-mode">
+<meta name="assert" content="mix-blend-mode computed value is as specified.">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("mix-blend-mode", "normal");
+test_computed_value("mix-blend-mode", "multiply");
+test_computed_value("mix-blend-mode", "screen");
+test_computed_value("mix-blend-mode", "overlay");
+test_computed_value("mix-blend-mode", "darken");
+test_computed_value("mix-blend-mode", "lighten");
+test_computed_value("mix-blend-mode", "color-dodge");
+test_computed_value("mix-blend-mode", "color-burn");
+test_computed_value("mix-blend-mode", "hard-light");
+test_computed_value("mix-blend-mode", "soft-light");
+test_computed_value("mix-blend-mode", "difference");
+test_computed_value("mix-blend-mode", "exclusion");
+test_computed_value("mix-blend-mode", "hue");
+test_computed_value("mix-blend-mode", "saturation");
+test_computed_value("mix-blend-mode", "color");
+test_computed_value("mix-blend-mode", "luminosity");
+</script>
+</body>
+</html>


### PR DESCRIPTION
background-blend-mode, isolation, mix-blend-mode computed values are as specified.
https://drafts.fxtf.org/compositing-1/#property-index

All tests pass with Firefox.

Three background-blend-mode tests fail with Blink/Edge/Safari:
expected "normal, luminosity" but got "normal"
expected "screen, overlay" but got "screen"
expected "color, saturation" but got "color"