### PR TITLE
Fix rejected promise in test

### DIFF
--- a/payment-request/PaymentRequestUpdateEvent/updateWith-method-abort-update-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-method-abort-update-manual.https.html
@@ -186,7 +186,7 @@ function testBadUpdate(button, badDetails, expectedError, errorCode) {
 <ol>
   <li>
     <button onclick="
-      const rejectedPromise = Promise.reject(new SyntaxError('test')).catch(err => err);
+      const rejectedPromise = Promise.reject(new SyntaxError('test'));
       testBadUpdate(this, rejectedPromise, 'AbortError');
     ">
       Rejection of detailsPromise must abort the update with an "AbortError" DOMException.


### PR DESCRIPTION
Removing the `.catch()` because it turns the rejected promise into a resolved promise.

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch#Parameters