### PR TITLE
[testharness.js] Sanitize unpaired surrogates

### DIFF
--- a/resources/test/tests/unit/unpaired-surrogates.html
+++ b/resources/test/tests/unit/unpaired-surrogates.html
@@ -1,0 +1,138 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <title>Restrictions on return value from `test`</title>
+</head>
+<body>
+<script>
+function makeTest(...bodies) {
+  const closeScript = '<' + '/script>';
+  let src = `
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Document title</title>
+<script src="/resources/testharness.js?${Math.random()}">${closeScript}
+</head>
+
+<body>
+<div id="log"></div>`;
+  bodies.forEach((body) => {
+    src += '<script>(' + body + ')();' + closeScript;
+  });
+
+  const iframe = document.createElement('iframe');
+
+  document.body.appendChild(iframe);
+  iframe.contentDocument.write(src);
+
+  return new Promise((resolve) => {
+    window.addEventListener('message', function onMessage(e) {
+      if (e.source !== iframe.contentWindow) {
+        return;
+      }
+      if (!e.data || e.data.type !=='complete') {
+        return;
+      }
+      window.removeEventListener('message', onMessage);
+      resolve(e.data);
+    });
+
+    iframe.contentDocument.close();
+  }).then(({ tests, status }) => {
+    const summary = {
+      harness: {
+        status: getEnumProp(status, status.status),
+        message: status.message
+      },
+      tests: {}
+    };
+
+    tests.forEach((test) => {
+      summary.tests[test.name] = getEnumProp(test, test.status);
+    });
+
+    return summary;
+  });
+}
+
+function getEnumProp(object, value) {
+  for (let property in object) {
+    if (!/^[A-Z]+$/.test(property)) {
+      continue;
+    }
+
+    if (object[property] === value) {
+      return property;
+    }
+  }
+}
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        test(() => {}, 'before');
+        test(() => {}, 'U+d7ff is not modified: \ud7ff');
+        test(() => {}, 'U+e000 is not modified: \ue000');
+        test(() => {}, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness.status, 'OK');
+      assert_equals(harness.message, null);
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests['U+d7ff is not modified: \ud7ff'], 'PASS');
+      assert_equals(tests['U+e000 is not modified: \ue000'], 'PASS');
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'sub-test names which include valid code units');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        test(() => {}, 'before');
+        test(() => {}, 'U+d800U+dfff is not modified: \ud800\udfff');
+        test(() => {}, 'U+dbffU+dc00 is not modified: \udbff\udc00');
+        test(() => {}, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness.status, 'OK');
+      assert_equals(harness.message, null);
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests['U+d800U+dfff is not modified: \ud800\udfff'], 'PASS');
+      assert_equals(tests['U+dbffU+dc00 is not modified: \udbff\udc00'], 'PASS');
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'sub-test names which include paired surrogates');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        test(() => {}, 'before');
+        test(() => {}, 'U+d800 must be sanitized: \ud800');
+        test(() => {}, 'U+d800U+d801 must be sanitized: \ud800\ud801');
+        test(() => {}, 'U+dfff must be sanitized: \udfff');
+        test(() => {}, 'U+dc00U+d800U+dc00U+d800 must be sanitized: \udc00\ud800\udc00\ud800');
+        test(() => {}, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness.status, 'OK');
+      assert_equals(harness.message, null);
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests['U+d800 must be sanitized: U+d800'], 'PASS');
+      assert_equals(tests['U+dfff must be sanitized: U+dfff'], 'PASS');
+      assert_equals(
+        tests['U+d800U+d801 must be sanitized: U+d800U+d801'],
+        'PASS'
+      );
+      assert_equals(
+        tests['U+dc00U+d800U+dc00U+d800 must be sanitized: U+dc00\ud800\udc00U+d800'],
+        'PASS'
+      );
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'sub-test names which include unpaired surrogates');
+</script>
+</body>
+</html>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2383,12 +2383,53 @@ policies and contribution forms [3].
         return duplicates;
     };
 
+    function code_unit_str(char) {
+        return 'U+' + char.charCodeAt(0).toString(16);
+    }
+
+    function sanitize_unpaired_surrogates(str) {
+        return str.replace(/([\ud800-\udbff])(?![\udc00-\udfff])/g,
+                           function(_, unpaired)
+                           {
+                               return code_unit_str(unpaired);
+                           })
+                  // This replacement is intentionally implemented without a
+                  // negative lookbehind assertion in the interest of
+                  // portability.
+                  .replace(/(^|[^\ud800-\udbff])([\udc00-\udfff])/g,
+                           function(_, previous, unpaired) {
+                              if (/[\udc00-\udfff]/.test(previous)) {
+                                  previous = code_unit_str(previous);
+                              }
+
+                              return previous + code_unit_str(unpaired);
+                           });
+    }
+
+    function sanitize_all_unpaired_surrogates(tests) {
+        forEach (tests,
+                 function (test)
+                 {
+                     var sanitized = sanitize_unpaired_surrogates(test.name);
+
+                     if (test.name !== sanitized) {
+                         test.name = sanitized;
+                         delete test._structured_clone;
+                     }
+                 });
+    }
+
     Tests.prototype.notify_complete = function() {
         var this_obj = this;
         var duplicates;
 
         if (this.status.status === null) {
             duplicates = this.find_duplicates();
+
+            // Some transports adhere to UTF-8's restriction on unpaired
+            // surrogates. Sanitize the titles so that the results can be
+            // consistently sent via all transports.
+            sanitize_all_unpaired_surrogates(this.tests);
 
             // Test names are presumed to be unique within test files--this
             // allows consumers to use them for identification purposes.

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2393,9 +2393,9 @@ policies and contribution forms [3].
                            {
                                return code_unit_str(unpaired);
                            })
-                  // This replacement is intentionally implemented without a
-                  // negative lookbehind assertion in the interest of
-                  // portability.
+                  // This replacement is intentionally implemented without an
+                  // ES2018 negative lookbehind assertion to support runtimes
+                  // which do not yet implement that language feature.
                   .replace(/(^|[^\ud800-\udbff])([\udc00-\udfff])/g,
                            function(_, previous, unpaired) {
                               if (/[\udc00-\udfff]/.test(previous)) {


### PR DESCRIPTION
@jgraham @gsnedders Here's what's changed since your review of gh-16253:

- sub-test titles with invalid UTF-8 no longer trigger a harness error
- the mechanism for detecting and replacing unpaired surrogates is correct (and supported by additional unit tests)
- the internal functions are no longer defined on the `Tests` prototype (making the input easier to identify)
- the original sub-test titles in `webstorage/storage_setitem.html` are restored