### PR TITLE
[docs] Correct page formatting

### DIFF
--- a/docs/_writing-tests/h2tests.md
+++ b/docs/_writing-tests/h2tests.md
@@ -1,4 +1,9 @@
-# Writing H2 Tests
+---
+layout: page
+title: Writing H2 Tests
+order: 2
+---
+
 > <b>Important:</b> The HTTP/2.0 server requires you to have Python 2.7.10+
 and OpenSSL 1.0.2+. This is because HTTP/2.0 is negotiated using the
 [TLS ALPN](https://tools.ietf.org/html/rfc7301) extension, which is only supported in [OpenSSL 1.0.2](https://www.openssl.org/news/openssl-1.0.2-notes.html) and up.


### PR DESCRIPTION
Insert the YAML frontmatter which distinguishes page content and causes
Jekyll to create an HTML document during the website rendering process.