### PR TITLE
Added parentheses to check minimum of 32 nested pairs inside calc

### DIFF
--- a/css/css-values/calc-parenthesis-stack.html
+++ b/css/css-values/calc-parenthesis-stack.html
@@ -4,11 +4,17 @@
 	<meta charset="utf-8">
 	<title>
 		CSS Values and Units Test:
-		Calc() inside calc()
+		32 nested pairs of parentheses inside calc()
 	</title>
 	<meta name="assert" content="
-		The calc() function notation is allowed inside a calc() notation.
+		This test checks the support for the minimum required number of 32 nested pairs of parentheses inside a calc() function.
 	" />
+
+  <!--
+  More info:
+  [css-values] Limit nested pairs of parentheses in calc to 32
+  https://github.com/w3c/csswg-drafts/issues/3462
+  -->
 
 	<link
 		rel="author"
@@ -29,7 +35,7 @@
 
 			html { background: red; overflow: hidden; }
 			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
-			#outer { height: calc((((((((((((((((((((((((100%)))))))))))))))))))))))); }
+			#outer { height: calc((((((((((((((((((((((((((((((((100%)))))))))))))))))))))))))))))))); }
 
 	</style>
 


### PR DESCRIPTION
- I added 8 pairs of nested parentheses to the original test
- I corrected title text
- I improved the text assert
- I referenced issue 3462
https://github.com/w3c/csswg-drafts/issues/3462
in a comment
@FremyCompany 