### PR TITLE
[wptrunner] Do not use undefined method

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -369,7 +369,8 @@ class SeleniumRefTestExecutor(RefTestExecutor):
             """return [window.outerWidth - window.innerWidth,
                        window.outerHeight - window.innerHeight];"""
         )
-        self.protocol.webdriver.set_window_rect(0, 0, 800 + width_offset, 600 + height_offset)
+        self.protocol.webdriver.set_window_size(0, 0)
+        self.protocol.webdriver.set_window_position(800 + width_offset, 600 + height_offset)
 
         result = self.implementation.run_test(test)
 


### PR DESCRIPTION
The Selenium wire protocol does not define a "set window rect" method
[1]. Implement the desired behavior by composing the "set window
position" and "set window size" methods.

[1] https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol