### PR TITLE
Remove domenic as a payment-request reviewer

### DIFF
--- a/payment-request/META.yml
+++ b/payment-request/META.yml
@@ -2,7 +2,6 @@ spec: https://w3c.github.io/payment-request/
 suggested_reviewers:
   - marcoscaceres
   - rsolomakhin
-  - domenic
   - zouhir
   - romandev
   - edenchuang


### PR DESCRIPTION
It's been fun, but it seems like folks have these in hand these days!