### PR TITLE
fix align start and end refs

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/align_end-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_end-ref.html
@@ -15,7 +15,6 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    width: 50%;
     text-align: right;
 }
 .cue > span {

--- a/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-ref.html
@@ -15,7 +15,6 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    width: 50%;
     text-align: right
 }
 .cue > span {

--- a/webvtt/rendering/cues-with-video/processing-model/align_start-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_start-ref.html
@@ -13,8 +13,9 @@ body { margin:0 }
 .cue {
     position: absolute;
     bottom: 0;
-    left: 50%;
+    left: 0;
     right: 0;
+    text-align: left;
 }
 .cue > span {
     font-family: Ahem, sans-serif;

--- a/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-ref.html
@@ -13,8 +13,9 @@ body { margin:0 }
 .cue {
     position: absolute;
     bottom: 0;
-    left: 50%;
+    left: 0;
     right: 0;
+    text-align: left;
 }
 .cue > span {
     font-family: Ahem, sans-serif;


### PR DESCRIPTION
align start and align end are equivalent to align left and align right in LTR writing mode, which is the default. The size of the cue box doesn't change. This means that align:start should be on the left side of the video viewport and align:end should be on the right side of the video viewport. Browsers have implemented this correctly but the reference set a width which cause a mismatch between the two.

This was updated in this PR https://github.com/w3c/webvtt/pull/421 which was likely done after these tests were first written.