### PR TITLE
Remove my deadname from everywhere except tools/third_party

### DIFF
--- a/css/CSS2/reference/filler-text-below-green.xht
+++ b/css/CSS2/reference/filler-text-below-green.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>Filler text below is green reference</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com"/>
         <style>
           .green { color: green; }
         </style>

--- a/css/CSS2/reference/no-red-filler-text-ref.xht
+++ b/css/CSS2/reference/no-red-filler-text-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>No red visible, filler text, reference</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com"/>
     </head>
     <body>
         <p>Test passes if there is no red visible on the page.</p>

--- a/css/CSS2/reference/no-red-on-blank-page-ref.xht
+++ b/css/CSS2/reference/no-red-on-blank-page-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>No red visible, blank page, reference</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com"/>
     </head>
     <body>
         <p>Test passes if there is no red visible on the page.</p>

--- a/css/CSS2/selectors/first-letter-punctuation-001-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-001-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-002-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-002-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-003-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-003-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-004-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-004-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark gug rtags gyas' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-005-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-005-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark ang khang gyas' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-006-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-006-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ogham reversed feather mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-007-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-007-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right square bracket with quill' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-008-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-008-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'superscript right parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-009-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-009-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'subscript right parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-010-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-010-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right-pointing angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-012-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-012-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'medium right parenthesis ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-013-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-013-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'medium flattened right parenthesis ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-014-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-014-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'medium right-pointing angle bracket ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-015-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-015-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'heavy right-pointing angle quotation mark ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-016-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-016-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'heavy right-pointing angle bracket ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-017-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-017-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'light right tortoise shell bracket ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-018-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-018-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'medium right curly bracket ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-019-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-019-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right s-shaped bag delimiter' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-020-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-020-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mathematical right white square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-021-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-021-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mathematical right angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-022-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-022-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mathematical right double angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-023-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-023-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right white curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-024-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-024-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right white parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-025-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-025-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'z notation right image bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-026-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-026-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'z notation right binding bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-027-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-027-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right square bracket with underbar' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-028-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-028-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right square bracket with tick in bottom corner' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-029-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-029-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right square bracket with tick in top corner' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-030-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-030-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right angle bracket with dot' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-031-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-031-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right arc greater-than bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-032-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-032-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double right arc less-than bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-033-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-033-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right black tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-034-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-034-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right wiggly fence' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-035-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-035-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right double wiggly fence' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-036-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-036-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right-pointing curved angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-037-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-037-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-038-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-038-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right double angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-039-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-039-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-040-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-040-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right white corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-041-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-041-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right black lenticular bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-042-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-042-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-043-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-043-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right white lenticular bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-044-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-044-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right white tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-045-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-045-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right white square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-046-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-046-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double prime quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-047-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-047-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'low double prime quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-048-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-048-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ornate right parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-049-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-049-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right white lenticular bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-050-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-050-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-051-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-051-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-052-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-052-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-053-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-053-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right black lenticular bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-054-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-054-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right double angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-055-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-055-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-056-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-056-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-057-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-057-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right white corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-058-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-058-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical right square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-059-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-059-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small right parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-060-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-060-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small right curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-061-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-061-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small right tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-062-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-062-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth right parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-063-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-063-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth right square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-064-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-064-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth right curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-065-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-065-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth right white parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-066-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-066-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'halfwidth right corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-067-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-067-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right-pointing double angle quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-068-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-068-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right single quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-069-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-069-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right double quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-070-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-070-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'single right-pointing angle quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-071-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-071-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right substitution bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-072-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-072-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right dotted substitution bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-073-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-073-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right transposition bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-074-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-074-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right raised omission bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-075-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-075-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right low paraphrase bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-076-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-076-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left-pointing double angle quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-077-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-077-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left single quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-078-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-078-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'single high-reversed-9 quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-079-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-079-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left double quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-080-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-080-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double high-reversed-9 quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-081-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-081-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'single left-pointing angle quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-082-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-082-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left substitution bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-083-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-083-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left dotted substitution bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-084-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-084-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left transposition bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-085-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-085-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left raised omission bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-086-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-086-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left low paraphrase bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-087-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-087-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'exclamation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-088-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-088-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-089-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-089-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'number sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-090-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-090-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'percent sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-091-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-091-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ampersand' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-092-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-092-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'apostrophe' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-093-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-093-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'asterisk' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-094-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-094-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-095-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-095-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-096-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-096-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'solidus' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-097-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-097-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-098-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-098-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'semicolon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-099-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-099-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-100-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-100-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'commercial at' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-101-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-101-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'reverse solidus' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-102-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-102-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'inverted exclamation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-103-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-103-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'middle dot' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-104-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-104-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'inverted question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-105-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-105-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'greek question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-106-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-106-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'greek ano teleia' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-107-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-107-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'armenian apostrophe' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-108-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-108-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'armenian emphasis mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-109-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-109-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'armenian exclamation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-110-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-110-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'armenian comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-111-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-111-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'armenian question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-112-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-112-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'armenian abbreviation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-113-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-113-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'armenian full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-115-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-115-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'hebrew punctuation paseq' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-116-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-116-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'hebrew punctuation sof pasuq' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-117-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-117-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'hebrew punctuation nun hafukha' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-118-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-118-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'hebrew punctuation geresh' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-119-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-119-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'hebrew punctuation gershayim' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-120-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-120-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-121-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-121-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic date separator' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-122-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-122-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic semicolon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-123-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-123-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic triple dot punctuation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-124-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-124-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-125-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-125-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic percent sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-126-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-126-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic decimal separator' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-127-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-127-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic thousands separator' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-128-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-128-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic five pointed star' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-129-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-129-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'arabic full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-130-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-130-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac end of paragraph' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-131-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-131-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac supralinear full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-132-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-132-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac sublinear full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-133-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-133-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac supralinear colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-134-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-134-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac sublinear colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-135-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-135-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac horizontal colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-136-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-136-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac colon skewed left' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-137-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-137-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac colon skewed right' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-138-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-138-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac supralinear colon skewed left' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-139-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-139-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac sublinear colon skewed right' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-140-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-140-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac contraction' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-141-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-141-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac harklean obelus' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-142-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-142-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac harklean metobelus' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-143-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-143-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'syriac harklean asteriscus' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-144-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-144-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'devanagari danda' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-145-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-145-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'devanagari double danda' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-146-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-146-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'devanagari abbreviation sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-147-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-147-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'sinhala punctuation kunddaliya' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-148-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-148-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'thai character fongman' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-149-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-149-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'thai character angkhankhu' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-150-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-150-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'thai character khomut' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-151-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-151-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark initial yig mgo mdun ma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-152-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-152-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark closing yig mgo sgab ma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-153-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-153-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark caret yig mgo phur shad ma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-154-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-154-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark yig mgo tsheg shad ma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-155-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-155-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark sbrul shad' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-156-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-156-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark bskur yig mgo' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-157-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-157-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark bka- shog yig mgo' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-158-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-158-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark intersyllabic tsheg' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-159-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-159-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark delimiter tsheg bstar' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-160-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-160-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark shad' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-161-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-161-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark nyis shad' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-162-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-162-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark tsheg shad' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-163-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-163-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark nyis tsheg shad' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-164-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-164-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark rin chen spungs shad' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-165-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-165-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark rgya gram shad' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-166-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-166-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark paluta' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-167-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-167-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark bska- shog gi mgo rgyan' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-168-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-168-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark mnyam yig gi mgo rgyan' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-169-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-169-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'myanmar sign little section' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-170-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-170-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'myanmar sign section' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-171-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-171-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'myanmar symbol locative' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-172-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-172-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'myanmar symbol completed' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-173-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-173-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'myanmar symbol aforementioned' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-174-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-174-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'myanmar symbol genitive' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-175-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-175-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'georgian paragraph separator' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-176-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-176-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ethiopic wordspace' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-177-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-177-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ethiopic full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-178-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-178-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ethiopic comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-179-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-179-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ethiopic semicolon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-180-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-180-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ethiopic colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-181-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-181-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ethiopic preface colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-182-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-182-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ethiopic question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-183-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-183-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ethiopic paragraph separator' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-184-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-184-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'canadian syllabics chi sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-185-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-185-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'canadian syllabics full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-186-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-186-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'runic single punctuation' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-187-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-187-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'runic multiple punctuation' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-188-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-188-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'runic cross punctuation' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-189-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-189-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'philippine single punctuation' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-190-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-190-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'philippine double punctuation' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-191-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-191-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'khmer sign khan' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-192-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-192-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'khmer sign bariyoosan' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-193-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-193-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'khmer sign camnuc pii kuuh' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-194-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-194-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'khmer sign beyyal' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-195-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-195-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'khmer sign phnaek muan' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-196-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-196-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'khmer sign koomuut' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-197-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-197-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian birga' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-198-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-198-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian ellipsis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-199-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-199-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-200-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-200-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-201-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-201-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-202-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-202-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian four dots' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-203-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-203-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian sibe syllable boundary marker' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-204-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-204-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian manchu comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-205-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-205-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian manchu full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-206-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-206-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mongolian nirugu' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-207-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-207-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'limbu exclamation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-208-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-208-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'limbu question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-211-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-211-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'buginese pallawa' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-212-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-212-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'buginese end of section' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-213-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-213-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double vertical line' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-214-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-214-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double low line' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-215-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-215-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'dagger' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-216-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-216-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double dagger' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-217-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-217-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'bullet' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-218-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-218-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'triangular bullet' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-219-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-219-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'one dot leader' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-220-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-220-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'two dot leader' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-221-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-221-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'horizontal ellipsis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-222-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-222-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'hyphenation point' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-223-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-223-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'per mille sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-224-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-224-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'per ten thousand sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-225-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-225-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'prime' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-226-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-226-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double prime' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-227-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-227-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'triple prime' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-228-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-228-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'reversed prime' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-229-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-229-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'reversed double prime' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-230-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-230-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'reversed triple prime' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-231-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-231-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'caret' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-232-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-232-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'reference mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-233-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-233-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double exclamation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-234-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-234-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'interrobang' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-235-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-235-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'overline' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-236-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-236-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'caret insertion point' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-237-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-237-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'asterism' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-238-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-238-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'hyphen bullet' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-239-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-239-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-240-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-240-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'question exclamation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-241-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-241-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'exclamation question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-242-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-242-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tironian sign et' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-243-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-243-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'reversed pilcrow sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-244-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-244-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'black leftwards bullet' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-245-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-245-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'black rightwards bullet' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-246-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-246-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'low asterisk' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-247-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-247-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'reversed semicolon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-248-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-248-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'close up' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-249-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-249-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'two asterisks aligned vertically' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-250-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-250-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'swung dash' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-251-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-251-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'flower punctuation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-252-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-252-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'three dot punctuation' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-253-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-253-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'quadruple prime' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-254-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-254-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'four dot punctuation' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-255-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-255-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'five dot punctuation' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-256-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-256-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'two dot punctuation' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-257-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-257-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'four dot mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-258-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-258-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'dotted cross' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-259-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-259-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tricolon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-260-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-260-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'vertical four dots' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-262-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-262-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'coptic old nubian full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-263-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-263-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'coptic old nubian direct question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-264-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-264-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'coptic old nubian indirect question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-265-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-265-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'coptic old nubian verse divider' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-266-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-266-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'coptic full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-267-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-267-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'coptic morphological divider' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-268-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-268-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right angle substitution marker' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-269-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-269-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'right angle dotted substitution marker' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-270-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-270-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'raised interpolation marker' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-271-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-271-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'raised dotted interpolation marker' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-272-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-272-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'dotted transposition marker' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-273-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-273-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'raised square' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-274-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-274-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'editorial coronis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-275-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-275-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'paragraphos' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-276-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-276-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'forked paragraphos' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-277-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-277-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'reversed forked paragraphos' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-278-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-278-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'hypodiastole' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-279-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-279-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'dotted obelos' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-280-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-280-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'downwards ancora' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-281-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-281-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'upwards ancora' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-282-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-282-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'dotted right-pointing angle' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-283-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-283-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ideographic comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-284-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-284-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ideographic full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-285-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-285-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ditto mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-286-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-286-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'part alternation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-287-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-287-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'katakana middle dot' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-288-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-288-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-289-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-289-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical ideographic comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-290-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-290-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical ideographic full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-291-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-291-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-292-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-292-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical semicolon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-293-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-293-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical exclamation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-294-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-294-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-295-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-295-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical horizontal ellipsis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-296-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-296-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical two dot leader' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-297-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-297-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'sesame dot' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-298-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-298-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'white sesame dot' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-299-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-299-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'dashed overline' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-300-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-300-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'centreline overline' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-301-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-301-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'wavy overline' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-302-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-302-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double wavy overline' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-303-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-303-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-304-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-304-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small ideographic comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-305-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-305-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-306-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-306-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small semicolon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-307-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-307-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-308-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-308-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-309-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-309-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small exclamation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-310-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-310-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small number sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-311-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-311-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small ampersand' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-312-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-312-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small asterisk' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-313-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-313-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small reverse solidus' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-314-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-314-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small percent sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-315-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-315-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small commercial at' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-316-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-316-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth exclamation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-317-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-317-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-318-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-318-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth number sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-319-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-319-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth percent sign' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-320-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-320-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth ampersand' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-321-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-321-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth apostrophe' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-322-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-322-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth asterisk' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-323-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-323-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-324-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-324-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-325-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-325-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth solidus' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-326-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-326-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth colon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-327-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-327-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth semicolon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-328-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-328-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth question mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-329-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-329-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth commercial at' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-330-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-330-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth reverse solidus' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-331-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-331-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'halfwidth ideographic full stop' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-332-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-332-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'halfwidth ideographic comma' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-333-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-333-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'halfwidth katakana middle dot' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-334-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-334-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'aegean word separator line' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-335-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-335-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'aegean word separator dot' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-336-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-336-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ugaritic word divider' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-337-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-337-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'kharoshthi punctuation dot' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-338-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-338-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'kharoshthi punctuation small circle' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-339-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-339-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'kharoshthi punctuation circle' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-340-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-340-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'kharoshthi punctuation crescent bar' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-341-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-341-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'kharoshthi punctuation mangalam' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-342-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-342-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'kharoshthi punctuation lotus' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-343-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-343-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'kharoshthi punctuation danda' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-344-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-344-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'kharoshthi punctuation double danda' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-345-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-345-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'kharoshthi punctuation lines' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-346-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-346-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-347-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-347-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-348-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-348-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-349-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-349-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark gug rtags gyon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-350-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-350-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'tibetan mark ang khang gyon' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-351-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-351-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ogham feather mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-352-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-352-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'single low-9 quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-353-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-353-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double low-9 quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-354-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-354-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left square bracket with quill' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-355-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-355-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'superscript left parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-356-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-356-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'subscript left parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-357-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-357-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left-pointing angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-359-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-359-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'medium left parenthesis ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-360-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-360-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'medium flattened left parenthesis ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-361-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-361-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'medium left-pointing angle bracket ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-362-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-362-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'heavy left-pointing angle quotation mark ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-363-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-363-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'heavy left-pointing angle bracket ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-364-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-364-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'light left tortoise shell bracket ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-365-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-365-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'medium left curly bracket ornament' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-366-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-366-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left s-shaped bag delimiter' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-367-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-367-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mathematical left white square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-368-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-368-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mathematical left angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-369-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-369-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'mathematical left double angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-370-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-370-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left white curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-371-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-371-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left white parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-372-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-372-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'z notation left image bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-373-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-373-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'z notation left binding bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-374-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-374-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left square bracket with underbar' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-375-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-375-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left square bracket with tick in top corner' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-376-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-376-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left square bracket with tick in bottom corner' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-377-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-377-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left angle bracket with dot' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-378-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-378-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left arc less-than bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-379-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-379-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'double left arc greater-than bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-380-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-380-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left black tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-381-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-381-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left wiggly fence' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-382-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-382-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left double wiggly fence' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-383-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-383-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left-pointing curved angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-384-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-384-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-385-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-385-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left double angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-386-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-386-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-387-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-387-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left white corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-388-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-388-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left black lenticular bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-389-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-389-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-390-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-390-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left white lenticular bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-391-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-391-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left white tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-392-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-392-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'left white square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-393-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-393-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'reversed double prime quotation mark' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-394-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-394-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'ornate left parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-395-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-395-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left white lenticular bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-396-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-396-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-397-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-397-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-398-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-398-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-399-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-399-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left black lenticular bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-400-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-400-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left double angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-401-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-401-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left angle bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-402-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-402-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-403-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-403-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left white corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-404-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-404-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'presentation form for vertical left square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-405-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-405-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small left parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-406-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-406-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small left curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-407-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-407-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'small left tortoise shell bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-408-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-408-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth left parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-409-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-409-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth left square bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-410-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-410-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth left curly bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-411-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-411-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'fullwidth left white parenthesis' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/CSS2/selectors/first-letter-punctuation-412-ref.xht
+++ b/css/CSS2/selectors/first-letter-punctuation-412-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>CSS Reference: Green 'halfwidth left corner bracket' punctuation character</title>
-        <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
         <style type="text/css">
             span
             {

--- a/css/css-color/t31-color-text-a-ref.xht
+++ b/css/css-color/t31-color-text-a-ref.xht
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<title>CSS Notref Black "should be green"</title>
-		<link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com" />
 		<style type="text/css"><![CDATA[
 			#one { color: #000; color: rgb(0,0,0); color: black; }
 		]]></style>

--- a/css/css-flexbox/flex-grow-007.html
+++ b/css/css-flexbox/flex-grow-007.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Flexbox Test: flex-grow - less than one</title>
-<link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com">
 <link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">

--- a/css/css-flexbox/flex-shrink-008.html
+++ b/css/css-flexbox/flex-shrink-008.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Flexbox Test: flex-shrink - less than one</title>
-<link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com">
 <link rel="help" title="7.3.1. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">

--- a/css/reference/pass_if_filler_text_slanted.xht
+++ b/css/reference/pass_if_filler_text_slanted.xht
@@ -3,7 +3,6 @@
 <head>
    <title>Reference rendering - pass if Filler Text slanted to one side</title>
    <link rel="author" title="Opera Software" href="https://opera.com"/>
-   <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com"/>
    <style>
       div {
          font-style: italic;


### PR DESCRIPTION
Given git has the history of all of these files and we don't require `<link rel=author>` any more, just delete all these lines. (And yes, I realise the immutable git history has my deadname and always shall.)