### PR TITLE
Sync Mozilla CSS tests as of 2019-02-27

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/float-retry-push-image.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/float-retry-push-image.html
@@ -15,7 +15,7 @@
 
   #too-wide {
     display: inline-block;
-    height: 20px;
+    height: 21px;
     width: 250px;
     background: blue;
   }
@@ -24,11 +24,31 @@
     width: 100px;
     height: 100px;
     float: left;
+    /* We use a gradient, which is part of the CSS 'image' type.
+     * We set it up to create a hard diagonal edge from the bottom left to the
+     * top right of #shape, which slices through each pixel along the diagonal.
+     * Theoretically, this should place #too-wide at position 50,50 within
+     * #shape's 100x100 region, but on some devices, the gradient rasterization
+     * may leave pixel 50,49 unshaded enough that #too-wide is placed there
+     * instead. To account for that possible off-by-one rounding scenario,
+     * we set things up as follows:
+     *  - We make #too-wide 1px taller than the corresponding content in the
+     * reference case.
+     *  - We clip the outermost div using a 'clip-path' that only paints
+     * the region where the corresponding content is in the reference case.
+     *  - If the testcase renders properly, then #too-wide will have 1px of
+     * content clipped off of its top or bottom (depending on how the
+     * linear-gradient rasterization and rounding works out). Either way,
+     * it'll match the reference case.
+     */
     shape-outside: linear-gradient(135deg, black, black 50%, transparent 50%);
+  }
+  .clip {
+    clip-path: inset(50px 0 30px 0px);
   }
 </style>
 
-<div style="width: 300px; height: 100px;">
+<div style="width: 300px; height: 100px;" class="clip"> 
 <div id="shape"></div>
 <span id="too-wide"></span>
 <div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/float-retry-push-image.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/float-retry-push-image.html
@@ -48,7 +48,7 @@
   }
 </style>
 
-<div style="width: 300px; height: 100px;" class="clip"> 
+<div style="width: 300px; height: 100px;" class="clip">
 <div id="shape"></div>
 <span id="too-wide"></span>
 <div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/float-retry-push-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/float-retry-push-ref.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <meta charset="utf-8">
-<title>Test for retrying floats and pushing them partway down the float area</title>
+<title>Reference for retrying floats and pushing them partway down the float area</title>
 <link rel="author" title="Brad Werth" href="mailto:bwerth@mozilla.com">
 <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
 <style>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/reftest.list
@@ -105,7 +105,6 @@
 
 # Tests of shape-outside layout behavior with too-wide inline elements
 == float-retry-push-circle.html float-retry-push-ref.html
-# The next test offsets a 250px wide element up to one pixel due to small offsets in gradient generation.
 == float-retry-push-image.html float-retry-push-ref.html
 == float-retry-push-inset.html float-retry-push-ref.html
 == float-retry-push-polygon.html float-retry-push-ref.html


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/198cd4a81bf2afa7cc79360f90da7bc91218b76d .

This contains a single change, from [bug 1530462](https://bugzilla.mozilla.org/show_bug.cgi?id=1530462), by @dholbert, reviewed by @bradwerth.