### PR TITLE
[csp] Enable string substitution behavior

### DIFF
--- a/content-security-policy/generic/generic-0_1-script-src.html
+++ b/content-security-policy/generic/generic-0_1-script-src.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>default-src should cascade to script-src directive</title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; report-uri  ../support/report.py?op=put&reportID={{uuid()}}">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline';">
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
     <script src='../support/siblingPath.js'></script>

--- a/content-security-policy/generic/generic-0_1-script-src.sub.html
+++ b/content-security-policy/generic/generic-0_1-script-src.sub.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>default-src should cascade to script-src directive</title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; report-uri  ../support/report.py?op=put&reportID={{$id}}">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; report-uri  ../support/report.py?op=put&reportID={{uuid()}}">
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
     <script src='../support/siblingPath.js'></script>

--- a/content-security-policy/generic/generic-0_10.sub.html
+++ b/content-security-policy/generic/generic-0_10.sub.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>test implicit port number matching (requires port 80)</title>
-    <meta http-equiv="Content-Security-Policy content="script-src 'self' www.{{host}} 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy content="script-src 'self' {{domains[www]}} 'unsafe-inline';">
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
     <script>

--- a/content-security-policy/generic/generic-0_10.sub.html
+++ b/content-security-policy/generic/generic-0_10.sub.html
@@ -12,7 +12,7 @@
       var head = document.getElementsByTagName('head')[0];
       var script = document.createElement('script');
       script.type = 'text/javascript';
-      script.src = "http://www." + location.hostname + "/content-security-policy/generic/positiveTest.js";
+      script.src = "http://{{domains[www]}}/content-security-policy/generic/positiveTest.js";
       head.appendChild(script);
     </script>
     


### PR DESCRIPTION
Two content-security policy tests were authored to use the wptserver's
substitution feature [1], but the files were not named in a way to
enable the desired functionality.

Rename the tests to enable substitution and rewrite the references to
reflect their intended purpose.

[1] https://wptserve.readthedocs.io/en/latest/pipes.html