### PR TITLE
Add script tags for test_driver into screen-orientation/onchange-event.html

### DIFF
--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script>
 promise_test(async t => {
   await test_driver.bless("request full screen", () => {


### PR DESCRIPTION
This html file needs a script tag for `testdriver.js` because of using `test_driver`. (A script tag for `testdriver-vendor.js` is declared to adjust to other htmls. 