### PR TITLE
[infra] Disallow usage of legacy key attribute

### DIFF
--- a/conformance-checkers/html-aria/_functional/tree/js/aria.js
+++ b/conformance-checkers/html-aria/_functional/tree/js/aria.js
@@ -102,15 +102,11 @@ Aria.Tree.prototype = {
 		}
 	},
 	handleKeyPress: function(inEvent){
-		switch(inEvent.keyCode){
-			// case Event.KEY_PAGEUP:   break;
-			// case Event.KEY_PAGEDOWN: break;
-			// case Event.KEY_END:      break;
-			// case Event.KEY_HOME:     break;
-			case Event.KEY_LEFT:     this.keyLeft();  break;
-			case Event.KEY_UP:       this.keyUp();    break;
-			case Event.KEY_RIGHT:    this.keyRight(); break;
-			case Event.KEY_DOWN:     this.keyDown();  break;
+		switch(inEvent.key){
+			case 'ArrowLeft':     this.keyLeft();  break;
+			case 'ArrowUp':       this.keyUp();    break;
+			case 'ArrowRight':    this.keyRight(); break;
+			case 'ArrowDown':     this.keyDown();  break;
 			default:
 				return;
 		}

--- a/docs/_writing-tests/lint-tool.md
+++ b/docs/_writing-tests/lint-tool.md
@@ -101,6 +101,10 @@ below to fix all errors reported.
   either replace the `w3c-test.org` string with the expression
   `{{host}}:{{ports[http][0]}}` or a generic hostname like `example.org`.
 
+* **KEYCODE**: Test file includes a reference to the `keyCode` property of the
+  DOM KeyboardEvent object. This property is platform-specific and deprecated.
+  **fix**: use the `key` property instead.
+
 ## Updating the whitelist
 
 Normally you must [fix all lint errors](#fixing-lint-errors). But in the

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-negative.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-negative.html
@@ -33,7 +33,7 @@ document.forms.fm.addEventListener("focus", function (evt) {
 
 document.addEventListener("keydown", function (evt) {
   t.step(function () {
-    assert_equals(evt.keyCode, 9, "Please press 'Tab' key.");
+    assert_equals(evt.key, 'Tab', "Please press 'Tab' key.");
   });
 }, true);
 

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html
@@ -54,7 +54,7 @@ document.forms.fm.addEventListener("focus", function (evt) {
 
 document.addEventListener("keydown", function (evt) {
   t.step(function () {
-    assert_equals(evt.keyCode, 9, "Please press 'Tab' key.");
+    assert_equals(evt.key, 'Tab', "Please press 'Tab' key.");
   });
 }, true);
 

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-positive.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-positive.html
@@ -32,7 +32,7 @@ document.forms.fm.addEventListener("focus", function (evt) {
 
 document.addEventListener("keydown", function (evt) {
   t.step(function () {
-    assert_equals(evt.keyCode, 9, "Please press 'Tab' key.");
+    assert_equals(evt.key, 'Tab', "Please press 'Tab' key.");
   });
 }, true);
 

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-zero.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-zero.html
@@ -34,7 +34,7 @@ document.forms.fm.addEventListener("focus", function (evt) {
 
 document.addEventListener("keydown", function (evt) {
   t.step(function () {
-    assert_equals(evt.keyCode, 9, "Please press 'Tab' key.");
+    assert_equals(evt.key, 'Tab', "Please press 'Tab' key.");
   });
 }, true);
 

--- a/html/semantics/forms/the-input-element/maxlength-manual.html
+++ b/html/semantics/forms/the-input-element/maxlength-manual.html
@@ -22,8 +22,7 @@
 
 
       on_event(input, 'keyup', function(event) {
-          if  ((event.keyCode >= 65 && event.keyCode <= 90) ||
-                (event.keyCode >= 97 && event.keyCode <= 122)) {
+          if  (/^[a-z]$/i.test(event.key)) {
             test(function() {
               assert_equals(input.value, "inpu");
             }, 'input content should limit to maxlength')

--- a/html/semantics/interactive-elements/commands/legend/focusable-legend-sibling-manual.html
+++ b/html/semantics/interactive-elements/commands/legend/focusable-legend-sibling-manual.html
@@ -10,7 +10,7 @@
 </fieldset>
 <script>
  onkeyup = e => {
-   if (e.keyCode === 65) {
+   if (e.key === 'a') {
      pass();
    }
  }

--- a/html/semantics/interactive-elements/commands/legend/input-outside-fieldset-manual.html
+++ b/html/semantics/interactive-elements/commands/legend/input-outside-fieldset-manual.html
@@ -10,7 +10,7 @@
 <input onfocus="fail('input outside fieldset was focused')">
 <script>
  onkeyup = e => {
-   if (e.keyCode === 65) {
+   if (e.key === 'a') {
      pass();
    }
  }

--- a/html/semantics/interactive-elements/commands/legend/label-sibling-manual.html
+++ b/html/semantics/interactive-elements/commands/legend/label-sibling-manual.html
@@ -11,7 +11,7 @@
 </fieldset>
 <script>
  onkeyup = e => {
-   if (e.keyCode === 65) {
+   if (e.key === 'a') {
      pass();
    }
  }

--- a/html/semantics/interactive-elements/commands/legend/no-fieldset-parent-manual.html
+++ b/html/semantics/interactive-elements/commands/legend/no-fieldset-parent-manual.html
@@ -11,7 +11,7 @@
 <input onfocus="fail('input after legend was focused')">
 <script>
  onkeyup = e => {
-   if (e.keyCode === 65) {
+   if (e.key === 'a') {
      pass();
    }
  }

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -806,3 +806,8 @@ CSS-COLLIDING-REF-NAME: css/vendor-imports/mozilla/mozilla-central-reftests/cont
 WEB-PLATFORM.TEST:signed-exchange/resources/*.sxg
 WEB-PLATFORM.TEST:signed-exchange/appcache/resources/*.sxg
 WEB-PLATFORM.TEST:signed-exchange/resources/generate-test-sxgs.sh
+
+# Tests for legacy feature
+KEYCODE: uievents/keyboard/key.js
+# Third-party dependency
+KEYCODE: css/css-regions/elements/support/Three.js

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -423,6 +423,12 @@ class SpecialPowersRegexp(Regexp):
     file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
     description = "SpecialPowers used; this is gecko-specific and not supported in wpt"
 
+class KeyCodeRegexp(Regexp):
+    pattern = r"\.keyCode\b"
+    error = "KEYCODE"
+    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    description = "KeyboardEvent#keyCode used; this is deprecated and platform-specific"
+
 
 regexps = [item() for item in
            [TrailingWhitespaceRegexp,
@@ -436,7 +442,8 @@ regexps = [item() for item in
             GenerateTestsRegexp,
             PrintRegexp,
             LayoutTestsRegexp,
-            SpecialPowersRegexp]]
+            SpecialPowersRegexp,
+            KeyCodeRegexp]]
 
 def check_regexp_line(repo_root, path, f):
     errors = []

--- a/webdriver/tests/perform_actions/support/test_actions_wdspec.html
+++ b/webdriver/tests/perform_actions/support/test_actions_wdspec.html
@@ -60,8 +60,7 @@
           appendMessage(event.type + " " +
               "code: " + event.code + ", " +
               "key: " + key + ", " +
-              "which: " + event.which + ", " +
-              "keyCode: " + event.keyCode);
+              "which: " + event.which);
         }
 
         function recordPointerEvent(event) {

--- a/webdriver/tests/release_actions/support/test_actions_wdspec.html
+++ b/webdriver/tests/release_actions/support/test_actions_wdspec.html
@@ -60,8 +60,7 @@
           appendMessage(event.type + " " +
               "code: " + event.code + ", " +
               "key: " + key + ", " +
-              "which: " + event.which + ", " +
-              "keyCode: " + event.keyCode);
+              "which: " + event.which);
         }
 
         function recordPointerEvent(event) {


### PR DESCRIPTION
The `keyCode` attribute of KeyboardEvent objects is not suitable for
conformance tests. Replace most existing references with the standard
`key` attribute. Persist those references whose intent is expressly to
test the legacy API. Introduce a new linting rule to disallow further
references.

> These features were never formally specified and the current browser
> implementations vary in significant ways. The large amount of legacy
> content, including script libraries, that relies upon detecting the
> user agent and acting accordingly means that any attempt to formalize
> these legacy attributes and events would risk breaking as much content
> as it would fix or enable. Additionally, these attributes are not
> suitable for international usage, nor do they address accessibility
> concerns.
>
> Therefore, this specification does not normatively define the events
> and attributes commonly employed for handling keyboard input, though
> they MAY be present in user agents for compatibility with legacy
> content. Authors SHOULD use the key attribute instead of the
> `charCode` and `keyCode` attributes.

https://www.w3.org/TR/uievents/#legacy-key-attributes