### PR TITLE
[wptrunner] Detect crash during script execution

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -356,6 +356,20 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
         while True:
             result = protocol.base.execute_script(
                 self.script_resume % format_map, async=True)
+
+            # As of 2019-03-29, WebDriver does not define expected behavior for
+            # cases where the browser crashes during script execution:
+            #
+            # https://github.com/w3c/webdriver/issues/1308
+            if not isinstance(result, list) or len(result) != 2:
+                try:
+                    is_alive = self.is_alive()
+                except:
+                    is_alive = False
+
+                if not is_alive:
+                    raise Exception("Browser crashed during script execution.")
+
             done, rv = handler(result)
             if done:
                 break

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -364,7 +364,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
             if not isinstance(result, list) or len(result) != 2:
                 try:
                     is_alive = self.is_alive()
-                except:
+                except client.WebDriverException:
                     is_alive = False
 
                 if not is_alive:


### PR DESCRIPTION
As of 2019-03-29, WebDriver does not define expected behavior for cases
where the browser crashes during script execution [1]. The type of the
value returned by `execute_script` therefore may defy the expectations
of subsequent statements, resulting in a Python exception which obscures
the reason for the problem.

Raise an exception describing a crash to make test results more clear
than the Python type-related error that would otherwise occur.

[1] https://github.com/w3c/webdriver/issues/1308