### PR TITLE
Improve perf when creating Item URLs

### DIFF
--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -84,6 +84,14 @@ class URLManifestItem(ManifestItem):
 
     @property
     def url(self):
+        # we can outperform urljoin, because we know we just have path relative URLs
+        if self._url[0] == "/":
+            # TODO: MANIFEST6
+            # this is actually a bug in older generated manifests, _url shouldn't
+            # be an absolute path
+            return self._url
+        if self.url_base == "/":
+            return "/" + self._url
         return urljoin(self.url_base, self._url)
 
     @property
@@ -125,6 +133,7 @@ class TestharnessTest(URLManifestItem):
         if "script_metadata" in self._extras:
             return self._extras["script_metadata"]
         else:
+            # TODO: MANIFEST6
             # this branch should go when the manifest version is bumped
             return self._source_file.script_metadata
 

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -173,7 +173,7 @@ class RefTestBase(URLManifestItem):
         return (self.timeout, self.viewport_size, self.dpi)
 
     def to_json(self):
-        rv = [self.url, self.references, {}]
+        rv = [self._url, self.references, {}]
         extras = rv[-1]
         if self.timeout is not None:
             extras["timeout"] = self.timeout

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -144,7 +144,7 @@ class TestharnessTest(URLManifestItem):
         return (self.timeout, self.testdriver, self.jsshell, script_metadata)
 
     def to_json(self):
-        rv = URLManifestItem.to_json(self)
+        rv = super(TestharnessTest, self).to_json()
         if self.timeout is not None:
             rv[-1]["timeout"] = self.timeout
         if self.testdriver:
@@ -249,7 +249,7 @@ class WebDriverSpecTest(URLManifestItem):
         return self._extras.get("timeout")
 
     def to_json(self):
-        rv = URLManifestItem.to_json(self)
+        rv = super(WebDriverSpecTest, self).to_json()
         if self.timeout is not None:
             rv[-1]["timeout"] = self.timeout
         return rv


### PR DESCRIPTION
Also fix JSON serialisation of reftests, which currently get serialised with their `url_base` (this bug goes back to the introduction of manifestv4).