### PR TITLE
Include html WebIDL in idlharness for WebRTC

### DIFF
--- a/webrtc/idlharness.https.window.js
+++ b/webrtc/idlharness.https.window.js
@@ -102,7 +102,7 @@ function asyncInit() {
 
 idl_test(
   ['webrtc'],
-  ['mediacapture-streams', 'dom'],
+  ['mediacapture-streams', 'dom', 'html'],
   async idlArray => {
     idlArray.add_objects({
       RTCPeerConnection: [`new RTCPeerConnection()`],


### PR DESCRIPTION
It needs EventHandler to validate event handler definitions