### PR TITLE
Change each sleep to be shorter when waiting for servers to come up

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -202,11 +202,13 @@ class TestEnvironment(object):
 
     def ensure_started(self):
         # Pause for a while to ensure that the server has a chance to start
-        for _ in xrange(60):
+        total_sleep_secs = 30
+        each_sleep_secs = 0.01
+        for _ in xrange(int(total_sleep_secs / each_sleep_secs)):
             failed = self.test_servers()
             if not failed:
                 return
-            time.sleep(0.5)
+            time.sleep(each_sleep_secs)
         raise EnvironmentError("Servers failed to start: %s" %
                                ", ".join("%s:%s" % item for item in failed))
 


### PR DESCRIPTION
This makes the average total sleep locally go from 0.5s to 0.04s.