### PR TITLE
Fetch: use `t.step_timeout()` instead of bare `step_timeout()`

### DIFF
--- a/fetch/stale-while-revalidate/stale-css.tentative.html
+++ b/fetch/stale-while-revalidate/stale-css.tentative.html
@@ -12,7 +12,7 @@ https://github.com/whatwg/fetch/pull/853
 
 async_test(t => {
   window.onload = t.step_func(() => {
-    step_timeout(() => {
+    t.step_timeout(() => {
       assert_equals(window.getComputedStyle(document.body).getPropertyValue('background-color'), "rgb(0, 128, 0)");
       var link2 = document.createElement("link");
       link2.onload = t.step_func(() => {

--- a/fetch/stale-while-revalidate/stale-image.tentative.html
+++ b/fetch/stale-while-revalidate/stale-image.tentative.html
@@ -18,7 +18,7 @@ See: https://html.spec.whatwg.org/#the-list-of-available-images
 
 async_test(t => {
   window.onload = t.step_func(() => {
-    step_timeout(() => {
+    t.step_timeout(() => {
       assert_equals(document.getElementById("firstimage").width, 16, "Width is 16");
       var childDocument = document.getElementById('child').contentDocument;
       var img2 = childDocument.createElement("img");


### PR DESCRIPTION
This avoid a harness error in the case of failure:
https://wpt.fyi/results/fetch/stale-while-revalidate?run_id=6045131320852480&run_id=4797529354928128&run_id=6524192509919232&run_id=6492651545165824