### PR TITLE
Make manifest items lists instead of sets

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -129,11 +129,11 @@ class TypeData(object):
     def load(self, key):
         """Load a specific Item given a path"""
         if self.json_data is not None:
-            data = set()
+            data = []
             path = from_os_path(key)
             for test in iterfilter(self.meta_filters, self.json_data.get(path, [])):
                 manifest_item = self.type_cls.from_json(self.manifest, path, test)
-                data.add(manifest_item)
+                data.append(manifest_item)
             try:
                 del self.json_data[path]
             except KeyError:
@@ -149,10 +149,10 @@ class TypeData(object):
                 key = to_os_path(path)
                 if key in self.data:
                     continue
-                data = set()
+                data = []
                 for test in iterfilter(self.meta_filters, self.json_data.get(path, [])):
                     manifest_item = self.type_cls.from_json(self.manifest, path, test)
-                    data.add(manifest_item)
+                    data.append(manifest_item)
                 self.data[key] = data
             self.json_data = None
 
@@ -217,7 +217,7 @@ class Manifest(object):
 
     def iterpath(self, path):
         for type_tests in self._data.values():
-            for test in type_tests.get(path, set()):
+            for test in type_tests.get(path, []):
                 yield test
 
     def iterdir(self, dir_name):
@@ -295,7 +295,7 @@ class Manifest(object):
                     if is_new or hash_changed:
                         reftest_changes = True
                 elif is_new or hash_changed:
-                    self._data[new_type][rel_path] = set(manifest_items)
+                    self._data[new_type][rel_path] = list(manifest_items)
 
                 self._path_hash[rel_path] = (file_hash, new_type)
 
@@ -335,8 +335,8 @@ class Manifest(object):
             for ref_url, ref_type in item.references:
                 has_inbound.add(ref_url)
 
-        reftests = defaultdict(set)
-        references = defaultdict(set)
+        reftests = defaultdict(list)
+        references = defaultdict(list)
         changed_hashes = {}
 
         for item, file_hash in reftest_nodes:
@@ -346,13 +346,13 @@ class Manifest(object):
                     item = item.to_RefTestNode()
                     changed_hashes[item.path] = (file_hash,
                                                  item.item_type)
-                references[item.path].add(item)
+                references[item.path].append(item)
             else:
                 if isinstance(item, RefTestNode):
                     item = item.to_RefTest()
                     changed_hashes[item.path] = (file_hash,
                                                  item.item_type)
-                reftests[item.path].add(item)
+                reftests[item.path].append(item)
             self._reftest_nodes_by_url[item.url] = item
 
         return reftests, references, changed_hashes

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -178,8 +178,8 @@ def test_reftest_computation_chain():
     test1 = s1.manifest_items()[1][0]
     test2 = s2.manifest_items()[1][0]
 
-    assert list(m) == [("reftest", test1.path, {test1.to_RefTest()}),
-                       ("reftest_node", test2.path, {test2})]
+    assert list(m) == [("reftest", test1.path, [test1.to_RefTest()]),
+                       ("reftest_node", test2.path, [test2])]
 
 
 def test_reftest_computation_chain_update_add():
@@ -190,7 +190,7 @@ def test_reftest_computation_chain_update_add():
 
     assert m.update([(s2, True)]) is True
 
-    assert list(m) == [("reftest", test2.path, {test2.to_RefTest()})]
+    assert list(m) == [("reftest", test2.path, [test2.to_RefTest()])]
 
     s1 = SourceFileWithTest("test1", "0"*40, item.RefTestNode, references=[("/test2", "==")])
     test1 = s1.manifest_items()[1][0]
@@ -198,8 +198,8 @@ def test_reftest_computation_chain_update_add():
     # s2's hash is unchanged, but it has gone from a test to a node
     assert m.update([(s1, True), (s2, True)]) is True
 
-    assert list(m) == [("reftest", test1.path, {test1.to_RefTest()}),
-                       ("reftest_node", test2.path, {test2})]
+    assert list(m) == [("reftest", test1.path, [test1.to_RefTest()]),
+                       ("reftest_node", test2.path, [test2])]
 
 
 def test_reftest_computation_chain_update_remove():
@@ -213,13 +213,13 @@ def test_reftest_computation_chain_update_remove():
     test1 = s1.manifest_items()[1][0]
     test2 = s2.manifest_items()[1][0]
 
-    assert list(m) == [("reftest", test1.path, {test1.to_RefTest()}),
-                       ("reftest_node", test2.path, {test2})]
+    assert list(m) == [("reftest", test1.path, [test1.to_RefTest()]),
+                       ("reftest_node", test2.path, [test2])]
 
     # s2's hash is unchanged, but it has gone from a node to a test
     assert m.update([(s2, True)]) is True
 
-    assert list(m) == [("reftest", test2.path, {test2.to_RefTest()})]
+    assert list(m) == [("reftest", test2.path, [test2.to_RefTest()])]
 
 
 def test_reftest_computation_chain_update_test_type():
@@ -231,7 +231,7 @@ def test_reftest_computation_chain_update_test_type():
 
     test1 = s1.manifest_items()[1][0]
 
-    assert list(m) == [("reftest", test1.path, {test1.to_RefTest()})]
+    assert list(m) == [("reftest", test1.path, [test1.to_RefTest()])]
 
     # test becomes a testharness test (hash change because that is determined
     # based on the file contents). The updated manifest should not includes the
@@ -241,7 +241,7 @@ def test_reftest_computation_chain_update_test_type():
 
     test2 = s2.manifest_items()[1][0]
 
-    assert list(m) == [("testharness", test2.path, {test2})]
+    assert list(m) == [("testharness", test2.path, [test2])]
 
 
 def test_reftest_computation_chain_update_node_change():
@@ -255,8 +255,8 @@ def test_reftest_computation_chain_update_node_change():
     test1 = s1.manifest_items()[1][0]
     test2 = s2.manifest_items()[1][0]
 
-    assert list(m) == [("reftest", test1.path, {test1.to_RefTest()}),
-                       ("reftest_node", test2.path, {test2})]
+    assert list(m) == [("reftest", test1.path, [test1.to_RefTest()]),
+                       ("reftest_node", test2.path, [test2])]
 
     #test2 changes to support type
     s2 = SourceFileWithTest("test2", "1"*40, item.SupportFile)
@@ -264,8 +264,8 @@ def test_reftest_computation_chain_update_node_change():
     assert m.update([(s1, True), (s2, True)]) is True
     test3 = s2.manifest_items()[1][0]
 
-    assert list(m) == [("reftest", test1.path, {test1.to_RefTest()}),
-                       ("support", test3.path, {test3})]
+    assert list(m) == [("reftest", test1.path, [test1.to_RefTest()]),
+                       ("support", test3.path, [test3])]
 
 
 def test_iterpath():
@@ -339,8 +339,8 @@ def test_no_update():
     test1 = s1.manifest_items()[1][0]
     test2 = s2.manifest_items()[1][0]
 
-    assert list(m) == [("testharness", test1.path, {test1}),
-                       ("testharness", test2.path, {test2})]
+    assert list(m) == [("testharness", test1.path, [test1]),
+                       ("testharness", test2.path, [test2])]
 
     s1_1 = SourceFileWithTest("test1", "1"*40, item.ManualTest)
 
@@ -348,8 +348,8 @@ def test_no_update():
 
     test1_1 = s1_1.manifest_items()[1][0]
 
-    assert list(m) == [("manual", test1_1.path, {test1_1}),
-                       ("testharness", test2.path, {test2})]
+    assert list(m) == [("manual", test1_1.path, [test1_1]),
+                       ("testharness", test2.path, [test2])]
 
 
 def test_no_update_delete():
@@ -366,7 +366,7 @@ def test_no_update_delete():
 
     m.update([(s1_1.rel_path, False)])
 
-    assert list(m) == [("testharness", test1.path, {test1})]
+    assert list(m) == [("testharness", test1.path, [test1])]
 
 
 def test_update_from_json():
@@ -384,4 +384,4 @@ def test_update_from_json():
 
     test1 = s1.manifest_items()[1][0]
 
-    assert list(m) == [("testharness", test1.path, {test1})]
+    assert list(m) == [("testharness", test1.path, [test1])]


### PR DESCRIPTION
This saves ~0.4s locally when running ./wpt run. Semantically, this is wrong and could potentially cause issue in tests when comparing when items we get, but it does provide a reasonable performance gain through avoiding hashing the items.

Pushing this PR up even though I fundamentally dislike it to at least show what the changes are.

The perf gain comes from two places:

 * updating the manifest at the start of the run (and we create all the reftest items then, which we won't have to do assuming https://github.com/web-platform-tests/rfcs/pull/15 passes),
 * when loading all manifest items prior to filtering tests to run (which we won't have to do if we're more intelligent about the filtering, which we need to be to get larger perf gains in the specified-test case).

Personally, I'd rather wait for the other two things to fix rather than using the wrong data structure here, despite the perf benefit.