### PR TITLE
[Azure] Make curl return non-zero upon failures

### DIFF
--- a/tools/ci/azure/fyi_hook.yml
+++ b/tools/ci/azure/fyi_hook.yml
@@ -12,7 +12,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-  - script: curl -s -S -d "artifact=${{ parameters.artifactName }}" -X POST https://wpt.fyi/api/checks/azure/$(Build.BuildId)
+  - script: curl -f -s -S -d "artifact=${{ parameters.artifactName }}" -X POST https://wpt.fyi/api/checks/azure/$(Build.BuildId)
     displayName: 'Invoke wpt.fyi hook'
-  - script: curl -s -S -d "artifact=${{ parameters.artifactName }}" -X POST https://staging.wpt.fyi/api/checks/azure/$(Build.BuildId)
+  - script: curl -f -s -S -d "artifact=${{ parameters.artifactName }}" -X POST https://staging.wpt.fyi/api/checks/azure/$(Build.BuildId)
     displayName: 'Invoke staging.wpt.fyi hook'


### PR DESCRIPTION
By default, curl always exits with zero even when it fails. This makes
it very hard to search for failures triggering the hook.

Related to https://github.com/web-platform-tests/wpt.fyi/issues/1227