### PR TITLE
[wptrunner] Fix #16232: Allow - at the beginning of parameters to --b…

### DIFF
--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -548,6 +548,12 @@ def check_args(kwargs):
     if kwargs["reftest_screenshot"] is None:
         kwargs["reftest_screenshot"] = "unexpected"
 
+    if kwargs["binary_args"] is not None:
+        updated_binary_args = []
+        for binary_arg in kwargs["binary_args"]:
+            updated_binary_args.append(binary_arg.replace("\\-","-"))
+        kwargs["binary_args"] = updated_binary_args
+
     return kwargs
 
 


### PR DESCRIPTION
…inary-arg

Replace "\-" with "-" in the option to `--binary-arg`. This
allows the user to specify arguments to the target binary
that begin with "-"s (as many options in Linux/OSX do).