### PR TITLE
Unclosed URL At EOF

### DIFF
--- a/css/css-syntax/unclosed-url-at-eof.html
+++ b/css/css-syntax/unclosed-url-at-eof.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<title>Unclosed URL At EOF</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<meta name=author title="Tab Atkins-Bittner">
+<link rel=help href="https://drafts.csswg.org/css-syntax/#consume-url-token">
+
+<div id=test1-control style="background-image:url(foo)"></div>
+<div id=test1-experiment style="background-image:url(foo"></div>
+
+<div id=test2-control style="background-image:url()"></div>
+<div id=test2-experiment style="background-image:url("></div>
+
+<script>
+
+test(()=>{
+    const control = document.querySelector("#test1-control");
+    const experiment = document.querySelector("#test1-experiment");
+    assert_equals(control.style.backgroundImage, experiment.style.backgroundImage);
+}, "Unclosed url token at EOF is valid.");
+
+test(()=>{
+    const control = document.querySelector("#test2-control");
+    const experiment = document.querySelector("#test2-experiment");
+    assert_equals(control.style.backgroundImage, experiment.style.backgroundImage);
+}, "Unclosed empty url token at EOF is valid.");
+
+</script>


### PR DESCRIPTION
Verifies that a url() (specifically, one that parses to a `<url-token>`) that's unclosed at EOF is still valid.

Also tests "empty" url(), because that was brought up as another source of divergence in the same issue. There's some disagreement on whether that's valid at all and how to represent it, so rather than take a stand, I just assert that it should parse the same as the closed version, whatever that is.

Tests <https://github.com/w3c/csswg-drafts/issues/3598>