### PR TITLE
CDC versus Ident Token

### DIFF
--- a/css/css-syntax/cdc-vs-ident-tokens.html
+++ b/css/css-syntax/cdc-vs-ident-tokens.html
@@ -22,7 +22,7 @@ if you get it wrong, ident-token can swallow cdc-token.
 
 test(()=>{
     const rule = document.styleSheets[0].cssRules[0];
-    assert_equals(rule.selectorText, "--foo");	
+    assert_equals(rule.selectorText, "--foo");
 }, "CDC-token is properly emitted, and not parsed as an ident.");
 
 </script>

--- a/css/css-syntax/cdc-vs-ident-tokens.html
+++ b/css/css-syntax/cdc-vs-ident-tokens.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<title>CDC versus Ident Token</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+
+-->
+
+--foo { color: blue; }
+
+</style>
+
+<meta name=author content="Tab Atkins-Bittner">
+<link rel=help href="https://drafts.csswg.org/css-syntax/#consume-token">
+
+<!--
+The ordering of the checks in the HYPHEN-MINUS step is important;
+if you get it wrong, ident-token can swallow cdc-token.
+-->
+
+<script>
+
+test(()=>{
+    const rule = document.styleSheets[0].cssRules[0];
+    assert_equals(rule.selectorText, "--foo");	
+}, "CDC-token is properly emitted, and not parsed as an ident.");
+
+</script>


### PR DESCRIPTION
Tests <https://github.com/w3c/csswg-drafts/issues/3623>.

If the CDC-vs-ident check is performed in the wrong order, you will attempt to parse the CDC as an ident instead, emitting a `--` ident token, and then a `>` delim token.

Thus, if this test is parsed incorrectly, it'll instead think the selector is `-- > --foo`, a valid selector with two tagname selectors separated by a child combinator.