### PR TITLE
Fix flakiness with stale-while-revalidate tests.

### DIFF
--- a/fetch/stale-while-revalidate/fetch.tentative.html
+++ b/fetch/stale-while-revalidate/fetch.tentative.html
@@ -7,11 +7,14 @@ https://github.com/whatwg/fetch/pull/853
 <title>Tests Stale While Revalidate is not executed for fetch API</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <script>
 promise_test(async (test) => {
-  const response = await fetch(`stale-script.py`);
-  const response2 = await fetch(`stale-script.py`);
+  var request_token = token();
 
-  assert_not_equals(response.headers.get('Token'), response2.headers.get('Token'));
+  const response = await fetch(`stale-script.py?token=` + request_token);
+  const response2 = await fetch(`stale-script.py?token=` + request_token);
+
+  assert_not_equals(response.headers.get('Unique-Id'), response2.headers.get('Unique-Id'));
 }, 'Second fetch does not return same response');
 </script>

--- a/fetch/stale-while-revalidate/stale-css.py
+++ b/fetch/stale-while-revalidate/stale-css.py
@@ -1,9 +1,10 @@
 def main(request, response):
 
-    cookie = request.cookies.first("Count", None)
+    token = request.GET.first("token", None)
+    value = request.server.stash.take(token)
     count = 0
-    if cookie != None:
-      count = int(cookie.value)
+    if value != None:
+      count = int(value)
     if request.GET.first("query", None) != None:
       headers = [("Count", count)]
       content = ""
@@ -15,6 +16,7 @@ def main(request, response):
         content = "body { background: rgb(255, 0, 0); }"
 
       headers = [("Content-Type", "text/css"),
-               ("Set-Cookie", "Count={}".format(count)),
-               ("Cache-Control", "private, max-age=0, stale-while-revalidate=10")]
+               ("Cache-Control", "private, max-age=0, stale-while-revalidate=60")]
+
+      request.server.stash.put(token, count)
       return 200, headers, content

--- a/fetch/stale-while-revalidate/stale-css.tentative.html
+++ b/fetch/stale-while-revalidate/stale-css.tentative.html
@@ -7,9 +7,11 @@ https://github.com/whatwg/fetch/pull/853
 <title>Tests Stale While Revalidate works for css</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <body>
 <script>
 
+var request_token = token();
 async_test(t => {
   window.onload = t.step_func(() => {
     t.step_timeout(() => {
@@ -19,10 +21,10 @@ async_test(t => {
         assert_equals(window.getComputedStyle(document.body).getPropertyValue('background-color'), "rgb(0, 128, 0)");
         var checkResult = () => {
           // We poll because we don't know when the revalidation will occur.
-          fetch("stale-css.py?query").then(t.step_func((response) => {
+          fetch("stale-css.py?query&token=" + request_token).then(t.step_func((response) => {
             var count = response.headers.get("Count");
             if (count == '2') {
-                t.done();
+              t.done();
             } else {
               t.step_timeout(checkResult, 25);
             }
@@ -32,7 +34,7 @@ async_test(t => {
       });
       link2.rel = "stylesheet";
       link2.type = "text/css";
-      link2.href = "stale-css.py";
+      link2.href = "stale-css.py?token=" + request_token;
       document.body.appendChild(link2);
     }, 0);
   });
@@ -41,7 +43,7 @@ async_test(t => {
 var link = document.createElement("link");
 link.rel = "stylesheet";
 link.type = "text/css";
-link.href = "stale-css.py";
+link.href = "stale-css.py?token=" + request_token;
 document.body.appendChild(link);
 </script>
 </body>

--- a/fetch/stale-while-revalidate/stale-image.py
+++ b/fetch/stale-while-revalidate/stale-image.py
@@ -2,10 +2,11 @@ import os.path
 
 def main(request, response):
 
-    cookie = request.cookies.first("Count", None)
+    token = request.GET.first("token", None)
+    value = request.server.stash.take(token)
     count = 0
-    if cookie != None:
-      count = int(cookie.value)
+    if value != None:
+      count = int(value)
     if request.GET.first("query", None) != None:
       headers = [("Count", count)]
       content = ""
@@ -13,18 +14,18 @@ def main(request, response):
     else:
       count = count + 1
       filename = "green-16x16.png"
-      if cookie > 1:
+      if count > 1:
         filename = "green-256x256.png"
 
       path = os.path.join(os.path.dirname(__file__), "../../images", filename)
       body = open(path, "rb").read()
 
+      request.server.stash.put(token, count)
       response.add_required_headers = False
       response.writer.write_status(200)
       response.writer.write_header("content-length", len(body))
-      response.writer.write_header("Cache-Control", "private, max-age=0, stale-while-revalidate=10")
+      response.writer.write_header("Cache-Control", "private, max-age=0, stale-while-revalidate=60")
       response.writer.write_header("content-type", "image/png")
-      response.writer.write_header("Set-Cookie", "Count={}".format(count))
       response.writer.end_headers()
 
       response.writer.write(body)

--- a/fetch/stale-while-revalidate/stale-image.tentative.html
+++ b/fetch/stale-while-revalidate/stale-image.tentative.html
@@ -7,6 +7,7 @@ https://github.com/whatwg/fetch/pull/853
 <title>Tests Stale While Revalidate works for images</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <body>
 <!--
 Use a child document to load the second stale image into because
@@ -16,6 +17,7 @@ See: https://html.spec.whatwg.org/#the-list-of-available-images
 <iframe id="child" srcdoc=""></iframe>
 <script>
 
+var request_token = token();
 async_test(t => {
   window.onload = t.step_func(() => {
     t.step_timeout(() => {
@@ -26,7 +28,7 @@ async_test(t => {
         assert_equals(img2.width, 16, "image dimension");
         var checkResult = () => {
           // We poll because we don't know when the revalidation will occur.
-          fetch("stale-image.py?query").then(t.step_func((response) => {
+          fetch("stale-image.py?query&token=" + request_token).then(t.step_func((response) => {
             var count = response.headers.get("Count");
             if (count == '2') {
                 t.done();
@@ -37,14 +39,14 @@ async_test(t => {
         };
         t.step_timeout(checkResult, 25);
       });
-      img2.src = "stale-image.py";
+      img2.src = "stale-image.py?token=" + request_token;
       childDocument.body.appendChild(img2);
     }, 0);
   });
 }, 'Cache returns stale resource');
 
 var img = document.createElement("img");
-img.src = "stale-image.py";
+img.src = "stale-image.py?token=" + request_token;
 img.id = "firstimage";
 document.body.appendChild(img);
 </script>

--- a/fetch/stale-while-revalidate/stale-script.py
+++ b/fetch/stale-while-revalidate/stale-script.py
@@ -1,14 +1,15 @@
 import random, string, datetime
 
-def token():
+def id_token():
    letters = string.ascii_lowercase
    return ''.join(random.choice(letters) for i in range(20))
 
 def main(request, response):
-    cookie = request.cookies.first("Count", None)
+    token = request.GET.first("token", None)
+    value = request.server.stash.take(token)
     count = 0
-    if cookie != None:
-      count = int(cookie.value)
+    if value != None:
+      count = int(value)
     if request.GET.first("query", None) != None:
       headers = [("Count", count)]
       content = ""
@@ -16,10 +17,10 @@ def main(request, response):
     else:
       count = count + 1
 
-      unique_id = token()
+      unique_id = id_token()
       headers = [("Content-Type", "text/javascript"),
-                 ("Cache-Control", "private, max-age=0, stale-while-revalidate=10"),
-                 ("Set-Cookie", "Count={}".format(count)),
-                 ("Token", unique_id)]
+                 ("Cache-Control", "private, max-age=0, stale-while-revalidate=60"),
+                 ("Unique-Id", unique_id)]
       content = "report('{}')".format(unique_id)
+      request.server.stash.put(token, count)
       return 200, headers, content

--- a/fetch/stale-while-revalidate/stale-script.tentative.html
+++ b/fetch/stale-while-revalidate/stale-script.tentative.html
@@ -7,10 +7,12 @@ https://github.com/whatwg/fetch/pull/853
 <title>Tests Stale While Revalidate works for scripts</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
 <body>
 <script>
 var last_modified;
 var last_modified_count = 0;
+var request_token = token();
 
 // The script will call report via a uniquely generated ID on the subresource.
 // If it is a cache hit the ID will be the same and the test will pass.
@@ -27,13 +29,13 @@ async_test(t => {
   window.onload = t.step_func(() => {
     step_timeout(() => {
       var script = document.createElement("script");
-      script.src = "stale-script.py";
+      script.src = "stale-script.py?token=" + request_token;
       document.body.appendChild(script);
       script.onload = t.step_func(() => {
           assert_equals(last_modified_count, 2, "last modified");
           var checkResult = () => {
             // We poll because we don't know when the revalidation will occur.
-            fetch("stale-script.py?query").then(t.step_func((response) => {
+            fetch("stale-script.py?query&token=" + request_token).then(t.step_func((response) => {
               var count = response.headers.get("Count");
               if (count == '2') {
                   t.done();
@@ -49,7 +51,7 @@ async_test(t => {
 }, 'Cache returns stale resource');
 
 var script = document.createElement("script");
-script.src = "stale-script.py";
+script.src = "stale-script.py?token=" + request_token;
 document.body.appendChild(script);
 </script>
 </body>


### PR DESCRIPTION
Using cookies didn't seem reliable in the wpt test runner when it was
re-run. Stop using cookies and use the server side stash instead
like the rest of the fetch tests do.

Increase timeout on staleness.