### PR TITLE
Add missing manifest item class

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from six import iteritems, iterkeys, itervalues, string_types
 
 from . import vcs
-from .item import (ManualTest, WebDriverSpecTest, Stub, RefTestNode, RefTest,
+from .item import (ManualTest, WebDriverSpecTest, Stub, RefTestNode, RefTest, RefTestBase,
                    TestharnessTest, SupportFile, ConformanceCheckerTest, VisualTest)
 from .log import get_logger
 from .utils import from_os_path, to_os_path
@@ -37,6 +37,7 @@ def iterfilter(filters, iter):
 item_classes = {"testharness": TestharnessTest,
                 "reftest": RefTest,
                 "reftest_node": RefTestNode,
+                "reftest_base": RefTestBase,
                 "manual": ManualTest,
                 "stub": Stub,
                 "wdspec": WebDriverSpecTest,

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -55,7 +55,7 @@ def update_expected(test_paths, serve_root, log_file_names,
                         print("disabled: %s" % test.root.test_path)
 
 
-def do_delayed_imports(serve_root):
+def do_delayed_imports(serve_root=None):
     global manifest, manifestitem
     from manifest import manifest, item as manifestitem
 
@@ -443,6 +443,7 @@ class ExpectedUpdater(object):
 def create_test_tree(metadata_path, test_manifest):
     """Create a map of test_id to TestFileData for that test.
     """
+    do_delayed_imports()
     id_test_map = {}
     exclude_types = frozenset(["stub", "helper", "manual", "support", "conformancechecker"])
     all_types = manifestitem.item_types.keys()

--- a/tools/wptrunner/wptrunner/tests/test_update.py
+++ b/tools/wptrunner/wptrunner/tests/test_update.py
@@ -58,17 +58,12 @@ def create_updater(tests, url_base="/", **kwargs):
     expected_data = {}
     metadata.load_expected = lambda _, __, test_path, *args: expected_data[test_path]
 
+    id_test_map = metadata.create_test_tree(None, m)
+
     for test_path, test_ids, test_type, manifest_str in tests:
-        tests = list(m.iterpath(test_path))
-        if isinstance(test_ids, (str, unicode)):
-            test_ids = [test_ids]
-        test_data = metadata.TestFileData("/", "testharness", None, test_path, tests)
         expected_data[test_path] = manifestupdate.compile(BytesIO(manifest_str),
                                                           test_path,
                                                           url_base)
-
-        for test_id in test_ids:
-            id_test_map[test_id] = test_data
 
     return id_test_map, metadata.ExpectedUpdater(id_test_map, **kwargs)
 
@@ -597,7 +592,8 @@ def test_update_wptreport_0():
 
 
 def test_update_wptreport_1():
-    tests = [("path/to/__dir__", ["path/to/__dir__"], None, "")]
+    tests = [("path/to/test.htm", ["/path/to/test.htm"], "testharness", ""),
+             ("path/to/__dir__", ["path/to/__dir__"], None, "")]
 
     log = {"run_info": {},
            "results": [],


### PR DESCRIPTION
fc4b2a2 added new manifest item classes but did not update the mapping from name to class. This broke Servo's code that slurps a WPT log and updates the expected test results based on the contents.