### PR TITLE
Optimise webnfc NFCReader option tests

### DIFF
--- a/web-nfc/NFCReader_options_recordType_empty-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_empty-manual.https.html
@@ -21,11 +21,11 @@
 
 setup({ explicit_timeout: true });
 
-const desc = "Test that write and read data succeed when recordType is set to 'empty'.";
+const desc = "Test that write and read data succeed when NFCReaderOptions's recordType is set to 'empty'.";
 const readOptions = {recordType: "empty"};
-const invalidReadOptions = {recordType: "json"};
+const unacceptableReadOptions = {recordType: "json"};
 const message = createMessage([createRecord('empty', '')]);
 
-testNDEFMessage(message, readOptions, invalidReadOptions, desc);
+testNFCReaderOptions(message, readOptions, unacceptableReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_recordType_empty-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_empty-manual.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Web NFC Test: write and read opaque records</title>
+<title>Web NFC Test: write and read empty records</title>
 <link rel="author" title="Intel" href="http://www.intel.com"/>
 <link rel="help" href="https://w3c.github.io/web-nfc/"/>
 <meta name="timeout" content="long">
@@ -21,14 +21,11 @@
 
 setup({ explicit_timeout: true });
 
-const desc = "Test that write and read data succeed when recordType is set to 'opaque'."
-const readOptions = {
-  recordType : "opaque",
-  mediaType : "application/octet-stream",
-  url : ""
-}
-const message = createMessage([createOpaqueRecord(test_buffer_data)]);
+const desc = "Test that write and read data succeed when recordType is set to 'empty'.";
+const readOptions = {recordType: "empty"};
+const invalidReadOptions = {recordType: "json"};
+const message = createMessage([createRecord('empty', '')]);
 
-testNDEFMessage(message, readOptions, desc);
+testNDEFMessage(message, readOptions, invalidReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_recordType_json-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_json-manual.https.html
@@ -21,11 +21,11 @@
 
 setup({ explicit_timeout: true });
 
-const desc = "Test that write and read data succeed when recordType is set to 'json'.";
+const desc = "Test that write and read data succeed when NFCReaderOptions's recordType is set to 'json'.";
 const readOptions = {recordType : "json"};
-const invalidReadOptions = {recordType: "url"};
+const unacceptableReadOptions = {recordType: "url"};
 const message = createMessage([createJsonRecord(test_json_data)]);
 
-testNDEFMessage(message, readOptions, invalidReadOptions, desc);
+testNFCReaderOptions(message, readOptions, unacceptableReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_recordType_json-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_json-manual.https.html
@@ -22,13 +22,10 @@
 setup({ explicit_timeout: true });
 
 const desc = "Test that write and read data succeed when recordType is set to 'json'.";
-const readOptions = {
-  recordType : "json",
-  mediaType : "application/json",
-  url : ""
-}
+const readOptions = {recordType : "json"};
+const invalidReadOptions = {recordType: "url"};
 const message = createMessage([createJsonRecord(test_json_data)]);
 
-testNDEFMessage(message, readOptions, desc);
+testNDEFMessage(message, readOptions, invalidReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_recordType_json-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_json-manual.https.html
@@ -22,7 +22,7 @@
 setup({ explicit_timeout: true });
 
 const desc = "Test that write and read data succeed when NFCReaderOptions's recordType is set to 'json'.";
-const readOptions = {recordType : "json"};
+const readOptions = {recordType: "json"};
 const unacceptableReadOptions = {recordType: "url"};
 const message = createMessage([createJsonRecord(test_json_data)]);
 

--- a/web-nfc/NFCReader_options_recordType_opaque-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_opaque-manual.https.html
@@ -21,11 +21,11 @@
 
 setup({ explicit_timeout: true });
 
-const desc = "Test that write and read data succeed when recordType is set to 'opaque'.";
+const desc = "Test that write and read data succeed when NFCReaderOptions's recordType is set to 'opaque'.";
 const readOptions = {recordType : "opaque"};
-const invalidReadOptions = {recordType: "json"};
+const unacceptableReadOptions = {recordType: "json"};
 const message = createMessage([createOpaqueRecord(test_buffer_data)]);
 
-testNDEFMessage(message, readOptions, invalidReadOptions, desc);
+testNFCReaderOptions(message, readOptions, unacceptableReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_recordType_opaque-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_opaque-manual.https.html
@@ -22,7 +22,7 @@
 setup({ explicit_timeout: true });
 
 const desc = "Test that write and read data succeed when NFCReaderOptions's recordType is set to 'opaque'.";
-const readOptions = {recordType : "opaque"};
+const readOptions = {recordType: "opaque"};
 const unacceptableReadOptions = {recordType: "json"};
 const message = createMessage([createOpaqueRecord(test_buffer_data)]);
 

--- a/web-nfc/NFCReader_options_recordType_opaque-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_opaque-manual.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Web NFC Test: write and read empty records</title>
+<title>Web NFC Test: write and read opaque records</title>
 <link rel="author" title="Intel" href="http://www.intel.com"/>
 <link rel="help" href="https://w3c.github.io/web-nfc/"/>
 <meta name="timeout" content="long">
@@ -21,14 +21,11 @@
 
 setup({ explicit_timeout: true });
 
-const desc = "Test that write and read data succeed when recordType is set to 'empty'.";
-const readOptions = {
-  recordType: "empty",
-  mediaType: "",
-  url: ""
-}
-const message = createMessage([createRecord('empty', '')]);
+const desc = "Test that write and read data succeed when recordType is set to 'opaque'.";
+const readOptions = {recordType : "opaque"};
+const invalidReadOptions = {recordType: "json"};
+const message = createMessage([createOpaqueRecord(test_buffer_data)]);
 
-testNDEFMessage(message, readOptions, desc);
+testNDEFMessage(message, readOptions, invalidReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_recordType_text-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_text-manual.https.html
@@ -21,11 +21,11 @@
 
 setup({ explicit_timeout: true });
 
-const desc = "Test that write and read data succeed when recordType is set to 'text'.";
+const desc = "Test that write and read data succeed when NFCReaderOptions's recordType is set to 'text'.";
 const readOptions = {recordType : "text"};
-const invalidReadOptions = {recordType: "json"};
+const unacceptableReadOptions = {recordType: "json"};
 const message = createMessage([createTextRecord(test_text_data)]);
 
-testNDEFMessage(message, readOptions, invalidReadOptions, desc);
+testNFCReaderOptions(message, readOptions, unacceptableReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_recordType_text-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_text-manual.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Web NFC Test: write and read url records</title>
+<title>Web NFC Test: write and read text records</title>
 <link rel="author" title="Intel" href="http://www.intel.com"/>
 <link rel="help" href="https://w3c.github.io/web-nfc/"/>
 <meta name="timeout" content="long">
@@ -21,15 +21,11 @@
 
 setup({ explicit_timeout: true });
 
-const test_message_origin = window.location.href.origin;
-const desc = "Test that write and read data succeed when recordType is set to 'url'.";
-const readOptions = {
-  recordType: "url",
-  mediaType: "text/plain",
-  url: test_message_origin
-}
-const message = createMessage([createUrlRecord(test_url_data)]);
+const desc = "Test that write and read data succeed when recordType is set to 'text'.";
+const readOptions = {recordType : "text"};
+const invalidReadOptions = {recordType: "json"};
+const message = createMessage([createTextRecord(test_text_data)]);
 
-testNDEFMessage(message, readOptions, desc);
+testNDEFMessage(message, readOptions, invalidReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_recordType_text-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_text-manual.https.html
@@ -22,7 +22,7 @@
 setup({ explicit_timeout: true });
 
 const desc = "Test that write and read data succeed when NFCReaderOptions's recordType is set to 'text'.";
-const readOptions = {recordType : "text"};
+const readOptions = {recordType: "text"};
 const unacceptableReadOptions = {recordType: "json"};
 const message = createMessage([createTextRecord(test_text_data)]);
 

--- a/web-nfc/NFCReader_options_recordType_url-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_url-manual.https.html
@@ -21,11 +21,11 @@
 
 setup({ explicit_timeout: true });
 
-const desc = "Test that write and read data succeed when recordType is set to 'url'.";
+const desc = "Test that write and read data succeed when NFCReaderOptions's recordType is set to 'url'.";
 const readOptions = {recordType: "url"};
-const invalidReadOptions = {recordType: "json"};
+const unacceptableReadOptions = {recordType: "json"};
 const message = createMessage([createUrlRecord(test_url_data)]);
 
-testNDEFMessage(message, readOptions, invalidReadOptions, desc);
+testNFCReaderOptions(message, readOptions, unacceptableReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_recordType_url-manual.https.html
+++ b/web-nfc/NFCReader_options_recordType_url-manual.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Web NFC Test: write and read text records</title>
+<title>Web NFC Test: write and read url records</title>
 <link rel="author" title="Intel" href="http://www.intel.com"/>
 <link rel="help" href="https://w3c.github.io/web-nfc/"/>
 <meta name="timeout" content="long">
@@ -21,14 +21,11 @@
 
 setup({ explicit_timeout: true });
 
-const desc = "Test that write and read data succeed when recordType is set to 'text'."
-const readOptions = {
-  recordType : "text",
-  mediaType : "text/plain",
-  url : ""
-}
-const message = createMessage([createTextRecord(test_text_data)]);
+const desc = "Test that write and read data succeed when recordType is set to 'url'.";
+const readOptions = {recordType: "url"};
+const invalidReadOptions = {recordType: "json"};
+const message = createMessage([createUrlRecord(test_url_data)]);
 
-testNDEFMessage(message, readOptions, desc);
+testNDEFMessage(message, readOptions, invalidReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_url-manual.https.html
+++ b/web-nfc/NFCReader_options_url-manual.https.html
@@ -6,6 +6,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="resources/nfc_help.js"></script>
 <meta name="flags" content="interact">
 
 <p>Tap an NFC tag to the test device with NFC support.</p>
@@ -20,25 +21,14 @@
 
 setup({ explicit_timeout: true });
 
-promise_test(async t => {
-  const writer = new NFCWriter();
-  const reader1 = new NFCReader({url: `${location.origin}/custom/invalid`});
-  const reader2 = new NFCReader({url: `${location.origin}/custom/path`});
-  await writer.push({
-    url: "/custom/path/update",
-    records: [{ recordType: "text", data: "valid" }]
-  });
+const desc = "Test that the url of NFCReaderOptions filters relevant data sources correctly.";
+const readOptions = {url: `${location.origin}/custom/path`};
+const invalidReadOptions = {url: `${location.origin}/custom/invalid`};
+const message = {
+  url: "/custom/path/update",
+  records: [createTextRecord(test_text_data)]
+}
 
-  reader1.onreading = t.unreached_func("reading event should not be fired.");
-  reader1.start();
-
-  const readerWatcher = new EventWatcher(t, reader2, ["reading", "error"]);
-  reader2.start();
-  const event = await readerWatcher.wait_for("reading");
-  const message = event.message;
-  assert_equals(message.records[0].recordType, "text");
-  assert_equals(message.records[0].data, "valid");
-  assert_equals(message.url, `${location.origin}/custom/path/update`);
-}, "Test that the url of NFCReaderOptions filters relevant data sources correctly.");
+testNDEFMessage(message, readOptions, invalidReadOptions, desc);
 
 </script>

--- a/web-nfc/NFCReader_options_url-manual.https.html
+++ b/web-nfc/NFCReader_options_url-manual.https.html
@@ -23,12 +23,12 @@ setup({ explicit_timeout: true });
 
 const desc = "Test that the url of NFCReaderOptions filters relevant data sources correctly.";
 const readOptions = {url: `${location.origin}/custom/path`};
-const invalidReadOptions = {url: `${location.origin}/custom/invalid`};
+const unacceptableReadOptions = {url: `${location.origin}/custom/invalid`};
 const message = {
   url: "/custom/path/update",
   records: [createTextRecord(test_text_data)]
 }
 
-testNDEFMessage(message, readOptions, invalidReadOptions, desc);
+testNFCReaderOptions(message, readOptions, unacceptableReadOptions, desc);
 
 </script>

--- a/web-nfc/resources/nfc_help.js
+++ b/web-nfc/resources/nfc_help.js
@@ -67,10 +67,10 @@ function assertWebNDEFMessagesEqual(a, b) {
   }
 }
 
-function testNDEFMessage(pushedMessage, readOptions, invalidReadOptions, desc) {
+function testNFCReaderOptions(pushedMessage, readOptions, unacceptableReadOptions, desc) {
   promise_test(async t => {
     const writer = new NFCWriter();
-    const reader1 = new NFCReader(invalidReadOptions);
+    const reader1 = new NFCReader(unacceptableReadOptions);
     const reader2 = new NFCReader(readOptions);
     await writer.push(pushedMessage);
 

--- a/web-nfc/resources/nfc_help.js
+++ b/web-nfc/resources/nfc_help.js
@@ -48,6 +48,7 @@ function createUrlRecord(url) {
 }
 
 function assertWebNDEFMessagesEqual(a, b) {
+  if (b.url) assert_equals(a.url, `${location.origin}${b.url}`);
   assert_equals(a.records.length, b.records.length);
   for(let i in a.records) {
     let recordA = a.records[i];
@@ -59,21 +60,25 @@ function assertWebNDEFMessagesEqual(a, b) {
           new Uint8Array(recordB.data));
     } else if (typeof recordA.data === 'object') {
       assert_object_equals(recordA.data, recordB.data);
-    }
-    if (typeof recordA.data === 'number'
+    } else if (typeof recordA.data === 'number'
         || typeof recordA.data === 'string') {
       assert_true(recordA.data == recordB.data);
     }
   }
 }
 
-function testNDEFMessage(pushedMessage, readOptions, desc) {
+function testNDEFMessage(pushedMessage, readOptions, invalidReadOptions, desc) {
   promise_test(async t => {
     const writer = new NFCWriter();
-    const reader = new NFCReader(readOptions);
+    const reader1 = new NFCReader(invalidReadOptions);
+    const reader2 = new NFCReader(readOptions);
     await writer.push(pushedMessage);
-    const readerWatcher = new EventWatcher(t, reader, ["reading", "error"]);
-    reader.start();
+
+    reader1.onreading = t.unreached_func("reading event should not be fired.");
+    reader1.start();
+
+    const readerWatcher = new EventWatcher(t, reader2, ["reading", "error"]);
+    reader2.start();
     const event = await readerWatcher.wait_for("reading");
     assertWebNDEFMessagesEqual(event.message, pushedMessage);
   }, desc);


### PR DESCRIPTION
- Add the checkpoint of invalid `recordType` option.
- Use common function to test `url/recordType` option.
- Remove `mediaType/url` in `readOptions`.
- Modify the `else if` structure in nfc_help.js `assertWebNDEFMessagesEqual` function.