### PR TITLE
PaymentDetailsModifier.supportedMethods should be a DOMString

### DIFF
--- a/payment-request/PaymentRequestUpdateEvent/updateWith-method-abort-update-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-method-abort-update-manual.https.html
@@ -141,7 +141,7 @@ recursiveData.foo = recursiveData;
 Object.freeze(recursiveData);
 
 const modifierWithRecursiveData = Object.freeze({
-  supportedMethods: validMethodBasicCard,
+  supportedMethods: "basic-card",
   total: validTotal,
   data: recursiveData,
 });


### PR DESCRIPTION
Fixing a bug in test configuration. This bug is causing the user agent to fail on invalid payment method identifier, instead of the later check of recursive payment data.