### PR TITLE
Terminate Edge browser process after test completion

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -85,12 +85,20 @@ class EdgeBrowser(Browser):
 
     def stop(self, force=False):
         self.server.stop(force=force)
-        time.sleep(3)
-        # close Edge process if it is still running
+        # Wait for Edge browser process to exit if driver process is found
         edge_proc_name = 'MicrosoftEdge.exe'
-        procs = subprocess.check_output(['tasklist', '/fi', 'ImageName eq ' + edge_proc_name])
+        for i in range(0,5):
+            procs = subprocess.check_output(['tasklist', '/fi', 'ImageName eq ' + edge_proc_name])
+            if 'MicrosoftWebDriver.exe' not in procs:
+                # Edge driver process already exited, don't wait for browser process to exit
+                break
+            elif edge_proc_name in procs:
+                time.sleep(0.5)
+            else: break
+
         if edge_proc_name in procs:
-            subprocess.call(['taskkill.exe', '/f', '/im', 'microsoftedge*']) # close all Edge browser instances
+            # close Edge process if it is still running
+            subprocess.call(['taskkill.exe', '/f', '/im', 'microsoftedge*'])
 
     def pid(self):
         return self.server.pid

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -91,7 +91,6 @@ class EdgeBrowser(Browser):
         procs = subprocess.check_output(['tasklist', '/fi', 'ImageName eq ' + edge_proc_name])
         if edge_proc_name in procs:
             subprocess.call(['taskkill.exe', '/f', '/im', 'microsoftedge*']) # close all Edge browser instances
-        subprocess.call(['taskkill.exe', '/f', '/im', 'microsoftwebdriver.exe']) # close all Edge driver instances
         self.logger.info("stopped")
 
     def pid(self):

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -91,7 +91,6 @@ class EdgeBrowser(Browser):
         procs = subprocess.check_output(['tasklist', '/fi', 'ImageName eq ' + edge_proc_name])
         if edge_proc_name in procs:
             subprocess.call(['taskkill.exe', '/f', '/im', 'microsoftedge*']) # close all Edge browser instances
-        self.logger.info("stopped")
 
     def pid(self):
         return self.server.pid

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import time
 import subprocess
 from .base import Browser, ExecutorBrowser, require_arg
 from ..webdriver_server import EdgeDriverServer

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -84,6 +84,14 @@ class EdgeBrowser(Browser):
 
     def stop(self, force=False):
         self.server.stop(force=force)
+        time.sleep(3)
+        # close Edge process if it is still running
+        edge_proc_name = 'MicrosoftEdge.exe'
+        procs = subprocess.check_output(['tasklist', '/fi', 'ImageName eq ' + edge_proc_name])
+        if edge_proc_name in procs:
+            subprocess.call(['taskkill.exe', '/f', '/im', 'microsoftedge*']) # close all Edge browser instances
+        subprocess.call(['taskkill.exe', '/f', '/im', 'microsoftwebdriver.exe']) # close all Edge driver instances
+        self.logger.info("stopped")
 
     def pid(self):
         return self.server.pid

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -94,7 +94,8 @@ class EdgeBrowser(Browser):
                 break
             elif edge_proc_name in procs:
                 time.sleep(0.5)
-            else: break
+            else:
+                break
 
         if edge_proc_name in procs:
             # close Edge process if it is still running


### PR DESCRIPTION
Edge driver doesn't automatically close Edge browser processes on exit and we end up with browser processes that linger after test completion and affect subsequent tests. This change will terminate any MicrosoftEdge* processes if they're still found after Edge driver process exits. 

Test results: https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=11315 