### PR TITLE
These tests should use Ahem font instead of monospace

### DIFF
--- a/css/css-text/overflow-wrap/overflow-wrap-break-word-008.html
+++ b/css/css-text/overflow-wrap/overflow-wrap-break-word-008.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap:break-word + white-space:break-spaces</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" title="3. White Space and Wrapping: the white-space property" href="https://drafts.csswg.org/css-text-3/#white-space-property">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property " href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-break-spaces">
+<meta name="flags" content="ahem">
+<link rel="match" href="reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="break-word + break-spaces do allow a break
+between the last character of a word and the first space of a sequence of preserved spaces
+if there are no other wrapping opportunities earlier in the line">
+<style>
+div {
+  position: relative;
+  font-family: Ahem;
+  font-size: 25px;
+  line-height: 1em;
+}
+.red {
+  position: absolute;
+  color: green;
+  width: 100px;
+  height: 100px;
+  white-space: pre;
+}
+.test {
+  background: green;
+  color: red;
+  width: 4ch;
+  z-index: -1;
+
+  white-space: break-spaces;
+  overflow-wrap: break-word;
+</style>
+
+<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div class="red">XXXX<br> <br>XXXX<br></div>
+<div class="test">XXXX XXXX </div>

--- a/css/css-text/white-space/break-spaces-009.html
+++ b/css/css-text/white-space/break-spaces-009.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-break:break-word + white-space:break-spaces</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" title="3. White Space and Wrapping: the white-space property" href="https://drafts.csswg.org/css-text-3/#white-space-property">
+<link rel="help" title="5.2. Breaking Rules for Letters: the word-break property" href="https://drafts.csswg.org/css-text-3/#word-break-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-break-spaces">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-break-word">
+<meta name="flags" content="ahem">
+<link rel="match" href="reference/white-space-break-spaces-005-ref.html">
+<meta name="assert" content="break-word + break-spaces do allow a break
+between the last character of a word and the first space of a sequence of preserved spaces
+if there are no other wrapping opportunities earlier in the line">
+<style>
+div {
+  position: relative;
+  font: 25px/1 Ahem;
+}
+.red {
+  position: absolute;
+  color: green;
+  width: 100px;
+  height: 100px;
+  white-space: pre;
+}
+.test {
+  background: green;
+  color: red;
+  width: 4ch;
+  z-index: -1;
+
+  white-space: break-spaces;
+  word-break: break-word;
+</style>
+
+<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div class="red">XXXX<br> <br>XXXX<br></div>
+<div class="test">XXXX XXXX </div>

--- a/css/css-text/white-space/reference/white-space-intrinsic-size-001-ref.html
+++ b/css/css-text/white-space/reference/white-space-intrinsic-size-001-ref.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
 <style>
 div {
-  font-family: monospace;
+  font-family: Ahem;
   color: transparent;
   font-size: 50px;
   background: green;

--- a/css/css-text/white-space/reference/white-space-intrinsic-size-002-ref.html
+++ b/css/css-text/white-space/reference/white-space-intrinsic-size-002-ref.html
@@ -6,7 +6,7 @@
 div {
   color: transparent;
   background: blue;
-  font-family: monospace;
+  font-family: Ahem;
   font-size: 50px;
   width: 3ch;
 }

--- a/css/css-text/white-space/reference/white-space-intrinsic-size-003-ref.html
+++ b/css/css-text/white-space/reference/white-space-intrinsic-size-003-ref.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
 <style>
 div {
+  font-family: Ahem;
   color: transparent;
   font-size: 50px;
   background: green;

--- a/css/css-text/white-space/reference/white-space-intrinsic-size-004-ref.html
+++ b/css/css-text/white-space/reference/white-space-intrinsic-size-004-ref.html
@@ -9,7 +9,7 @@ aside {
 }
 div {
   color: transparent;
-  font-family: monospace;
+  font-family: Ahem;
   font-size: 50px;
   width: 5ch;
 }

--- a/css/css-text/white-space/white-space-intrinsic-size-001.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-001.html
@@ -15,7 +15,7 @@ aside {
 }
 aside:last-of-type { overflow-wrap: break-word; }
 div {
-  font-family: monospace;
+  font-family: Ahem;
   color: transparent;
   font-size: 50px;
   width: 0ch;

--- a/css/css-text/white-space/white-space-intrinsic-size-002.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-002.html
@@ -19,7 +19,7 @@ aside:last-of-type {
 }
 div {
   color: transparent;
-  font-family: monospace;
+  font-family: Ahem;
   font-size: 50px;
   width: 3ch;
   /* both floats should take the full 3ch,

--- a/css/css-text/white-space/white-space-intrinsic-size-003.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-003.html
@@ -15,6 +15,7 @@ aside {
 }
 div {
   color: transparent;
+  font-family: Ahem;
   font-size: 50px;
   width: 0ch;
 }

--- a/css/css-text/white-space/white-space-intrinsic-size-004.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-004.html
@@ -17,7 +17,7 @@ aside {
 aside:last-of-type { overflow-wrap: break-word; }
 div {
   color: transparent;
-  font-family: monospace;
+  font-family: Ahem;
   font-size: 50px;
   width: 3ch; /* enough room for both floats if their max-content size does not include the preserved spaces,
 		 but not enough if they do, causing a line break in that case. */


### PR DESCRIPTION
When using 'ch' units for the width property's value some engines experience rounding issues that lead to false failures. The use of Ahem doesn't affect the purpose of the test and gives more accuracy results.