### PR TITLE
Avoid flagging setTimeout(..., 0) in lint

### DIFF
--- a/tools/lint/jsfnargs.py
+++ b/tools/lint/jsfnargs.py
@@ -1,0 +1,65 @@
+import re
+from collections import deque
+
+next_char = re.compile(br"[\(\)\[\]\{\},\"\'`]|//|/\*", re.MULTILINE)
+
+
+def get_args(data, offset=0):
+    if not data or data[offset:offset+1] != b"(":
+        raise ValueError("Failed to find function args (No leading paren)")
+    arg_indicies = []
+    remove_indicies = deque([])
+    paren_count = 1
+    offset += 1
+    start_idx = offset
+    while paren_count > 0:
+        m = next_char.search(data, offset)
+        if not m:
+            raise ValueError("Failed to find function args (eof before matching all parens)")
+        symbol = m.group()
+        offset = m.span()[1]
+        if symbol in b"([{":
+            paren_count += 1
+        elif symbol in b")]}":
+            paren_count -= 1
+        elif symbol == b",":
+            if paren_count == 1:
+                arg_indicies.append((start_idx, offset - 1))
+                start_idx = offset
+        elif symbol in (b"//", b"/*"):
+            remove_start_idx = offset - len(symbol)
+            if symbol == b"//":
+                # Various other line end character combinations are also allowed
+                end_comment = re.compile(b"\n")
+            else:
+                end_comment = re.compile(b"\*/")
+
+            end_comment_m = end_comment.search(data, offset)
+            if not end_comment_m:
+                raise ValueError("Failed to find function args (failed to find end of comment)")
+
+            offset = end_comment_m.span()[1]
+            remove_indicies.append((remove_start_idx, offset))
+        else:
+            # TODO: correct support for ` is harder
+            end_quote = re.compile(br"(?<!\\)%s" % symbol, re.MULTILINE)
+            quote_m = end_quote.search(data, offset)
+            if not quote_m:
+                raise ValueError("Failed to find function args (failed to find end of string)")
+            offset = quote_m.span()[1]
+
+    arg_indicies.append((start_idx, offset - 1))
+    args = []
+    for start, end in arg_indicies:
+        arg = data[start:end]
+        remove_offset = start
+        while remove_indicies and start <= remove_indicies[0][0] <= end:
+            indicies = remove_indicies.popleft()
+            assert indicies[1] <= end
+            arg = arg[:indicies[0] - remove_offset] + arg[indicies[1] - remove_offset:]
+            remove_offset += indicies[1] - indicies[0]
+        arg = arg.strip()
+        if arg:
+            args.append(arg)
+
+    return args

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -158,6 +158,20 @@ def test_setTimeout():
                                1)]
 
 
+def test_setTimeout_0():
+    error_map = check_with_files(b"""<script>setTimeout(() => 1,
+0)</script>""")
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind == "python":
+            assert errors == [("PARSE-FAILED", "Unable to parse file", filename, 1)]
+        else:
+            assert errors == []
+
+
+
 def test_eventSender():
     error_map = check_with_files(b"<script>eventSender.mouseDown()</script>")
 

--- a/tools/lint/tests/test_jsfnargs.py
+++ b/tools/lint/tests/test_jsfnargs.py
@@ -1,0 +1,31 @@
+import pytest
+
+from .. import jsfnargs
+
+
+@pytest.mark.parametrize("input, expected",
+                         [(b"()", []),
+                          (b"('foo')", [b"'foo'"]),
+                          (b"( 0 )", [b"0"]),
+                          (b"( 0, 1)", [b"0", b"1"]),
+                          (b"( 'foo', \"bar\")", [b"'foo'", b"\"bar\""]),
+                          (b"( 0, 1,)", [b"0", b"1"]),
+                          (b"( 0, `foo\nbar`))", [b"0", b"`foo\nbar`"]),
+                          (b"((1), () => {})", [b"(1)", b"() => {}"]),
+                          (b"(')', '(')", [b"')'", b"'('"]),
+                          (b"('', \"\")", [b"''", b'""']),
+                          (b"('a\\'b', \"a\\\"b\")", [b"'a\\'b'", b'"a\\"b"']),
+                          (b"({1:2, 3:4}, [5,6], () => {7,8})",
+                           [b"{1:2, 3:4}", b"[5,6]", b"() => {7,8}"]),
+                          (b"(1,\n//foo\n2)", [b"1", b"2"]),
+                          (b"(1/*foo,*/,2,/*bar,*/3/*baz*/)", [b"1", b"2", b"3"]),
+                          (b"(1/*foo,\n*/,2,//bar\n,3/*baz*/,)", [b"1", b"2", b"3"])])
+def test_valid(input, expected):
+    assert jsfnargs.get_args(input) == expected
+
+
+@pytest.mark.parametrize("input",
+                         [b"(", b"(\")", b"(1,'foo)", b"(1,'foo\\')"])
+def test_invalid(input):
+    with pytest.raises(ValueError):
+        assert jsfnargs.get_args(input)


### PR DESCRIPTION
There isn't any difference between setTimeout(foo, 0) and step_timeout(foo, 0),
so it doesn't make sense to fail the lint in either case. Unfortunately getting
this perfectly correct is a bit tricky since there can be arbitary js in the
first argument to setTimeout. So doing it correctly requires a full js parser,
but we can do something with an approach that simply counts parens, skipping
strings, to find the end of the arguments.

This won't handle all cases, particularly involving template literals, but
may be better than nothing. In particular expressions like

setTimeout(() => `${"`"}`, 0}

will break since we won't skip the embedded expression in the template
literal.