### PR TITLE
Correcting use of pytest.approx for approximate equality checking

### DIFF
--- a/webdriver/tests/perform_actions/pointer.py
+++ b/webdriver/tests/perform_actions/pointer.py
@@ -85,8 +85,8 @@ def test_click_element_center(session, test_actions_page, mouse_chain):
     assert ["mousemove", "mousedown", "mouseup", "click"] == event_types
     for e in events:
         if e["type"] != "mousemove":
-            assert pytest.approx(e["pageX"], center["x"])
-            assert pytest.approx(e["pageY"], center["y"])
+            assert e["pageX"] == pytest.approx(center["x"], abs = 1.0)
+            assert e["pageY"] == pytest.approx(center["y"], abs = 1.0)
             assert e["target"] == "outer"
 
 
@@ -135,8 +135,8 @@ def test_drag_and_drop(session,
     # mouseup that ends the drag is at the expected destination
     e = get_events(session)[1]
     assert e["type"] == "mouseup"
-    assert pytest.approx(e["pageX"], initial_center["x"] + dx)
-    assert pytest.approx(e["pageY"], initial_center["y"] + dy)
+    assert e["pageX"] == pytest.approx(initial_center["x"] + dx, abs = 1.0)
+    assert e["pageY"] == pytest.approx(initial_center["y"] + dy, abs = 1.0)
     # check resulting location of the dragged element
     final_rect = drag_target.rect
     assert initial_rect["x"] + dx == final_rect["x"]

--- a/webdriver/tests/perform_actions/pointer_origin.py
+++ b/webdriver/tests/perform_actions/pointer_origin.py
@@ -28,8 +28,8 @@ def test_viewport_inside(session, mouse_chain):
         .perform()
 
     click_coords = session.execute_script("return window.coords;")
-    assert pytest.approx(click_coords["x"], point["x"])
-    assert pytest.approx(click_coords["y"], point["y"])
+    assert click_coords["x"] == pytest.approx(point["x"], abs = 1.0)
+    assert click_coords["y"] == pytest.approx(point["y"], abs = 1.0)
 
 
 def test_viewport_outside(session, mouse_chain):
@@ -50,8 +50,8 @@ def test_pointer_inside(session, mouse_chain):
         .perform()
 
     click_coords = session.execute_script("return window.coords;")
-    assert pytest.approx(click_coords["x"], start_point["x"] + offset["x"])
-    assert pytest.approx(click_coords["y"], start_point["y"] + offset["y"])
+    assert click_coords["x"] == pytest.approx(start_point["x"] + offset["x"], abs = 1.0)
+    assert click_coords["y"] == pytest.approx(start_point["y"] + offset["y"], abs = 1.0)
 
 
 def test_pointer_outside(session, mouse_chain):
@@ -71,8 +71,8 @@ def test_element_center_point(session, mouse_chain):
         .perform()
 
     click_coords = get_click_coordinates(session)
-    assert pytest.approx(click_coords["x"], center["x"])
-    assert pytest.approx(click_coords["y"], center["y"])
+    assert click_coords["x"] == pytest.approx(center["x"], abs = 1.0)
+    assert click_coords["y"] == pytest.approx(center["y"], abs = 1.0)
 
 
 def test_element_center_point_with_offset(session, mouse_chain):
@@ -85,8 +85,8 @@ def test_element_center_point_with_offset(session, mouse_chain):
         .perform()
 
     click_coords = get_click_coordinates(session)
-    assert pytest.approx(click_coords["x"], center["x"] + 10)
-    assert pytest.approx(click_coords["y"], center["y"] + 15)
+    assert click_coords["x"] == pytest.approx(center["x"] + 10, abs = 1.0)
+    assert click_coords["y"] == pytest.approx(center["y"] + 15, abs = 1.0)
 
 
 def test_element_in_view_center_point_partly_visible(session, mouse_chain):
@@ -100,8 +100,8 @@ def test_element_in_view_center_point_partly_visible(session, mouse_chain):
         .perform()
 
     click_coords = get_click_coordinates(session)
-    assert pytest.approx(click_coords["x"], center["x"])
-    assert pytest.approx(click_coords["y"], center["y"])
+    assert click_coords["x"] == pytest.approx(center["x"], abs = 1.0)
+    assert click_coords["y"] == pytest.approx(center["y"], abs = 1.0)
 
 
 def test_element_larger_than_viewport(session, mouse_chain):
@@ -114,8 +114,8 @@ def test_element_larger_than_viewport(session, mouse_chain):
         .perform()
 
     click_coords = get_click_coordinates(session)
-    assert pytest.approx(click_coords["x"], center["x"])
-    assert pytest.approx(click_coords["y"], center["y"])
+    assert click_coords["x"] == pytest.approx(center["x"], abs = 1.0)
+    assert click_coords["y"] == pytest.approx(center["y"], abs = 1.0)
 
 
 def test_element_outside_of_view_port(session, mouse_chain):


### PR DESCRIPTION
For the pointer action tests, this now tests that the pointer
coordinates are within +/- 1 pixel. If this tolerance is too high,
it can be adjusted in the PR.