### PR TITLE
Updating Edge os_version os_build powershell strings to be raw_strings.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -102,8 +102,8 @@ class EdgeBrowser(Browser):
 
 
 def run_info_extras(**kwargs):
-    osReleaseCommand = "(Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion').ReleaseId"
-    osBuildCommand = "(Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion').BuildLabEx"
+    osReleaseCommand = r"(Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion').ReleaseId"
+    osBuildCommand = r"(Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion').BuildLabEx"
     try:
         os_release = subprocess.check_output(["powershell.exe", osReleaseCommand]).strip()
         os_build = subprocess.check_output(["powershell.exe", osBuildCommand]).strip()


### PR DESCRIPTION
Based on feedback from [this CR](https://github.com/web-platform-tests/wpt/pull/15992#discussion_r271168132) updating the powershell strings to be python raw strings to avoid a warning.