### PR TITLE
[css-syntax] Add character encoding tests

### DIFF
--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-001.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-001.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="ISO-8859-15"/>
+<title>CSS3 Syntax, input byte stream: CSS with UTF-signature</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="A UTF-8 signature at the beginning of a css style sheet sets the encoding for the style sheet to UTF-8.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/bom.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ýäè">&#xA0;</div></div>
+
+
+<!--Notes:
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as ISO 8859-15 and uses a different byte sequence (fd e4 e8) for the class name that equates to the character sequence ýäè.
+
+The class ids will therefore only match if the CSS is read as UTF-8.  (ISO 8859-15 is used for this page to avoid false matching due to UTF-8 fallback.)
+
+The CSS file encoding is established as utf-8 using only a UTF-8 signature.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ýäè"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-001.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-001.html
@@ -20,13 +20,13 @@ p { color: gray; margin-top: 3em; font-size: 80%; }
 
 
 
-<div class="test"><div id="box" class="???">&#xA0;</div></div>
+<div class="test"><div id="box" class="эди">&#xA0;</div></div>
 
 
 <!--Notes:
-In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ???.  Read as ISO 8850-15, this gives эди.
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters эди.  Read as ISO 8850-15, this gives ГЅГ¤ГЁ.
 
-This HTML page is served as ISO 8859-15 and uses a different byte sequence (fd e4 e8) for the class name that equates to the character sequence ???.
+This HTML page is served as ISO 8859-15 and uses a different byte sequence (fd e4 e8) for the class name that equates to the character sequence эди.
 
 The class ids will therefore only match if the CSS is read as UTF-8.  (ISO 8859-15 is used for this page to avoid false matching due to UTF-8 fallback.)
 
@@ -41,6 +41,6 @@ assert_equals(document.getElementById('box').offsetWidth, 100);
 
 <div id='log'></div>
 
-<p class="???"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+<p class="эди"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
 </body>
 </html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-001.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-001.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: CSS with UTF-signature</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="A UTF-8 signature at the beginning of a css style sheet sets the encoding for the style sheet to UTF-8.">
 <style type='text/css'>
@@ -20,13 +20,13 @@ p { color: gray; margin-top: 3em; font-size: 80%; }
 
 
 
-<div class="test"><div id="box" class="эди">&#xA0;</div></div>
+<div class="test"><div id="box" class="???">&#xA0;</div></div>
 
 
 <!--Notes:
-In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters эди.  Read as ISO 8850-15, this gives ГЅГ¤ГЁ.
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ???.  Read as ISO 8850-15, this gives эди.
 
-This HTML page is served as ISO 8859-15 and uses a different byte sequence (fd e4 e8) for the class name that equates to the character sequence эди.
+This HTML page is served as ISO 8859-15 and uses a different byte sequence (fd e4 e8) for the class name that equates to the character sequence ???.
 
 The class ids will therefore only match if the CSS is read as UTF-8.  (ISO 8859-15 is used for this page to avoid false matching due to UTF-8 fallback.)
 
@@ -41,6 +41,6 @@ assert_equals(document.getElementById('box').offsetWidth, 100);
 
 <div id='log'></div>
 
-<p class="эди"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+<p class="???"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
 </body>
 </html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-001.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-001.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=iso-8859-15

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-002.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-002.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: HTTP declaration</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="The HTTP header can set the character encoding of a style sheet.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/http15.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+The CSS file encoding is established as ISO 8859-15 using only the HTTP header.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-002.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-002.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: HTTP declaration</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="The HTTP header can set the character encoding of a style sheet.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-002.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-002.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-003.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-003.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: @charset declaration (uppercase value)</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="An @charset rule with an uppercase value sets the encoding of a css stylesheet.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+The CSS file encoding is established as ISO 8859-15 using only an @charset rule, with the name of the encoding in uppercase.
+
+-->
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-003.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-003.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: @charset declaration (uppercase value)</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="An @charset rule with an uppercase value sets the encoding of a css stylesheet.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-003.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-003.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-004.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-004.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: @charset declaration (lowercase value)</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="An @charset rule with a lowercase value sets the encoding of a css stylesheet.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15lcvalue.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+The CSS file encoding is established as ISO 8859-15 using only an @charset rule, with the name of the encoding in lowercase.
+
+-->
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-004.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-004.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: @charset declaration (lowercase value)</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="An @charset rule with a lowercase value sets the encoding of a css stylesheet.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-004.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-004.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-005.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-005.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: link charset</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="A charset attribute on the HTML link element sets the encoding of a css stylesheet.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel='stylesheet' charset='ISO-8859-15' type='text/css' href='support/none.css' /></head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+The CSS file encoding is established as ISO 8859-15 using only a charset attribute in the HTML link element.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-005.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-005.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: link charset</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="A charset attribute on the HTML link element sets the encoding of a css stylesheet.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-005.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-005.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-006.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-006.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="ISO-8859-15"/>
+<title>CSS3 Syntax, input byte stream: inheritance from HTML encoding</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="The user agent applies the encoding of the HTML file to a css stylesheet whose encoding is not otherwise declared.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/none.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ýäè">&#xA0;</div></div>
+
+
+<!--Notes:
+This test assumes that meta charset works.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ���.  Read as ISO 8850-15, this gives ýäè.
+
+This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence ýäè.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.  (ISO 8859-15 is used for this page to avoid false matching due to UTF-8 fallback.)
+
+The CSS file has no encoding set nor BOM.
+
+-->
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ýäè"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-006.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-006.html
@@ -20,15 +20,15 @@ p { color: gray; margin-top: 3em; font-size: 80%; }
 
 
 
-<div class="test"><div id="box" class="ýäè">&#xA0;</div></div>
+<div class="test"><div id="box" class="Ã½Ã¤Ã¨">&#xA0;</div></div>
 
 
 <!--Notes:
 This test assumes that meta charset works.
 
-In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ???.  Read as ISO 8850-15, this gives ýäè.
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8850-15, this gives Ã½Ã¤Ã¨.
 
-This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence ýäè.
+This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence Ã½Ã¤Ã¨.
 
 The class ids will therefore only match if the CSS is read as ISO 8859-15.  (ISO 8859-15 is used for this page to avoid false matching due to UTF-8 fallback.)
 
@@ -44,6 +44,6 @@ assert_equals(document.getElementById('box').offsetWidth, 100);
 
 <div id='log'></div>
 
-<p class="ýäè"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+<p class="Ã½Ã¤Ã¨"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
 </body>
 </html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-006.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-006.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: inheritance from HTML encoding</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="The user agent applies the encoding of the HTML file to a css stylesheet whose encoding is not otherwise declared.">
 <style type='text/css'>
@@ -20,15 +20,15 @@ p { color: gray; margin-top: 3em; font-size: 80%; }
 
 
 
-<div class="test"><div id="box" class="Ã½Ã¤Ã¨">&#xA0;</div></div>
+<div class="test"><div id="box" class="ýäè">&#xA0;</div></div>
 
 
 <!--Notes:
 This test assumes that meta charset works.
 
-In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8850-15, this gives Ã½Ã¤Ã¨.
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ???.  Read as ISO 8850-15, this gives ýäè.
 
-This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence Ã½Ã¤Ã¨.
+This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence ýäè.
 
 The class ids will therefore only match if the CSS is read as ISO 8859-15.  (ISO 8859-15 is used for this page to avoid false matching due to UTF-8 fallback.)
 
@@ -44,6 +44,6 @@ assert_equals(document.getElementById('box').offsetWidth, 100);
 
 <div id='log'></div>
 
-<p class="Ã½Ã¤Ã¨"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+<p class="ýäè"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
 </body>
 </html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-006.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-006.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=iso-8859-15

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-007.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-007.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="ISO-8859-15"/>
+<title>CSS3 Syntax, input byte stream: unknown @charset value</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="When a stylesheet has a @charset declaration with an unknown value, the stylesheet will be interpreted using the encoding of the calling document.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset-unknown.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ýäè">&#xA0;</div></div>
+
+
+<!--Notes:
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ���.  Read as ISO 8850-15, this gives ýäè.
+
+This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence ýäè.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.  (ISO 8859-15 is used for this page to avoid false matching due to UTF-8 fallback.)
+
+The CSS file encoding uses an @charset sequence with a made up value that won't be recognised by the browser.
+
+-->
+
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ýäè"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-007.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-007.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: unknown @charset value</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="When a stylesheet has a @charset declaration with an unknown value, the stylesheet will be interpreted using the encoding of the calling document.">
 <style type='text/css'>
@@ -20,13 +20,13 @@ p { color: gray; margin-top: 3em; font-size: 80%; }
 
 
 
-<div class="test"><div id="box" class="Ã½Ã¤Ã¨">&#xA0;</div></div>
+<div class="test"><div id="box" class="ýäè">&#xA0;</div></div>
 
 
 <!--Notes:
-In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8850-15, this gives Ã½Ã¤Ã¨.
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ???.  Read as ISO 8850-15, this gives ýäè.
 
-This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence Ã½Ã¤Ã¨.
+This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence ýäè.
 
 The class ids will therefore only match if the CSS is read as ISO 8859-15.  (ISO 8859-15 is used for this page to avoid false matching due to UTF-8 fallback.)
 
@@ -42,6 +42,6 @@ assert_equals(document.getElementById('box').offsetWidth, 100);
 
 <div id='log'></div>
 
-<p class="Ã½Ã¤Ã¨"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+<p class="ýäè"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
 </body>
 </html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-007.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-007.html
@@ -20,13 +20,13 @@ p { color: gray; margin-top: 3em; font-size: 80%; }
 
 
 
-<div class="test"><div id="box" class="ýäè">&#xA0;</div></div>
+<div class="test"><div id="box" class="Ã½Ã¤Ã¨">&#xA0;</div></div>
 
 
 <!--Notes:
-In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ???.  Read as ISO 8850-15, this gives ýäè.
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8850-15, this gives Ã½Ã¤Ã¨.
 
-This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence ýäè.
+This HTML page is served as ISO 8859-15 and uses a byte sequence for the class name that equates to the character sequence Ã½Ã¤Ã¨.
 
 The class ids will therefore only match if the CSS is read as ISO 8859-15.  (ISO 8859-15 is used for this page to avoid false matching due to UTF-8 fallback.)
 
@@ -42,6 +42,6 @@ assert_equals(document.getElementById('box').offsetWidth, 100);
 
 <div id='log'></div>
 
-<p class="ýäè"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+<p class="Ã½Ã¤Ã¨"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
 </body>
 </html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-007.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-007.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=iso-8859-15

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-008.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-008.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: no semicolon at end of charset rule</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="If a @charset declaration is missing a final semicolon, the encoding declaration will not be recognised.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: white; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15-nocolon.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset rule.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+There is an @charset rule at the start of the style sheet that can set the encoding to ISO 8859-15, but it is incorrectly formed, and so should be ignored. If the previously mentioned selector matches, ie. the @charset rule has not been ignored, the test fails.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-008.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-008.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: no semicolon at end of charset rule</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="If a @charset declaration is missing a final semicolon, the encoding declaration will not be recognised.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-008.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-008.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-009.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-009.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: extra spaces after @charset</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="If a @charset declaration has more than one space after 'charset', the encoding declaration will not be recognised.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: white; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15-midspaces.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset rule.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+There is an @charset rule at the start of the style sheet that can set the encoding to ISO 8859-15, but it is incorrectly formed, and so should be ignored. If the previously mentioned selector matches, ie. the @charset rule has not been ignored, the test fails.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-009.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-009.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: extra spaces after @charset</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="If a @charset declaration has more than one space after 'charset', the encoding declaration will not be recognised.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-009.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-009.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-010.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-010.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: extra spaces before semicolon in charset rule</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="If a @charset declaration has a space just before the semicolon, the encoding declaration will not be recognised.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: white; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15-endspaces.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset rule.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+There is an @charset rule at the start of the style sheet that can set the encoding to ISO 8859-15, but it is incorrectly formed, and so should be ignored. If the previously mentioned selector matches, ie. the @charset rule has not been ignored, the test fails.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-010.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-010.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: extra spaces before semicolon in charset rule</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="If a @charset declaration has a space just before the semicolon, the encoding declaration will not be recognised.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-010.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-010.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-011.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-011.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: linebreak in middle of charset rule</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="If a @charset declaration has a line break in the middle, the encoding declaration will not be recognised.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: white; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15-linebreak.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset rule.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+There is an @charset rule at the start of the style sheet that can set the encoding to ISO 8859-15, but it is incorrectly formed, and so should be ignored. If the previously mentioned selector matches, ie. the @charset rule has not been ignored, the test fails.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-011.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-011.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: linebreak in middle of charset rule</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="If a @charset declaration has a line break in the middle, the encoding declaration will not be recognised.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-011.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-011.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-012.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-012.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: single quotes around charset name</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="If a @charset declaration value has single, rather than double, quotes around it, the encoding declaration will not be recognised.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: white; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15-singlequotes.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset rule.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+There is an @charset rule at the start of the style sheet that can set the encoding to ISO 8859-15, but it is incorrectly formed, and so should be ignored. If the previously mentioned selector matches, ie. the @charset rule has not been ignored, the test fails.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-012.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-012.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: single quotes around charset name</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="If a @charset declaration value has single, rather than double, quotes around it, the encoding declaration will not be recognised.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-012.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-012.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-014.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-014.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: blank line before @charset</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="If a @charset declaration is not on the first line of the file, the encoding declaration will not be recognised.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: white; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15-blankline.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset rule.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+There is an @charset rule at the start of the style sheet that can set the encoding to ISO 8859-15, but it is incorrectly formed, and so should be ignored. If the previously mentioned selector matches, ie. the @charset rule has not been ignored, the test fails.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-014.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-014.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: blank line before @charset</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="If a @charset declaration is not on the first line of the file, the encoding declaration will not be recognised.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-014.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-014.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-015.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-015.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: blank spaces before @charset</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="If a @charset declaration does not start at the beginning of the first line of the file (when there is no BOM), the encoding declaration will not be recognised.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: white; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15-beforespaces.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset rule.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+There is an @charset rule at the start of the style sheet that can set the encoding to ISO 8859-15, but it is incorrectly formed, and so should be ignored. If the previously mentioned selector matches, ie. the @charset rule has not been ignored, the test fails.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-015.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-015.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: blank spaces before @charset</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="If a @charset declaration does not start at the beginning of the first line of the file (when there is no BOM), the encoding declaration will not be recognised.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-015.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-015.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-016.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-016.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: @charset declaration (uppercase)</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="If a @charset declaration is written in uppercase (@CHARSET), the encoding declaration will not be recognised.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: white; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/charset15uc.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ÃœÃ€Ãš">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset rule.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨. Read as ISO 8850-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c5 93 c3 83 e2 82 ac c3 83 c5 a1) that equates to the character sequence ÃœÃ€Ãš.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-15.
+
+There is an @charset rule at the start of the style sheet that can set the encoding to ISO 8859-15, but it is incorrectly formed, and so should be ignored. If the previously mentioned selector matches, ie. the @charset rule has not been ignored, the test fails.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ÃœÃ€Ãš"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-016.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-016.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: @charset declaration (uppercase)</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="If a @charset declaration is written in uppercase (@CHARSET), the encoding declaration will not be recognised.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-016.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-016.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-017.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-017.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="ISO-8859-1"/>
+<title>CSS3 Syntax, input byte stream: http vs. bom</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="A UTF-8 signature overrides an HTTP encoding declaration for a stylesheet .">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/http1-bom.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ýäè">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the HTTP and BOM declarations.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives Ã½Ã¤Ã¨.
+
+This HTML page is served as ISO 8859-1 and uses a different byte sequence for the class name (fd e4 e8) that equates to the character sequence ýäè.
+
+The class ids will therefore only match if the CSS is read as UTF-8.
+
+The style sheet has a UTF-8 signature at the start, but the HTTP header for the style sheet says ISO 8859-1. If the HTTP header overrides the bom, the CSS will not be read as UTF-8, the selector will not match the class name, and the test will fail.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ýäè"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-017.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-017.html
@@ -20,15 +20,15 @@ p { color: gray; margin-top: 3em; font-size: 80%; }
 
 
 
-<div class="test"><div id="box" class="???">&#xA0;</div></div>
+<div class="test"><div id="box" class="эди">&#xA0;</div></div>
 
 
 <!--Notes:
 This test is only valid if the user agent recognises the HTTP and BOM declarations.
 
-In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ???.  Read as ISO 8859-1, this gives эди.
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters эди.  Read as ISO 8859-1, this gives ГЅГ¤ГЁ.
 
-This HTML page is served as ISO 8859-1 and uses a different byte sequence for the class name (fd e4 e8) that equates to the character sequence ???.
+This HTML page is served as ISO 8859-1 and uses a different byte sequence for the class name (fd e4 e8) that equates to the character sequence эди.
 
 The class ids will therefore only match if the CSS is read as UTF-8.
 
@@ -43,6 +43,6 @@ assert_equals(document.getElementById('box').offsetWidth, 100);
 
 <div id='log'></div>
 
-<p class="???"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+<p class="эди"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
 </body>
 </html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-017.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-017.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: http vs. bom</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="A UTF-8 signature overrides an HTTP encoding declaration for a stylesheet .">
 <style type='text/css'>
@@ -20,15 +20,15 @@ p { color: gray; margin-top: 3em; font-size: 80%; }
 
 
 
-<div class="test"><div id="box" class="эди">&#xA0;</div></div>
+<div class="test"><div id="box" class="???">&#xA0;</div></div>
 
 
 <!--Notes:
 This test is only valid if the user agent recognises the HTTP and BOM declarations.
 
-In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters эди.  Read as ISO 8859-1, this gives ГЅГ¤ГЁ.
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ???.  Read as ISO 8859-1, this gives эди.
 
-This HTML page is served as ISO 8859-1 and uses a different byte sequence for the class name (fd e4 e8) that equates to the character sequence эди.
+This HTML page is served as ISO 8859-1 and uses a different byte sequence for the class name (fd e4 e8) that equates to the character sequence ???.
 
 The class ids will therefore only match if the CSS is read as UTF-8.
 
@@ -43,6 +43,6 @@ assert_equals(document.getElementById('box').offsetWidth, 100);
 
 <div id='log'></div>
 
-<p class="эди"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+<p class="???"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
 </body>
 </html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-017.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-017.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=ISO-8859-1

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-018.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-018.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="UTF-8"/>
+<title>CSS3 Syntax, input byte stream: css bom and @charset iso15</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="When a stylesheet has a BOM and a @charset declaration that is not for a Unicode encoding, the BOM takes precedence.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/bom-charset15.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="ýäè">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset and BOM declarations.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-15, this gives ÃœÃ€Ãš.
+
+This HTML page is served as UTF-8 and uses the same byte sequence for the class name that equates to the character sequence ýäè.
+
+The class ids will therefore only match if the CSS is read as UTF-8.
+
+The CSS starts with a UTF-8 signature but also has an @charset rule declaring the encoding to be ISO 8859-15. There is no HTTP encoding information. The browser should set the encoding to UTF-8, because of the BOM, and ignore the @charset rule.
+
+The class value above will only match if the CSS is read by the browser as UTF-8.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="ýäè"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-018.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-018.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: css bom and @charset iso15</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="When a stylesheet has a BOM and a @charset declaration that is not for a Unicode encoding, the BOM takes precedence.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-018.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-018.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-019.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-019.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8" />
+<title>CSS3 Syntax, input byte stream: http vs. @charset</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="An HTTP encoding declaration for a stylesheet takes precedence over an @charset declaration.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel="stylesheet" type="text/css" href="support/http1-charset8.css">
+</head>
+<body>
+
+
+
+<div class="test"><div id="box" class="Ã½Ã¤Ã¨">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the HTTP and @charset declarations.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c2 bd c3 83 c2 a4 c3 83 c2 a8) that equates to the character sequence Ã½Ã¤Ã¨.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-1.
+
+The CSS style sheet contains an @charset rule that says the file is UTF-8, but the HTTP header says ISO 8859-1. If the HTTP header overrides the @charset rule, the selector will match the class name and the test will pass.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="Ã½Ã¤Ã¨"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-019.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-019.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: http vs. @charset</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="An HTTP encoding declaration for a stylesheet takes precedence over an @charset declaration.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-019.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-019.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=utf-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-020.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-020.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="utf-8"/>
+<title>CSS3 Syntax, input byte stream: http vs. charset link</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="An HTTP encoding declaration for a stylesheet takes precedence over a charset attribute in the link element.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel='stylesheet' charset='utf-8' type='text/css' href='support/http1.css' /></head>
+<body>
+
+
+
+<div class="test"><div id="box" class="Ã½Ã¤Ã¨">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the HTTP and charset link declarations.
+
+The HTML link element contains a charset attribute that says that the style sheet is UTF-8, but the HTTP header for the style sheet says ISO 8859-1. If the HTTP header overrides the charset attribute, the selector will match the class name and the test will pass.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="Ã½Ã¤Ã¨"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-020.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-020.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: http vs. charset link</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="An HTTP encoding declaration for a stylesheet takes precedence over a charset attribute in the link element.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-020.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-020.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-021.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-021.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html  lang="en" >
+<head>
+<meta charset="UTF-8"/>
+<title>CSS3 Syntax, input byte stream: @charset vs. link charset</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<meta name="assert" content="An @charset encoding declaration for a stylesheet takes precedence over a charset attribute in a link element.">
+<style type='text/css'>
+.test div { width:50px; }
+
+p { color: gray; margin-top: 3em; font-size: 80%; }
+</style>
+<link rel='stylesheet' charset='utf-8' type='text/css' href='support/charset1.css' /></head>
+<body>
+
+
+
+<div class="test"><div id="box" class="Ã½Ã¤Ã¨">&#xA0;</div></div>
+
+
+<!--Notes:
+This test is only valid if the user agent recognises the @charset and charset attribute declarations.
+
+In the style sheet, the CSS selector identifies a class name with the following byte sequence: c3 bd c3 a4 c3 a8.  Read as UTF-8 this gives the characters ýäè.  Read as ISO 8859-1, this gives  Ã½Ã¤Ã¨.
+
+This HTML page is served as UTF-8 and uses a different byte sequence for the class name (c3 83 c2 bd c3 83 c2 a4 c3 83 c2 a8) that equates to the character sequence Ã½Ã¤Ã¨.
+
+The class ids will therefore only match if the CSS is read as ISO 8859-1.
+
+The style sheet has an @charset rule that says the file is ISO 8859-1, but the HTML link charset attribute says UTF-8. If the @charset overrides the charset attribute, the selector will match the class name and the test will pass.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('box').offsetWidth, 100);
+}, " ");
+</script>
+
+<div id='log'></div>
+
+<p class="Ã½Ã¤Ã¨"><span><span id="debug">Text as read from the style sheet: </span><br />(If blank, the style sheet hasn't been read at all.)</span></p>
+</body>
+</html>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-021.html
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-021.html
@@ -5,8 +5,8 @@
 <title>CSS3 Syntax, input byte stream: @charset vs. link charset</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <link rel='help' href='http://www.w3.org/TR/css3-syntax/#input-byte-stream'>
-<script src="../../../resources/testharness.js"></script>
-<script src="../../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='http dom'>
 <meta name="assert" content="An @charset encoding declaration for a stylesheet takes precedence over a charset attribute in a link element.">
 <style type='text/css'>

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-021.html.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/i18n-css-syntax-bytes-021.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html; charset=UTF-8

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom-charset15.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom-charset15.css
@@ -1,0 +1,15 @@
+﻿@charset "iso-8859-15";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom-charset15.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom-charset15.css
@@ -1,15 +1,15 @@
 ﻿@charset "iso-8859-15";
 
 .test div.ýäè {
-	width: 100px;
-	}
+    width: 100px;
+}
 
 /* for debugging line */
 p.ýäè { color: white; }
 span#debug:after { content: 'ýäè'; }
-	
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom-charset15.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom-charset15.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom.css
@@ -1,0 +1,13 @@
+﻿.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom.css
@@ -1,13 +1,13 @@
 ﻿.test div.ýäè {
-	width: 100px;
-	}
+    width: 100px;
+}
 
 /* for debugging line */
 p.ýäè { color: white; }
 span#debug:after { content: 'ýäè'; }
-	
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/bom.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset-unknown.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset-unknown.css
@@ -1,0 +1,15 @@
+@charset "xxxunknownEncodingxxx";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset-unknown.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset-unknown.css
@@ -1,12 +1,12 @@
 @charset "xxxunknownEncodingxxx";
 
-.test div.эди {
+.test div.ГЅГ¤ГЁ {
     width: 100px;
 }
 
 /* for debugging line */
-p.эди { color: white; }
-span#debug:after { content: 'эди'; }
+p.ГЅГ¤ГЁ { color: white; }
+span#debug:after { content: 'ГЅГ¤ГЁ'; }
 
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
     iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset-unknown.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset-unknown.css
@@ -1,15 +1,15 @@
 @charset "xxxunknownEncodingxxx";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: white; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset-unknown.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset-unknown.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset1.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset1.css
@@ -1,0 +1,16 @@
+@charset "iso-8859-1";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/
+

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset1.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset1.css
@@ -1,12 +1,12 @@
 @charset "iso-8859-1";
 
-.test div.эди {
+.test div.ГЅГ¤ГЁ {
     width: 100px;
 }
 
 /* for debugging line */
-p.эди { color: white; }
-span#debug:after { content: 'эди'; }
+p.ГЅГ¤ГЁ { color: white; }
+span#debug:after { content: 'ГЅГ¤ГЁ'; }
 
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
     iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset1.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset1.css
@@ -1,16 +1,16 @@
 @charset "iso-8859-1";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: white; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/
 

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset1.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset1.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-beforespaces.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-beforespaces.css
@@ -1,0 +1,15 @@
+   @charset "iso-8859-15";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-beforespaces.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-beforespaces.css
@@ -1,15 +1,15 @@
    @charset "iso-8859-15";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+   width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: gray; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+   iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+   iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+   utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-beforespaces.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-beforespaces.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-blankline.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-blankline.css
@@ -1,0 +1,16 @@
+
+@charset "iso-8859-15";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-blankline.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-blankline.css
@@ -1,16 +1,16 @@
 
 @charset "iso-8859-15";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: gray; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+    */

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-blankline.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-blankline.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-endspaces.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-endspaces.css
@@ -1,0 +1,15 @@
+@charset "iso-8859-15" ;
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-endspaces.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-endspaces.css
@@ -1,15 +1,15 @@
 @charset "iso-8859-15" ;
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: gray; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-endspaces.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-endspaces.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-linebreak.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-linebreak.css
@@ -1,0 +1,16 @@
+@charset 
+"iso-8859-15";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-linebreak.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-linebreak.css
@@ -1,16 +1,16 @@
-@charset 
+@charset
 "iso-8859-15";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: gray; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-linebreak.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-linebreak.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-midspaces.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-midspaces.css
@@ -1,0 +1,15 @@
+@charset	"iso-8859-15";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-midspaces.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-midspaces.css
@@ -1,15 +1,15 @@
 @charset	"iso-8859-15";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: gray; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-midspaces.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-midspaces.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-nocolon.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-nocolon.css
@@ -1,0 +1,17 @@
+@charset "iso-8859-15"
+dummy { font-family: serif; } /* provides a colon to make the important stuff work */
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/
+

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-nocolon.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-nocolon.css
@@ -1,17 +1,17 @@
 @charset "iso-8859-15"
 dummy { font-family: serif; } /* provides a colon to make the important stuff work */
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: gray; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/
 

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-nocolon.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-nocolon.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-singlequotes.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-singlequotes.css
@@ -1,0 +1,15 @@
+@charset 'iso-8859-15';
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-singlequotes.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-singlequotes.css
@@ -1,15 +1,15 @@
 @charset 'iso-8859-15';
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: gray; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: gray; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-singlequotes.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15-singlequotes.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15.css
@@ -1,0 +1,16 @@
+@charset "ISO-8859-15";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/
+

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15.css
@@ -1,12 +1,12 @@
 @charset "ISO-8859-15";
 
-.test div.эди {
+.test div.ГЅГ¤ГЁ {
     width: 100px;
 }
 
 /* for debugging line */
-p.эди { color: white; }
-span#debug:after { content: 'эди'; }
+p.ГЅГ¤ГЁ { color: white; }
+span#debug:after { content: 'ГЅГ¤ГЁ'; }
 
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
     iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15.css
@@ -1,16 +1,16 @@
 @charset "ISO-8859-15";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: white; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/
 

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15lcvalue.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15lcvalue.css
@@ -1,0 +1,15 @@
+@charset "iso-8859-15";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15lcvalue.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15lcvalue.css
@@ -1,15 +1,15 @@
 @charset "iso-8859-15";
 
-.test div.ýäè {
+.test div.Ã½Ã¤Ã¨ {
     width: 100px;
 }
 
 /* for debugging line */
-p.ýäè { color: white; }
-span#debug:after { content: 'ýäè'; }
+p.Ã½Ã¤Ã¨ { color: white; }
+span#debug:after { content: 'Ã½Ã¤Ã¨'; }
 
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
     iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
     iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
     utf-8: yacute, adiaeresis, egrave
-    */
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15lcvalue.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15lcvalue.css
@@ -1,15 +1,15 @@
 @charset "iso-8859-15";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: white; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+    */

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15lcvalue.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15lcvalue.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15uc.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15uc.css
@@ -1,0 +1,15 @@
+@CHARSET "ISO-8859-15";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15uc.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15uc.css
@@ -1,15 +1,15 @@
 @CHARSET "ISO-8859-15";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: white; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15uc.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset15uc.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset8.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset8.css
@@ -1,0 +1,17 @@
+@charset "utf-8";
+.test div {
+	background-color: #FF0000;
+	font-weight: bold;
+	color: white;
+	height: 90px;
+	width: 90px;
+	font-family: Arial, Helvetica, sans-serif; 
+	}
+.ýäè {
+	background-color: #00FF00;
+	font-weight: bold;
+	color: white;
+	height: 100px;
+	width: 100px;
+	font-family: Arial, Helvetica, sans-serif; 
+	}

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset8.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/charset8.css
@@ -1,17 +1,17 @@
 @charset "utf-8";
 .test div {
-	background-color: #FF0000;
-	font-weight: bold;
-	color: white;
-	height: 90px;
-	width: 90px;
-	font-family: Arial, Helvetica, sans-serif; 
-	}
-.Ã½Ã¤Ã¨ {
-	background-color: #00FF00;
-	font-weight: bold;
-	color: white;
-	height: 100px;
-	width: 100px;
-	font-family: Arial, Helvetica, sans-serif; 
-	}
+    background-color: #FF0000;
+    font-weight: bold;
+    color: white;
+    height: 90px;
+    width: 90px;
+    font-family: Arial, Helvetica, sans-serif;
+}
+.ýäè {
+    background-color: #00FF00;
+    font-weight: bold;
+    color: white;
+    height: 100px;
+    width: 100px;
+    font-family: Arial, Helvetica, sans-serif;
+}

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-bom.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-bom.css
@@ -1,0 +1,14 @@
+﻿.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/
+

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-bom.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-bom.css
@@ -1,14 +1,14 @@
 ﻿.test div.ýäè {
-	width: 100px;
-	}
+    width: 100px;
+}
 
 /* for debugging line */
 p.ýäè { color: white; }
 span#debug:after { content: 'ýäè'; }
-	
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/
 

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-bom.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-bom.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css; charset=iso-8859-1

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-charset8.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-charset8.css
@@ -1,0 +1,16 @@
+@charset "utf-8";
+
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/
+

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-charset8.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-charset8.css
@@ -1,12 +1,12 @@
 @charset "utf-8";
 
-.test div.эди {
+.test div.ГЅГ¤ГЁ {
     width: 100px;
 }
 
 /* for debugging line */
-p.эди { color: white; }
-span#debug:after { content: 'эди'; }
+p.ГЅГ¤ГЁ { color: white; }
+span#debug:after { content: 'ГЅГ¤ГЁ'; }
 
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
     iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-charset8.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-charset8.css
@@ -1,16 +1,16 @@
 @charset "utf-8";
 
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: white; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/
 

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-charset8.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1-charset8.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css; charset=iso-8859-1

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1.css
@@ -1,0 +1,14 @@
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/
+

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1.css
@@ -1,14 +1,14 @@
-.test div.ýäè {
+.test div.Ã½Ã¤Ã¨ {
     width: 100px;
 }
 
 /* for debugging line */
-p.ýäè { color: white; }
-span#debug:after { content: 'ýäè'; }
+p.Ã½Ã¤Ã¨ { color: white; }
+span#debug:after { content: 'Ã½Ã¤Ã¨'; }
 
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
     iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
     iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
     utf-8: yacute, adiaeresis, egrave
-    */
+*/
 

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1.css
@@ -1,14 +1,14 @@
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: white; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+    */
 

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http1.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css; charset=iso-8859-1

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http15.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http15.css
@@ -1,0 +1,13 @@
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http15.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http15.css
@@ -1,13 +1,13 @@
-.test div.Ã½Ã¤Ã¨ {
-	width: 100px;
-	}
+.test div.ýäè {
+    width: 100px;
+}
 
 /* for debugging line */
-p.Ã½Ã¤Ã¨ { color: white; }
-span#debug:after { content: 'Ã½Ã¤Ã¨'; }
-	
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http15.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http15.css
@@ -1,10 +1,10 @@
-.test div.эди {
+.test div.ГЅГ¤ГЁ {
     width: 100px;
 }
 
 /* for debugging line */
-p.эди { color: white; }
-span#debug:after { content: 'эди'; }
+p.ГЅГ¤ГЁ { color: white; }
+span#debug:after { content: 'ГЅГ¤ГЁ'; }
 
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
     iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http15.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/http15.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css; charset=iso-8859-15

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/none.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/none.css
@@ -1,0 +1,13 @@
+.test div.ýäè {
+	width: 100px;
+	}
+
+/* for debugging line */
+p.ýäè { color: white; }
+span#debug:after { content: 'ýäè'; }
+	
+/* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
+	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+	utf-8: yacute, adiaeresis, egrave
+	*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/none.css
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/none.css
@@ -1,13 +1,13 @@
 .test div.ýäè {
-	width: 100px;
-	}
+    width: 100px;
+}
 
 /* for debugging line */
 p.ýäè { color: white; }
 span#debug:after { content: 'ýäè'; }
-	
+
 /* the second selector uses the following sequence of bytes 0xC3 0xBD 0xC3 0xA4 0xC3 0xA8, which is read as different characters by the application, depending on the encoding used, ie.
-	iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
-	iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
-	utf-8: yacute, adiaeresis, egrave
-	*/
+    iso 8859-1: Atilde, half, Atilde, box, Atilde, diaeresis
+    iso 8859-15: Atilde, oe, Atilde, euro, Atilde, shacek
+    utf-8: yacute, adiaeresis, egrave
+*/

--- a/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/none.css.headers
+++ b/css/css-syntax/tokenizing-and-parsing/input-byte-stream/support/none.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css


### PR DESCRIPTION
This PR ports https://www.w3.org/International/tests/repo/results/css-input-byte-stream to WPT.

It contains tests for basic functionalities, unknown `@charset` value, `@charset` typos, and the precedence of HTML/HTTP/BOM/`@charset`.

/cc @r12a
