### PR TITLE
Fix running tests on Taskcluster in PRs

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -112,14 +112,14 @@ tasks:
               $map:
                 # This is the main place to define new stability checks
                 - name: wpt-${browser.name}-${browser.channel}-stability
-                  checkout: FETCH_HEAD
+                  checkout: HEAD
                   diff_range: HEAD^
                   description: >-
                     Verify that all tests affected by a pull request are stable
                     when executed in ${browser.name}.
                   extra_args: '--verify'
                 - name: wpt-${browser.name}-${browser.channel}-results
-                  checkout: FETCH_HEAD
+                  checkout: HEAD
                   diff_range: HEAD^
                   description: >-
                     Collect results for all tests affected by a pull request in
@@ -129,8 +129,8 @@ tasks:
                     --log-wptreport=../artifacts/wpt_report.json
                     --log-wptscreenshot=../artifacts/wpt_screenshot.txt
                 - name: wpt-${browser.name}-${browser.channel}-results-without-changes
-                  checkout: FETCH_HEAD^
-                  diff_range: FETCH_HEAD
+                  checkout: HEAD^
+                  diff_range: HEAD
                   description: >-
                     Collect results for all tests affected by a pull request in
                     ${browser.name} but without the changes in the PR.

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -113,11 +113,11 @@ def start_userspace_oom_killer():
 
 
 def make_hosts_file():
-    subprocess.check_call(["sudo", "sh", "-c", "./wpt make-hosts-file >> /etc/hosts"])
+    run(["sudo", "sh", "-c", "./wpt make-hosts-file >> /etc/hosts"])
 
 
 def checkout_revision(rev):
-    subprocess.check_call(["git", "checkout", "-q", rev])
+    run(["git", "checkout", "-q", rev])
 
 
 def install_chrome(channel):
@@ -135,8 +135,8 @@ def install_chrome(channel):
     with open(dest, "w") as f:
         f.write(resp.read())
 
-    subprocess.check_call(["sudo", "apt-get", "-qqy", "update"])
-    subprocess.check_call(["sudo", "gdebi", "-n", "/tmp/%s" % deb_archive])
+    run(["sudo", "apt-get", "-qqy", "update"])
+    run(["sudo", "gdebi", "-n", "/tmp/%s" % deb_archive])
 
 
 def start_xvfb():


### PR DESCRIPTION
We've not been running tests on PRs properly since 53e263d0d8297a02390d56c3d8f75ee82544780d, given it added an extra fetch and then checking  out FETCH_HEAD has been wrong.