### PR TITLE
Add missing tests for ReadableStream

### DIFF
--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -342,3 +342,12 @@ promise_test(async t => {
   await it.return();
   return promise_rejects(t, new TypeError(), it.next(), 'next() should reject');
 }, 'calling next() after return() should reject');
+
+for (const preventCancel in [false, true]) {
+  test(t => {
+    const rs = new ReadableStream();
+    rs.getIterator({ preventCancel }).return();
+    // The test passes if this line doesn't throw.
+    rs.getReader();
+  }, `return() should unlock the stream synchronously when preventCancel = ${preventCancel}`);
+}

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -343,8 +343,8 @@ promise_test(async t => {
   return promise_rejects(t, new TypeError(), it.next(), 'next() should reject');
 }, 'calling next() after return() should reject');
 
-for (const preventCancel in [false, true]) {
-  test(t => {
+for (const preventCancel of [false, true]) {
+  test(() => {
     const rs = new ReadableStream();
     rs.getIterator({ preventCancel }).return();
     // The test passes if this line doesn't throw.

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -225,14 +225,11 @@ for (const preventCancel of [false, true]) {
   }, `Cancellation behavior when manually calling return(); preventCancel = ${preventCancel}`);
 }
 
-promise_test(async () => {
+promise_test(async t => {
   const s = new ReadableStream();
   const it = s[Symbol.asyncIterator]();
   await it.return();
-  try {
-    await it.return();
-    assert_unreached();
-  } catch (e) {}
+  return promise_rejects(t, new TypeError(), it.return(), 'return should reject');
 }, 'Calling return() twice rejects');
 
 promise_test(async () => {
@@ -338,3 +335,10 @@ promise_test(async () => {
   assert_equals(readResult.value, 3, 'should read remaining chunk');
   await reader.closed;
 }, 'Acquiring a reader and reading the remaining chunks after partially async-iterating a stream with preventCancel = true');
+
+promise_test(async t => {
+  const rs = new ReadableStream();
+  const it = rs.getIterator();
+  await it.return();
+  return promise_rejects(t, new TypeError(), it.next(), 'next() should reject');
+}, 'calling next() after return() should reject');

--- a/streams/readable-streams/brand-checks.any.js
+++ b/streams/readable-streams/brand-checks.any.js
@@ -92,10 +92,24 @@ promise_test(t => {
 
 test(() => {
 
+  methodThrowsForAll(ReadableStream.prototype, 'getIterator',
+                     [fakeRS(), realRSDefaultReader(), realRSDefaultController(), undefined, null]);
+
+}, 'ReadableStream.prototype.getIterator enforces a brand check');
+
+test(() => {
+
   methodThrowsForAll(ReadableStream.prototype, 'getReader',
                      [fakeRS(), realRSDefaultReader(), realRSDefaultController(), undefined, null]);
 
 }, 'ReadableStream.prototype.getReader enforces a brand check');
+
+test(() => {
+
+  getterThrowsForAll(ReadableStream.prototype, 'locked',
+                     [fakeRS(), realRSDefaultReader(), realRSDefaultController(), undefined, null]);
+
+}, 'ReadableStream.prototype.locked enforces a brand check');
 
 test(() => {
 
@@ -151,6 +165,13 @@ test(() => {
                 'Constructing a ReadableStreamDefaultController should throw');
 
 }, 'ReadableStreamDefaultController can\'t be given a fully-constructed ReadableStream');
+
+test(() => {
+
+  getterThrowsForAll(ReadableStreamDefaultController.prototype, 'desiredSize',
+                     [fakeRSDefaultController(), realRS(), realRSDefaultReader(), undefined, null]);
+
+}, 'ReadableStreamDefaultController.prototype.desiredSize enforces a brand check');
 
 test(() => {
 

--- a/streams/readable-streams/default-reader.any.js
+++ b/streams/readable-streams/default-reader.any.js
@@ -494,3 +494,17 @@ test(() => {
   assert_throws(new RangeError(), () => rs.getReader({ mode }), 'getReader() should throw');
   assert_true(toStringCalled, 'toString() should be called');
 }, 'getReader() should call ToString() on mode');
+
+promise_test(() => {
+  const rs = new ReadableStream({
+    pull(controller) {
+      controller.close();
+    }
+  });
+
+  const reader = rs.getReader();
+  return reader.read().then(() => {
+    // The test passes if releaseLock() does not throw.
+    reader.releaseLock();
+  });
+}, 'controller.close() should clear the list of pending read requests');


### PR DESCRIPTION
* Test the specific rejection returned by calling it.return() twice (to avoid
  being confused by assertions).
* Verify that it.next() after it.return() fails.
* Verify that it.return() unlocks the stream synchronously.
* Add brand checks for getIterator(), locked and desiredSize.
* Verify that canceling tee branches in reverse order works.
* Test that erroring a teed stream errors both branches, even when they
  are not waiting for chunks.
* Verify that controller.close() clears the list of pending reads