### PR TITLE
Refactor lint rules

### DIFF
--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -1,0 +1,316 @@
+from __future__ import unicode_literals
+import os
+import re
+
+class Rule(object):
+    name = None
+    description = None
+    to_fix = None
+
+    @classmethod
+    def error(cls, path, context=(), line_no=None):
+        description = cls.description % context
+        return (cls.name, description, path, line_no)
+
+
+class MissingLink(Rule):
+    name = "MISSING-LINK"
+    description = "Testcase file must have a link to a spec"
+    to_fix = """
+        Ensure that there is a `<link rel="help" href="[url]">` for the spec.
+        `MISSING-LINK` is designed to ensure that the CSS build tool can find
+        the tests. Note that the CSS build system is primarily used by
+        [test.csswg.org/](http://test.csswg.org/), which doesn't use
+        `wptserve`, so `*.any.js` and similar tests won't work there; stick
+        with the `.html` equivalent.
+    """
+
+
+class PathLength(Rule):
+    name = "PATH LENGTH"
+    description = "/%s longer than maximum path length (%d > 150)"
+
+
+class WorkerCollision(Rule):
+    name = "WORKER COLLISION"
+    description = ("path ends with %s which collides with generated tests "
+        "from %s files")
+
+
+class GitIgnoreFile(Rule):
+    name = "GITIGNORE"
+    description = ".gitignore found outside the root"
+
+
+class AhemCopy(Rule):
+    name = "AHEM COPY"
+    description = "Don't add extra copies of Ahem, use /fonts/Ahem.ttf"
+
+
+# TODO: Add tests for this rule
+class IgnoredPath(Rule):
+    name = "IGNORED PATH"
+    description = ("%s matches an ignore filter in .gitignore - "
+        "please add a .gitignore exception")
+
+
+class CSSCollidingTestName(Rule):
+    name = "CSS-COLLIDING-TEST-NAME"
+    description = "The filename %s in the %s testsuite is shared by: %s"
+
+
+class CSSCollidingRefName(Rule):
+    name = "CSS-COLLIDING-REF-NAME"
+    description = "The filename %s is shared by: %s"
+
+
+class CSSCollidingSupportName(Rule):
+    name = "CSS-COLLIDING-SUPPORT-NAME"
+    description = "The filename %s is shared by: %s"
+
+
+class SupportWrongDir(Rule):
+    name = "SUPPORT-WRONG-DIR"
+    description = "Support file not in support directory"
+
+
+class ParseFailed(Rule):
+    name = "PARSE-FAILED"
+    description = "Unable to parse file"
+
+
+class ContentManual(Rule):
+    name = "CONTENT-MANUAL"
+    description = "Manual test whose filename doesn't end in '-manual'"
+
+
+class ContentVisual(Rule):
+    name = "CONTENT-VISUAL"
+    description = "Visual test whose filename doesn't end in '-visual'"
+
+
+class AbsoluteUrlRef(Rule):
+    name = "ABSOLUTE-URL-REF"
+    description = ("Reference test with a reference file specified via an "
+        "absolute URL: '%s'")
+
+
+class SameFileRef(Rule):
+    name = "SAME-FILE-REF"
+    description = "Reference test which points at itself as a reference"
+
+
+class NonexistentRef(Rule):
+    name = "NON-EXISTENT-REF"
+    description = ("Reference test with a non-existent '%s' relationship "
+        "reference: '%s'")
+
+
+class MultipleTimeout(Rule):
+    name = "MULTIPLE-TIMEOUT"
+    description = "More than one meta name='timeout'"
+
+
+class InvalidTimeout(Rule):
+    name = "INVALID-TIMEOUT"
+    description = "Invalid timeout value %s"
+
+
+class MultipleTestharness(Rule):
+    name = "MULTIPLE-TESTHARNESS"
+    description = "More than one <script src='/resources/testharness.js'>"
+
+
+class MissingTestharnessReport(Rule):
+    name = "MISSING-TESTHARNESSREPORT"
+    description = "Missing <script src='/resources/testharnessreport.js'>"
+
+
+class MultipleTestharnessReport(Rule):
+    name = "MULTIPLE-TESTHARNESSREPORT"
+    description = "More than one <script src='/resources/testharnessreport.js'>"
+
+
+class PresentTestharnessCSS(Rule):
+    name = "PRESENT-TESTHARNESSCSS"
+    description = "Explicit link to testharness.css present"
+
+
+class VariantMissing(Rule):
+    name = "VARIANT-MISSING"
+    description = "<meta name=variant> missing 'content' attribute"
+
+
+class MalformedVariant(Rule):
+    name = "MALFORMED-VARIANT"
+    description = ("%s <meta name=variant> 'content' attribute must be the "
+        "empty string or start with '?' or '#'")
+
+
+class LateTimeout(Rule):
+    name = "LATE-TIMEOUT"
+    description = "<meta name=timeout> seen after testharness.js script"
+
+
+class EarlyTestharnessReport(Rule):
+    name = "EARLY-TESTHARNESSREPORT"
+    description = "testharnessreport.js script seen before testharness.js script"
+
+
+class MultipleTestdriver(Rule):
+    name = "MULTIPLE-TESTDRIVER"
+    description = "More than one <script src='/resources/testdriver.js'>"
+
+
+class MissingTestdriverVendor(Rule):
+    name = "MISSING-TESTDRIVER-VENDOR"
+    description = "Missing <script src='/resources/testdriver-vendor.js'>"
+
+
+class MultipleTestdriverVendor(Rule):
+    name = "MULTIPLE-TESTDRIVER-VENDOR"
+    description = "More than one <script src='/resources/testdriver-vendor.js'>"
+
+
+class TestharnessPath(Rule):
+    name = "TESTHARNESS-PATH"
+    description = "testharness.js script seen with incorrect path"
+
+
+class TestharnessReportPath(Rule):
+    name = "TESTHARNESSREPORT-PATH"
+    description = "testharnessreport.js script seen with incorrect path"
+
+
+class TestdriverPath(Rule):
+    name = "TESTDRIVER-PATH"
+    description = "testdriver.js script seen with incorrect path"
+
+
+class TestdriverVendorPath(Rule):
+    name = "TESTDRIVER-VENDOR-PATH"
+    description = "testdriver-vendor.js script seen with incorrect path"
+
+
+class OpenNoMode(Rule):
+    name = "OPEN-NO-MODE"
+    description = "File opened without providing an explicit mode (note: binary files must be read with 'b' in the mode flags)"
+
+
+class UnknownGlobalMetadata(Rule):
+    name = "UNKNOWN-GLOBAL-METADATA"
+    description = "Unexpected value for global metadata"
+
+
+class BrokenGlobalMetadata(Rule):
+    name = "BROKEN-GLOBAL-METADATA"
+    description = "Invalid global metadata: %s"
+
+
+class UnknownTimeoutMetadata(Rule):
+    name = "UNKNOWN-TIMEOUT-METADATA"
+    description = "Unexpected value for timeout metadata"
+
+
+class UnknownMetadata(Rule):
+    name = "UNKNOWN-METADATA"
+    description = "Unexpected kind of metadata"
+
+
+class StrayMetadata(Rule):
+    name = "STRAY-METADATA"
+    description = "Metadata comments should start the file"
+
+
+class IndentedMetadata(Rule):
+    name = "INDENTED-METADATA"
+    description = "Metadata comments should start the line"
+
+
+class BrokenMetadata(Rule):
+    name = "BROKEN-METADATA"
+    description = "Metadata comment is not formatted correctly"
+
+
+class Regexp(Rule):
+    pattern = None
+    file_extensions = None
+    _re = None
+
+    def __init__(self):
+        self._re = re.compile(self.pattern)
+
+    def applies(self, path):
+        return (self.file_extensions is None or
+                os.path.splitext(path)[1] in self.file_extensions)
+
+    def search(self, line):
+        return self._re.search(line)
+
+
+class TabsRegexp(Regexp):
+    pattern = b"^\t"
+    name = "INDENT TABS"
+    description = "Tabs used for indentation"
+
+class CRRegexp(Regexp):
+    pattern = b"\r$"
+    name = "CR AT EOL"
+    description = "CR character in line separator"
+
+class SetTimeoutRegexp(Regexp):
+    pattern = br"setTimeout\s*\("
+    name = "SET TIMEOUT"
+    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    description = "setTimeout used; step_timeout should typically be used instead"
+
+class W3CTestOrgRegexp(Regexp):
+    pattern = br"w3c\-test\.org"
+    name = "W3C-TEST.ORG"
+    description = "External w3c-test.org domain used"
+
+class WebPlatformTestRegexp(Regexp):
+    pattern = br"web\-platform\.test"
+    name = "WEB-PLATFORM.TEST"
+    description = "Internal web-platform.test domain used"
+
+class Webidl2Regexp(Regexp):
+    pattern = br"webidl2\.js"
+    name = "WEBIDL2.JS"
+    description = "Legacy webidl2.js script used"
+
+class ConsoleRegexp(Regexp):
+    pattern = br"console\.[a-zA-Z]+\s*\("
+    name = "CONSOLE"
+    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    description = "Console logging API used"
+
+class GenerateTestsRegexp(Regexp):
+    pattern = br"generate_tests\s*\("
+    name = "GENERATE_TESTS"
+    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    description = "generate_tests used"
+
+class PrintRegexp(Regexp):
+    pattern = br"print(?:\s|\s*\()"
+    name = "PRINT STATEMENT"
+    file_extensions = [".py"]
+    description = "Print function used"
+
+class LayoutTestsRegexp(Regexp):
+    pattern = br"eventSender|testRunner|window\.internals"
+    name = "LAYOUTTESTS APIS"
+    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    description = "eventSender/testRunner/window.internals used; these are LayoutTests-specific APIs (WebKit/Blink)"
+
+class SpecialPowersRegexp(Regexp):
+    pattern = b"SpecialPowers"
+    name = "SPECIALPOWERS API"
+    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    description = "SpecialPowers used; this is gecko-specific and not supported in wpt"
+
+class TrailingWhitespaceRegexp(Regexp):
+    name = "TRAILING WHITESPACE"
+    description = "Whitespace at EOL"
+    pattern = b"[ \t\f\v]$"
+    to_fix = """Remove trailing whitespace from all lines in the file."""

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -560,7 +560,7 @@ def test_variant_missing():
 
 
 # A corresponding "positive" test cannot be written because the manifest
-# SourceFile implementation raises a runtime error for the condition this
+# SourceFile implementation raises a runtime exception for the condition this
 # linting rule describes
 @pytest.mark.parametrize("content", ["",
                                      "?"

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -296,6 +296,79 @@ def test_multiple_testharnessreport():
             ]
 
 
+def test_multiple_testdriver():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("MULTIPLE-TESTDRIVER", "More than one <script src='/resources/testdriver.js'>", filename, None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_multiple_testdriver_vendor():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("MULTIPLE-TESTDRIVER-VENDOR", "More than one <script src='/resources/testdriver-vendor.js'>", filename, None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
+def test_missing_testdriver_vendor():
+    code = b"""
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind in ["web-lax", "web-strict"]:
+            assert errors == [
+                ("MISSING-TESTDRIVER-VENDOR", "Missing <script src='/resources/testdriver-vendor.js'>", filename, None),
+            ]
+        elif kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 2),
+            ]
+
+
 def test_present_testharnesscss():
     code = b"""
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -373,12 +446,81 @@ def test_testharnessreport_path():
         assert errors == expected
 
 
+def test_testdriver_path():
+    code = b"""\
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="testdriver.js"></script>
+<script src="/elsewhere/testdriver.js"></script>
+<script src="/elsewhere/resources/testdriver.js"></script>
+<script src="/resources/elsewhere/testdriver.js"></script>
+<script src="../resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        expected = []
+        if kind == "python":
+            expected.append(("PARSE-FAILED", "Unable to parse file", filename, 1))
+        elif kind in ["web-lax", "web-strict"]:
+            expected.extend([
+                ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),
+                ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),
+                ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),
+                ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None),
+                ("TESTDRIVER-PATH", "testdriver.js script seen with incorrect path", filename, None)
+            ])
+        assert errors == expected
+
+
+def test_testdriver_vendor_path():
+    code = b"""\
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="testdriver-vendor.js"></script>
+<script src="/elsewhere/testdriver-vendor.js"></script>
+<script src="/elsewhere/resources/testdriver-vendor.js"></script>
+<script src="/resources/elsewhere/testdriver-vendor.js"></script>
+<script src="../resources/testdriver-vendor.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind == "python":
+            expected = set([("PARSE-FAILED", "Unable to parse file", filename, 1)])
+        elif kind in ["web-lax", "web-strict"]:
+            expected = set([
+                ("MISSING-TESTDRIVER-VENDOR", "Missing <script src='/resources/testdriver-vendor.js'>", filename, None),
+                ("TESTDRIVER-VENDOR-PATH", "testdriver-vendor.js script seen with incorrect path", filename, None),
+                ("TESTDRIVER-VENDOR-PATH", "testdriver-vendor.js script seen with incorrect path", filename, None),
+                ("TESTDRIVER-VENDOR-PATH", "testdriver-vendor.js script seen with incorrect path", filename, None),
+                ("TESTDRIVER-VENDOR-PATH", "testdriver-vendor.js script seen with incorrect path", filename, None),
+                ("TESTDRIVER-VENDOR-PATH", "testdriver-vendor.js script seen with incorrect path", filename, None)
+            ])
+        else:
+            expected = set()
+
+        assert set(errors) == expected
+
+
 def test_not_testharness_path():
     code = b"""\
 <html xmlns="http://www.w3.org/1999/xhtml">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/webperftestharness.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 </html>
 """
     error_map = check_with_files(code)
@@ -392,6 +534,79 @@ def test_not_testharness_path():
             ]
         else:
             assert errors == []
+
+
+def test_variant_missing():
+    code = b"""\
+<html xmlns="http://www.w3.org/1999/xhtml">
+<meta name="variant">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 1),
+            ]
+        elif kind == "web-lax":
+            assert errors == [
+                ("VARIANT-MISSING", "<meta name=variant> missing 'content' attribute", filename, None)
+            ]
+
+
+# A corresponding "positive" test cannot be written because the manifest
+# SourceFile implementation raises a runtime error for the condition this
+# linting rule describes
+@pytest.mark.parametrize("content", ["",
+                                     "?"
+                                     "#"])
+def test_variant_malformed_negative(content):
+    code = """\
+<html xmlns="http://www.w3.org/1999/xhtml">
+<meta name="variant" content="{}">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</html>
+""".format(content).encode("utf-8")
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 1),
+            ]
+        elif kind == "web-lax":
+            assert errors == []
+
+
+def test_late_timeout():
+    code = b"""\
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<meta name="timeout" content="long">
+<script src="/resources/testharnessreport.js"></script>
+</html>
+"""
+    error_map = check_with_files(code)
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind == "python":
+            assert errors == [
+                ("PARSE-FAILED", "Unable to parse file", filename, 1),
+            ]
+        elif kind == "web-lax":
+            assert errors == [
+                ("LATE-TIMEOUT", "<meta name=timeout> seen after testharness.js script", filename, None)
+            ]
 
 
 @pytest.mark.skipif(six.PY3, reason="Cannot parse print statements from python 3")

--- a/tools/lint/tests/test_path_lints.py
+++ b/tools/lint/tests/test_path_lints.py
@@ -38,3 +38,61 @@ def test_forbidden_path_endings(path_ending, generated):
     errors = check_path("/foo/", path)
     check_errors(errors)
     assert errors == [("WORKER COLLISION", message, path, None)]
+
+
+@pytest.mark.parametrize("path", ["ahem.ttf",
+                                  "Ahem.ttf",
+                                  "ahem.tTf",
+                                  "not-ahem.ttf",
+                                  "support/ahem.ttf",
+                                  "ahem/other.ttf"])
+def test_ahem_copy(path):
+    expected_error = ("AHEM COPY",
+                      "Don't add extra copies of Ahem, use /fonts/Ahem.ttf",
+                      path,
+                      None)
+
+    errors = check_path("/foo/", path)
+
+    assert errors == [expected_error]
+
+@pytest.mark.parametrize("path", ["ahem.woff",
+                                  "ahem.ttff",
+                                  "support/ahem.woff",
+                                  "ahem/other.woff"])
+def test_ahem_copy_negative(path):
+    errors = check_path("/foo/", path)
+
+    assert errors == []
+
+@pytest.mark.parametrize("path", ["elsewhere/.gitignore",
+                                  "else/where/.gitignore"
+                                  "elsewhere/tools/.gitignore",
+                                  "elsewhere/docs/.gitignore",
+                                  "elsewhere/resources/webidl2/.gitignore",
+                                  "elsewhere/css/tools/apiclient/.gitignore"])
+def test_gitignore_file(path):
+    expected_error = ("GITIGNORE",
+                      ".gitignore found outside the root",
+                      path,
+                      None)
+
+    errors = check_path("/foo/", path)
+
+    assert errors == [expected_error]
+
+@pytest.mark.parametrize("path", [".gitignore",
+                                  "elsewhere/.gitignores",
+                                  "elsewhere/name.gitignore",
+                                  "tools/.gitignore",
+                                  "tools/elsewhere/.gitignore",
+                                  "docs/.gitignore"
+                                  "docs/elsewhere/.gitignore",
+                                  "resources/webidl2/.gitignore",
+                                  "resources/webidl2/elsewhere/.gitignore",
+                                  "css/tools/apiclient/.gitignore",
+                                  "css/tools/apiclient/elsewhere/.gitignore"])
+def test_gitignore_negative(path):
+    errors = check_path("/foo/", path)
+
+    assert errors == []


### PR DESCRIPTION
As described in gh-15824, we're revamping WPT's documentation in a fork of the project. We'd like to automatically generate rules for the project's linter, and that requires some change to the source code. In [the initial proposal for that improvement](https://github.com/bocoup/wpt-docs/pull/15), @jgraham wrote:

> This approach looks good. Please endeavour to land the lint changes upstream rather than in a docs branch, even if the motivating documentation isn't ready yet, otherwise there's a severe chance of conflicts which in this case would likely lead to regressing whole lint rules.

This is the requested change.

Because not all rules are backed with unit tests, the first commit in this patch improves coverage. Two rules remain uncovered:

- `IGNORED PATH` - because this rule integrates with git and the filesystem, testing it effectively is non-trivial
- `MALFORMED-VARIANT` - [the application code has an assertion guarding against this
  case](https://github.com/web-platform-tests/wpt/blob/055bf244474e8b0f0302555f41d9723e34dfde19/tools/manifest/sourcefile.py#L562-L563) which resists attempts to test. Should we change the assertion to a `raise` and remove the linting rule?