### PR TITLE
Add missing manifest item class.

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from six import iteritems, iterkeys, itervalues, string_types
 
 from . import vcs
-from .item import (ManualTest, WebDriverSpecTest, Stub, RefTestNode, RefTest,
+from .item import (ManualTest, WebDriverSpecTest, Stub, RefTestNode, RefTest, RefTestBase,
                    TestharnessTest, SupportFile, ConformanceCheckerTest, VisualTest)
 from .log import get_logger
 from .utils import from_os_path, to_os_path
@@ -37,6 +37,7 @@ def iterfilter(filters, iter):
 item_classes = {"testharness": TestharnessTest,
                 "reftest": RefTest,
                 "reftest_node": RefTestNode,
+                "reftest_base": RefTestBase,
                 "manual": ManualTest,
                 "stub": Stub,
                 "wdspec": WebDriverSpecTest,


### PR DESCRIPTION
fc4b2a2ca209a1987198a1d35a1d66d8b13837e6 added new manifest item classes but did not update the mapping from name to class. This broke Servo's code that slurps a WPT log and updates the expected test results based on the contents.