### PR TITLE
[Resource Timing] Fix buffer-full-add-after-full-event test flakiness

### DIFF
--- a/resource-timing/buffer-full-add-after-full-event.html
+++ b/resource-timing/buffer-full-add-after-full-event.html
@@ -53,15 +53,21 @@ let clearAndAddAnotherEntryToBuffer = () => {
 };
 
 let testThatEntryWasAdded = () => {
-    return new Promise((resolve, reject) => {
-        let waitForIt = function() {
-            if (performance.getEntriesByType("resource").length) {
-                resolve();
+    let tries = 1;
+    let maxTries = 5;
+    return waitUntilConditionIsMet( function() {
+        if (performance.getEntriesByType("resource").length) {
+            return true;
+        } else {
+            if (tries < maxTries) {
+                tries++;
+                return false;
             } else {
-                reject("After buffer full, entry never added to primary");
+                return true;
             }
         }
-        step_timeout(waitForIt, 0);
+    }).then( () => {
+        assert_true((performance.getEntriesByType("resource").length) === 1);
     });
 };
 
@@ -74,7 +80,6 @@ promise_test(async () => {
     await clearAndAddAnotherEntryToBuffer();
     // Since we have no strict guarantees when an entry will be added to the
     // buffer, waiting till next task to try to avoid flakiness.
-    await waitForNextTask();
     await testThatEntryWasAdded();
 }, "Test that entry was added to the buffer after a buffer full event");
 </script>

--- a/resource-timing/resources/buffer-full-utilities.js
+++ b/resource-timing/resources/buffer-full-utilities.js
@@ -18,6 +18,19 @@ let waitForNextTask = () => {
     });
 };
 
+let waitUntilConditionIsMet = cond => {
+    return new Promise(resolve => {
+        let checkCondition = function() {
+            if (cond.apply(null)) {
+                resolve();
+            } else {
+                step_timeout(checkCondition.bind(null,cond), 0);
+            }
+        }
+        step_timeout(checkCondition.bind(null, cond), 0);
+    });
+}
+
 let waitForEventToFire = () => {
     return new Promise(resolve => {
         let waitForIt = function() {


### PR DESCRIPTION
Resolve #15849 by offering up to five opportunities to
recognize that a new resource has been added to the page
after the buffer full event. This does not change
the semantics of the test but does make it more robust
in the face of timing variability.