### PR TITLE
Revert "Use the checks API with taskcluster jobs"

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,5 +1,4 @@
 version: 1
-reporting: checks-v1
 policy:
   pullRequests: public
 tasks:


### PR DESCRIPTION
Reverts web-platform-tests/wpt#15946

Because of https://github.com/web-platform-tests/wpt.fyi/issues/1240 and #16026