### PR TITLE
HTML: escape CR character with &#xD; in canvas test

### DIFF
--- a/2dcontext/tools/tests.yaml
+++ b/2dcontext/tools/tests.yaml
@@ -198,7 +198,7 @@
         ("empty", "", None),
         ("onlyspace", "  ", None),
         ("space", "  100", 100),
-        ("whitespace", "\n\t\f100", 100),
+        ("whitespace", "\r\n\t\f100", 100),
         ("plus", "+100", 100),
         ("minus", "-100", None),
         ("octal", "0100", 100),
@@ -235,11 +235,13 @@
     for name, string, exp in cases:
         code = ""
         code, testing, expected = gen(name, string, exp, code)
+        # We need to replace \r with &#xD; because \r\n gets converted to \n in the HTML parser.
+        htmlString = string.replace('\r', '&#xD;')
         tests.append( {
             "name": "size.attributes.parse.%s" % name,
             "desc": "Parsing of non-negative integers",
             "testing": testing,
-            "canvas": 'width="%s" height="%s"' % (string, string),
+            "canvas": 'width="%s" height="%s"' % (htmlString, htmlString),
             "code": code,
             "expected": expected
         } )

--- a/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html
+++ b/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html
@@ -12,8 +12,8 @@
 
 
 <p class="output">Actual output:</p>
-<canvas id="c" class="output" width="
-	100" height="
+<canvas id="c" class="output" width="&#xD;
+	100" height="&#xD;
 	100"><p class="fallback">FAIL (fallback content)</p></canvas>
 <p class="output expectedtext">Expected output:<p><img src="size.attributes.parse.whitespace.png" class="output expected" id="expected" alt="">
 <ul id="d"></ul>
@@ -24,8 +24,8 @@ _addTest(function(canvas, ctx) {
 _assertSame(canvas.width, 100, "canvas.width", "100");
 _assertSame(canvas.height, 100, "canvas.height", "100");
 _assertSame(window.getComputedStyle(canvas, null).getPropertyValue("width"), "100px", "window.getComputedStyle(canvas, null).getPropertyValue(\"width\")", "\"100px\"");
-_assertSame(canvas.getAttribute('width'), '\n\t\x0c100', "canvas.getAttribute('width')", "'\\n\\t\\x0c100'");
-_assertSame(canvas.getAttribute('height'), '\n\t\x0c100', "canvas.getAttribute('height')", "'\\n\\t\\x0c100'");
+_assertSame(canvas.getAttribute('width'), '\r\n\t\x0c100', "canvas.getAttribute('width')", "'\\r\\n\\t\\x0c100'");
+_assertSame(canvas.getAttribute('height'), '\r\n\t\x0c100', "canvas.getAttribute('height')", "'\\r\\n\\t\\x0c100'");
 
 
 });

--- a/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.whitespace.html
+++ b/html/semantics/embedded-content/the-canvas-element/size.attributes.setAttribute.whitespace.html
@@ -19,13 +19,13 @@
 var t = async_test("Parsing of non-negative integers in setAttribute");
 _addTest(function(canvas, ctx) {
 
-canvas.setAttribute('width', '\n\t\x0c100');
-canvas.setAttribute('height', '\n\t\x0c100');
+canvas.setAttribute('width', '\r\n\t\x0c100');
+canvas.setAttribute('height', '\r\n\t\x0c100');
 _assertSame(canvas.width, 100, "canvas.width", "100");
 _assertSame(canvas.height, 100, "canvas.height", "100");
 _assertSame(window.getComputedStyle(canvas, null).getPropertyValue("width"), "100px", "window.getComputedStyle(canvas, null).getPropertyValue(\"width\")", "\"100px\"");
-_assertSame(canvas.getAttribute('width'), '\n\t\x0c100', "canvas.getAttribute('width')", "'\\n\\t\\x0c100'");
-_assertSame(canvas.getAttribute('height'), '\n\t\x0c100', "canvas.getAttribute('height')", "'\\n\\t\\x0c100'");
+_assertSame(canvas.getAttribute('width'), '\r\n\t\x0c100', "canvas.getAttribute('width')", "'\\r\\n\\t\\x0c100'");
+_assertSame(canvas.getAttribute('height'), '\r\n\t\x0c100', "canvas.getAttribute('height')", "'\\r\\n\\t\\x0c100'");
 
 
 });


### PR DESCRIPTION
See https://github.com/web-platform-tests/wpt/pull/1599