### PR TITLE
Corrected 1 error in calc-numbers.html

### DIFF
--- a/css/css-values/calc-numbers.html
+++ b/css/css-values/calc-numbers.html
@@ -71,7 +71,7 @@ https://chromium.googlesource.com/chromium/src/+/c825d655f6aaf73484f9d56e9012793
 
     verifyComputedStyle("opacity", "initial", "calc(2 / 4)", "0.5", "testing opacity: calc(2 / 4)");
 
-    verifyComputedStyle("tab-size", "12345", "calc(2 / 4)", "1", "testing tab-size: calc(2 / 4)");
+    verifyComputedStyle("tab-size", "12345", "calc(2 / 4)", "0.5", "testing tab-size: calc(2 / 4)");
     /*
     'tab-size' accepts <number> values.
     */


### PR DESCRIPTION
Changed , replaced
`verifyComputedStyle("tab-size", "12345", "calc(2 / 4)", "1", "testing tab-size: calc(2 / 4)");`
with
`verifyComputedStyle("tab-size", "12345", "calc(2 / 4)", "0.5", "testing tab-size: calc(2 / 4)");`