### PR TITLE
Set default log formatter when `--verify` is set

### DIFF
--- a/tools/wptrunner/wptrunner/wptlogging.py
+++ b/tools/wptrunner/wptrunner/wptlogging.py
@@ -8,6 +8,7 @@ from mozlog import commandline, stdadapter, set_default_logger
 from mozlog.structuredlog import StructuredLogger
 
 def setup(args, defaults):
+    set_default_log_formatter(args)
     logger = args.pop('log', None)
     if logger:
         set_default_logger(logger)
@@ -26,6 +27,22 @@ def setup(args, defaults):
 def setup_stdlib_logger():
     logging.root.handlers = []
     logging.root = stdadapter.std_logging_adapter(logging.root)
+
+
+def set_default_log_formatter(kwargs):
+    """When --verify is set and no default log formatter was set,
+    set a default log formatter to mach and its value is sys.stdout.
+    This is useful for ./wpt run --verify."""
+    log_formatters = ("raw", "unittest", "xunit", "html", "mach", "tbpl",
+                      "grouped", "errorsummary")
+    is_formatter_set = False
+    if kwargs.get("verify"):
+        for log_formatter in log_formatters:
+            if kwargs.get("log_" + log_formatter):
+                is_formatter_set = True
+                return
+        if not is_formatter_set:
+            kwargs["log_mach"] = "-"
 
 
 class LogLevelRewriter(object):

--- a/tools/wptrunner/wptrunner/wptlogging.py
+++ b/tools/wptrunner/wptrunner/wptlogging.py
@@ -33,13 +33,10 @@ def set_default_log_formatter(kwargs):
     """When --verify is set and no default log formatter was set,
     set a default log formatter to mach and its value is sys.stdout.
     This is useful for ./wpt run --verify."""
-    log_formatters = ("raw", "unittest", "xunit", "html", "mach", "tbpl",
-                      "grouped", "errorsummary")
     is_formatter_set = False
     if kwargs.get("verify"):
-        for log_formatter in log_formatters:
+        for log_formatter in commandline.log_formatters:
             if kwargs.get("log_" + log_formatter):
-                is_formatter_set = True
                 return
         if not is_formatter_set:
             kwargs["log_mach"] = "-"


### PR DESCRIPTION
When no log formatter is set, `./wpt run --verify` is not useful as
no output is printed. This patch tries to set the default log formatter
to `log_mach` with the value of sys.stdout.
Fixed: #15013