### PR TITLE
[js] Remove invalid tests for JavaScript built-ins

### DIFF
--- a/js/builtins/Object.prototype.freeze.html
+++ b/js/builtins/Object.prototype.freeze.html
@@ -38,14 +38,6 @@ test(function() {
     assert_equals('exist', that.prop, 'Confirm to prevent deleting a property.');
   });
 });
-
-
-test(function() {
-  ['foo', 42, null, undefined].forEach(function(that) {
-    assert_throws(new TypeError(),
-        function() { Object.freeze(that) });
-  });
-});
 </script>
 
 </body>

--- a/js/builtins/Object.prototype.preventExtensions.html
+++ b/js/builtins/Object.prototype.preventExtensions.html
@@ -38,13 +38,6 @@ test(function() {
     assert_equals(undefined, that.prop, 'Confirm to be able to delete a property.');
   });
 });
-
-test(function() {
-  ['foo', 42, null, undefined].forEach(function(that) {
-    assert_throws(new TypeError(),
-        function() { Object.preventExtensions(that) });
-  });
-});
 </script>
 
 </body>

--- a/js/builtins/Object.prototype.seal.html
+++ b/js/builtins/Object.prototype.seal.html
@@ -38,13 +38,6 @@ test(function() {
     assert_equals('changed', that.prop, 'Confirm to prevent deleting a property.');
   });
 });
-
-test(function() {
-  ['foo', 42, null, undefined].forEach(function(that) {
-    assert_throws(new TypeError(),
-        function() { Object.seal(that) });
-  });
-});
 </script>
 
 </body>


### PR DESCRIPTION
The 2015 edition of ECMAScript modified the semantics of a number of
built-in methods to tolerate non-object values [1]. The tests asserting
a TypeError under these conditions are no longer valid. ~~Remove them
completely in favor of the more comprehensive coverage offered by the
Test262 project.~~

[1] https://tc39.github.io/ecma262/#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions