### PR TITLE
HTML: window.closed

### DIFF
--- a/html/browsers/the-window-object/closed-attribute.window.js
+++ b/html/browsers/the-window-object/closed-attribute.window.js
@@ -1,3 +1,5 @@
+// META: script=/common/get-host-info.sub.js
+
 function closedTest(newWindow, closeNewWindowsBrowsingContext) {
   assert_equals(newWindow.closed, false);
   closeNewWindowsBrowsingContext();
@@ -13,3 +15,17 @@ test(() => {
   const openee = window.open();
   closedTest(openee, () => openee.close());
 });
+
+async_test(t => {
+  const frame = document.createElement("iframe"),
+        support = new URL("support/closed.html", location.href).pathname,
+        ident = "nestedframe";
+  frame.src = `${get_host_info().HTTP_REMOTE_ORIGIN}${support}?window=parent&ident=${ident}`;
+  const listener = t.step_func_done(() => {
+    closedTest(frame.contentWindow, () => frame.remove());
+    self.removeEventListener("message", listener);
+  });
+  self.addEventListener("message", listener);
+  document.body.append(frame);
+});
+

--- a/html/browsers/the-window-object/closed-attribute.window.js
+++ b/html/browsers/the-window-object/closed-attribute.window.js
@@ -1,0 +1,15 @@
+function closedTest(newWindow, closeNewWindowsBrowsingContext) {
+  assert_equals(newWindow.closed, false);
+  closeNewWindowsBrowsingContext();
+  assert_equals(newWindow.closed, true);
+}
+
+test(() => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  closedTest(frame.contentWindow, () => frame.remove());
+});
+
+test(() => {
+  const openee = window.open();
+  closedTest(openee, () => openee.close());
+});

--- a/html/browsers/the-window-object/closed-attribute.window.js
+++ b/html/browsers/the-window-object/closed-attribute.window.js
@@ -9,23 +9,59 @@ function closedTest(newWindow, closeNewWindowsBrowsingContext) {
 test(() => {
   const frame = document.body.appendChild(document.createElement("iframe"));
   closedTest(frame.contentWindow, () => frame.remove());
-});
+}, "closed and same-origin nested browsing context");
 
 test(() => {
   const openee = window.open();
   closedTest(openee, () => openee.close());
-});
 
-async_test(t => {
-  const frame = document.createElement("iframe"),
-        support = new URL("support/closed.html", location.href).pathname,
-        ident = "nestedframe";
-  frame.src = `${get_host_info().HTTP_REMOTE_ORIGIN}${support}?window=parent&ident=${ident}`;
-  const listener = t.step_func_done(() => {
-    closedTest(frame.contentWindow, () => frame.remove());
-    self.removeEventListener("message", listener);
-  });
-  self.addEventListener("message", listener);
-  document.body.append(frame);
-});
+  // This should not matter
+  openee.close();
+  assert_equals(openee.closed, true);
+}, "closed/close() and same-origin auxiliary browsing context");
 
+const support = new URL("support/closed.html", location.href).pathname;
+[
+  {
+    type: "cross-origin",
+    url: `${get_host_info().HTTP_REMOTE_ORIGIN}${support}`
+  },
+  {
+    type: "cross-site",
+    url: `${get_host_info().HTTP_NOTSAMESITE_ORIGIN}${support}`
+  }
+].forEach(val => {
+  async_test(t => {
+    const frame = document.createElement("iframe"),
+          ident = `${val.type}-nestedframe`;
+    frame.src = `${val.url}?window=parent&ident=${ident}`;
+    const listener = t.step_func(e => {
+      if (e.data === ident) {
+        closedTest(frame.contentWindow, () => frame.remove());
+        self.removeEventListener("message", listener);
+        t.done();
+      }
+    });
+    self.addEventListener("message", listener);
+    document.body.append(frame);
+  }, `closed and ${val.type} nested browsing context`);
+
+  async_test(t => {
+    const ident = `${val.type}-auxiliaryframe`,
+          support = new URL("support/closed.html", location.href).pathname,
+          openee = window.open(`${val.url}?window=opener&ident=${ident}`),
+          listener = t.step_func(e => {
+      if (e.data === ident) {
+        closedTest(openee, () => openee.close());
+
+        // This should not matter
+        openee.close();
+        assert_equals(openee.closed, true);
+
+        self.removeEventListener("message", listener);
+        t.done();
+      }
+    });
+    self.addEventListener("message", listener);
+  }, `closed/close() and ${val.type} auxiliary browsing context`);
+});

--- a/html/browsers/the-window-object/support/closed.html
+++ b/html/browsers/the-window-object/support/closed.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+  There's two URL parameters supported here:
+
+  window: The property name of a getter on the global object that returns the relevant WindowProxy
+          object to message.
+  ident:  A reasonably unique identifier that will be echoed as the message.
+-->
 <script>
   const params = new URLSearchParams(location.search);
   self[params.get("window")].postMessage(params.get("ident"), "*");

--- a/html/browsers/the-window-object/support/closed.html
+++ b/html/browsers/the-window-object/support/closed.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script>
+  const params = new URLSearchParams(location.search);
+  self[params.get("window")].postMessage(params.get("ident"), "*");
+</script>


### PR DESCRIPTION
- [x] Better test titles.
- [x] Create some cross-origin/site tests. (In particular is this all still sync?)
- [x] Maybe add testing of `close()` by invoking it on WindowProxy objects formerly belonging to removed browsing contexts and seeing to it that nothing happens