### PR TITLE
Fix typo in a field name inside chromium log formatter.

### DIFF
--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -88,7 +88,7 @@ class ChromiumFormatter(base.BaseFormatter):
         final_result = {
             # There are some required fields that we just hard-code.
             "interrupted": False,
-            "path_delimeter": "/",
+            "path_delimiter": "/",
             "version": 3,
             "seconds_since_epoch": self.start_timestamp_seconds,
             "num_failures_by_type": self.num_failures_by_status,

--- a/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
@@ -35,7 +35,7 @@ def test_chromium_required_fields(capfd):
 
     # Check for existence of required fields
     assert "interrupted" in output_obj
-    assert "path_delimeter" in output_obj
+    assert "path_delimiter" in output_obj
     assert "version" in output_obj
     assert "num_failures_by_type" in output_obj
     assert "tests" in output_obj


### PR DESCRIPTION
It should be path_delimiter not path_delimeter.