### PR TITLE
[xhr] Remove None headers from the server handler

### DIFF
--- a/xhr/resources/authentication.py
+++ b/xhr/resources/authentication.py
@@ -11,9 +11,7 @@ def main(request, response):
             if token is not None:
                 request.server.stash.put(token, "1")
             status = (401, 'Unauthorized')
-            headers = [('WWW-Authenticate', 'Basic realm="test"'),
-                       ('XHR-USER', expected_user_name),
-                       ('SES-USER', session_user)]
+            headers = [('WWW-Authenticate', 'Basic realm="test"')]
             return status, headers, 'FAIL (should be transparent)'
     else:
         if request.server.stash.take(token) == "1":


### PR DESCRIPTION
authentication.py incorrectly returns some headers with None as the
value, which causes exceptions in wptserve.

The file was created in 234a672d023e8f57f3c78ca129788ca650242cc0 as a
rewrite from some PHP code and has been buggy since. This commit fixes
the bug by making the Python code more faithful to the original
XMLHttpRequest/resources/auth1/auth.php.