### PR TITLE
Revert "Remove PaymentAddress.regionCode tests"

### DIFF
--- a/payment-request/PaymentAddress/attributes-and-toJSON-method-manual.https.html
+++ b/payment-request/PaymentAddress/attributes-and-toJSON-method-manual.https.html
@@ -68,6 +68,7 @@ function runManualTest(button, expected = {}) {
     <button onclick="
     const expectedAddress = {
       country: 'AU',
+      regionCode: 'QLD',
       addressLine: '55 test st',
       city: 'Chapel Hill',
       dependentLocality: '',

--- a/payment-request/PaymentValidationErrors/retry-shows-shippingAddress-member-manual.https.html
+++ b/payment-request/PaymentValidationErrors/retry-shows-shippingAddress-member-manual.https.html
@@ -82,6 +82,11 @@ function retryShowsShippingAddressMember(button, error) {
     </button>
   </li>
   <li>
+    <button onclick="retryShowsShippingAddressMember(this, { regionCode: 'REGIONCODE ERROR' });">
+      The payment sheet shows "REGIONCODE ERROR" for the shipping address' region code.
+    </button>
+  </li>
+  <li>
     <button onclick="retryShowsShippingAddressMember(this, { sortingCode: 'SORTINGCODE ERROR' });">
       The payment sheet shows "SORTINGCODE ERROR" for the shipping address' sorting code.
     </button>

--- a/payment-request/historical.https.html
+++ b/payment-request/historical.https.html
@@ -21,9 +21,6 @@
 
   // https://github.com/w3c/payment-request/pull/765
   ["languageCode", "PaymentAddress"],
-
-  // https://github.com/w3c/payment-request/pull/823
-  ["regionCode", "PaymentAddress"],
 ].forEach(([member, interf]) => {
   test(() => {
     assert_false(member in window[interf].prototype);


### PR DESCRIPTION
Tests for https://github.com/w3c/payment-request/pull/836

Bring back PaymentAddress.regionCode for Payment Request API 1.1.

This reverts commit 4b7ad2a0c3b6b8c9cda425f7b2567bcd832c115d.