### PR TITLE
CORS/XHR: mark Client Hints tentative

### DIFF
--- a/cors/client-hint-request-headers-2.tentative.htm
+++ b/cors/client-hint-request-headers-2.tentative.htm
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>CORS and Client Hints, potentially</title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js?pipe=sub></script>
+
+<h1>Request headers</h1>
+<div id=log></div>
+<script>
+
+test(function() {
+    var client = new XMLHttpRequest()
+    client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-print,', false)
+    client.setRequestHeader('x-print', 'unicorn')
+    client.setRequestHeader('content-type', 'text/plain')
+    client.setRequestHeader('accept', 'test')
+    client.setRequestHeader('accept-language', 'nn')
+    client.setRequestHeader('content-language', 'nn')
+    client.setRequestHeader('save-data', 'on')
+    client.setRequestHeader('device-memory', '1.0')
+    client.setRequestHeader('dpr', '2.0')
+    client.setRequestHeader('width', '35')
+    client.setRequestHeader('viewport-width', '42')
+    client.send(null)
+
+    const res = JSON.parse(client.response)
+    assert_equals(res['x-print'], 'unicorn')
+    assert_equals(res['content-type'], 'text/plain')
+    assert_equals(res['accept'], 'test')
+    assert_equals(res['accept-language'], 'nn')
+    assert_equals(res['content-language'], 'nn')
+    assert_equals(res['save-data'], 'on')
+    assert_equals(res['device-memory'], '1.0')
+    assert_equals(res['dpr'], '2.0')
+    assert_equals(res['width'], '35')
+    assert_equals(res['viewport-width'], '42')
+}, 'Client hint headers are simple headers')
+
+</script>

--- a/cors/client-hint-request-headers.htm
+++ b/cors/client-hint-request-headers.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>CORS - client hint request headers - Access-Control-Allow-Headers</title>
+<title>CORS and Client Hints</title>
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -9,34 +9,6 @@
 <h1>Request headers</h1>
 <div id=log></div>
 <script>
-
-test(function() {
-    var client = new XMLHttpRequest()
-    client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-print,', false)
-    client.setRequestHeader('x-print', 'unicorn')
-    client.setRequestHeader('content-type', 'text/plain')
-    client.setRequestHeader('accept', 'test')
-    client.setRequestHeader('accept-language', 'nn')
-    client.setRequestHeader('content-language', 'nn')
-    client.setRequestHeader('save-data', 'on')
-    client.setRequestHeader('device-memory', '1.0')
-    client.setRequestHeader('dpr', '2.0')
-    client.setRequestHeader('width', '35')
-    client.setRequestHeader('viewport-width', '42')
-    client.send(null)
-
-    const res = JSON.parse(client.response)
-    assert_equals(res['x-print'], 'unicorn')
-    assert_equals(res['content-type'], 'text/plain')
-    assert_equals(res['accept'], 'test')
-    assert_equals(res['accept-language'], 'nn')
-    assert_equals(res['content-language'], 'nn')
-    assert_equals(res['save-data'], 'on')
-    assert_equals(res['device-memory'], '1.0')
-    assert_equals(res['dpr'], '2.0')
-    assert_equals(res['width'], '35')
-    assert_equals(res['viewport-width'], '42')
-}, 'Client hint headers are simple headers')
 
 test(function() {
     var client = new XMLHttpRequest()

--- a/cors/simple-requests-ch.tentative.htm
+++ b/cors/simple-requests-ch.tentative.htm
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>CORS - simple requests</title>
+<meta name=author title="Odin Hørthe Omdal" href="mailto:odiho@opera.com">
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js?pipe=sub></script>
+<script src=/common/utils.js></script>
+
+<h1>Simple requests</h1>
+<p>Simple requests shouldn't trigger preflight</p>
+
+<div id=log></div>
+<script>
+
+var test_c = 0;
+
+function check_simple(method, headers)
+{
+    test(function() {
+        var client = new XMLHttpRequest()
+        var uuid_token = token();
+        client.open(method, CROSSDOMAIN + 'resources/preflight.py?token='
+                            + uuid_token, false)
+        for (head in headers)
+            client.setRequestHeader(head, headers[head])
+        client.send("data")
+        assert_equals(client.getResponseHeader('content-type'), "text/plain")
+        if (method == 'HEAD')
+            assert_equals(client.response, '', 'response')
+        else
+            assert_equals(client.response, 'NO', 'response')
+
+        client.open('GET', 'resources/preflight.py?check&token='
+                          + uuid_token, false)
+        client.send("data")
+        assert_equals(client.response, "0", "Found preflight log")
+    },
+    'No preflight ' + method + ' and ' + JSON.stringify(headers))
+}
+
+function check_simple_headers(headers) {
+    check_simple('GET', headers)
+    check_simple('HEAD', headers)
+    check_simple('POST', headers)
+}
+
+check_simple_headers({
+                        'save-data': 'on',
+                        'device-memory': '2.0',
+                        'dpr': '3.0',
+                        'width': '1200',
+                        'viewport-width': '1300'
+                     })
+
+</script>

--- a/cors/simple-requests.htm
+++ b/cors/simple-requests.htm
@@ -61,14 +61,6 @@ check_simple_headers({
                         'content-type': 'text/plain; parameter=whatever'
                      })
 
-check_simple_headers({
-                        'save-data': 'on',
-                        'device-memory': '2.0',
-                        'dpr': '3.0',
-                        'width': '1200',
-                        'viewport-width': '1300'
-                     })
-
 check_simple('Get', {'content-type': 'text/plain; parameter=extra_bonus'})
 check_simple('post', {'content-type': 'text/plain'})
 

--- a/xhr/access-control-basic-cors-safelisted-request-headers.htm
+++ b/xhr/access-control-basic-cors-safelisted-request-headers.htm
@@ -17,7 +17,6 @@
       xhr.setRequestHeader("Accept-Language", "ru");
       xhr.setRequestHeader("Content-Language", "ru");
       xhr.setRequestHeader("Content-Type", "text/plain");
-      xhr.setRequestHeader("Save-Data", "on");
 
       xhr.send();
 


### PR DESCRIPTION
This ensures Client Hints related tests outside the client-hints/ directory are marked as tentative (and one is effectively removed as it duplicates other tests) as there's no Fetch integration anymore.