### PR TITLE
Verify that ReadableStreamTee doesn't pull more chunks than the branch HWM

### DIFF
--- a/streams/readable-streams/tee.any.js
+++ b/streams/readable-streams/tee.any.js
@@ -370,3 +370,82 @@ promise_test(t => {
   });
 
 }, 'ReadableStreamTee should only pull enough to fill the emptiest queue');
+
+promise_test(t => {
+
+  const rs = recordingReadableStream({}, { highWaterMark: 0 });
+  const theError = { name: 'boo!' };
+
+  rs.controller.error(theError);
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(rs.events, [], 'pull should not be called');
+
+    return Promise.all([
+      promise_rejects(t, theError, reader1.closed),
+      promise_rejects(t, theError, reader2.closed)
+    ]);
+  });
+
+}, 'ReadableStreamTee should not pull when original is already errored');
+
+for (const branch of [1, 2]) {
+  promise_test(t => {
+
+    const rs = recordingReadableStream({}, { highWaterMark: 0 });
+    const theError = { name: 'boo!' };
+
+    const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+
+    return flushAsyncEvents().then(() => {
+      assert_array_equals(rs.events, ['pull'], 'pull should be called once');
+
+      rs.controller.enqueue('a');
+
+      const reader = (branch === 1) ? reader1 : reader2;
+      return reader.read();
+    }).then(() => flushAsyncEvents()).then(() => {
+      assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+
+      rs.controller.error(theError);
+
+      return Promise.all([
+        promise_rejects(t, theError, reader1.closed),
+        promise_rejects(t, theError, reader2.closed)
+      ]);
+    }).then(() => flushAsyncEvents()).then(() => {
+      assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+    });
+
+  }, `ReadableStreamTee stops pulling when original stream errors while branch ${branch} is reading`);
+}
+
+promise_test(t => {
+
+  const rs = recordingReadableStream({}, { highWaterMark: 0 });
+  const theError = { name: 'boo!' };
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(rs.events, ['pull'], 'pull should be called once');
+
+    rs.controller.enqueue('a');
+
+    return Promise.all([reader1.read(), reader2.read()]);
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+
+    rs.controller.error(theError);
+
+    return Promise.all([
+      promise_rejects(t, theError, reader1.closed),
+      promise_rejects(t, theError, reader2.closed)
+    ]);
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+  });
+
+}, 'ReadableStreamTee stops pulling when original stream errors while both branches are reading');

--- a/streams/readable-streams/tee.any.js
+++ b/streams/readable-streams/tee.any.js
@@ -159,7 +159,7 @@ promise_test(() => {
     })
   ]);
 
-}, 'ReadableStream teeing: canceling branch2 should not impact branch2');
+}, 'ReadableStream teeing: canceling branch2 should not impact branch1');
 
 promise_test(() => {
 


### PR DESCRIPTION
`ReadableStreamTee()` should only pull enough chunks to fill the HWM of the branches (which is 1), and no more. When pulling from the branches, verify that `pull()` on the original stream still is only called enough to fill the emptiest branch.

Verify also that `tee()` stops pulling when the original stream becomes errored.

Spec change: whatwg/streams#997
Supersedes: #15521