### PR TITLE
Revert marionette reftest reset

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -865,8 +865,9 @@ class InternalRefTestImplementation(object):
         self.executor.protocol.marionette._send_message("reftest:setup", data)
 
     def reset(self, screenshot=None):
-        self.teardown()
-        self.setup(screenshot)
+        # this is obvious wrong; it shouldn't be a no-op
+        # see https://github.com/web-platform-tests/wpt/issues/15604
+        pass
 
     def run_test(self, test):
         references = self.get_references(test)


### PR DESCRIPTION
Partial revert of f650eb264890a42067f0703fa1e7350c4d8f31d2 (#15488).

See #15596.

This contains #15581 to check they now pass.