### PR TITLE
Verify that tee doesn't pull more chunks than the branch HWM

### DIFF
--- a/streams/readable-streams/tee.any.js
+++ b/streams/readable-streams/tee.any.js
@@ -1,5 +1,7 @@
 // META: global=worker,jsshell
 // META: script=../resources/rs-utils.js
+// META: script=../resources/test-utils.js
+// META: script=../resources/recording-streams.js
 'use strict';
 
 test(() => {
@@ -286,3 +288,32 @@ test(t => {
   assert_not_equals(getReader.call(rs2), undefined, 'getReader should work on rs2');
 
 }, 'ReadableStreamTee should not use a modified ReadableStream constructor from the global object');
+
+promise_test(t => {
+
+  const rs = recordingReadableStream({}, { highWaterMark: 0 });
+
+  // Create two branches, each with a HWM of 1. This should result in one
+  // chunk being pulled, not two.
+  rs.tee();
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(rs.events, ['pull'], 'pull should only be called once');
+  });
+
+}, 'ReadableStreamTee should not pull more chunks than can fit in the branch queue');
+
+promise_test(t => {
+
+  const rs = recordingReadableStream({
+    pull(controller) {
+      controller.enqueue('a');
+    }
+  }, { highWaterMark: 0 });
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+  return Promise.all([reader1.read(), reader2.read()])
+      .then(() => {
+    assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+  });
+
+}, 'ReadableStreamTee should only pull enough to fill the emptiest queue');


### PR DESCRIPTION
ReadableStreamTee should only pull enough chunks to fill the HWM of the
branches (which is 1), and no more.

When pulling from the branches, verify that pull() on the original
stream still is only called enough to fill the emptiest branch.

Corresponding standard change is https://github.com/whatwg/streams/pull/997.