### PR TITLE
HTML: Test that <details open> fires the event even from the parser.

### DIFF
--- a/html/semantics/interactive-elements/the-details-element/toggleEvent.html
+++ b/html/semantics/interactive-elements/the-details-element/toggleEvent.html
@@ -175,4 +175,9 @@
     t10.done();
   }, 0);
 
+  async_test(function(t) {
+    new DOMParser().parseFromString("<details open>", "text/html").querySelector("details").ontoggle = t.step_func_done(function(e) {
+      assert_true(e.target.open);
+    });
+  }, "Setting open from the parser fires a toggle event");
 </script>


### PR DESCRIPTION
https://github.com/whatwg/html/issues/4500