### PR TITLE
Add RTCCertificate setConfiguration tests

### DIFF
--- a/webrtc/RTCCertificate-postMessage.html
+++ b/webrtc/RTCCertificate-postMessage.html
@@ -73,5 +73,28 @@
         assert_throws("InvalidAccessError", () => { new RTCPeerConnection({certificates: [certificate2]}) });
         iframe.remove();
     }, "Check cross-origin created RTCCertificate");
+
+    promise_test(async t => {
+        let certificate1 = await  RTCPeerConnection.generateCertificate({ name: 'ECDSA', namedCurve: 'P-256' });
+        let certificate2 = await  RTCPeerConnection.generateCertificate({ name: 'ECDSA', namedCurve: 'P-256' });
+
+        let url = "resources/RTCCertificate-postMessage-iframe.html";
+        let iframe = await with_iframe(url);
+
+        let promise = new Promise((resolve, reject) => {
+            window.onmessage = (event) => {
+                resolve(event.data);
+            };
+            t.step_timeout(() => reject("Timed out waiting for frame to send back certificate"), 5000);
+        });
+        iframe.contentWindow.postMessage(certificate1, "*");
+        let certificate3 = await promise;
+        iframe.remove();
+
+        const pc = new RTCPeerConnection({ certificates: [certificate1, certificate2] });
+        pc.setConfiguration({ certificates: [certificate1, certificate2] });
+        assert_throws("InvalidModificationError", () => { pc.setConfiguration({ certificates: [certificate3, certificate2] }) });
+        assert_throws("InvalidModificationError", () => { pc.setConfiguration({ certificates: [certificate2, certificate1] }) });
+    }, "Check order and equality of certificates when setting configuration");
 </script>
 </body>

--- a/webrtc/RTCCertificate.html
+++ b/webrtc/RTCCertificate.html
@@ -135,6 +135,22 @@
         pc.setConfiguration({
           certificates: [cert1, cert2]
         }));
+
+      const pc2 = new RTCPeerConnection({
+        certificates: [cert1, cert2]
+      });
+
+      assert_throws('InvalidModificationError', () =>
+        pc2.setConfiguration({
+          certificates: [cert2, cert1]
+      }));
+
+      assert_throws('InvalidModificationError', () =>
+        pc2.setConfiguration({
+          certificates: undefined
+      }));
+      pc2.setConfiguration({ certificates: [cert1, cert2] });
+      pc2.setConfiguration({ });
     });
   }, 'Calling setConfiguration with different set of certs should reject with InvalidModificationError');
 


### PR DESCRIPTION
Verify order and equality checks for setConfiguration with certificates.
Check the case of undefined/unset certificates.
This should cover https://github.com/web-platform-tests/wpt/issues/15840