### PR TITLE
HTML: initial about:blank navigation

### DIFF
--- a/html/browsers/browsing-the-web/navigating-across-documents/about-blank-iframe.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/about-blank-iframe.window.js
@@ -1,9 +1,11 @@
 async_test(t => {
   const frame = document.body.appendChild(document.createElement("iframe")),
-        frameW = frame.contentWindow;
+        frameW = frame.contentWindow,
+        path = "/common/blank.html";
   frameW.perGlobalVariable = "heya";
   frame.onload = t.step_func_done(() => {
+    assert_equals(frameW.location.pathname, path);
     assert_equals(frameW.perGlobalVariable, "heya");
   });
-  frame.src = "/common/blank.html";
+  frame.src = path;
 }, "Navigating from initial about:blank and the global object");

--- a/html/browsers/browsing-the-web/navigating-across-documents/about-blank-iframe.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/about-blank-iframe.window.js
@@ -1,0 +1,9 @@
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe")),
+        frameW = frame.contentWindow;
+  frameW.perGlobalVariable = "heya";
+  frame.onload = t.step_func_done(() => {
+    assert_equals(frameW.perGlobalVariable, "heya");
+  });
+  frame.src = "/common/blank.html";
+}, "Navigating from initial about:blank and the global object");


### PR DESCRIPTION
This fails in Chrome and Safari, against the HTML Standard.

See also https://github.com/whatwg/html/issues/3267. This bit me today.