### PR TITLE
Fix expectation in attributes-and-toJSON-method-manual.https.html

### DIFF
--- a/payment-request/PaymentAddress/attributes-and-toJSON-method-manual.https.html
+++ b/payment-request/PaymentAddress/attributes-and-toJSON-method-manual.https.html
@@ -72,6 +72,7 @@ function runManualTest(button, expected = {}) {
       city: 'Chapel Hill',
       dependentLocality: '',
       postalCode: '6095',
+      region: 'QLD',
       sortingCode: '',
       organization: 'w3c',
       recipient: 'web platform test',


### PR DESCRIPTION
This test currently fails when the PaymentAddress returned by the user agent contains a `region` field. Since `region` is part of the PaymentAddress interface [1], I think we should add `region` to the expected output to fix the test.

[1] https://w3c.github.io/payment-request/#dom-paymentaddress

