### PR TITLE
Streamline executors

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -71,6 +71,10 @@ class MarionetteBaseProtocolPart(BaseProtocolPart):
             self.timeout = timeout
 
     def set_window(self, handle):
+        """Set the top level browsing context to one specified by a given handle.
+
+        :param handle: A protocol-specific handle identifying a top level browsing
+                       context."""
         self.marionette.switch_to_window(handle)
 
     def wait(self):

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -70,10 +70,6 @@ class MarionetteBaseProtocolPart(BaseProtocolPart):
             self.marionette.timeout.script = timeout
             self.timeout = timeout
 
-    @property
-    def current_window(self):
-        return self.marionette.current_window_handle
-
     def set_window(self, handle):
         self.marionette.switch_to_window(handle)
 

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -54,6 +54,10 @@ class SeleniumBaseProtocolPart(BaseProtocolPart):
         self.webdriver.set_script_timeout(timeout * 1000)
 
     def set_window(self, handle):
+        """Set the top level browsing context to one specified by a given handle.
+
+        :param handle: A protocol-specific handle identifying a top level browsing
+                       context."""
         self.webdriver.switch_to_window(handle)
 
     def wait(self):

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -53,10 +53,6 @@ class SeleniumBaseProtocolPart(BaseProtocolPart):
     def set_timeout(self, timeout):
         self.webdriver.set_script_timeout(timeout * 1000)
 
-    @property
-    def current_window(self):
-        return self.webdriver.current_window_handle
-
     def set_window(self, handle):
         self.webdriver.switch_to_window(handle)
 

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -76,9 +76,6 @@ class ServoBaseProtocolPart(BaseProtocolPart):
     def wait(self):
         pass
 
-    def set_window(self, handle):
-        pass
-
 
 class ServoWebDriverProtocol(Protocol):
     implements = [ServoBaseProtocolPart]

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -46,6 +46,10 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
             self.webdriver.send_session_command("POST", "timeouts", body)
 
     def set_window(self, handle):
+        """Set the top level browsing context to one specified by a given handle.
+
+        :param handle: A protocol-specific handle identifying a top level browsing
+                       context."""
         self.webdriver.window_handle = handle
 
     def wait(self):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -45,10 +45,6 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
             body = {"type": "script", "ms": timeout * 1000}
             self.webdriver.send_session_command("POST", "timeouts", body)
 
-    @property
-    def current_window(self):
-        return self.webdriver.window_handle
-
     def set_window(self, handle):
         self.webdriver.window_handle = handle
 

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -132,13 +132,6 @@ class BaseProtocolPart(ProtocolPart):
         """Wait indefinitely for the browser to close"""
         pass
 
-    @property
-    def current_window(self):
-        """Return a handle identifying the current top level browsing context
-
-        :returns: A protocol-specific handle"""
-        pass
-
     @abstractmethod
     def set_window(self, handle):
         """Set the top level browsing context to one specified by a given handle.

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -132,14 +132,6 @@ class BaseProtocolPart(ProtocolPart):
         """Wait indefinitely for the browser to close"""
         pass
 
-    @abstractmethod
-    def set_window(self, handle):
-        """Set the top level browsing context to one specified by a given handle.
-
-        :param handle: A protocol-specific handle identifying a top level browsing
-                       context."""
-        pass
-
 
 class TestharnessProtocolPart(ProtocolPart):
     """Protocol part required to run testharness tests."""


### PR DESCRIPTION
These are a couple simplifications I found while experimenting with an "ExecutorCDP" (a wptrunner Executor build on Chrome DevTools Protocol).

@jdm I've removed a method from the ExecutorServoDriver class, but I'm still having trouble running wpt with Servo--even on `master`. Does this look okay to you?