### PR TITLE
Manifest v6

### DIFF
--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -68,7 +68,9 @@ class URLManifestItem(ManifestItem):
 
     def __init__(self, tests_root, path, url_base, url, **extras):
         super(URLManifestItem, self).__init__(tests_root, path)
+        assert url_base[0] == "/"
         self.url_base = url_base
+        assert url[0] != "/"
         self._url = url
         self._extras = extras
 
@@ -79,11 +81,6 @@ class URLManifestItem(ManifestItem):
     @property
     def url(self):
         # we can outperform urljoin, because we know we just have path relative URLs
-        if self._url[0] == "/":
-            # TODO: MANIFEST6
-            # this is actually a bug in older generated manifests, _url shouldn't
-            # be an absolute path
-            return self._url
         if self.url_base == "/":
             return "/" + self._url
         return urljoin(self.url_base, self._url)

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -73,12 +73,6 @@ class URLManifestItem(ManifestItem):
         self._extras = extras
 
     @property
-    def _source_file(self):
-        """create a SourceFile for the item"""
-        from .sourcefile import SourceFile
-        return SourceFile(self._tests_root, self.path, self.url_base)
-
-    @property
     def id(self):
         return self.url
 
@@ -130,12 +124,7 @@ class TestharnessTest(URLManifestItem):
 
     @property
     def script_metadata(self):
-        if "script_metadata" in self._extras:
-            return self._extras["script_metadata"]
-        else:
-            # TODO: MANIFEST6
-            # this branch should go when the manifest version is bumped
-            return self._source_file.script_metadata
+        return self._extras.get("script_metadata")
 
     def meta_key(self):
         script_metadata = self.script_metadata
@@ -151,8 +140,7 @@ class TestharnessTest(URLManifestItem):
             rv[-1]["testdriver"] = self.testdriver
         if self.jsshell:
             rv[-1]["jsshell"] = True
-        if self.script_metadata is not None:
-            # we store this even if it is [] to avoid having to read the source file
+        if self.script_metadata:
             rv[-1]["script_metadata"] = self.script_metadata
         return rv
 

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -16,7 +16,7 @@ except ImportError:
     import json
     JSON_LIBRARY = 'json'
 
-CURRENT_VERSION = 5
+CURRENT_VERSION = 6
 
 
 class ManifestError(Exception):

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -13,7 +13,7 @@ except ImportError:
 import html5lib
 
 from . import XMLParser
-from .item import Stub, ManualTest, WebDriverSpecTest, RefTestNode, TestharnessTest, SupportFile, ConformanceCheckerTest, VisualTest
+from .item import Stub, ManualTest, WebDriverSpecTest, RefTest, RefTestNode, TestharnessTest, SupportFile, ConformanceCheckerTest, VisualTest
 from .utils import ContextManagerBytesIO, cached_property
 
 wd_pattern = "*.py"
@@ -812,6 +812,20 @@ class SourceFile(object):
                     testdriver=testdriver,
                     script_metadata=self.script_metadata
                 ))
+
+        elif self.content_is_ref_node and not self.name_is_reference:
+            rv = RefTest.item_type, [
+                RefTest(
+                    self.tests_root,
+                    self.rel_path,
+                    self.url_base,
+                    self.rel_url,
+                    references=self.references,
+                    timeout=self.timeout,
+                    viewport_size=self.viewport_size,
+                    dpi=self.dpi,
+                    fuzzy=self.fuzzy
+                )]
 
         elif self.content_is_ref_node:
             rv = RefTestNode.item_type, [


### PR DESCRIPTION
This probably needs a proper RFC.

This also doesn't actually change the on-disk format, just gets rid of a bunch of support for broken old manifests and implements the reftest search change from https://github.com/web-platform-tests/rfcs/pull/15.

Note it's feasible to keep v5 going for longer, we don't actually need to do this yet.