### PR TITLE
Add .mailmap to map people to their current names

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# People who've changed name:
+
+# Sam Sneddon:
+Sam Sneddon <me@gsnedders.com>
+Sam Sneddon <me@gsnedders.com> <geoffers@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -3,3 +3,7 @@
 # Sam Sneddon:
 Sam Sneddon <me@gsnedders.com>
 Sam Sneddon <me@gsnedders.com> <geoffers@gmail.com>
+
+# Theresa O'Connor:
+Theresa O'Connor <eoconnor@apple.com>
+Theresa O'Connor <hober0@gmail.com>


### PR DESCRIPTION
Note that this isn't used by `git log` by default (as of 2.20.1): that depends on log.mailmap being set to true.

Given I added @hober here we should probably let her review it too before landing. Skimming through `git shortlog -s` (which does use `.mailmap` by default), she's the only other person I'm aware of with an incorrect name in the git history.