### PR TITLE
Remove new lines in the reference for 'white-space: pre' tests

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre_wrapped-ref.html
@@ -25,4 +25,4 @@ body { margin:0 }
     white-space: pre
 }
 </style>
-<div class="video"><span class="cue"><span>A A  A   A	A	<br>	A		<br>A	A   A  A A</span></span></div>
+<div class="video"><span class="cue"><span>A A  A   A	A		A		A	A   A  A A</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue/white-space_pre_wrapped-ref.html
@@ -18,6 +18,7 @@ body { margin:0 }
     width: 40%;
     font-family: sans-serif;
     text-align: center;
+    overflow: hidden;
 }
 .cue > span {
     background: rgba(0,0,0,0.8);

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre_wrapped-ref.html
@@ -17,6 +17,7 @@ body { margin:0 }
     right: 0;
     width: 50%;
     text-align: center;
+    overflow: hidden;
 }
 .cue > span {
     font-family: sans-serif;

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/bold_object/bold_white-space_pre_wrapped-ref.html
@@ -26,4 +26,4 @@ body { margin:0 }
     white-space: pre
 }
 </style>
-<div class="video"><span class="cue"><span>This is a test subtitle that most <br>likely 	will span over several <br>rows since it's a pretty long cue <br>with a lot of text.</span></span></div>
+<div class="video"><span class="cue"><span>This is a test subtitle that most likely 	will span over several rows since it's a pretty long cue with a lot of text.</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre_wrapped-ref.html
@@ -17,6 +17,7 @@ body { margin:0 }
     right: 0;
     width: 50%;
     text-align: center;
+    overflow: hidden;
 }
 .cue > span {
     font-family: sans-serif;

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre_wrapped-ref.html
@@ -25,4 +25,4 @@ body { margin:0 }
     white-space: pre
 }
 </style>
-<div class="video"><span class="cue"><span>This is a test subtitle that most <br>likely 	will span over several <br>rows since it's a pretty long cue <br>with a lot of text.</span></span></div>
+<div class="video"><span class="cue"><span>This is a test subtitle that most likely 	will span over several rows since it's a pretty long cue with a lot of text.</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre_wrapped-ref.html
@@ -17,6 +17,7 @@ body { margin:0 }
     right: 0;
     width: 50%;
     text-align: center;
+    overflow: hidden;
 }
 .cue > span {
     font-family: sans-serif;

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/italic_object/italic_white-space_pre_wrapped-ref.html
@@ -26,4 +26,4 @@ body { margin:0 }
     white-space: pre
 }
 </style>
-<div class="video"><span class="cue"><span>This is a test subtitle that most <br>likely 	will span over several <br>rows since it's a pretty long cue <br>with a lot of text.</span></span></div>
+<div class="video"><span class="cue"><span>This is a test subtitle that most likely 	will span over several rows since it's a pretty long cue with a lot of text.</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre_wrapped-ref.html
@@ -17,6 +17,7 @@ body { margin:0 }
     right: 0;
     width: 50%;
     text-align: center;
+    overflow: hidden;
 }
 .cue > span {
     font-family: sans-serif;

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/underline_object/underline_white-space_pre_wrapped-ref.html
@@ -26,4 +26,4 @@ body { margin:0 }
     white-space: pre
 }
 </style>
-<div class="video"><span class="cue"><span>This is a test subtitle that most <br>likely 	will span over several <br>rows since it's a pretty long cue <br>with a lot of text.</span></span></div>
+<div class="video"><span class="cue"><span>This is a test subtitle that most likely 	will span over several rows since it's a pretty long cue with a lot of text.</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre_wrapped-ref.html
@@ -17,6 +17,7 @@ body { margin:0 }
     right: 0;
     width: 50%;
     text-align: center;
+    overflow: hidden;
 }
 .cue > span {
     font-family: sans-serif;

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_white-space_pre_wrapped-ref.html
@@ -25,4 +25,4 @@ body { margin:0 }
     white-space: pre
 }
 </style>
-<div class="video"><span class="cue"><span>This is a test subtitle that most <br>likely 	will span over several <br>rows since it's a pretty long cue <br>with a lot of text.</span></span></div>
+<div class="video"><span class="cue"><span>This is a test subtitle that most likely 	will span over several rows since it's a pretty long cue with a lot of text.</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped-ref.html
@@ -25,4 +25,4 @@ body { margin:0 }
     white-space: pre
 }
 </style>
-<div class="video"><span class="cue"><span>A A  A   A	A	<br>	A		<br>A	A   A  A A</span></span></div>
+<div class="video"><span class="cue"><span>A A  A   A	A		A		A	A   A  A A</span></span></div>

--- a/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped-ref.html
@@ -18,6 +18,7 @@ body { margin:0 }
     width: 40%;
     font-family: sans-serif;
     text-align: center;
+    overflow: hidden;
 }
 .cue > span {
     background: rgba(0,0,0,0.8);


### PR DESCRIPTION
After spending some time thinking about what the spec says and what `white-space: pre` is supposed to do. The references for these tests is incorrect. From my reading of the spec and the white-space property behavior, the CSS should take precedence over the regular behavior of cues (which is to wrap) and `white-space: pre` is specifically a no-wrap property except for explicit new-lines.