### PR TITLE
fix(webvtt): one-line cue and wrapped-cue example

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-ref.html
@@ -24,4 +24,4 @@ body { margin:0 }
     color: green;
 }
 </style>
-<div class="video"><span class="cue"><span>This is a test subtitle<br>This test subtitle wraps and should be visible</span></span></div>
+<div class="video"><span class="cue"><span>This test subtitle wraps and should be visible<br>This is a test subtitle</span></span></div>


### PR DESCRIPTION
In my reading of the spec, cues are rendered one at a time and once a
cue has been rendered, it isn't allowed to move. This means, that two
cues that happen at the same time would be rendered starting with the
first cue at the bottom and rendering up subsequent cues.