### PR TITLE
HTML: noreferer was never a property of hyperlinks

### DIFF
--- a/html/semantics/text-level-semantics/historical.html
+++ b/html/semantics/text-level-semantics/historical.html
@@ -26,7 +26,4 @@ t('datetime', 'time');
 
 // removed in https://github.com/whatwg/html/commit/66fcb2357f205448fe2f40d7834a1e8ea2ed283b
 t('media', ['a', 'area']);
-
-// renamed to noreferrer in https://github.com/whatwg/html/commit/6a34274e99593e767ae99744a6c38a19489915c6
-t('noreferer', ['link', 'a', 'area']);
 </script>


### PR DESCRIPTION
This should have tested the rel attribute value, but as it hasn't been doing that and it would be quite a bit of work, let's remove this instead.