### PR TITLE
Revert "Use the checks API with taskcluster jobs (#14859)"

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,5 +1,4 @@
 version: 1
-reporting: checks-v1
 policy:
   pullRequests: public
 tasks:


### PR DESCRIPTION
There are no wpt.fyi checks on https://github.com/web-platform-tests/wpt/pull/15575.

This reverts commit a9f087c1dc0bec1f322339926f7056d0ac47cd0b.