### PR TITLE
Remove redundant test in show-method-postmessage-manual.https.html

### DIFF
--- a/payment-request/show-method-postmessage-manual.https.html
+++ b/payment-request/show-method-postmessage-manual.https.html
@@ -12,43 +12,6 @@ setup({
   allow_uncaught_exception: true,
 });
 
-const defaultMethods = Object.freeze([
-  { supportedMethods: "basic-card" },
-  {
-    supportedMethods: "https://apple.com/apple-pay",
-    data: {
-      version: 3,
-      merchantIdentifier: "merchant.com.example",
-      countryCode: "US",
-      merchantCapabilities: ["supports3DS"],
-      supportedNetworks: ["visa"],
-    }
-  },
-]);
-
-const defaultDetails = Object.freeze({
-  id: "fail",
-  total: {
-    label: "Total",
-    amount: {
-      currency: "USD",
-      value: "1.00",
-    },
-  },
-});
-
-test(() => {
-  assert_throws(
-    "SecurityError",
-    () => {
-      const request = new PaymentRequest(defaultMethods, defaultDetails);
-      request.show(); // <--- should throw here
-      request.abort();
-    },
-    "throws a SecurityError if not triggered by user activation"
-  );
-});
-
 async function runUserActivation(button) {
   button.disabled = true;
   const { contentWindow: iframeWindow } = document.getElementById("iframe");


### PR DESCRIPTION
The corresponding behavior, i.e. throwing a SecurityError when .show() is triggered without a user gesture, is already tested in https://github.com/web-platform-tests/wpt/blob/master/payment-request/payment-request-show-method.https.html#L36.