### PR TITLE
Events from GlobalEventHandlers must dispatch on disabled form elements

### DIFF
--- a/dom/events/Event-dispatch-on-disabled-elements.html
+++ b/dom/events/Event-dispatch-on-disabled-elements.html
@@ -99,6 +99,123 @@ test(() => {
 }, "Calling click() on disabled elements must not dispatch events.");
 
 promise_test(async () => {
+  // Based on GlobalEventHandlers and mixins
+  // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
+  // https://drafts.csswg.org/css-transitions/#interface-globaleventhandlers-idl
+  const globalEventHandlers = new Map([
+    [
+      DragEvent,
+      [
+        "drag",
+        "dragend",
+        "dragenter",
+        "dragexit",
+        "dragleave",
+        "dragover",
+        "dragstart",
+        "drop",
+      ],
+    ],
+    [
+      Event,
+      [
+        "abort",
+        "cancel",
+        "canplay",
+        "canplaythrough",
+        "change",
+        "close",
+        "cuechange",
+        "durationchange",
+        "emptied",
+        "ended",
+        "input",
+        "invalid",
+        "loadeddata",
+        "loadedmetadata",
+        "loadend",
+        "pause",
+        "play",
+        "playing",
+        "progress",
+        "ratechange",
+        "reset",
+        "securitypolicyviolation",
+        "seeked",
+        "seeking",
+        "select",
+        "stalled",
+        "submit",
+        "suspend",
+        "timeupdate",
+        "toggle",
+        "volumechange",
+        "waiting",
+      ],
+    ],
+    [FormDataEvent, ["formdata"]],
+    [KeyboardEvent, ["keydown", "keypress", "keyup"]],
+    [
+      MouseEvent,
+      [
+        "auxclick",
+        "contextmenu",
+        "dblclick",
+        "mousedown",
+        "mouseenter",
+        "mouseleave",
+        "mousemove",
+        "mouseout",
+        "mouseover",
+        "mouseup",
+      ],
+    ],
+    [ProgressEvent, ["loadend", "loadstart"]],
+    [
+      TransitionEvent,
+      ["transitionstart", "transitionend", "transitionrun", "transitioncancel"],
+    ],
+    [WheelEvent, ["wheel"]],
+  ]);
+  // Using the appropriate interface, dispatch an event of each type.
+  for (const localName of formElements) {
+    const elem = document.createElement(localName);
+    elem.disabled = true;
+    document.body.appendChild(elem);
+    // Each interface.
+    for (const interfaceToTest of globalEventHandlers.keys()) {
+      // Each event type.
+      for (const type of globalEventHandlers.get(interfaceToTest)) {
+        let listenerFired = false;
+        elem.addEventListener(type, function f() {
+          listenerFired = true;
+          elem.removeEventListener(type, f);
+        });
+        let handlerFired = false;
+        const handlerAttrName = `on${type}`;
+        elem[handlerAttrName] = () => {
+          handlerFired = true;
+          elem[handlerAttrName] = undefined;
+        };
+        elem.dispatchEvent(new interfaceToTest(type));
+
+        // Generate expectation message.
+        const { name: constructorName } = Object.getPrototypeOf(
+          elem
+        ).constructor;
+        const msg = `on disabled ${constructorName} to receive ${
+          interfaceToTest.name
+        } of type "${type}".`;
+        //See how it went...
+        assert_true(listenerFired, `Expected listener ${msg}`);
+        assert_true(handlerFired, `Expected handler ${msg}`);
+      }
+    }
+    elem.remove();
+  }
+}, "Events from GlobalEventHandlers must dispatch on disabled form elements.");
+
+promise_test(async () => {
   for (const localName of formElements) {
     const elem = document.createElement(localName);
     elem.disabled = true;

--- a/dom/events/Event-dispatch-on-disabled-elements.html
+++ b/dom/events/Event-dispatch-on-disabled-elements.html
@@ -101,119 +101,318 @@ test(() => {
 promise_test(async () => {
   // Based on GlobalEventHandlers and mixins
   // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
-  // https://drafts.csswg.org/css-transitions/#interface-globaleventhandlers-idl
-  const globalEventHandlers = new Map([
-    [
-      DragEvent,
-      [
-        "drag",
-        "dragend",
-        "dragenter",
-        "dragexit",
-        "dragleave",
-        "dragover",
-        "dragstart",
-        "drop",
-      ],
-    ],
-    [
-      Event,
-      [
-        "abort",
-        "cancel",
-        "canplay",
-        "canplaythrough",
-        "change",
-        "close",
-        "cuechange",
-        "durationchange",
-        "emptied",
-        "ended",
-        "input",
-        "invalid",
-        "loadeddata",
-        "loadedmetadata",
-        "loadend",
-        "pause",
-        "play",
-        "playing",
-        "progress",
-        "ratechange",
-        "reset",
-        "securitypolicyviolation",
-        "seeked",
-        "seeking",
-        "select",
-        "stalled",
-        "submit",
-        "suspend",
-        "timeupdate",
-        "toggle",
-        "volumechange",
-        "waiting",
-      ],
-    ],
-    [FormDataEvent, ["formdata"]],
-    [KeyboardEvent, ["keydown", "keypress", "keyup"]],
-    [
-      MouseEvent,
-      [
-        "auxclick",
-        "contextmenu",
-        "dblclick",
-        "mousedown",
-        "mouseenter",
-        "mouseleave",
-        "mousemove",
-        "mouseout",
-        "mouseover",
-        "mouseup",
-      ],
-    ],
-    [ProgressEvent, ["loadend", "loadstart"]],
-    [
-      TransitionEvent,
-      ["transitionstart", "transitionend", "transitionrun", "transitioncancel"],
-    ],
-    [WheelEvent, ["wheel"]],
-  ]);
-  // Using the appropriate interface, dispatch an event of each type.
+  const eventTypes = [
+    "drag",
+    "dragend",
+    "dragenter",
+    "dragexit",
+    "dragleave",
+    "dragover",
+    "dragstart",
+    "drop",
+  ]
   for (const localName of formElements) {
     const elem = document.createElement(localName);
     elem.disabled = true;
     document.body.appendChild(elem);
-    // Each interface.
-    for (const interfaceToTest of globalEventHandlers.keys()) {
-      // Each event type.
-      for (const type of globalEventHandlers.get(interfaceToTest)) {
-        let listenerFired = false;
-        elem.addEventListener(type, function f() {
-          listenerFired = true;
-          elem.removeEventListener(type, f);
-        });
-        let handlerFired = false;
-        const handlerAttrName = `on${type}`;
-        elem[handlerAttrName] = () => {
-          handlerFired = true;
-          elem[handlerAttrName] = undefined;
-        };
-        elem.dispatchEvent(new interfaceToTest(type));
+    // Each event type.
+    for (const type of eventTypes) {
+      let listenerFired = false;
+      elem.addEventListener(type, function f() {
+        listenerFired = true;
+        elem.removeEventListener(type, f);
+      });
+      let handlerFired = false;
+      const handlerAttrName = `on${type}`;
+      elem[handlerAttrName] = () => {
+        handlerFired = true;
+        elem[handlerAttrName] = undefined;
+      };
+      elem.dispatchEvent(new DragEvent(type));
 
-        // Generate expectation message.
-        const { name: constructorName } = Object.getPrototypeOf(
-          elem
-        ).constructor;
-        const msg = `on disabled ${constructorName} to receive ${
-          interfaceToTest.name
-        } of type "${type}".`;
-        //See how it went...
-        assert_true(listenerFired, `Expected listener ${msg}`);
-        assert_true(handlerFired, `Expected handler ${msg}`);
-      }
+      // Generate expectation message.
+      const { name: constructorName } = Object.getPrototypeOf(
+        elem
+      ).constructor;
+      const msg = `on disabled ${constructorName} to receive ${
+        DragEvent.name
+      } of type "${type}".`;
+      //See how it went...
+      assert_true(listenerFired, `Expected listener ${msg}`);
+      assert_true(handlerFired, `Expected handler ${msg}`);
     }
     elem.remove();
   }
-}, "Events from GlobalEventHandlers must dispatch on disabled form elements.");
+}, "Events from DragEvent must dispatch on disabled form elements.");
+
+promise_test(async () => {
+  // Based on GlobalEventHandlers and mixins
+  // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
+  const eventTypes = [
+      "abort",
+      "cancel",
+      "canplay",
+      "canplaythrough",
+      "change",
+      "close",
+      "cuechange",
+      "durationchange",
+      "emptied",
+      "ended",
+      "input",
+      "invalid",
+      "loadeddata",
+      "loadedmetadata",
+      "loadend",
+      "pause",
+      "play",
+      "playing",
+      "progress",
+      "ratechange",
+      "reset",
+      "securitypolicyviolation",
+      "seeked",
+      "seeking",
+      "select",
+      "stalled",
+      "submit",
+      "suspend",
+      "timeupdate",
+      "toggle",
+      "volumechange",
+      "waiting",
+  ]
+  for (const localName of formElements) {
+    const elem = document.createElement(localName);
+    elem.disabled = true;
+    document.body.appendChild(elem);
+    // Each event type.
+    for (const type of eventTypes) {
+      let listenerFired = false;
+      elem.addEventListener(type, function f() {
+        listenerFired = true;
+        elem.removeEventListener(type, f);
+      });
+      let handlerFired = false;
+      const handlerAttrName = `on${type}`;
+      elem[handlerAttrName] = () => {
+        handlerFired = true;
+        elem[handlerAttrName] = undefined;
+      };
+      elem.dispatchEvent(new CustomEvent(type));
+
+      // Generate expectation message.
+      const { name: constructorName } = Object.getPrototypeOf(
+        elem
+      ).constructor;
+      const msg = `on disabled ${constructorName} to receive Event of type "${type}".`;
+      //See how it went...
+      assert_true(listenerFired, `Expected listener ${msg}`);
+      assert_true(handlerFired, `Expected handler ${msg}`);
+    }
+    elem.remove();
+  }
+}, "Events from Event interface must dispatch on disabled form elements.");
+
+promise_test(async () => {
+  // Based on GlobalEventHandlers and mixins
+  // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
+  const eventTypes = [
+    "formdata"
+  ]
+  for (const localName of formElements) {
+    const elem = document.createElement(localName);
+    elem.disabled = true;
+    document.body.appendChild(elem);
+    // Each event type.
+    for (const type of eventTypes) {
+      let listenerFired = false;
+      elem.addEventListener(type, function f() {
+        listenerFired = true;
+        elem.removeEventListener(type, f);
+      });
+      let handlerFired = false;
+      const handlerAttrName = `on${type}`;
+      elem[handlerAttrName] = () => {
+        handlerFired = true;
+        elem[handlerAttrName] = undefined;
+      };
+      elem.dispatchEvent(new FormDataEvent(type, {formData: new FormData()}));
+
+      // Generate expectation message.
+      const { name: constructorName } = Object.getPrototypeOf(
+        elem
+      ).constructor;
+      const msg = `on disabled ${constructorName} to receive FormDataEvent of type "${type}".`;
+      //See how it went...
+      assert_true(listenerFired, `Expected listener ${msg}`);
+      assert_true(handlerFired, `Expected handler ${msg}`);
+    }
+    elem.remove();
+  }
+}, "Events from FormDataEvent must dispatch on disabled form elements.");
+
+promise_test(async () => {
+  // Based on GlobalEventHandlers and mixins
+  // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
+  const eventTypes = [
+   "keydown", "keypress", "keyup"
+  ]
+  for (const localName of formElements) {
+    const elem = document.createElement(localName);
+    elem.disabled = true;
+    document.body.appendChild(elem);
+    // Each event type.
+    for (const type of eventTypes) {
+      let listenerFired = false;
+      elem.addEventListener(type, function f() {
+        listenerFired = true;
+        elem.removeEventListener(type, f);
+      });
+      let handlerFired = false;
+      const handlerAttrName = `on${type}`;
+      elem[handlerAttrName] = () => {
+        handlerFired = true;
+        elem[handlerAttrName] = undefined;
+      };
+      elem.dispatchEvent(new KeyboardEvent(type));
+
+      // Generate expectation message.
+      const { name: constructorName } = Object.getPrototypeOf(
+        elem
+      ).constructor;
+      const msg = `on disabled ${constructorName} to receive KeyboardEvent of type "${type}".`;
+      //See how it went...
+      assert_true(listenerFired, `Expected listener ${msg}`);
+      assert_true(handlerFired, `Expected handler ${msg}`);
+    }
+    elem.remove();
+  }
+}, "Events from KeyboardEvent must dispatch on disabled form elements.");
+
+
+promise_test(async () => {
+  // Based on GlobalEventHandlers and mixins
+  // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
+  const eventTypes = [
+    "loadend", "loadstart"
+  ]
+  for (const localName of formElements) {
+    const elem = document.createElement(localName);
+    elem.disabled = true;
+    document.body.appendChild(elem);
+    // Each event type.
+    for (const type of eventTypes) {
+      let listenerFired = false;
+      elem.addEventListener(type, function f() {
+        listenerFired = true;
+        elem.removeEventListener(type, f);
+      });
+      let handlerFired = false;
+      const handlerAttrName = `on${type}`;
+      elem[handlerAttrName] = () => {
+        handlerFired = true;
+        elem[handlerAttrName] = undefined;
+      };
+      elem.dispatchEvent(new ProgressEvent(type));
+
+      // Generate expectation message.
+      const { name: constructorName } = Object.getPrototypeOf(
+        elem
+      ).constructor;
+      const msg = `on disabled ${constructorName} to receive ProgressEvent of type "${type}".`;
+      //See how it went...
+      assert_true(listenerFired, `Expected listener ${msg}`);
+      assert_true(handlerFired, `Expected handler ${msg}`);
+    }
+    elem.remove();
+  }
+}, "Events from ProgressEvent must dispatch on disabled form elements.");
+
+promise_test(async () => {
+  // Based on GlobalEventHandlers and mixins
+  // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
+  const eventTypes = [
+    "wheel",
+  ]
+  for (const localName of formElements) {
+    const elem = document.createElement(localName);
+    elem.disabled = true;
+    document.body.appendChild(elem);
+    // Each event type.
+    for (const type of eventTypes) {
+      let listenerFired = false;
+      elem.addEventListener(type, function f() {
+        listenerFired = true;
+        elem.removeEventListener(type, f);
+      });
+      let handlerFired = false;
+      const handlerAttrName = `on${type}`;
+      elem[handlerAttrName] = () => {
+        handlerFired = true;
+        elem[handlerAttrName] = undefined;
+      };
+      elem.dispatchEvent(new WheelEvent(type));
+
+      // Generate expectation message.
+      const { name: constructorName } = Object.getPrototypeOf(
+        elem
+      ).constructor;
+      const msg = `on disabled ${constructorName} to receive WheelEvent of type "${type}".`;
+      //See how it went...
+      assert_true(listenerFired, `Expected listener ${msg}`);
+      assert_true(handlerFired, `Expected handler ${msg}`);
+    }
+    elem.remove();
+  }
+}, "Events from WheelEvent must dispatch on disabled form elements.");
+
+promise_test(async () => {
+  // Based on GlobalEventHandlers and mixins
+  // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
+  const eventTypes = [
+    "auxclick",
+    "contextmenu",
+    "dblclick",
+    "mousedown",
+    "mouseenter",
+    "mouseleave",
+    "mousemove",
+    "mouseout",
+    "mouseover",
+    "mouseup",
+  ]
+  for (const localName of formElements) {
+    const elem = document.createElement(localName);
+    elem.disabled = true;
+    document.body.appendChild(elem);
+    // Each event type.
+    for (const type of eventTypes) {
+      let listenerFired = false;
+      elem.addEventListener(type, function f() {
+        listenerFired = true;
+        elem.removeEventListener(type, f);
+      });
+      let handlerFired = false;
+      const handlerAttrName = `on${type}`;
+      elem[handlerAttrName] = () => {
+        handlerFired = true;
+        elem[handlerAttrName] = undefined;
+      };
+      elem.dispatchEvent(new MouseEvent(type));
+
+      // Generate expectation message.
+      const { name: constructorName } = Object.getPrototypeOf(
+        elem
+      ).constructor;
+      const msg = `on disabled ${constructorName} to receive MouseEvent of type "${type}".`;
+      //See how it went...
+      assert_true(listenerFired, `Expected listener ${msg}`);
+      assert_true(handlerFired, `Expected handler ${msg}`);
+    }
+    elem.remove();
+  }
+}, "Events from MouseEvent must dispatch on disabled form elements.");
 
 promise_test(async () => {
   for (const localName of formElements) {

--- a/dom/events/Event-dispatch-on-disabled-elements.html
+++ b/dom/events/Event-dispatch-on-disabled-elements.html
@@ -110,7 +110,7 @@ promise_test(async () => {
     "dragover",
     "dragstart",
     "drop",
-  ]
+  ];
   for (const localName of formElements) {
     const elem = document.createElement(localName);
     elem.disabled = true;
@@ -131,9 +131,7 @@ promise_test(async () => {
       elem.dispatchEvent(new DragEvent(type));
 
       // Generate expectation message.
-      const { name: constructorName } = Object.getPrototypeOf(
-        elem
-      ).constructor;
+      const { name: constructorName } = Object.getPrototypeOf(elem).constructor;
       const msg = `on disabled ${constructorName} to receive ${
         DragEvent.name
       } of type "${type}".`;
@@ -149,39 +147,39 @@ promise_test(async () => {
   // Based on GlobalEventHandlers and mixins
   // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
   const eventTypes = [
-      "abort",
-      "cancel",
-      "canplay",
-      "canplaythrough",
-      "change",
-      "close",
-      "cuechange",
-      "durationchange",
-      "emptied",
-      "ended",
-      "input",
-      "invalid",
-      "loadeddata",
-      "loadedmetadata",
-      "loadend",
-      "pause",
-      "play",
-      "playing",
-      "progress",
-      "ratechange",
-      "reset",
-      "securitypolicyviolation",
-      "seeked",
-      "seeking",
-      "select",
-      "stalled",
-      "submit",
-      "suspend",
-      "timeupdate",
-      "toggle",
-      "volumechange",
-      "waiting",
-  ]
+    "abort",
+    "cancel",
+    "canplay",
+    "canplaythrough",
+    "change",
+    "close",
+    "cuechange",
+    "durationchange",
+    "emptied",
+    "ended",
+    "input",
+    "invalid",
+    "loadeddata",
+    "loadedmetadata",
+    "loadend",
+    "pause",
+    "play",
+    "playing",
+    "progress",
+    "ratechange",
+    "reset",
+    "securitypolicyviolation",
+    "seeked",
+    "seeking",
+    "select",
+    "stalled",
+    "submit",
+    "suspend",
+    "timeupdate",
+    "toggle",
+    "volumechange",
+    "waiting",
+  ];
   for (const localName of formElements) {
     const elem = document.createElement(localName);
     elem.disabled = true;
@@ -202,9 +200,7 @@ promise_test(async () => {
       elem.dispatchEvent(new CustomEvent(type));
 
       // Generate expectation message.
-      const { name: constructorName } = Object.getPrototypeOf(
-        elem
-      ).constructor;
+      const { name: constructorName } = Object.getPrototypeOf(elem).constructor;
       const msg = `on disabled ${constructorName} to receive Event of type "${type}".`;
       //See how it went...
       assert_true(listenerFired, `Expected listener ${msg}`);
@@ -217,9 +213,7 @@ promise_test(async () => {
 promise_test(async () => {
   // Based on GlobalEventHandlers and mixins
   // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
-  const eventTypes = [
-    "formdata"
-  ]
+  const eventTypes = ["formdata"];
   for (const localName of formElements) {
     const elem = document.createElement(localName);
     elem.disabled = true;
@@ -237,12 +231,10 @@ promise_test(async () => {
         handlerFired = true;
         elem[handlerAttrName] = undefined;
       };
-      elem.dispatchEvent(new FormDataEvent(type, {formData: new FormData()}));
+      elem.dispatchEvent(new FormDataEvent(type, { formData: new FormData() }));
 
       // Generate expectation message.
-      const { name: constructorName } = Object.getPrototypeOf(
-        elem
-      ).constructor;
+      const { name: constructorName } = Object.getPrototypeOf(elem).constructor;
       const msg = `on disabled ${constructorName} to receive FormDataEvent of type "${type}".`;
       //See how it went...
       assert_true(listenerFired, `Expected listener ${msg}`);
@@ -255,9 +247,7 @@ promise_test(async () => {
 promise_test(async () => {
   // Based on GlobalEventHandlers and mixins
   // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
-  const eventTypes = [
-   "keydown", "keypress", "keyup"
-  ]
+  const eventTypes = ["keydown", "keypress", "keyup"];
   for (const localName of formElements) {
     const elem = document.createElement(localName);
     elem.disabled = true;
@@ -278,9 +268,7 @@ promise_test(async () => {
       elem.dispatchEvent(new KeyboardEvent(type));
 
       // Generate expectation message.
-      const { name: constructorName } = Object.getPrototypeOf(
-        elem
-      ).constructor;
+      const { name: constructorName } = Object.getPrototypeOf(elem).constructor;
       const msg = `on disabled ${constructorName} to receive KeyboardEvent of type "${type}".`;
       //See how it went...
       assert_true(listenerFired, `Expected listener ${msg}`);
@@ -290,13 +278,10 @@ promise_test(async () => {
   }
 }, "Events from KeyboardEvent must dispatch on disabled form elements.");
 
-
 promise_test(async () => {
   // Based on GlobalEventHandlers and mixins
   // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
-  const eventTypes = [
-    "loadend", "loadstart"
-  ]
+  const eventTypes = ["loadend", "loadstart"];
   for (const localName of formElements) {
     const elem = document.createElement(localName);
     elem.disabled = true;
@@ -317,9 +302,7 @@ promise_test(async () => {
       elem.dispatchEvent(new ProgressEvent(type));
 
       // Generate expectation message.
-      const { name: constructorName } = Object.getPrototypeOf(
-        elem
-      ).constructor;
+      const { name: constructorName } = Object.getPrototypeOf(elem).constructor;
       const msg = `on disabled ${constructorName} to receive ProgressEvent of type "${type}".`;
       //See how it went...
       assert_true(listenerFired, `Expected listener ${msg}`);
@@ -332,9 +315,7 @@ promise_test(async () => {
 promise_test(async () => {
   // Based on GlobalEventHandlers and mixins
   // https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers
-  const eventTypes = [
-    "wheel",
-  ]
+  const eventTypes = ["wheel"];
   for (const localName of formElements) {
     const elem = document.createElement(localName);
     elem.disabled = true;
@@ -355,9 +336,7 @@ promise_test(async () => {
       elem.dispatchEvent(new WheelEvent(type));
 
       // Generate expectation message.
-      const { name: constructorName } = Object.getPrototypeOf(
-        elem
-      ).constructor;
+      const { name: constructorName } = Object.getPrototypeOf(elem).constructor;
       const msg = `on disabled ${constructorName} to receive WheelEvent of type "${type}".`;
       //See how it went...
       assert_true(listenerFired, `Expected listener ${msg}`);
@@ -381,7 +360,7 @@ promise_test(async () => {
     "mouseout",
     "mouseover",
     "mouseup",
-  ]
+  ];
   for (const localName of formElements) {
     const elem = document.createElement(localName);
     elem.disabled = true;
@@ -402,9 +381,7 @@ promise_test(async () => {
       elem.dispatchEvent(new MouseEvent(type));
 
       // Generate expectation message.
-      const { name: constructorName } = Object.getPrototypeOf(
-        elem
-      ).constructor;
+      const { name: constructorName } = Object.getPrototypeOf(elem).constructor;
       const msg = `on disabled ${constructorName} to receive MouseEvent of type "${type}".`;
       //See how it went...
       assert_true(listenerFired, `Expected listener ${msg}`);


### PR DESCRIPTION
Web Compatibility bugs bonanza... weird failures across all UAs. 

I'm thinking I might split this into multiple test based on each interface type. 
