### PR TITLE
Remove unneeded call to isdir when updating the manifest in git

### DIFF
--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -100,16 +100,15 @@ class Git(object):
         for result in self.git(*cmd).split("\0")[:-1]:
             rel_path = result.split("\t")[-1]
             hash = result.split()[2]
-            if not os.path.isdir(os.path.join(self.root, rel_path)):
-                if rel_path in local_changes:
-                    contents = self._show_file(rel_path)
-                else:
-                    contents = None
-                yield SourceFile(self.root,
-                                 rel_path,
-                                 self.url_base,
-                                 hash,
-                                 contents=contents), True
+            if rel_path in local_changes:
+                contents = self._show_file(rel_path)
+            else:
+                contents = None
+            yield SourceFile(self.root,
+                             rel_path,
+                             self.url_base,
+                             hash,
+                             contents=contents), True
 
     def dump_caches(self):
         pass


### PR DESCRIPTION
In the clean manifest case, this is the majority of the cost of the update nowadays.

I'm pretty sure this is safe. Though myself and @jgraham did debate this before…

The risk, IIRC, is if `rel_path not in local_changes` but it has changed locally. I'm pretty sure this is impossible (either becoming a directory or becoming a file it should show up as `D`).