### PR TITLE
Run full Edge runs every 6 hours

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -165,9 +165,10 @@ jobs:
 
 - job: results_edge
   displayName: 'all tests (Edge)'
-  # This job is only triggered manually until it has been shown to be robust.
-  condition: and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge'])
-  # There are 5 agents in the pool, but use more jobs so that each takes <1h.
+  condition: |
+    or(eq(variables['Build.Reason'], 'Schedule'),
+       and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge']))
+  # There are 12 agents in the pool, but use more jobs so that each takes <1h.
   strategy:
     parallel: 20
   timeoutInMinutes: 360

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -163,6 +163,8 @@ jobs:
     condition: always()
   - template: tools/ci/azure/cleanup_win10.yml
 
+# All `./wpt run` tests are run from epochs/* branches on a schedule. See
+# documentation at the top of this file for required setup.
 - job: results_edge
   displayName: 'all tests (Edge)'
   condition: |
@@ -196,8 +198,6 @@ jobs:
     dependsOn: results_edge
     artifactName: edge-results
 
-# All `./wpt run` tests are run from epochs/* branches on a schedule. See
-# documentation at the top of this file for required setup.
 - job: results_safari_preview
   displayName: 'all tests (Safari Technology Preview)'
   condition: |


### PR DESCRIPTION
This will end up in the same build as the Safari TP run. The wpt.fyi
integration should ensure that one failing doesn't affect the other,
but there is some risk here and it will need to be monitored.