### PR TITLE
[wasm] Add JS-API tests for wasm threads

### DIFF
--- a/wasm/jsapi/memory/constructor.any.js
+++ b/wasm/jsapi/memory/constructor.any.js
@@ -8,15 +8,18 @@ function assert_Memory(memory, expected) {
 
   // https://github.com/WebAssembly/spec/issues/840
   assert_equals(memory.buffer, memory.buffer, "buffer should be idempotent");
-  assert_equals(Object.getPrototypeOf(memory.buffer), ArrayBuffer.prototype,
-                "prototype of buffer");
-  assert_true(Object.isExtensible(memory.buffer), "buffer extensibility");
+  const isShared = !!expected.shared;
+  const bufferType = isShared ? self.SharedArrayBuffer : ArrayBuffer;
+  assert_equals(Object.getPrototypeOf(memory.buffer), bufferType.prototype,
+                'prototype of buffer');
   assert_equals(memory.buffer.byteLength, 0x10000 * expected.size, "size of buffer");
   if (expected.size > 0) {
     const array = new Uint8Array(memory.buffer);
     assert_equals(array[0], 0, "first element of buffer");
     assert_equals(array[array.byteLength - 1], 0, "last element of buffer");
   }
+  assert_equals(isShared, Object.isFrozen(memory.buffer), "buffer frozen");
+  assert_not_equals(Object.isExtensible(memory.buffer), isShared, "buffer extensibility");
 }
 
 test(() => {
@@ -84,6 +87,10 @@ test(() => {
 }, "Initial value exceeds maximum");
 
 test(() => {
+  assert_throws(new TypeError(), () => new WebAssembly.Memory({ "initial": 10, "shared": true }));
+}, "Shared memory without maximum");
+
+test(() => {
   const proxy = new Proxy({}, {
     has(o, x) {
       assert_unreached(`Should not call [[HasProperty]] with ${x}`);
@@ -128,6 +135,47 @@ test(() => {
   ]);
 }, "Order of evaluation for descriptor");
 
+test(t => {
+  const order = [];
+
+  new WebAssembly.Memory({
+    get maximum() {
+      order.push("maximum");
+      return {
+        valueOf() {
+          order.push("maximum valueOf");
+          return 1;
+        },
+      };
+    },
+
+    get initial() {
+      order.push("initial");
+      return {
+        valueOf() {
+          order.push("initial valueOf");
+          return 1;
+        },
+      };
+    },
+
+    get shared() {
+      order.push("shared");
+      return {
+        valueOf: t.unreached_func("should not call shared valueOf"),
+      };
+    },
+  });
+
+  assert_array_equals(order, [
+    "initial",
+    "initial valueOf",
+    "maximum",
+    "maximum valueOf",
+    "shared",
+  ]);
+}, "Order of evaluation for descriptor (with shared)");
+
 test(() => {
   const argument = { "initial": 0 };
   const memory = new WebAssembly.Memory(argument);
@@ -145,3 +193,9 @@ test(() => {
   const memory = new WebAssembly.Memory(argument, {});
   assert_Memory(memory, { "size": 0 });
 }, "Stray argument");
+
+test(() => {
+  const argument = { "initial": 4, "maximum": 10, shared: true };
+  const memory = new WebAssembly.Memory(argument);
+  assert_Memory(memory, { "size": 4, "shared": true });
+}, "Shared memory");


### PR DESCRIPTION
Continuation of #15144, and for ref https://github.com/WebAssembly/threads/issues/133.

cc @binji @Ms2ger 

Here's the corresponding CL in Chromium https://chromium-review.googlesource.com/c/chromium/src/+/1478791. I guess the WPT bot had some trouble.

Change-Id: I1b3eee109ed951c7e9d7245bca7900c2e01799af
Bug: v8:8319
Reviewed-on: https://chromium-review.googlesource.com/c/1478791
Reviewed-by: Ben Smith <binji@chromium.org>
Commit-Queue: Sven Sauleau <ssauleau@igalia.com>
Cr-Commit-Position: refs/heads/master@{#634108}