### PR TITLE
Don't use HEAD or FETCH_HEAD to checkout specific revisions.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -64,7 +64,7 @@ tasks:
                 owner: ${event.pusher.email}
                 source: ${event.repository.url}
               payload:
-                image: harjgam/web-platform-tests:0.30
+                image: harjgam/web-platform-tests:0.32
                 maxRunTime: 7200
                 artifacts:
                   public/results:
@@ -80,8 +80,7 @@ tasks:
                     echo "wpt-${browser.name}-${browser.channel}-${chunk[0]}-${chunk[1]}";
                     ~/start.sh
                       ${event.repository.url}
-                      ${event.ref}
-                      ${event.after};
+                      ${event.ref};
                     cd ~/web-platform-tests;
                     ./tools/ci/run_tc.py
                       --oom-killer
@@ -93,6 +92,7 @@ tasks:
                       ./tools/ci/taskcluster-run.py
                         ${browser.name}
                         --
+                        --checkout=${event.after}
                         --channel=${browser.channel}
                         --log-wptreport=../artifacts/wpt_report.json
                         --log-wptscreenshot=../artifacts/wpt_screenshot.txt
@@ -112,15 +112,15 @@ tasks:
               $map:
                 # This is the main place to define new stability checks
                 - name: wpt-${browser.name}-${browser.channel}-stability
-                  checkout: FETCH_HEAD
-                  diff_range: HEAD^
+                  checkout: task_head
+                  diff_base: base_head
                   description: >-
                     Verify that all tests affected by a pull request are stable
                     when executed in ${browser.name}.
                   extra_args: '--verify'
                 - name: wpt-${browser.name}-${browser.channel}-results
-                  checkout: FETCH_HEAD
-                  diff_range: HEAD^
+                  checkout: task_head
+                  diff_base: base_head
                   description: >-
                     Collect results for all tests affected by a pull request in
                     ${browser.name}.
@@ -129,8 +129,8 @@ tasks:
                     --log-wptreport=../artifacts/wpt_report.json
                     --log-wptscreenshot=../artifacts/wpt_screenshot.txt
                 - name: wpt-${browser.name}-${browser.channel}-results-without-changes
-                  checkout: FETCH_HEAD^
-                  diff_range: FETCH_HEAD
+                  checkout: base_head
+                  diff_base: task_head
                   description: >-
                     Collect results for all tests affected by a pull request in
                     ${browser.name} but without the changes in the PR.
@@ -156,7 +156,7 @@ tasks:
                   owner: ${event.pull_request.user.login}@users.noreply.github.com
                   source: ${event.repository.url}
                 payload:
-                  image: harjgam/web-platform-tests:0.30
+                  image: harjgam/web-platform-tests:0.32
                   maxRunTime: 7200
                   artifacts:
                     public/results:
@@ -178,8 +178,7 @@ tasks:
                       echo "${operation.name}";
                       ~/start.sh
                         ${event.repository.clone_url}
-                        refs/pull/${event.number}/merge
-                        FETCH_HEAD;
+                        refs/pull/${event.number}/merge;
                       cd web-platform-tests;
                       ./tools/ci/run_tc.py
                         --checkout=${operation.checkout}
@@ -189,7 +188,7 @@ tasks:
                         --xvfb
                         stability
                         ./tools/ci/taskcluster-run.py
-                          --commit-range ${operation.diff_range}
+                          --commit-range ${operation.diff_base}
                           ${browser.name}
                           --
                           --channel=${browser.channel}
@@ -310,7 +309,7 @@ tasks:
                   owner: ${event.sender.login}@users.noreply.github.com
                   source: ${event.repository.url}
                 payload:
-                  image: harjgam/web-platform-tests:0.30
+                  image: harjgam/web-platform-tests:0.32
                   maxRunTime: 7200
                   artifacts:
                     public/results:
@@ -326,7 +325,6 @@ tasks:
                       echo "${operation.name}";
                       ~/start.sh
                         ${event.repository.clone_url}
-                        ${checkout_ref}
-                        FETCH_HEAD;
+                        ${checkout_ref};
                       cd ~/web-platform-tests;
                       ${operation.script};

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -117,7 +117,7 @@ def make_hosts_file():
 
 
 def checkout_revision(rev):
-    subprocess.check_call(["git", "checkout", "-q", rev])
+    subprocess.check_call(["git", "--quiet", "checkout", rev])
 
 
 def install_chrome(channel):
@@ -232,6 +232,19 @@ def main():
 
     if event:
         set_variables(event)
+
+    if os.environ.get("GITHUB_PULL_REQUEST", "false") != "false":
+        parents = run(["git", "show", "--format=%P", "task_head"], return_stdout=True).strip().split()
+        if len(parents) == 2:
+            base_head = parents[0]
+            pr_head = parents[1]
+
+            run(["git", "branch", "base_head", base_head])
+            run(["git", "branch", "pr_head", pr_head])
+        else:
+            print("ERROR: Pull request HEAD wasn't a 2-parent merge commit; "
+                  "expected to test the merge of PR into the base")
+            sys.exit(1)
 
     if os.environ.get("GITHUB_BRANCH"):
         # Ensure that the remote base branch exists

--- a/tools/ci/start.sh
+++ b/tools/ci/start.sh
@@ -1,1 +1,0 @@
-# Contents of this script superceeded by tools/ci/run_tc.py

--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -14,9 +14,6 @@ set -ex
 
 REMOTE=${1:-https://github.com/web-platform-tests/wpt}
 REF=${2:-master}
-REVISION=${3:-FETCH_HEAD}
-BROWSER=${4:-all}
-CHANNEL=${5:-nightly}
 
 cd ~
 
@@ -27,15 +24,6 @@ git init
 git remote add origin ${REMOTE}
 
 # Initially we just fetch 50 commits in order to save several minutes of fetching
-retry git fetch --quiet --depth=50 --tags origin ${REF}
+retry git fetch --quiet --depth=50 --tags origin ${REF}:task_head
 
-if [[ ! `git rev-parse --verify -q ${REVISION}` ]];
-then
-    # But if for some reason the commit under test isn't in that range, we give in and
-    # fetch everything
-    retry git fetch -q --unshallow ${REMOTE}
-    git rev-parse --verify ${REVISION}
-fi
-git checkout -b build ${REVISION}
-
-source tools/ci/start.sh
+git checkout --quiet task_head


### PR DESCRIPTION
FETCH_HEAD is unreliable because it's a global variable that can be
accidentially clobbered by adding an additional fetch anywhere in the
pipeline. As a result running tests in CI has been broken since we
chose the wrong revisions. HEAD is more reliable but doesn't exist
until we first check something out.

Instead, do the following:

* Fetch the initial commits into a branch called task_head and check
  this out unconditionally.

* For PRs, create branches called base_head and pr_head pointing to
  the two parents of the merge commit that we test on PRs.

* Express all the other revisions in terms of task_head, pr_head and
  base_head, since they are both correct and more descriptive than
  using complex revision specifiers.

* Move as much logic as possible out of the script baked in to the
  docker image since that's hardest to update.