### PR TITLE
Split wptrunner formatters into separate files in their own directory

### DIFF
--- a/tools/wptrunner/wptrunner/formatters/wptreport.py
+++ b/tools/wptrunner/wptrunner/formatters/wptreport.py
@@ -159,5 +159,3 @@ class WptreportFormatter(BaseFormatter):
         scope_data["total"].append({"bytes": data["bytes"],
                                     "threshold": data.get("threshold", 0),
                                     "process": data["process"]})
-
-

--- a/tools/wptrunner/wptrunner/formatters/wptreport.py
+++ b/tools/wptrunner/wptrunner/formatters/wptreport.py
@@ -3,7 +3,7 @@ import re
 import sys
 
 from mozlog.structured.formatters.base import BaseFormatter
-from .executors.base import strip_server
+from ..executors.base import strip_server
 
 
 LONE_SURROGATE_RE = re.compile(u"[\uD800-\uDFFF]")
@@ -161,23 +161,3 @@ class WptreportFormatter(BaseFormatter):
                                     "process": data["process"]})
 
 
-class WptscreenshotFormatter(BaseFormatter):
-    """Formatter that outputs screenshots in the format expected by wpt.fyi."""
-
-    def __init__(self):
-        self.cache = set()
-
-    def suite_start(self, data):
-        # TODO: ask wpt.fyi for known hashes.
-        pass
-
-    def test_end(self, data):
-        if "reftest_screenshots" not in data.get("extra", {}):
-            return
-        output = ""
-        for item in data["extra"]["reftest_screenshots"]:
-            if type(item) != dict or item["hash"] in self.cache:
-                continue
-            self.cache.add(item["hash"])
-            output += "data:image/png;base64,{}\n".format(item["screenshot"])
-        return output if output else None

--- a/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
+++ b/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
@@ -1,0 +1,23 @@
+from mozlog.structured.formatters.base import BaseFormatter
+
+
+class WptscreenshotFormatter(BaseFormatter):
+  """Formatter that outputs screenshots in the format expected by wpt.fyi."""
+
+  def __init__(self):
+    self.cache = set()
+
+  def suite_start(self, data):
+    # TODO: ask wpt.fyi for known hashes.
+    pass
+
+  def test_end(self, data):
+    if "reftest_screenshots" not in data.get("extra", {}):
+      return
+    output = ""
+    for item in data["extra"]["reftest_screenshots"]:
+      if type(item) != dict or item["hash"] in self.cache:
+        continue
+      self.cache.add(item["hash"])
+      output += "data:image/png;base64,{}\n".format(item["screenshot"])
+    return output if output else None

--- a/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
+++ b/tools/wptrunner/wptrunner/formatters/wptscreenshot.py
@@ -2,22 +2,22 @@ from mozlog.structured.formatters.base import BaseFormatter
 
 
 class WptscreenshotFormatter(BaseFormatter):
-  """Formatter that outputs screenshots in the format expected by wpt.fyi."""
+    """Formatter that outputs screenshots in the format expected by wpt.fyi."""
 
-  def __init__(self):
-    self.cache = set()
+    def __init__(self):
+        self.cache = set()
 
-  def suite_start(self, data):
-    # TODO: ask wpt.fyi for known hashes.
-    pass
+    def suite_start(self, data):
+        # TODO: ask wpt.fyi for known hashes.
+        pass
 
-  def test_end(self, data):
-    if "reftest_screenshots" not in data.get("extra", {}):
-      return
-    output = ""
-    for item in data["extra"]["reftest_screenshots"]:
-      if type(item) != dict or item["hash"] in self.cache:
-        continue
-      self.cache.add(item["hash"])
-      output += "data:image/png;base64,{}\n".format(item["screenshot"])
-    return output if output else None
+    def test_end(self, data):
+        if "reftest_screenshots" not in data.get("extra", {}):
+            return
+        output = ""
+        for item in data["extra"]["reftest_screenshots"]:
+            if type(item) != dict or item["hash"] in self.cache:
+                continue
+            self.cache.add(item["hash"])
+            output += "data:image/png;base64,{}\n".format(item["screenshot"])
+        return output if output else None

--- a/tools/wptrunner/wptrunner/tests/test_formatters.py
+++ b/tools/wptrunner/wptrunner/tests/test_formatters.py
@@ -10,8 +10,8 @@ from mozlog import handlers, structuredlog
 
 sys.path.insert(0, join(dirname(__file__), "..", ".."))
 
-from wptrunner import formatters
-from wptrunner.formatters import WptreportFormatter
+from wptrunner.formatters import wptreport
+from wptrunner.formatters.wptreport import WptreportFormatter
 
 
 def test_wptreport_runtime(capfd):
@@ -108,7 +108,7 @@ def test_wptreport_lone_surrogate_ucs2(capfd):
     logger = structuredlog.StructuredLogger("test_a")
     logger.add_handler(handlers.StreamHandler(output, WptreportFormatter()))
 
-    with mock.patch.object(formatters, 'surrogate_replacement', formatters.SurrogateReplacementUcs2()):
+    with mock.patch.object(wptreport, 'surrogate_replacement', wptreport.SurrogateReplacementUcs2()):
         # output a bunch of stuff
         logger.suite_start(["test-id-1"])  # no run_info arg!
         logger.test_start("test-id-1")

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 
 import config
 import wpttest
-import formatters
+from formatters import wptreport, wptscreenshot
 
 
 def abs_path(path):
@@ -326,8 +326,8 @@ scheme host and port.""")
                         help="List of URLs for tests to run, or paths including tests to run. "
                              "(equivalent to --include)")
 
-    commandline.log_formatters["wptreport"] = (formatters.WptreportFormatter, "wptreport format")
-    commandline.log_formatters["wptscreenshot"] = (formatters.WptscreenshotFormatter, "wpt.fyi screenshots")
+    commandline.log_formatters["wptreport"] = (wptreport.WptreportFormatter, "wptreport format")
+    commandline.log_formatters["wptscreenshot"] = (wptscreenshot.WptscreenshotFormatter, "wpt.fyi screenshots")
 
     commandline.add_logging_group(parser)
     return parser


### PR DESCRIPTION
We have 2 formatters (wptreport, wptscreenshot) in the same file (formatters.py) right now. A third formatter is being created and, instead of adding it to formatters.py, I propose creating a new `formatters` directory and splitting each formatter into its own file.