### PR TITLE
[Azure Pipelines] Enable experimental Server Timing in Safari TP

### DIFF
--- a/docs/_running-tests/safari.md
+++ b/docs/_running-tests/safari.md
@@ -2,21 +2,22 @@
 layout: page
 title: Safari
 ---
-To run Safari on macOS, some manual setup is required:
+To run Safari on macOS, some manual setup is required. Some steps are different
+for Safari and Safari Technology Preview, in which case only step is needed.
 
-  * Allow Safari to be controlled by SafariDriver: `safaridriver --enable`
+  * Allow Safari to be controlled by SafariDriver:
+    * `safaridriver --enable` or
+    * `"/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable`
 
   * Allow pop-up windows:
-    `defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1`
+    * `defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1` or
+    * `defaults write com.apple.SafariTechnologyPreview WebKitJavaScriptCanOpenWindowsAutomatically 1`
 
-  * Turn on experimental features that are "off" by default:
-
-    * `defaults write com.apple.Safari ExperimentalServerTimingEnabled -bool true`
-
-    [//]: # (TODO\(cvazac\) Remove this if/when Server-Timing is enabled by default in Safari)
+  * Turn on additional experimental features Safari Technology Preview:
+    * `defaults write com.apple.SafariTechnologyPreview ExperimentalServerTimingEnabled 1`
 
   * Trust the certificate:
-    `security add-trusted-cert -k "$(security default-keychain | cut -d\" -f2)" tools/certs/cacert.pem`
+    * `security add-trusted-cert -k "$(security default-keychain | cut -d\" -f2)" tools/certs/cacert.pem`
 
   * Set `no_proxy='*'` in your environment. This is a
     workaround for a known

--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -1,19 +1,19 @@
 parameters:
   channel: preview
 
+# Should match https://web-platform-tests.org/running-tests/safari.html
 steps:
 - ${{ if eq(parameters.channel, 'preview') }}:
   - script: |
       # This is equivalent to `Homebrew/homebrew-cask-versions/safari-technology-preview`,
       # but the raw URL is used to bypass caching.
       HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/safari-technology-preview.rb
-      # https://web-platform-tests.org/running-tests/safari.html
       sudo "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable
-      defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
+      defaults write com.apple.SafariTechnologyPreview WebKitJavaScriptCanOpenWindowsAutomatically 1
+      defaults write com.apple.SafariTechnologyPreview ExperimentalServerTimingEnabled 1
     displayName: 'Install Safari Technology Preview'
 - ${{ if eq(parameters.channel, 'stable') }}:
   - script: |
-      # https://web-platform-tests.org/running-tests/safari.html
       sudo safaridriver --enable
       defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
     displayName: 'Configure Safari'


### PR DESCRIPTION
Like https://github.com/web-platform-tests/results-collection/pull/621.