### PR TITLE
[wptrunner] Add screenshot hashes to wptreport JSON along with a new formatter for screenshot data URIs

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -323,8 +323,8 @@ class RefTestImplementation(object):
         log_data = [{"url": nodes[0].url, "screenshot": screenshots[0]}, relation,
                     {"url": nodes[1].url, "screenshot": screenshots[1]}]
         # For wpt.fyi (included in wptreport.json):
-        new_log_data = {nodes[0].url: "sha1:" + hashes[0],
-                        nodes[1].url: "sha1:" + hashes[1]}
+        new_log_data = {nodes[0].url: (hashes[0], screenshots[0]),
+                        nodes[1].url: (hashes[1], screenshots[1])}
 
         return {"status": "FAIL",
                 "message": "\n".join(self.message),

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -327,6 +327,7 @@ scheme host and port.""")
                              "(equivalent to --include)")
 
     commandline.log_formatters["wptreport"] = (formatters.WptreportFormatter, "wptreport format")
+    commandline.log_formatters["wptscreenshot"] = (formatters.WptscreenshotFormatter, "wpt.fyi screenshots")
 
     commandline.add_logging_group(parser)
     return parser


### PR DESCRIPTION
Data flow:
1. In executors, if external reftest runner is used, we directly add hashes to the `reftest_screenshots` field of the `extra` log data in [`RefTestImplementation`](https://github.com/web-platform-tests/wpt/pull/15570/files#diff-2358aba85eb4ec818ff48199ced359dcR345).
2. Marionette internal reftests does not use `RefTestImplementation` and produces log data from within Marionette, so we use [`reftest_result_converter`](https://github.com/web-platform-tests/wpt/pull/15570/files#diff-2358aba85eb4ec818ff48199ced359dcR103) to check & compute the hash if it does not exist. This introduces some additional computation inadvertently.
3. When log data is sent to the formatter, [`WptreportFormatter`](https://github.com/web-platform-tests/wpt/pull/15570/files#diff-3d4aa557b26cec06dbd54ecd31ead833R119) extracts test paths and hashes from `reftest_screenshots` into `wptreport.json` in the format expected by wpt.fyi; [`WptscreenshotFormatter`](https://github.com/web-platform-tests/wpt/pull/15570/files#diff-3d4aa557b26cec06dbd54ecd31ead833R164), a new formatter, extracts only the screenshots and dumps them into another file as data URIs.

The implementation should be compatible with all existing log formatters and other consumers of logs, since we only add a new field without modifying existing fields. I've checked `--log-mach` and `--log-tbpl` formatters, as well as `reftest-analyzer-structured` (which takes raw logs produced by `--log-raw`).

See individual commit messages for more detailed explanation.

Working towards [web-platform-tests/wpt.fyi#57](https://github.com/web-platform-tests/wpt.fyi/issues/57)