### PR TITLE
Wrap Feature Policy common code in setup()

### DIFF
--- a/feature-policy/experimental-features/resources/common.js
+++ b/feature-policy/experimental-features/resources/common.js
@@ -66,13 +66,15 @@ function wait_for_load(e) {
   });
 }
 
-window.reporting_observer_instance = new ReportingObserver((reports, observer) => {
-  if (window.reporting_observer_callback) {
-    reports.forEach(window.reporting_observer_callback);
-  }
-}, {types: ["feature-policy-violation"]});
-window.reporting_observer_instance.observe();
-window.reporting_observer_callback = null;
+setup(() => {
+  window.reporting_observer_instance = new ReportingObserver((reports, observer) => {
+    if (window.reporting_observer_callback) {
+      reports.forEach(window.reporting_observer_callback);
+    }
+  }, {types: ["feature-policy-violation"]});
+  window.reporting_observer_instance.observe();
+  window.reporting_observer_callback = null;
+});
 
 // Waits for a violation in |feature| and source file containing |file_name|.
 function wait_for_violation_in_file(feature, file_name) {


### PR DESCRIPTION
That ReportingObserver isn't available in Safari causes the test to be
treated as a single page test with a single failing subtest:
https://wpt.fyi/results/feature-policy/experimental-features/layout-animations-disabled-violation-report-js-tentative.html?run_id=5374658471788544&run_id=5135755412242432&run_id=5719614843518976

Wrapping it will cause there to be a harness error instead.

This will help with https://bugzilla.mozilla.org/show_bug.cgi?id=1530648.