### PR TITLE
Make updater code exclude meaningless manifest item types.

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from six import iteritems, iterkeys, itervalues, string_types
 
 from . import vcs
-from .item import (ManualTest, WebDriverSpecTest, Stub, RefTestNode, RefTest, RefTestBase,
+from .item import (ManualTest, WebDriverSpecTest, Stub, RefTestNode, RefTest,
                    TestharnessTest, SupportFile, ConformanceCheckerTest, VisualTest)
 from .log import get_logger
 from .utils import from_os_path, to_os_path
@@ -37,7 +37,6 @@ def iterfilter(filters, iter):
 item_classes = {"testharness": TestharnessTest,
                 "reftest": RefTest,
                 "reftest_node": RefTestNode,
-                "reftest_base": RefTestBase,
                 "manual": ManualTest,
                 "stub": Stub,
                 "wdspec": WebDriverSpecTest,

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -445,7 +445,7 @@ def create_test_tree(metadata_path, test_manifest):
     """
     do_delayed_imports()
     id_test_map = {}
-    exclude_types = frozenset(["stub", "helper", "manual", "support", "conformancechecker"])
+    exclude_types = frozenset(["stub", "helper", "manual", "support", "conformancechecker", "reftest_base"])
     all_types = manifestitem.item_types.keys()
     include_types = set(all_types) - exclude_types
     for item_type, test_path, tests in test_manifest.itertypes(*include_types):


### PR DESCRIPTION
Per https://github.com/web-platform-tests/wpt/pull/15704#issuecomment-470320041 this is a better fix for the problem that #15704 addressed.