### PR TITLE
Use step_timeout() to force spin the EventLoop

### DIFF
--- a/payment-request/PaymentRequestUpdateEvent/updateWith-call-immediate-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-call-immediate-manual.https.html
@@ -55,17 +55,17 @@ function testImmediateUpdate({ textContent: testName }) {
     const eventPromise = new Promise((resolve, reject) => {
       request.addEventListener(
         "shippingaddresschange",
-        async ev => {
-          // spin the event loop, sets [[waitForUpdate]] to true.
-          await new Promise((resolve, reject) => {
-            setTimeout(resolve, 0);
+        ev => {
+          // Forces updateWith() to be run in the next event loop tick so that
+          // [[waitForUpdate]] is already true when it runs.
+          t.step_timeout(() => {
+            try {
+              ev.updateWith(validDetails);
+              resolve(); // This is bad.
+            } catch (err) {
+              reject(err); // this is good.
+            }
           });
-          try {
-            ev.updateWith(validDetails);
-            resolve(); // This is bad.
-          } catch (err) {
-            reject(err); // this is good.
-          }
         },
         { once: true }
       );

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-call-immediate-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-call-immediate-manual.https.html
@@ -57,7 +57,9 @@ function testImmediateUpdate({ textContent: testName }) {
         "shippingaddresschange",
         async ev => {
           // spin the event loop, sets [[waitForUpdate]] to true.
-          await Promise.resolve();
+          await new Promise((resolve, reject) => {
+            setTimeout(resolve, 0);
+          });
           try {
             ev.updateWith(validDetails);
             resolve(); // This is bad.
@@ -68,13 +70,14 @@ function testImmediateUpdate({ textContent: testName }) {
         { once: true }
       );
     });
-    const response = await request.show();
+    const acceptPromise = request.show();
     await promise_rejects(
       t,
       "InvalidStateError",
       eventPromise,
       "The event loop already spun, so [[waitForUpdate]] is now true"
     );
+    const response = await acceptPromise;
     await response.complete();
   }, testName.trim());
 }


### PR DESCRIPTION
Test improvement for w3c/payment-request#854.

Empirically in Chrome, await Promise.resolve() doesn't cause what comes after it to be run in the next event loop tick, which the test requires. My best understanding of the ES6 Job Queue is that this is expected. So changing this test to use step_timeout which guarantees a new tick.

Also properly catch the rejection of eventPromise because it happens before acceptPromise resolves.