### PR TITLE
Fill testing holes for WritableStream

### DIFF
--- a/streams/writable-streams/brand-checks.any.js
+++ b/streams/writable-streams/brand-checks.any.js
@@ -104,6 +104,11 @@ promise_test(t => {
 }, 'WritableStreamDefaultWriter.prototype.close enforces a brand check');
 
 test(() => {
+  methodThrowsForAll(WriterProto, 'releaseLock',
+                     [fakeWSDefaultWriter(), realWS(), realWSDefaultController(), undefined, null]);
+}, 'WritableStreamDefaultWriter.prototype.releaseLock enforces a brand check');
+
+test(() => {
   methodThrowsForAll(WritableStreamDefaultController.prototype, 'error',
                      [fakeWSDefaultController(), realWS(), realWSDefaultWriter(), undefined, null]);
 }, 'WritableStreamDefaultController.prototype.error enforces a brand check');

--- a/streams/writable-streams/close.any.js
+++ b/streams/writable-streams/close.any.js
@@ -399,3 +399,15 @@ promise_test(t => {
     });
   });
 }, 'close() should not reject until no sink methods are in flight');
+
+promise_test(() => {
+  const ws = new WritableStream();
+  const writer1 = ws.getWriter();
+  return writer1.close().then(() => {
+    writer1.releaseLock();
+    const writer2 = ws.getWriter();
+    const ready = writer2.ready;
+    assert_true(ready instanceof Promise);
+    return ready;
+  });
+}, 'ready promise should be initialised as resolved for a writer on a closed stream');

--- a/streams/writable-streams/close.any.js
+++ b/streams/writable-streams/close.any.js
@@ -407,7 +407,7 @@ promise_test(() => {
     writer1.releaseLock();
     const writer2 = ws.getWriter();
     const ready = writer2.ready;
-    assert_true(ready instanceof Promise);
+    assert_equals(ready.constructor, Promise);
     return ready;
   });
-}, 'ready promise should be initialised as resolved for a writer on a closed stream');
+}, 'ready promise should be initialised as fulfilled for a writer on a closed stream');

--- a/streams/writable-streams/write.any.js
+++ b/streams/writable-streams/write.any.js
@@ -281,4 +281,4 @@ promise_test(t => {
   const writer = ws.getWriter();
   writer.releaseLock();
   return promise_rejects(t, new TypeError(), writer.write(), 'write should reject');
-}, 'writing to a released writer should rejected the returned promise');
+}, 'writing to a released writer should reject the returned promise');

--- a/streams/writable-streams/write.any.js
+++ b/streams/writable-streams/write.any.js
@@ -275,3 +275,10 @@ promise_test(t => {
     promise_rejects(t, error1, writer.write(), 'write() should be rejected')
   ]);
 }, 'write() on a stream with HWM 0 should not cause the ready Promise to resolve');
+
+promise_test(t => {
+  const ws = new WritableStream();
+  const writer = ws.getWriter();
+  writer.releaseLock();
+  return promise_rejects(t, new TypeError(), writer.write(), 'write should reject');
+}, 'writing to a released writer should throw an exception');

--- a/streams/writable-streams/write.any.js
+++ b/streams/writable-streams/write.any.js
@@ -281,4 +281,4 @@ promise_test(t => {
   const writer = ws.getWriter();
   writer.releaseLock();
   return promise_rejects(t, new TypeError(), writer.write(), 'write should reject');
-}, 'writing to a released writer should throw an exception');
+}, 'writing to a released writer should rejected the returned promise');


### PR DESCRIPTION
* Verify that the ready promise is initialised on a writer created on a
  closed stream.
* Add a brand check test for writer.releaseLock()
* Test that writing to a released writer throws an exception