### PR TITLE
[service-workers] Improve test stability

### DIFF
--- a/service-workers/service-worker/skip-waiting-using-registration.https.html
+++ b/service-workers/service-worker/skip-waiting-using-registration.https.html
@@ -59,7 +59,7 @@ promise_test(function(t) {
       .then(function() {
           assert_not_equals(sw_registration.active, null,
                             'Registration active worker should not be null');
-          fetch_tests_from_worker(sw_registration.active);
+          return fetch_tests_from_worker(sw_registration.active);
         });
   }, 'Test skipWaiting while a client is using the registration');
 

--- a/service-workers/service-worker/skip-waiting-without-using-registration.https.html
+++ b/service-workers/service-worker/skip-waiting-without-using-registration.https.html
@@ -37,7 +37,7 @@ promise_test(function(t) {
                         'Document controller should still be null');
           assert_not_equals(sw_registration.active, null,
                             'Registration active worker should not be null');
-          fetch_tests_from_worker(sw_registration.active);
+          return fetch_tests_from_worker(sw_registration.active);
         });
   }, 'Test skipWaiting while a client is not being controlled');
 


### PR DESCRIPTION
The `fetch_tests_from_worker` utility function initiates an asynchronous
operation. The requests tests are eventually defined, but if the harness
status has detected completion before this, the new tests will trigger
undefined behavior.

In order to avoid this race condition, ensure that the test which is
active at the call site does not complete until after the new tests have
been fetched.