### PR TITLE
override `align-items` in flex-vertical-align-effect.html

### DIFF
--- a/css/css-flexbox/flex-vertical-align-effect.html
+++ b/css/css-flexbox/flex-vertical-align-effect.html
@@ -11,6 +11,7 @@
 	<style type="text/css">
 		#container {
 			display:flex;
+			align-items:flex-start;
 		}
 		input{
 			margin:0;padding:0;vertical-align:middle;


### PR DESCRIPTION
This fixes issue #16304 by removing the (default) influence of
`align-items:stretch` on the radio button flex-item, which influences its
sizing/rendering regardless of the value of the `vertical-align` property
(which is what the testcase is really trying to test). So, let's take that
`stretch` behavior out of the equation entirely.