### PR TITLE
[wptrunner] Remove unused method

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -213,9 +213,6 @@ class SeleniumProtocol(Protocol):
                                                                             resolve_ip=False),
                                           desired_capabilities=self.capabilities)
 
-    def after_conect(self):
-        pass
-
     def teardown(self):
         self.logger.debug("Hanging up on Selenium session")
         try:

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -214,9 +214,6 @@ class WebDriverProtocol(Protocol):
         self.webdriver.start()
 
 
-    def after_conect(self):
-        pass
-
     def teardown(self):
         self.logger.debug("Hanging up on WebDriver session")
         try:


### PR DESCRIPTION
`after_conect` is a misnomer for the `after_connect` method of the
generic `Protocol` class.