### PR TITLE
[Azure Pipelines] Remove the wpt.fyi hook (no longer needed)

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -211,16 +211,3 @@ jobs:
     displayName: 'Publish results'
     inputs:
       artifactName: 'safari-preview-results'
-
-# The InvokeRESTAPI task can only run in a server job.
-- job: results_post
-  displayName: 'all tests (wpt.fyi hook)'
-  dependsOn: results_safari_preview
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - script: curl -s -S https://wpt.fyi/api/checks/azure/$(Build.BuildId)
-    displayName: 'Invoke wpt.fyi hook'
-  - script: curl -s -S https://staging.wpt.fyi/api/checks/azure/$(Build.BuildId)
-    displayName: 'Invoke staging.wpt.fyi hook'
-    condition: succeededOrFailed()


### PR DESCRIPTION
As found in https://github.com/web-platform-tests/wpt.fyi/issues/1130,
this hook is no longer needed, check runs are created also for
scheduled builds on Azure Pipelines.