### PR TITLE
Drop item.meta_key as we only need hashes to depend on test ID

### DIFF
--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -39,18 +39,13 @@ class ManifestItem(object):
         """A unique identifier for the test"""
         return (self.item_type, self.id)
 
-    def meta_key(self):
-        """Extra metadata that doesn't form part of the test identity, but for
-        which changes mean regenerating the manifest (e.g. the test timeout)."""
-        return ()
-
     def __eq__(self, other):
         if not hasattr(other, "key"):
             return False
         return self.key() == other.key()
 
     def __hash__(self):
-        return hash(self.key() + self.meta_key())
+        return hash(self.key())
 
     def __repr__(self):
         return "<%s.%s id=%s, path=%s>" % (self.__module__, self.__class__.__name__, self.id, self.path)
@@ -137,12 +132,6 @@ class TestharnessTest(URLManifestItem):
             # this branch should go when the manifest version is bumped
             return self._source_file.script_metadata
 
-    def meta_key(self):
-        script_metadata = self.script_metadata
-        if script_metadata is not None:
-            script_metadata = tuple(tuple(x) for x in script_metadata)
-        return (self.timeout, self.testdriver, self.jsshell, script_metadata)
-
     def to_json(self):
         rv = super(TestharnessTest, self).to_json()
         if self.timeout is not None:
@@ -188,9 +177,6 @@ class RefTestBase(URLManifestItem):
             return {tuple(item[0]): item[1]
                     for item in self._extras.get("fuzzy", [])}
         return rv
-
-    def meta_key(self):
-        return (self.timeout, self.viewport_size, self.dpi)
 
     def to_json(self):
         rv = [self._url, self.references, {}]

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -843,6 +843,8 @@ class SourceFile(object):
                     self.rel_path
                 )]
 
+        assert len(rv[1]) == len(set(rv[1]))
+
         self.items_cache = rv
 
         return rv

--- a/tools/manifest/tests/test_item.py
+++ b/tools/manifest/tests/test_item.py
@@ -39,28 +39,3 @@ def test_url_not_https(path):
     m = URLManifestItem("/foobar", "/" + path, "/", "/foo.bar/" + path)
 
     assert m.https is False
-
-
-def test_testharness_meta_key_includes_jsshell():
-    a = TestharnessTest("/foobar", "/foo", "/foo.bar", "/foo.bar/foo",
-                        jsshell=False, script_metadata=[])
-    b = TestharnessTest("/foobar", "/foo", "/foo.bar", "/foo.bar/foo",
-                        jsshell=True, script_metadata=[])
-
-    assert a.meta_key() != b.meta_key()
-
-
-@pytest.mark.parametrize("script_metadata", [
-    None,
-    [],
-    [('script', '/resources/WebIDLParser.js'), ('script', '/resources/idlharness.js')],
-    [[u'script', u'/resources/WebIDLParser.js'], [u'script', u'/resources/idlharness.js']],
-])
-def test_testharness_hashable_script_metadata(script_metadata):
-    a = TestharnessTest("/",
-                        "BackgroundSync/interfaces.https.any.js",
-                        "/",
-                        "/BackgroundSync/interfaces.https.any.js",
-                        script_metadata=script_metadata)
-
-    assert hash(a) is not None

--- a/tools/manifest/tests/test_item.py
+++ b/tools/manifest/tests/test_item.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..item import URLManifestItem, TestharnessTest
+from ..item import URLManifestItem
 
 
 @pytest.mark.parametrize("path", [


### PR DESCRIPTION
We used to rely on hash(item) changing to update the manifest; we haven't had that (dubious) behaviour in many years now, so all this can go.