### PR TITLE
HTML: test queueing behavior of window.close()

### DIFF
--- a/html/browsers/the-window-object/close-method.window.js
+++ b/html/browsers/the-window-object/close-method.window.js
@@ -1,0 +1,30 @@
+async_test(t => {
+  const openee = window.open();
+  assert_false(openee.closed);
+  openee.close();
+  assert_true(openee.closed);
+  assert_equals(openee.opener, self);
+  t.step_timeout(() => {
+    assert_equals(openee.opener, null);
+    t.done();
+  }, 100);
+}, "window.close() queues a task to discard, but window.closed knows immediately");
+
+async_test(t => {
+  const openee = window.open("", "greatname");
+  assert_false(openee.closed);
+  openee.close();
+  assert_true(openee.closed);
+  const openee2 = window.open("", "greatname");
+  assert_not_equals(openee, openee2);
+
+  assert_equals(openee.opener, self);
+  openee2.close();
+  assert_equals(openee2.opener, self);
+
+  t.step_timeout(() => {
+    assert_equals(openee.opener, null);
+    assert_equals(openee2.opener, null);
+    t.done();
+  }, 100);
+}, "window.close() affects name targeting immediately");

--- a/html/browsers/the-window-object/close-method.window.js
+++ b/html/browsers/the-window-object/close-method.window.js
@@ -1,30 +1,39 @@
+function assert_closed_opener(w, closed, opener) {
+  assert_equals(w.closed, closed);
+  assert_equals(w.opener, opener);
+}
+
 async_test(t => {
   const openee = window.open();
-  assert_false(openee.closed);
+  assert_closed_opener(openee, false, self);
+  openee.onunload = t.step_func(() => {
+    assert_closed_opener(openee, true, self);
+    t.step_timeout(() => {
+      assert_closed_opener(openee, true, null);
+      t.done();
+    }, 0);
+  });
   openee.close();
-  assert_true(openee.closed);
-  assert_equals(openee.opener, self);
-  t.step_timeout(() => {
-    assert_equals(openee.opener, null);
-    t.done();
-  }, 250);
+  assert_closed_opener(openee, true, self);
 }, "window.close() queues a task to discard, but window.closed knows immediately");
 
 async_test(t => {
   const openee = window.open("", "greatname");
-  assert_false(openee.closed);
+  assert_closed_opener(openee, false, self);
   openee.close();
-  assert_true(openee.closed);
+  assert_closed_opener(openee, true, self);
   const openee2 = window.open("", "greatname");
   assert_not_equals(openee, openee2);
-
-  assert_equals(openee.opener, self);
+  assert_closed_opener(openee, true, self); // Ensure second window.open() call was synchronous
+  openee2.onunload = t.step_func(() => {
+    assert_closed_opener(openee2, true, self);
+    t.step_timeout(() => {
+      assert_closed_opener(openee, true, null);
+      assert_closed_opener(openee2, true, null);
+      t.done();
+    }, 0);
+  });
   openee2.close();
-  assert_equals(openee2.opener, self);
-
-  t.step_timeout(() => {
-    assert_equals(openee.opener, null);
-    assert_equals(openee2.opener, null);
-    t.done();
-  }, 250);
+  assert_closed_opener(openee, true, self); // Ensure second close() call was synchronous
+  assert_closed_opener(openee2, true, self);
 }, "window.close() affects name targeting immediately");

--- a/html/browsers/the-window-object/close-method.window.js
+++ b/html/browsers/the-window-object/close-method.window.js
@@ -7,7 +7,7 @@ async_test(t => {
   t.step_timeout(() => {
     assert_equals(openee.opener, null);
     t.done();
-  }, 100);
+  }, 250);
 }, "window.close() queues a task to discard, but window.closed knows immediately");
 
 async_test(t => {

--- a/html/browsers/the-window-object/close-method.window.js
+++ b/html/browsers/the-window-object/close-method.window.js
@@ -26,5 +26,5 @@ async_test(t => {
     assert_equals(openee.opener, null);
     assert_equals(openee2.opener, null);
     t.done();
-  }, 100);
+  }, 250);
 }, "window.close() affects name targeting immediately");


### PR DESCRIPTION
The reason the second test fails in Firefox is due to `window.open()` using a nested event loop. I could make Firefox pass the test by removing the `openee.opener` assert, but seems bad?