### PR TITLE
Don't return a string in navigationUI()

### DIFF
--- a/fullscreen/api/element-request-fullscreen-options.html
+++ b/fullscreen/api/element-request-fullscreen-options.html
@@ -11,7 +11,7 @@
 test(() => {
   let invoked = false;
   document.body.requestFullscreen({
-    get navigationUI() { invoked = true; return "irrelevant-value"; }
+    get navigationUI() { invoked = true; }
   });
   assert_true(invoked, "navigationUI getter invoked");
 });


### PR DESCRIPTION
Returning a non valid enum string raises a Javascript type error.

Source: https://wpt.fyi/results/fullscreen/api/element-request-fullscreen-options.html?q=%28chrome%3A%21pass%26chrome%3A%21ok%29+%28firefox%3Apass%7Cfirefox%3Aok%29+%28safari%3Apass%7Csafari%3Aok%29&run_id=6282765238534144&run_id=5750440918515712&run_id=5111343174647808