### PR TITLE
Use IDL mixin syntax for pointerevents GlobalEventHandlers

### DIFF
--- a/interfaces/pointerevents.idl
+++ b/interfaces/pointerevents.idl
@@ -36,7 +36,7 @@ partial interface Element {
   boolean hasPointerCapture(long pointerId);
 };
 
-partial interface GlobalEventHandlers {
+partial interface mixin GlobalEventHandlers {
     attribute EventHandler ongotpointercapture;
     attribute EventHandler onlostpointercapture;
     attribute EventHandler onpointerdown;


### PR DESCRIPTION
This matches
  https://github.com/w3c/pointerevents/pull/275