### PR TITLE
[Azure Pipelines] Put artifact name in urlencoded POST body

### DIFF
--- a/tools/ci/azure/fyi_hook.yml
+++ b/tools/ci/azure/fyi_hook.yml
@@ -12,7 +12,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-  - script: curl -s -S -X POST https://wpt.fyi/api/checks/azure/$(Build.BuildId)?artifact=${{ parameters.artifactName }}
+  - script: curl -s -S -d "artifact=${{ parameters.artifactName }}" -X POST https://wpt.fyi/api/checks/azure/$(Build.BuildId)
     displayName: 'Invoke wpt.fyi hook'
-  - script: curl -s -S -X POST https://staging.wpt.fyi/api/checks/azure/$(Build.BuildId)?artifact=${{ parameters.artifactName }}
+  - script: curl -s -S -d "artifact=${{ parameters.artifactName }}" -X POST https://staging.wpt.fyi/api/checks/azure/$(Build.BuildId)
     displayName: 'Invoke staging.wpt.fyi hook'


### PR DESCRIPTION
... instead of in the query string. This will probably resolve the
"POST requests require a Content-length header" problem [1] assuming
that the cause is a version of curl that doesn't send the header if
the request has no body.

[1] https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=7671