### PR TITLE
Screen Orientation: active lock orientation algorithm tests

### DIFF
--- a/screen-orientation/active-lock.html
+++ b/screen-orientation/active-lock.html
@@ -11,11 +11,13 @@
     const fragment = document.createElement("p");
     fragment.id = "fragment";
     document.body.appendChild(fragment);
-    const preType = screen.orientation.type;
+    const { type: preType } = screen.orientation;
     const isPortrait = preType.startsWith("portrait");
     const newType = `${isPortrait ? "landscape" : "portrait"}-primary`;
     await screen.orientation.lock(newType);
-    screen.orientation.onchange = t.unreached_func("change event should not be fired"); 
+    screen.orientation.onchange = t.unreached_func(
+      "change event should not be fired"
+    );
     window.location.href = "#fragment";
   }, "Fragment navigation test: orientation should not change");
 </script>

--- a/screen-orientation/active-lock.html
+++ b/screen-orientation/active-lock.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<p id="#fragment"></p>
 <script>
   promise_test(async t => {
     await test_driver.bless("request full screen", () => {

--- a/screen-orientation/active-lock.html
+++ b/screen-orientation/active-lock.html
@@ -14,10 +14,11 @@
     const { type: preType } = screen.orientation;
     const isPortrait = preType.startsWith("portrait");
     const newType = `${isPortrait ? "landscape" : "portrait"}-primary`;
-    await screen.orientation.lock(newType);
+    const p = screen.orientation.lock(newType);
     screen.orientation.onchange = t.unreached_func(
-      "change event should not be fired"
+      "change event must not fire"
     );
     window.location.href = "#fragment";
-  }, "Fragment navigation test: orientation should not change");
+    await p;
+  }, "When performing a fragment navigation, the orientation must not change or unlock");
 </script>

--- a/screen-orientation/active-lock.html
+++ b/screen-orientation/active-lock.html
@@ -12,20 +12,10 @@
     fragment.id = "fragment";
     document.body.appendChild(fragment);
     const preType = screen.orientation.type;
-    const isPortrait = preType.includes("portrait");
+    const isPortrait = preType.startsWith("portrait");
     const newType = `${isPortrait ? "landscape" : "portrait"}-primary`;
     await screen.orientation.lock(newType);
+    screen.orientation.onchange = t.unreached_func("change event should not be fired"); 
     window.location.href = "#fragment";
-    assert_equals(
-    screen.orientation.type,
-    newType,
-    "If locked, fragment navigation does not result in an orientation change"
-    );
-    window.location.href = "https://not-web-platform.test:8443";
-    assert_equals(
-    screen.orientation.type,
-    newType,
-    "Navigating to new top-level browsing context does not result in an orientation change"
-    );
-  }, "Active orientation lock tests");
+  }, "Fragment navigation test: orientation should not change");
 </script>

--- a/screen-orientation/active-lock.html
+++ b/screen-orientation/active-lock.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+  promise_test(async t => {
+    await test_driver.bless("request full screen", () => {
+      return document.documentElement.requestFullscreen();
+    });
+    const fragment = document.createElement("p");
+    fragment.id = "fragment";
+    document.body.appendChild(fragment);
+    const preType = screen.orientation.type;
+    const isPortrait = preType.includes("portrait");
+    const newType = `${isPortrait ? "landscape" : "portrait"}-primary`;
+    await screen.orientation.lock(newType);
+    window.location.href = "#fragment";
+    assert_equals(
+    screen.orientation.type,
+    newType,
+    "If locked, fragment navigation does not result in an orientation change"
+    );
+    window.location.href = "https://not-web-platform.test:8443";
+    assert_equals(
+    screen.orientation.type,
+    newType,
+    "Navigating to new top-level browsing context does not result in an orientation change"
+    );
+  }, "Active orientation lock tests");
+</script>


### PR DESCRIPTION
@marcoscaceres For review

For the second test - what I really want to test is whether the orientation is now unlocked, which is obviously easy to test manually but not sure how to do it here.  So at the moment just checking that the screen orientation has stayed the same once navigated to new location (but it should also now be unlocked and be able to be rotated).