### PR TITLE
[css-text-decor] Add text-decoration tests

### DIFF
--- a/css/css-text-decor/text-decoration-001.html
+++ b/css/css-text-decor/text-decoration-001.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration underline</title>
+<meta name="assert" content="text-decoration:underline; there is a line at or under the alphabetic baseline">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+}
+</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line at or under the alphabetic baseline.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-002.html
+++ b/css/css-text-decor/text-decoration-002.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration overline</title>
+<meta name="assert" content="text-decoration:overline; there is an overline">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is an overline.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-003.html
+++ b/css/css-text-decor/text-decoration-003.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration line-through</title>
+<meta name="assert" content="text-decoration:line-through; there is a solid line through the centre of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:line-through;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a solid line through the centre of the characters.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-004.html
+++ b/css/css-text-decor/text-decoration-004.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration underline overline</title>
+<meta name="assert" content="text-decoration:underline overline; there is an overline and an underline">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is an overline and an underline.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-040.html
+++ b/css/css-text-decor/text-decoration-040.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration underline tbrl hor scripts</title>
+<meta name="assert" content="text-decoration:underline; there is a line to the LEFT of the characters for horizontal scripts set vertically using writing-mode: vertical-rl">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the LEFT of the characters for all lines.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p-->
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-040a.html
+++ b/css/css-text-decor/text-decoration-040a.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration underline tbrl mixed</title>
+<meta name="assert" content="text-decoration:underline; there is an unbroken line to the LEFT of the characters for each lines">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 3.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div p {
+text-decoration:underline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is an unbroken line to the LEFT of the characters for all lines.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh">引发<span lang="en">quick brown fox</span>网络<span lang="ar">جهانی سازیم</span>的全<span lang="my">အပြည်ပြည်</span>部潜<span lang="th">ปิ้งอยู่ในถ้ำ</span>能引<span lang="bo">འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་</span>發網<span lang="hi">विश्वव्यापी बना रहें हैं絡</span>的全<span lang="ja">部潛能</span></p>
+</div>
+</div>
+</body>
+</html>
+

--- a/css/css-text-decor/text-decoration-041.html
+++ b/css/css-text-decor/text-decoration-041.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration underline tbrl (zh)</title>
+<meta name="assert" content="text-decoration:underline; there is a line to the LEFT of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the LEFT of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-044.html
+++ b/css/css-text-decor/text-decoration-044.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration overline tbrl hor scripts</title>
+<meta name="assert" content="text-decoration-line:overline; there is a line to the RIGHT of the characters for horizontal scripts set vertically using writing-mode: vertical-rl">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the RIGHT of the characters for all lines.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-045.html
+++ b/css/css-text-decor/text-decoration-045.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration overline tbrl (zh)</title>
+<meta name="assert" content="text-decoration-line:overline; there is a line to the RIGHT of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the RIGHT of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-046a.html
+++ b/css/css-text-decor/text-decoration-046a.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration overline tbrl mixed</title>
+<meta name="assert" content="text-decoration-line:overline; there is an unbroken line to the RIGHT of the characters for all lines">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 3.5;
+	}
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div p {
+text-decoration:overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is an unbroken line to the RIGHT of the characters for each line.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh">引发<span lang="en">quick brown fox</span>网络<span lang="ar">جهانی سازیم</span>的全<span lang="my">အပြည်ပြည်</span>部潜<span lang="th">ปิ้งอยู่ในถ้ำ</span>能引<span lang="bo">འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་</span>發網<span lang="hi">विश्वव्यापी बना रहें हैं絡</span>的全<span lang="ja">部潛能</span></p>
+</div>
+</div>
+</body>
+</html>
+

--- a/css/css-text-decor/text-decoration-048.html
+++ b/css/css-text-decor/text-decoration-048.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration line-through vertical-rl</title>
+<meta name="assert" content="text-decoration:line-through; there is a solid vertical line through the centre of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:line-through;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a solid vertical line through the centre of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-048a.html
+++ b/css/css-text-decor/text-decoration-048a.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration line-through vertical-rl hor scripts</title>
+<meta name="assert" content="text-decoration:line-through; there is a solid vertical line through the centre of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:line-through;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a solid vertical line through the centre of the characters.<br/><span class="hint">Skip the test if the text the text fails for the Chinese line, or is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-049.html
+++ b/css/css-text-decor/text-decoration-049.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration vertical-rl over+under</title>
+<meta name="assert" content="text-decoration:underline overline; there is a vertical line on both sides of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a vertical line on both sides of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-082.html
+++ b/css/css-text-decor/text-decoration-082.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration underline overline tblr</title>
+<meta name="assert" content="text-decoration:underline overline; there is a line on both sides of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line on both sides of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-lr">
+<div>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-085.html
+++ b/css/css-text-decor/text-decoration-085.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration line-through tblr</title>
+<meta name="assert" content="text-decoration:line-through; there is a solid vertical line through the centre of the characters.">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:line-through;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a solid vertical line through the centre of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-lr">
+<div>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-090.html
+++ b/css/css-text-decor/text-decoration-090.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration underline sideways-rl</title>
+<meta name="assert" content="text-decoration:underline; there is a line to the LEFT of the characters for horizontal scripts set vertically using writing-mode: sideways-rl">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the LEFT of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-rl">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-090a.html
+++ b/css/css-text-decor/text-decoration-090a.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration underline sideways-rl non-Latin</title>
+<meta name="assert" content="text-decoration:underline; there is a line to the LEFT of the characters for horizontal scripts set vertically using writing-mode: sideways-rl">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the LEFT of the characters for all lines.<br/><span class="hint">Skip the test if it fails for the English text, or if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-rl">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p-->
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-091.html
+++ b/css/css-text-decor/text-decoration-091.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration overline sideways-rl</title>
+<meta name="assert" content="text-decoration:overline; there is a line to the RIGHT of the characters for horizontal scripts set vertically using writing-mode: sideways-rl">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the RIGHT of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-rl">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-091a.html
+++ b/css/css-text-decor/text-decoration-091a.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration overline sideways-rl non-Latin</title>
+<meta name="assert" content="text-decoration:overline; there is a line to the RIGHT of the characters for horizontal scripts set vertically using writing-mode: sideways-rl">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the RIGHT of the characters for all lines.<br/><span class="hint">Skip the test if it fails for the English sentence, or if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-rl">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p-->
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-092.html
+++ b/css/css-text-decor/text-decoration-092.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration line-through sideways-rl</title>
+<meta name="assert" content="text-decoration:line-through; there is a line through the CENTRE of the characters for horizontal scripts set vertically using writing-mode: sideways-rl">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:line-through;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line through the CENTRE of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-rl">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-092a.html
+++ b/css/css-text-decor/text-decoration-092a.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration line-through sideways-rl non-Latin</title>
+<meta name="assert" content="text-decoration:line-through; there is a line through the CENTRE of the characters for horizontal scripts set vertically using writing-mode: sideways-rl">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:line-through;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line through the CENTRE of the characters for all lines.<br/><span class="hint">Skip the test if it fails for the English sentence, or if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-rl">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p-->
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-095a.html
+++ b/css/css-text-decor/text-decoration-095a.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration underline sideways-lr non-Latin</title>
+<meta name="assert" content="text-decoration:underline; there is a line to the RIGHT of the characters for horizontal scripts set vertically using writing-mode: sideways-lr">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the RIGHT of the characters for all lines.<br/><span class="hint">Skip the test if it fails for the English sentence, or if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-lr">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p-->
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-096.html
+++ b/css/css-text-decor/text-decoration-096.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration overline sideways-lr</title>
+<meta name="assert" content="text-decoration:overline; there is a line to the LEFT of the characters for horizontal scripts set vertically using writing-mode: sideways-lr">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the LEFT of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-lr">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-096a.html
+++ b/css/css-text-decor/text-decoration-096a.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration overline sideways-lr non-Latin</title>
+<meta name="assert" content="text-decoration:overline; there is a line to the LEFT of the characters for horizontal scripts set vertically using writing-mode: sideways-lr">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:overline;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line to the LEFT of the characters for all lines.<br/><span class="hint">Skip the test if it fails for the English sentence, or if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-lr">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p-->
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-097.html
+++ b/css/css-text-decor/text-decoration-097.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration line-through sideways-lr</title>
+<meta name="assert" content="text-decoration:line-through; there is a line through the CENTRE of the characters for horizontal scripts set vertically using writing-mode: sideways-lr">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:line-through;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line through the CENTRE of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-lr">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-097a.html
+++ b/css/css-text-decor/text-decoration-097a.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration line-through sideways-lr non-Latin</title>
+<meta name="assert" content="text-decoration:line-through; there is a line through the CENTRE of the characters for horizontal scripts set vertically using writing-mode: sideways-lr">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:line-through;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a line through the CENTRE of the characters for all lines.<br/><span class="hint">Skip the test if it fails for the English sentence, or if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:sideways-lr">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درستی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာလှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้งอยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འབད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को सचमुच विश्वव्यापी बना रहें हैं !</span></p-->
+</div>  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR ports https://w3c.github.io/i18n-tests/results/line-decoration#text_dec to WPT. Currently, the tests are manual tests, since we're unable to come up with a way to automate them.

The `-00X.html` tests are in horizontal writing mode, the `-04X.html` tests are in `vertical-rl`, the `-08X.html` tests are in `vertical-lr`, and the `-09X.html` tests are in `sideways-{rl,lr}`. (Currently, only Firefox supports `sideways-{rl,lr}`.)

I didn't include the exploratory tests.

/cc @r12a
