### PR TITLE
Put TaskCluster environment variables into the yml file

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -71,13 +71,14 @@ tasks:
                   public/results:
                     path: /home/test/artifacts
                     type: directory
+                env:
+                    TASK_EVENT: "${event_str}"
                 command:
                   - /bin/bash
                   - --login
                   - -c
                   - set -ex;
                     echo "wpt-${browser.name}-${browser.channel}-${chunk[0]}-${chunk[1]}";
-                    export TASK_EVENT='${event_str}';
                     ~/start.sh
                       ${event.repository.url}
                       ${event.ref}
@@ -161,6 +162,8 @@ tasks:
                     public/results:
                       path: /home/test/artifacts
                       type: directory
+                  env:
+                    TASK_EVENT: "${event_str}"
                   # Fetch the GitHub-provided merge commit (rather than the pull
                   # request branch) so that the tasks simulate the behavior of the
                   # submitted patch after it is merged. Using the merge commit also
@@ -173,7 +176,6 @@ tasks:
                     - -c
                     - set -ex;
                       echo "${operation.name}";
-                      export TASK_EVENT='${event_str}';
                       ~/start.sh
                         ${event.repository.clone_url}
                         refs/pull/${event.number}/merge
@@ -314,13 +316,14 @@ tasks:
                     public/results:
                       path: /home/test/artifacts
                       type: directory
+                  env:
+                    TASK_EVENT: "${event_str}"
                   command:
                     - /bin/bash
                     - --login
                     - -c
                     - set -ex;
                       echo "${operation.name}";
-                      export TASK_EVENT='${event_str}';
                       ~/start.sh
                         ${event.repository.clone_url}
                         ${checkout_ref}

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -220,6 +220,7 @@ def main():
     try:
         event = json.loads(os.environ["TASK_EVENT"])
     except KeyError:
+        print("WARNING: Missing TASK_EVENT environment variable")
         # For example under local testing
         event = {}
 


### PR DESCRIPTION
This avoids escaping issues when the data contains unescaped shell
special characters, notably ' but possibly also ` " $ ! and similar.

Fixes https://github.com/web-platform-tests/wpt/issues/15994