### PR TITLE
[Azure] Use curl instead of InvokeRESTAPI@1

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -214,15 +214,11 @@ jobs:
 - job: all_post
   displayName: 'all tests (wpt.fyi hook)'
   dependsOn: all_macOS
-  pool: server
+  pool:
+    vmImage: 'ubuntu-16.04'
   steps:
-  - task: InvokeRESTAPI@1
+  - script: curl -s -S https://wpt.fyi/api/checks/azure/$(Build.BuildId)
     displayName: 'Invoke wpt.fyi hook'
-    inputs:
-      serviceConnection: wpt.fyi
-      urlSuffix: /api/checks/azure/$(Build.BuildId)
-  - task: InvokeRESTAPI@1
+  - script: curl -s -S https://staging.wpt.fyi/api/checks/azure/$(Build.BuildId)
     displayName: 'Invoke staging.wpt.fyi hook'
-    inputs:
-      serviceConnection: staging.wpt.fyi
-      urlSuffix: /api/checks/azure/$(Build.BuildId)
+    condition: succeededOrFailed()


### PR DESCRIPTION
InvokeRESTAPI@1 doesn't seem to allow us to customize the timeout (it
has a builtin timeout of 20s), and the notify endpoint takes a while to
complete as it needs to download the artifacts from Azure.

Also, run both hooks (prod & staging) independently.

Hope to alleviate #1131.