### PR TITLE
[testharness.js] Tolerate late tests

### DIFF
--- a/resources/test/tests/unit/late-test.html
+++ b/resources/test/tests/unit/late-test.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Test declared after harness completion</title>
+</head>
+<body>
+<div id="log"></div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<p>This test simulates an automated test running scenario, where the test
+results emitted by testharness.js may be interpreted after some delay. It is
+intended to demonstrate that in such cases, any additional tests which are
+executed during that delay are <em>not</em> included in the dataset.</p>
+
+<p>Although these "late" tests are likely an indication of a mistake in test
+design, they cannot be detected deterministically, so in the interest of
+stability, they should be silently tolerated.</p>
+<script>
+async_test(function(t) {
+    var source = [
+        "<div id='log'></div>",
+        "<script src='/resources/testharness.js'></" + "script>",
+        "<script src='/resources/testharnessreport.js'></" + "script>",
+        "<script>",
+        "parent.childReady(window);",
+        "setup({ explicit_done: true });",
+        "test(function() {}, 'acceptable test');",
+        "onload = function() {",
+        "  done();",
+        "  test(function() {}, 'this test is late and should be ignored');",
+        "};",
+        "</" + "script>"
+    ].join("\n");
+    var iframe = document.createElement("iframe");
+
+    document.body.appendChild(iframe);
+    window.childReady = t.step_func(function(childWindow) {
+        childWindow.add_completion_callback(t.step_func(function(tests, status) {
+            setTimeout(t.step_func(function() {
+                assert_equals(tests.length, 1);
+                assert_equals(tests[0].name, "acceptable test");
+                assert_equals(status.status, status.OK);
+                t.done();
+            }), 0);
+        }));
+    });
+
+    iframe.contentDocument.open();
+    iframe.contentDocument.write(source);
+    iframe.contentDocument.close();
+});
+</script>
+</body>
+</html>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1499,7 +1499,7 @@ policies and contribution forms [3].
         }
         this.name = name;
 
-        this.phase = tests.is_aborted ?
+        this.phase = (tests.is_aborted || tests.phase === tests.phases.COMPLETE) ?
             this.phases.COMPLETE : this.phases.INITIAL;
 
         this.status = this.NOTRUN;
@@ -1521,6 +1521,13 @@ policies and contribution forms [3].
         this.cleanup_callbacks = [];
         this._user_defined_cleanup_count = 0;
         this._done_callbacks = [];
+
+        // Tests declared following harness completion are likely an indication
+        // of a programming error, but they cannot be reported
+        // deterministically.
+        if (tests.phase === tests.phases.COMPLETE) {
+            return;
+        }
 
         tests.push(this);
     }
@@ -2631,7 +2638,7 @@ policies and contribution forms [3].
         if (this.phase < this.STARTED) {
             this.init();
         }
-        if (!this.enabled) {
+        if (!this.enabled || this.phase === this.COMPLETE) {
             return;
         }
         this.resolve_log();


### PR DESCRIPTION
We might try to signal a harness error whenever this occurs, but a few details eventually convinced me to silently ignore it:

First, correctly reporting this condition would require a large amount of structural change. testharness.js was not designed for a "COMPLETE to COMPLETE" transition, so things like updating the DOM will take some doing. In gh-14533, @mdittmer noted a discrepancy between the reported data and the JSON written to the document--that's a side effect of the harness emitting an array which it later extends.

It's also not clear how this would effect `test_done_callback`. It would be tricky to name/document if we allowed for functions registered with that API to be invoked more than once. Alternatively, we could implement some kind of "all clear" period, where the harness sits idle waiting for late tests before reporting completion. I don't know how to balance the desire to guard against this edge case against our interest to minimize the duration of test execution.

Finally, we can't detect this situation deterministically. We currently ignore late tests--just in an inconsistent way. If we tried to disallow them, then we might prevent some test bugs, but we might also allow test bugs to detract from stability.

There are a handful of tests which exhibit this behavior today. I've submitted corrections for those in separate patches:

- https://github.com/web-platform-tests/wpt/pull/15631
- https://github.com/web-platform-tests/wpt/pull/15632
- https://github.com/web-platform-tests/wpt/pull/15633