### PR TITLE
[wptrunner] Reset internal state during "rerun"

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -152,6 +152,11 @@ class TestExecutor(object):
         if self.protocol is not None:
             self.protocol.teardown()
 
+    def reset(self):
+        """Re-initialize internal state to facilitate repeated test execution
+        as implemented by the `--rerun` command-line argument."""
+        pass
+
     def run_test(self, test):
         """Run a particular test.
 
@@ -266,6 +271,9 @@ class RefTestImplementation(object):
 
         self.message.append("%s %s" % (test.url, rv[0]))
         return True, rv
+
+    def reset(self):
+        self.screenshot_cache.clear()
 
     def is_pass(self, lhs_hash, rhs_hash, relation):
         assert relation in ("==", "!=")

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -780,6 +780,9 @@ class MarionetteRefTestExecutor(RefTestExecutor):
             self.logger.warning("Exception during reftest teardown:\n%s" %
                                 traceback.format_exc(e))
 
+    def reset(self):
+        self.implementation.reset(**self.implementation_kwargs)
+
     def is_alive(self):
         return self.protocol.is_alive
 
@@ -860,6 +863,10 @@ class InternalRefTestImplementation(object):
                                 if value > 1}
         self.executor.protocol.marionette.set_context(self.executor.protocol.marionette.CONTEXT_CHROME)
         self.executor.protocol.marionette._send_message("reftest:setup", data)
+
+    def reset(self, screenshot=None):
+        self.teardown()
+        self.setup(screenshot)
 
     def run_test(self, test):
         references = self.get_references(test)

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -359,6 +359,9 @@ class SeleniumRefTestExecutor(RefTestExecutor):
         with open(os.path.join(here, "reftest-wait_webdriver.js")) as f:
             self.wait_script = f.read()
 
+    def reset(self):
+        self.implementation.reset()
+
     def is_alive(self):
         return self.protocol.is_alive()
 

--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -181,6 +181,9 @@ class ServoRefTestExecutor(ProcessTestExecutor):
         self.tempdir = tempfile.mkdtemp()
         self.hosts_path = write_hosts_file(server_config)
 
+    def reset(self):
+        self.implementation.reset()
+
     def teardown(self):
         try:
             os.unlink(self.hosts_path)

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -260,6 +260,9 @@ class ServoWebDriverRefTestExecutor(RefTestExecutor):
         with open(os.path.join(here, "reftest-wait_webdriver.js")) as f:
             self.wait_script = f.read()
 
+    def reset(self):
+        self.implementation.reset()
+
     def is_alive(self):
         return self.protocol.is_alive()
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -405,6 +405,9 @@ class WebDriverRefTestExecutor(RefTestExecutor):
         with open(os.path.join(here, "reftest-wait_webdriver.js")) as f:
             self.wait_script = f.read()
 
+    def reset(self):
+        self.implementation.reset()
+
     def is_alive(self):
         return self.protocol.is_alive()
 

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -91,6 +91,7 @@ class TestRunner(object):
         the associated methods"""
         self.setup()
         commands = {"run_test": self.run_test,
+                    "reset": self.reset,
                     "stop": self.stop,
                     "wait": self.wait}
         while True:
@@ -107,6 +108,9 @@ class TestRunner(object):
 
     def stop(self):
         return Stop
+
+    def reset(self):
+        self.executor.reset()
 
     def run_test(self, test):
         try:
@@ -540,6 +544,7 @@ class TestRunnerManager(threading.Thread):
         self.logger.test_start(self.state.test.id)
         if self.rerun > 1:
             self.logger.info("Run %d/%d" % (self.run_count, self.rerun))
+            self.send_message("reset")
         self.run_count += 1
         self.send_message("run_test", self.state.test)
 


### PR DESCRIPTION
The "reftest" implementation uses an internal cache for screenshots as
an optimization for running similar tests. That optimization is
inappropriate for the CLI's "rerun" feature since in that context,
repeatedly running the same tests is an explicit goal.

Introduce a generic "reset" message that is emitted by the
TestRunnerManager during "rerun", and extend the RefTestExecutor to
handle this message by emptying its internal cache.