### PR TITLE
[webdriver] Add test for control key

### DIFF
--- a/webdriver/tests/element_send_keys/send_keys.py
+++ b/webdriver/tests/element_send_keys/send_keys.py
@@ -58,3 +58,21 @@ def test_stale_element(session):
 
     response = element_send_keys(session, element, "foo")
     assert_error(response, "stale element reference")
+
+def test_cancel(session):
+    session.url = inline("")
+
+    session.execute_script("""
+        document.body.addEventListener('keydown', function(event) {
+            document.body.innerHTML = event.key;
+          });
+    """)
+    element = session.find.css("body", all=False)
+
+    response = element_send_keys(session, element, u"\ue001")
+    value = assert_success(response)
+    assert value is None
+
+    result = session.execute_script("return document.body.innerHTML;")
+
+    assert result == "Cancel"


### PR DESCRIPTION
@andreastt This test fails in the latest release of Chromedriver. I'd rather test all of the special code points (likely reusing [`tests.perform_actions.support.keys`](https://github.com/web-platform-tests/wpt/blob/24dd35d24272746f1d2ccb46b20d886235f0514b/webdriver/tests/perform_actions/support/keys.py)), but testing each key in isolation takes a while--long enough to consistently trigger a timeout if done from the modified file. The only idea I have is to subdivide the set of keys across a few files. Would you prefer that to testing this one known failure?