### PR TITLE
[css-text-decor] Add text-underline-position tests

### DIFF
--- a/css/css-text-decor/text-underline-position-019-manual.html
+++ b/css/css-text-decor/text-underline-position-019-manual.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position auto</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:auto; the underline is placed at or under the alphabetic baseline, unless the script works better with a line further from the baseline">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+:lang(ja) { font-family: "Hiragino Maru Gothic Pro", "MS Mincho", sans-serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:auto;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the underline is placed at or under the alphabetic baseline, unless the script works better with a line further from the baseline.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درس</span><span>تی جهانی سازیم!</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာ</span><span>လှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้ง</span><span>อยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འ</span><span>བད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को स</span><span>चमुच विश्वव्यापी बना रहें हैं !</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-underline-position-020-manual.html
+++ b/css/css-text-decor/text-underline-position-020-manual.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position under</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:under; the underline is low enough to avoid crossing the descenders">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+:lang(ja) { font-family: "Hiragino Maru Gothic Pro", "MS Mincho", sans-serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:under;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the underline is low enough to avoid crossing the descenders.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درس</span><span>تی جهانی سازیم!</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာ</span><span>လှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้ง</span><span>อยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འ</span><span>བད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को स</span><span>चमुच विश्वव्यापी बना रहें हैं !</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-underline-position-021-manual.html
+++ b/css/css-text-decor/text-underline-position-021-manual.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position under left</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:under left; the underline is low enough to avoid crossing the descenders">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+:lang(ja) { font-family: "Hiragino Maru Gothic Pro", "MS Mincho", sans-serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:under left;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the underline is low enough to avoid crossing the descenders.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درس</span><span>تی جهانی سازیم!</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာ</span><span>လှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้ง</span><span>อยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འ</span><span>བད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को स</span><span>चमुच विश्वव्यापी बना रहें हैं !</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-underline-position-022-manual.html
+++ b/css/css-text-decor/text-underline-position-022-manual.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position under right</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:under right; the underline is low enough to avoid crossing the descenders">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+:lang(ja) { font-family: "Hiragino Maru Gothic Pro", "MS Mincho", sans-serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:under right;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the underline is low enough to avoid crossing the descenders.</p>
+<div id="htmlsrc">
+
+<div>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درس</span><span>تی جهانی سازیم!</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာ</span><span>လှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้ง</span><span>อยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འ</span><span>བད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को स</span><span>चमुच विश्वव्यापी बना रहें हैं !</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-underline-position-071-manual.html
+++ b/css/css-text-decor/text-underline-position-071-manual.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position tbrl auto vertical-rl</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:auto; the underline is placed alongside the characters, and may or may not cross any descenders">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:auto;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the underline is placed alongside the characters - it may or may not cross any descenders.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درس</span><span>تی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာ</span><span>လှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้ง</span><span>อยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འ</span><span>བད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को स</span><span>चमुच विश्वव्यापी बना रहें हैं !</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-underline-position-072-manual.html
+++ b/css/css-text-decor/text-underline-position-072-manual.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position under vertical-rl</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:under; the line is far enough away to avoid crossing any descenders">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:under;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the line is far enough away to avoid crossing any descenders.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+<p lang="ar"><span>وب جهانی را به‌درس</span><span>تی جهانی سازیم!</span></p>
+<p lang="my"><span>အပြည်ပြည်ဆိုင်ရာ</span><span>လှုပ်ရှားမှု၊</span></p>
+<p lang="th"><span>กูกินกุ้งปิ้ง</span><span>อยู่ในถ้ำ กูกินกุ้งปิ้งอยู่ในถ้ำ</span></p>
+<p lang="bo"><span>འཛམ་གླིང་ཡོངས་འབྲེལ་འདི་ ངོ་མ་འ</span><span>བད་རང་ འཛམ་གླིང་ཡོངས་ལུ་ཁྱབ་ཚུགསཔ་བཟོ་བ།</span></p>
+<p lang="hi"><span>वर्ल्ड वाईड वेब को स</span><span>चमुच विश्वव्यापी बना रहें हैं !</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-underline-position-073-manual.html
+++ b/css/css-text-decor/text-underline-position-073-manual.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position left vertical-rl</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:left; the line is to the left of the characters for all lines">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:left;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the line is to the LEFT of the characters for all lines.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-underline-position-074-manual.html
+++ b/css/css-text-decor/text-underline-position-074-manual.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position under left vertical-rl</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:under left; the line is to the left of the characters for all lines">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:under left;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the line is to the LEFT of the characters for all lines.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-underline-position-075-manual.html
+++ b/css/css-text-decor/text-underline-position-075-manual.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position right vertical-rl</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:right; the line is to the right of the characters for all lines">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:right;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the line is to the RIGHT of the characters for all lines.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-underline-position-076-manual.html
+++ b/css/css-text-decor/text-underline-position-076-manual.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-underline-position under right vertical-rl</title>
+<meta name="assert" content="text-decoration:underline; text-underline-position:under right; the line is to the right of the characters for all lines">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+.hint { color: brown; font-family: sans-serif; font-size: 90%; }
+.hint:before { content: '❗ '; }
+:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
+</style>
+<!-- the test -->
+<style>
+div span {
+text-decoration:underline;
+text-underline-position:under right;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the line is to the RIGHT of the characters for all lines.<br/><span class="hint">Skip the test if the text is not vertical.</span></p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh"><span>引发网络的全部潜能</span><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に</span><span>導き出すために</span></p>
+<p lang="mn"><span>ᠣᠯᠠᠨ ᠦᠨᠳᠦᠰ</span><span>ᠦᠲᠡᠨ ᠦ ᠪᠣᠯᠭᠠᠬᠤ ᠦᠢᠯᠡ ᠠᠵᠢᠯᠯᠠᠭ᠎ᠠ</span></p>
+<p lang="en"><span>The quick brown f</span><span>ox jumps over the lazy dog.</span></p>
+</div>  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR ports https://w3c.github.io/i18n-tests/results/line-decoration#text_und_pos to WPT. Currently, the tests are manual tests, since we're unable to come up with a way to automate them.

The `-019-` and `-02X-` tests are in horizontal writing mode, and the `-07X-` tests are in `vertical-rl`.

/cc @r12a
