### PR TITLE
[css-text-decor] Add text-decoration-style tests

### DIFF
--- a/css/css-text-decor/text-decoration-style-009-manual.html
+++ b/css/css-text-decor/text-decoration-style-009-manual.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style solid</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:solid; there is a solid line below the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:solid;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a solid line below the characters.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-010-manual.html
+++ b/css/css-text-decor/text-decoration-style-010-manual.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style double</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:double; there is a double solid line below the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:double;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a double solid line below the characters.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-011-manual.html
+++ b/css/css-text-decor/text-decoration-style-011-manual.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style dashed</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:dashed; there is a dashed line below the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:dashed;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a dashed line below the characters.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-012-manual.html
+++ b/css/css-text-decor/text-decoration-style-012-manual.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style dotted</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:dotted; there is a dotted line below the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:dotted;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a dotted line below the characters.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-014-manual.html
+++ b/css/css-text-decor/text-decoration-style-014-manual.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style wavy</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:wavy; there is a wavy line below the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:wavy;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a wavy line below the characters.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown fox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-060-manual.html
+++ b/css/css-text-decor/text-decoration-style-060-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style solid tbrl</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:solid; there is a solid vertical line on one side of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:solid;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a solid vertical line on one side of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-061-manual.html
+++ b/css/css-text-decor/text-decoration-style-061-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style double tbrl</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:double; there is a solid vertical double line on one side of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:double;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a solid vertical double line on one side of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-062-manual.html
+++ b/css/css-text-decor/text-decoration-style-062-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style dashed tbrl</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:dashed; there is a dashed vertical line on one side of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:dashed;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a dashed vertical line on one side of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-063-manual.html
+++ b/css/css-text-decor/text-decoration-style-063-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style dotted tbrl</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:dotted; there is a dotted vertical line on one side of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:dotted;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a dotted vertical line on one side of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-064-manual.html
+++ b/css/css-text-decor/text-decoration-style-064-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style wavy tbrl</title>
+<meta name="assert" content="text-decoration:underline; text-decoration-style:wavy; there is a wavy vertical line on one side of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-decoration-style:wavy;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a wavy vertical line on one side of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-decoration-style-065-manual.html
+++ b/css/css-text-decor/text-decoration-style-065-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-decoration-style overline dashed tbrl</title>
+<meta name="assert" content="text-decoration:overline; text-decoration-style:dashed; there is a dashed vertical line on one side of the characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:overline;
+text-decoration-style:dashed;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if there is a dashed vertical line on one side of the characters.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能引發網絡的全部潛能</span></p>
+</div>  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR ports https://w3c.github.io/i18n-tests/results/line-decoration#text_dec_style to WPT. Currently, the tests are manual tests, since we're unable to come up with a way to automate them.

The `-009-` and `-01X-` tests are in horizontal writing mode, and the `-06X-` tests are in `vertical-rl`.

I didn't include the exploratory tests.

/cc @r12a
