### PR TITLE
[Azure Pipelines] Skip checkout for wpt.fyi hook jobs

### DIFF
--- a/tools/ci/azure/fyi_hook.yml
+++ b/tools/ci/azure/fyi_hook.yml
@@ -12,6 +12,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
+  - checkout: none
   - script: curl -f -s -S -d "artifact=${{ parameters.artifactName }}" -X POST https://wpt.fyi/api/checks/azure/$(Build.BuildId)
     displayName: 'Invoke wpt.fyi hook'
   - script: curl -f -s -S -d "artifact=${{ parameters.artifactName }}" -X POST https://staging.wpt.fyi/api/checks/azure/$(Build.BuildId)


### PR DESCRIPTION
No checkout is needed. This will save ~40s, which for PRs could matter.