### PR TITLE
Fix git manifest generation to actually find local changes

### DIFF
--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -96,8 +96,8 @@ class Git(object):
         cmd = ["ls-tree", "-r", "-z", "HEAD"]
         local_changes = self._local_changes()
         for result in self.git(*cmd).split("\0")[:-1]:
-            rel_path = result.split("\t")[-1]
-            hash = result.split()[2]
+            rel_path = result.rsplit("\t", 1)[-1]
+            hash = result.split(" ", 3)[2]
             if rel_path in local_changes:
                 contents = self._show_file(rel_path)
             else:

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -69,25 +69,23 @@ class Git(object):
                        manifest_path=manifest_path, rebuild=rebuild)
 
     def _local_changes(self):
-        changes = {}
+        """get a set of files which have changed between HEAD and working copy"""
+        changes = set()
+
         cmd = ["status", "-z", "--ignore-submodules=all"]
         data = self.git(*cmd)
 
-        if data == "":
-            return changes
-
-        rename_data = None
-        for entry in data.split("\0")[:-1]:
-            if rename_data is not None:
-                status, rel_path = entry.split(" ")
-                if status[0] == "R":
-                    rename_data = (rel_path, status)
-                else:
-                    changes[rel_path] = (status, None)
+        in_rename = False
+        for line in data.split(b"\0")[:-1]:
+            if in_rename:
+                changes.add(line)
+                in_rename = False
             else:
-                rel_path = entry
-                changes[rel_path] = rename_data
-                rename_data = None
+                status = line[:2]
+                if b"R" in status or b"C" in status:
+                    in_rename = True
+                changes.add(line[3:])
+
         return changes
 
     def _show_file(self, path):


### PR DESCRIPTION
Previously we'd never consider anything changed, ever, because we took the whole short-format line to be the `rel_path` (it isn't). This has been broken since MANIFESTv4 landed in 2016(!).