### PR TITLE
Add Permissions as dependency for Wake Lock idlharness test

### DIFF
--- a/wake-lock/idlharness.https.any.js
+++ b/wake-lock/idlharness.https.any.js
@@ -7,7 +7,7 @@
 
 idl_test(
   ['wake-lock'],
-  ['dom', 'html'],
+  ['dom', 'html', 'permissions'],
   idl_array => {
     idl_array.add_objects({
       WakeLock: ['new WakeLock("screen")']


### PR DESCRIPTION
The test was totally broken becase of this:
https://wpt.fyi/results/wake-lock/idlharness.https.any.html?run_id=6282765238534144&run_id=5671833655312384&run_id=5750440918515712&run_id=5111343174647808