### PR TITLE
service workers: Simplified tests with async/await - Part 2

### DIFF
--- a/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
@@ -1,221 +1,225 @@
 <!DOCTYPE html>
 <title>ServiceWorkerGlobalScope: ExtendableMessageEvent</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="../resources/test-helpers.sub.js"></script>
-<script src="./resources/extendable-message-event-utils.js"></script>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='../resources/test-helpers.sub.js'></script>
+<script src='./resources/extendable-message-event-utils.js'></script>
 <script>
-  promise_test(async t => {
-    const SCRIPT = "resources/extendable-message-event-worker.js";
-    const SCOPE = "resources/scope/extendable-message-event-from-toplevel";
-    const registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT,
-      SCOPE
-    );
+promise_test(async t => {
+  const SCRIPT = 'resources/extendable-message-event-worker.js';
+  const SCOPE = 'resources/scope/extendable-message-event-from-toplevel';
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
 
-    t.add_cleanup(async () => {
-      if (registration) await registration.unregister();
-    });
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+  });
 
-    await wait_for_state(t, registration.installing, "activated");
-    const saw_message = new Promise(function(resolve) {
-      navigator.serviceWorker.onmessage = function(event) {
-        resolve(event.data);
+  await wait_for_state(t, registration.installing, 'activated');
+  const saw_message = new Promise(function(resolve) {
+    navigator.serviceWorker.onmessage = function(event) { 
+      resolve(event.data);
+    };
+  });
+  const channel = new MessageChannel;
+  registration.active.postMessage('', [channel.port1]);
+  const results = await saw_message;
+  const expected = {
+    constructor: { name: 'ExtendableMessageEvent' },
+    origin: location.origin,
+    lastEventId: '',
+    source: {
+      constructor: { name: 'WindowClient' },
+      frameType: 'top-level',
+      url: location.href,
+      visibilityState: 'visible',
+      focused: true
+    },
+    ports: [ { constructor: { name: 'MessagePort' } } ]
+  };
+  ExtendableMessageEventUtils.assert_equals(results, expected);
+}, 'Post an extendable message from a top-level client');
+
+promise_test(async t => {
+  const SCRIPT = 'resources/extendable-message-event-worker.js';
+  const SCOPE = 'resources/scope/extendable-message-event-from-nested';
+
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE);
+  const saw_message = new Promise(function(resolve) {
+    frame.contentWindow.navigator.serviceWorker.onmessage = function(event) {
+      resolve(event.data);
+    };
+  });
+  frame.contentWindow.navigator.serviceWorker.controller.postMessage('');
+  const results = await saw_message;
+  const expected = {
+    constructor: { name: 'ExtendableMessageEvent' },
+    origin: location.origin,
+    lastEventId: '',
+    source: {
+      constructor: { name: 'WindowClient' },
+      url: frame.contentWindow.location.href,
+      frameType: 'nested',
+      visibilityState: 'visible',
+      focused: false
+    },
+    ports: []
+  };
+
+  t.add_cleanup(async() => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+
+  ExtendableMessageEventUtils.assert_equals(results, expected);
+}, 'Post an extendable message from a nested client');
+
+
+promise_test(async t => {
+  const SCRIPT = 'resources/extendable-message-event-loopback-worker.js';
+  const SCOPE = 'resources/scope/extendable-message-event-loopback';
+  let results = [];
+
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+  });
+
+  await wait_for_state(t, registration.installing, 'activated');
+  const saw_message = new Promise(function(resolve) {
+    navigator.serviceWorker.onmessage = function(event) {
+      switch (event.data.type) {
+        case 'record':
+          results.push(event.data.results);
+          break;
+        case 'finish':
+          resolve(results);
+          break;
       };
-    });
-    const channel = new MessageChannel();
-    registration.active.postMessage("", [channel.port1]);
-    const results = await saw_message;
-    const expected = {
-      constructor: { name: "ExtendableMessageEvent" },
-      origin: location.origin,
-      lastEventId: "",
-      source: {
-        constructor: { name: "WindowClient" },
-        frameType: "top-level",
-        url: location.href,
-        visibilityState: "visible",
-        focused: true
-      },
-      ports: [{ constructor: { name: "MessagePort" } }]
     };
-    ExtendableMessageEventUtils.assert_equals(results, expected);
-  }, "Post an extendable message from a top-level client");
+  });
+  registration.active.postMessage({type: 'start'});
+  results = await saw_message;
+  assert_equals(results.length, 2);
+  const expected_trial_1 = {
+    constructor: { name: 'ExtendableMessageEvent' },
+    origin: location.origin,
+    lastEventId: '',
+    source: {
+      constructor: { name: 'ServiceWorker' },
+      scriptURL: normalizeURL(SCRIPT),
+      state: 'activated'
+    },
+    ports: []
+  };
+  assert_equals(results[0].trial, 1);
+  ExtendableMessageEventUtils.assert_equals(
+    results[0].event, expected_trial_1
+  );
 
-  promise_test(async t => {
-    const SCRIPT = "resources/extendable-message-event-worker.js";
-    const SCOPE = "resources/scope/extendable-message-event-from-nested";
+  const expected_trial_2 = {
+    constructor: { name: 'ExtendableMessageEvent' },
+    origin: location.origin,
+    lastEventId: '',
+    source: {
+      constructor: { name: 'ServiceWorker' },
+      scriptURL: normalizeURL(SCRIPT),
+      state: 'activated'
+    },
+    ports: [],
+  };
+  assert_equals(results[1].trial, 2);
+  ExtendableMessageEventUtils.assert_equals(
+    results[1].event, expected_trial_2
+  );
+}, 'Post loopback extendable messages');
 
-    const registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT,
-      SCOPE
-    );
+promise_test(async t => {
+  const SCRIPT1 = 'resources/extendable-message-event-ping-worker.js';
+  const SCRIPT2= 'resources/extendable-message-event-pong-worker.js';
+  const SCOPE = 'resources/scope/extendable-message-event-pingpong';
+  let results = [];
 
-    await wait_for_state(t, registration.installing, "activated");
-    const frame = await with_iframe(SCOPE);
-    const saw_message = new Promise(function(resolve) {
-      frame.contentWindow.navigator.serviceWorker.onmessage = function(event) {
-        resolve(event.data);
+  let registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT1,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE);
+
+  registration = await navigator.serviceWorker.register(
+    SCRIPT2,
+    {scope: SCOPE}
+  );
+
+  t.add_cleanup(async() => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+
+  await wait_for_state(t, registration.installing, 'installed');
+  const saw_message = new Promise(function(resolve) {
+    navigator.serviceWorker.onmessage = function(event) {
+      switch (event.data.type) {
+        case 'record':
+          results.push(event.data.results);
+          break;
+        case 'finish':
+          resolve(results);
+          break;
       };
-    });
-    frame.contentWindow.navigator.serviceWorker.controller.postMessage("");
-    const results = await saw_message;
-    const expected = {
-      constructor: { name: "ExtendableMessageEvent" },
-      origin: location.origin,
-      lastEventId: "",
-      source: {
-        constructor: { name: "WindowClient" },
-        url: frame.contentWindow.location.href,
-        frameType: "nested",
-        visibilityState: "visible",
-        focused: false
-      },
-      ports: []
     };
+  });
+  registration.active.postMessage({type: 'start'});
+  results = await saw_message;
+  assert_equals(results.length, 2);
 
-    t.add_cleanup(async () => {
-      if (frame) frame.remove();
-      if (registration) await registration.unregister();
-    });
+  const expected_ping = {
+    constructor: { name: 'ExtendableMessageEvent' },
+    origin: location.origin,
+    lastEventId: '',
+    source: {
+      constructor: { name: 'ServiceWorker' },
+      scriptURL: normalizeURL(SCRIPT1),
+      state: 'activated'
+    },
+    ports: []
+  };
+  assert_equals(results[0].pingOrPong, 'ping');
+  ExtendableMessageEventUtils.assert_equals(
+    results[0].event, expected_ping
+  );
 
-    ExtendableMessageEventUtils.assert_equals(results, expected);
-  }, "Post an extendable message from a nested client");
-
-  promise_test(async t => {
-    const SCRIPT = "resources/extendable-message-event-loopback-worker.js";
-    const SCOPE = "resources/scope/extendable-message-event-loopback";
-    let results = [];
-
-    const registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT,
-      SCOPE
-    );
-
-    t.add_cleanup(async () => {
-      if (registration) await registration.unregister();
-    });
-
-    await wait_for_state(t, registration.installing, "activated");
-    const saw_message = new Promise(function(resolve) {
-      navigator.serviceWorker.onmessage = function(event) {
-        switch (event.data.type) {
-          case "record":
-            results.push(event.data.results);
-            break;
-          case "finish":
-            resolve(results);
-            break;
-        }
-      };
-    });
-    registration.active.postMessage({ type: "start" });
-    results = await saw_message;
-    assert_equals(results.length, 2);
-    const expected_trial_1 = {
-      constructor: { name: "ExtendableMessageEvent" },
-      origin: location.origin,
-      lastEventId: "",
-      source: {
-        constructor: { name: "ServiceWorker" },
-        scriptURL: normalizeURL(SCRIPT),
-        state: "activated"
-      },
-      ports: []
-    };
-    assert_equals(results[0].trial, 1);
-    ExtendableMessageEventUtils.assert_equals(
-      results[0].event,
-      expected_trial_1
-    );
-
-    const expected_trial_2 = {
-      constructor: { name: "ExtendableMessageEvent" },
-      origin: location.origin,
-      lastEventId: "",
-      source: {
-        constructor: { name: "ServiceWorker" },
-        scriptURL: normalizeURL(SCRIPT),
-        state: "activated"
-      },
-      ports: []
-    };
-    assert_equals(results[1].trial, 2);
-    ExtendableMessageEventUtils.assert_equals(
-      results[1].event,
-      expected_trial_2
-    );
-  }, "Post loopback extendable messages");
-
-  promise_test(async t => {
-    const SCRIPT1 = "resources/extendable-message-event-ping-worker.js";
-    const SCRIPT2 = "resources/extendable-message-event-pong-worker.js";
-    const SCOPE = "resources/scope/extendable-message-event-pingpong";
-    let results = [];
-
-    let registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT1,
-      SCOPE
-    );
-    await wait_for_state(t, registration.installing, "activated");
-    const frame = await with_iframe(SCOPE);
-
-    registration = await navigator.serviceWorker.register(SCRIPT2, {
-      scope: SCOPE
-    });
-
-    t.add_cleanup(async () => {
-      if (registration) await registration.unregister();
-      if (frame) frame.remove();
-    });
-
-    await wait_for_state(t, registration.installing, "installed");
-    const saw_message = new Promise(function(resolve) {
-      navigator.serviceWorker.onmessage = function(event) {
-        switch (event.data.type) {
-          case "record":
-            results.push(event.data.results);
-            break;
-          case "finish":
-            resolve(results);
-            break;
-        }
-      };
-    });
-    registration.active.postMessage({ type: "start" });
-    results = await saw_message;
-    assert_equals(results.length, 2);
-
-    const expected_ping = {
-      constructor: { name: "ExtendableMessageEvent" },
-      origin: location.origin,
-      lastEventId: "",
-      source: {
-        constructor: { name: "ServiceWorker" },
-        scriptURL: normalizeURL(SCRIPT1),
-        state: "activated"
-      },
-      ports: []
-    };
-    assert_equals(results[0].pingOrPong, "ping");
-    ExtendableMessageEventUtils.assert_equals(results[0].event, expected_ping);
-
-    const expected_pong = {
-      constructor: { name: "ExtendableMessageEvent" },
-      origin: location.origin,
-      lastEventId: "",
-      source: {
-        constructor: { name: "ServiceWorker" },
-        scriptURL: normalizeURL(SCRIPT2),
-        state: "installed"
-      },
-      ports: []
-    };
-    assert_equals(results[1].pingOrPong, "pong");
-    ExtendableMessageEventUtils.assert_equals(results[1].event, expected_pong);
-  }, "Post extendable messages among service workers");
+  const expected_pong = {
+    constructor: { name: 'ExtendableMessageEvent' },
+    origin: location.origin,
+    lastEventId: '',
+    source: {
+      constructor: { name: 'ServiceWorker' },
+      scriptURL: normalizeURL(SCRIPT2),
+      state: 'installed'
+    },
+    ports: []
+  };
+  assert_equals(results[1].pingOrPong, 'pong');
+  ExtendableMessageEventUtils.assert_equals(
+    results[1].event, expected_pong
+  );
+}, 'Post extendable messages among service workers');
 </script>

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
@@ -18,6 +18,7 @@ promise_test(async t => {
     SCOPE
   );
   await wait_for_state(t, registration.installing, 'activated');
+
   const saw_message = new Promise(function(resolve) {
     navigator.serviceWorker.onmessage = function(event) {
       resolve(event.data);
@@ -26,6 +27,7 @@ promise_test(async t => {
   const channel = new MessageChannel;
   registration.active.postMessage('', [channel.port1]);
   const results = await saw_message;
+
   const expected = {
     constructor: { name: 'ExtendableMessageEvent' },
     origin: location.origin,
@@ -56,9 +58,9 @@ promise_test(async t => {
     SCRIPT,
     SCOPE
   );
-
   await wait_for_state(t, registration.installing, 'activated');
   const frame = await with_iframe(SCOPE);
+
   const saw_message = new Promise(function(resolve) {
     frame.contentWindow.navigator.serviceWorker.onmessage = function(event) {
       resolve(event.data);
@@ -66,6 +68,7 @@ promise_test(async t => {
   });
   frame.contentWindow.navigator.serviceWorker.controller.postMessage('');
   const results = await saw_message;
+
   const expected = {
     constructor: { name: 'ExtendableMessageEvent' },
     origin: location.origin,
@@ -90,7 +93,6 @@ promise_test(async t => {
 
   const SCRIPT = 'resources/extendable-message-event-loopback-worker.js';
   const SCOPE = 'resources/scope/extendable-message-event-loopback';
-  let results = [];
 
   const registration = await service_worker_unregister_and_register(
     t,
@@ -99,19 +101,20 @@ promise_test(async t => {
   );
   await wait_for_state(t, registration.installing, 'activated');
   const saw_message = new Promise(function(resolve) {
+    const records = [];
     navigator.serviceWorker.onmessage = function(event) {
       switch (event.data.type) {
         case 'record':
-          results.push(event.data.results);
+          records.push(event.data.results);
           break;
         case 'finish':
-          resolve(results);
+          resolve(records);
           break;
       };
     };
   });
   registration.active.postMessage({type: 'start'});
-  results = await saw_message;
+  const results = await saw_message;
   assert_equals(results.length, 2);
   const expected_trial_1 = {
     constructor: { name: 'ExtendableMessageEvent' },
@@ -155,7 +158,6 @@ promise_test(async t => {
   const SCRIPT1 = 'resources/extendable-message-event-ping-worker.js';
   const SCRIPT2 = 'resources/extendable-message-event-pong-worker.js';
   const SCOPE = 'resources/scope/extendable-message-event-pingpong';
-  let results = [];
 
   let registration = await service_worker_unregister_and_register(
     t,
@@ -171,19 +173,20 @@ promise_test(async t => {
   );
   await wait_for_state(t, registration.installing, 'installed');
   const saw_message = new Promise(function(resolve) {
+    const records = [];
     navigator.serviceWorker.onmessage = function(event) {
       switch (event.data.type) {
         case 'record':
-          results.push(event.data.results);
+          records.push(event.data.results);
           break;
         case 'finish':
-          resolve(results);
+          resolve(records);
           break;
       }
     };
   });
   registration.active.postMessage({type: 'start'});
-  results = await saw_message;
+  const results = await saw_message;
   assert_equals(results.length, 2);
 
   const expected_ping = {

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
@@ -6,6 +6,10 @@
 <script src='./resources/extendable-message-event-utils.js'></script>
 <script>
 promise_test(async t => {
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+  });
+
   const SCRIPT = 'resources/extendable-message-event-worker.js';
   const SCOPE = 'resources/scope/extendable-message-event-from-toplevel';
   const registration = await service_worker_unregister_and_register(
@@ -13,14 +17,9 @@ promise_test(async t => {
     SCRIPT,
     SCOPE
   );
-
-  t.add_cleanup(async() => {
-    if (registration) await registration.unregister();
-  });
-
   await wait_for_state(t, registration.installing, 'activated');
   const saw_message = new Promise(function(resolve) {
-    navigator.serviceWorker.onmessage = function(event) { 
+    navigator.serviceWorker.onmessage = function(event) {
       resolve(event.data);
     };
   });
@@ -44,6 +43,11 @@ promise_test(async t => {
 }, 'Post an extendable message from a top-level client');
 
 promise_test(async t => {
+  t.add_cleanup(async() => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+
   const SCRIPT = 'resources/extendable-message-event-worker.js';
   const SCOPE = 'resources/scope/extendable-message-event-from-nested';
 
@@ -75,17 +79,15 @@ promise_test(async t => {
     },
     ports: []
   };
-
-  t.add_cleanup(async() => {
-    if (frame) frame.remove();
-    if (registration) await registration.unregister();
-  });
-
   ExtendableMessageEventUtils.assert_equals(results, expected);
 }, 'Post an extendable message from a nested client');
 
 
 promise_test(async t => {
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+  });
+
   const SCRIPT = 'resources/extendable-message-event-loopback-worker.js';
   const SCOPE = 'resources/scope/extendable-message-event-loopback';
   let results = [];
@@ -95,11 +97,6 @@ promise_test(async t => {
     SCRIPT,
     SCOPE
   );
-
-  t.add_cleanup(async() => {
-    if (registration) await registration.unregister();
-  });
-
   await wait_for_state(t, registration.installing, 'activated');
   const saw_message = new Promise(function(resolve) {
     navigator.serviceWorker.onmessage = function(event) {
@@ -150,8 +147,13 @@ promise_test(async t => {
 }, 'Post loopback extendable messages');
 
 promise_test(async t => {
+  t.add_cleanup(async() => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+
   const SCRIPT1 = 'resources/extendable-message-event-ping-worker.js';
-  const SCRIPT2= 'resources/extendable-message-event-pong-worker.js';
+  const SCRIPT2 = 'resources/extendable-message-event-pong-worker.js';
   const SCOPE = 'resources/scope/extendable-message-event-pingpong';
   let results = [];
 
@@ -167,12 +169,6 @@ promise_test(async t => {
     SCRIPT2,
     {scope: SCOPE}
   );
-
-  t.add_cleanup(async() => {
-    if (frame) frame.remove();
-    if (registration) await registration.unregister();
-  });
-
   await wait_for_state(t, registration.installing, 'installed');
   const saw_message = new Promise(function(resolve) {
     navigator.serviceWorker.onmessage = function(event) {
@@ -183,7 +179,7 @@ promise_test(async t => {
         case 'finish':
           resolve(results);
           break;
-      };
+      }
     };
   });
   registration.active.postMessage({type: 'start'});

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
@@ -1,226 +1,221 @@
 <!DOCTYPE html>
 <title>ServiceWorkerGlobalScope: ExtendableMessageEvent</title>
-<script src='/resources/testharness.js'></script>
-<script src='/resources/testharnessreport.js'></script>
-<script src='../resources/test-helpers.sub.js'></script>
-<script src='./resources/extendable-message-event-utils.js'></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/test-helpers.sub.js"></script>
+<script src="./resources/extendable-message-event-utils.js"></script>
 <script>
-promise_test(function(t) {
-    var script = 'resources/extendable-message-event-worker.js';
-    var scope = 'resources/scope/extendable-message-event-from-toplevel';
-    var registration;
+  promise_test(async t => {
+    const SCRIPT = "resources/extendable-message-event-worker.js";
+    const SCOPE = "resources/scope/extendable-message-event-from-toplevel";
+    const registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT,
+      SCOPE
+    );
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(function(r) {
-          registration = r;
-          add_completion_callback(function() { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() {
-          var saw_message = new Promise(function(resolve) {
-              navigator.serviceWorker.onmessage =
-                  function(event) { resolve(event.data); }
-            });
-          var channel = new MessageChannel;
-          registration.active.postMessage('', [channel.port1]);
-          return saw_message;
-        })
-      .then(function(results) {
-          var expected = {
-            constructor: { name: 'ExtendableMessageEvent' },
-            origin: location.origin,
-            lastEventId: '',
-            source: {
-                constructor: { name: 'WindowClient' },
-                frameType: 'top-level',
-                url: location.href,
-                visibilityState: 'visible',
-                focused: true
-            },
-            ports: [ { constructor: { name: 'MessagePort' } } ]
-          };
-          ExtendableMessageEventUtils.assert_equals(results, expected);
-        });
-  }, 'Post an extendable message from a top-level client');
+    t.add_cleanup(async () => {
+      if (registration) await registration.unregister();
+    });
 
-promise_test(function(t) {
-    var script = 'resources/extendable-message-event-worker.js';
-    var scope = 'resources/scope/extendable-message-event-from-nested';
-    var frame;
+    await wait_for_state(t, registration.installing, "activated");
+    const saw_message = new Promise(function(resolve) {
+      navigator.serviceWorker.onmessage = function(event) {
+        resolve(event.data);
+      };
+    });
+    const channel = new MessageChannel();
+    registration.active.postMessage("", [channel.port1]);
+    const results = await saw_message;
+    const expected = {
+      constructor: { name: "ExtendableMessageEvent" },
+      origin: location.origin,
+      lastEventId: "",
+      source: {
+        constructor: { name: "WindowClient" },
+        frameType: "top-level",
+        url: location.href,
+        visibilityState: "visible",
+        focused: true
+      },
+      ports: [{ constructor: { name: "MessagePort" } }]
+    };
+    ExtendableMessageEventUtils.assert_equals(results, expected);
+  }, "Post an extendable message from a top-level client");
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(function(registration) {
-          add_completion_callback(function() { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() { return with_iframe(scope); })
-      .then(function(f) {
-          frame = f;
-          add_completion_callback(function() { frame.remove(); });
-          var saw_message = new Promise(function(resolve) {
-              frame.contentWindow.navigator.serviceWorker.onmessage =
-                  function(event) { resolve(event.data); }
-            });
-          f.contentWindow.navigator.serviceWorker.controller.postMessage('');
-          return saw_message;
-        })
-      .then(function(results) {
-          var expected = {
-              constructor: { name: 'ExtendableMessageEvent' },
-              origin: location.origin,
-              lastEventId: '',
-              source: {
-                  constructor: { name: 'WindowClient' },
-                  url: frame.contentWindow.location.href,
-                  frameType: 'nested',
-                  visibilityState: 'visible',
-                  focused: false
-              },
-              ports: []
-            };
-          ExtendableMessageEventUtils.assert_equals(results, expected);
-        });
-  }, 'Post an extendable message from a nested client');
+  promise_test(async t => {
+    const SCRIPT = "resources/extendable-message-event-worker.js";
+    const SCOPE = "resources/scope/extendable-message-event-from-nested";
 
-promise_test(function(t) {
-    var script = 'resources/extendable-message-event-loopback-worker.js';
-    var scope = 'resources/scope/extendable-message-event-loopback';
-    var registration;
+    const registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT,
+      SCOPE
+    );
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(function(r) {
-          registration = r;
-          add_completion_callback(function() { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() {
-          var results = [];
-          var saw_message = new Promise(function(resolve) {
-              navigator.serviceWorker.onmessage = function(event) {
-                switch (event.data.type) {
-                  case 'record':
-                    results.push(event.data.results);
-                    break;
-                  case 'finish':
-                    resolve(results);
-                    break;
-                }
-              };
-            });
-          registration.active.postMessage({type: 'start'});
-          return saw_message;
-        })
-      .then(function(results) {
-          assert_equals(results.length, 2);
+    await wait_for_state(t, registration.installing, "activated");
+    const frame = await with_iframe(SCOPE);
+    const saw_message = new Promise(function(resolve) {
+      frame.contentWindow.navigator.serviceWorker.onmessage = function(event) {
+        resolve(event.data);
+      };
+    });
+    frame.contentWindow.navigator.serviceWorker.controller.postMessage("");
+    const results = await saw_message;
+    const expected = {
+      constructor: { name: "ExtendableMessageEvent" },
+      origin: location.origin,
+      lastEventId: "",
+      source: {
+        constructor: { name: "WindowClient" },
+        url: frame.contentWindow.location.href,
+        frameType: "nested",
+        visibilityState: "visible",
+        focused: false
+      },
+      ports: []
+    };
 
-          var expected_trial_1 = {
-              constructor: { name: 'ExtendableMessageEvent' },
-              origin: location.origin,
-              lastEventId: '',
-              source: {
-                  constructor: { name: 'ServiceWorker' },
-                  scriptURL: normalizeURL(script),
-                  state: 'activated'
-              },
-              ports: []
-          };
-          assert_equals(results[0].trial, 1);
-          ExtendableMessageEventUtils.assert_equals(
-              results[0].event, expected_trial_1
-          );
+    t.add_cleanup(async () => {
+      if (frame) frame.remove();
+      if (registration) await registration.unregister();
+    });
 
-          var expected_trial_2 = {
-              constructor: { name: 'ExtendableMessageEvent' },
-              origin: location.origin,
-              lastEventId: '',
-              source: {
-                  constructor: { name: 'ServiceWorker' },
-                  scriptURL: normalizeURL(script),
-                  state: 'activated'
-              },
-              ports: [],
-          };
-          assert_equals(results[1].trial, 2);
-          ExtendableMessageEventUtils.assert_equals(
-              results[1].event, expected_trial_2
-          );
-        });
-  }, 'Post loopback extendable messages');
+    ExtendableMessageEventUtils.assert_equals(results, expected);
+  }, "Post an extendable message from a nested client");
 
-promise_test(function(t) {
-    var script1 = 'resources/extendable-message-event-ping-worker.js';
-    var script2 = 'resources/extendable-message-event-pong-worker.js';
-    var scope = 'resources/scope/extendable-message-event-pingpong';
-    var registration;
+  promise_test(async t => {
+    const SCRIPT = "resources/extendable-message-event-loopback-worker.js";
+    const SCOPE = "resources/scope/extendable-message-event-loopback";
+    let results = [];
 
-    return service_worker_unregister_and_register(t, script1, scope)
-      .then(function(r) {
-          registration = r;
-          add_completion_callback(function() { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() {
-          // A controlled frame is necessary for keeping a waiting worker.
-          return with_iframe(scope);
-        })
-      .then(function(frame) {
-          add_completion_callback(function() { frame.remove(); });
-          return navigator.serviceWorker.register(script2, {scope: scope});
-        })
-      .then(function(r) {
-          return wait_for_state(t, r.installing, 'installed');
-        })
-      .then(function() {
-          var results = [];
-          var saw_message = new Promise(function(resolve) {
-              navigator.serviceWorker.onmessage = function(event) {
-                switch (event.data.type) {
-                  case 'record':
-                    results.push(event.data.results);
-                    break;
-                  case 'finish':
-                    resolve(results);
-                    break;
-                }
-              };
-            });
-          registration.active.postMessage({type: 'start'});
-          return saw_message;
-        })
-      .then(function(results) {
-          assert_equals(results.length, 2);
+    const registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT,
+      SCOPE
+    );
 
-          var expected_ping = {
-              constructor: { name: 'ExtendableMessageEvent' },
-              origin: location.origin,
-              lastEventId: '',
-              source: {
-                  constructor: { name: 'ServiceWorker' },
-                  scriptURL: normalizeURL(script1),
-                  state: 'activated'
-              },
-              ports: []
-          };
-          assert_equals(results[0].pingOrPong, 'ping');
-          ExtendableMessageEventUtils.assert_equals(
-              results[0].event, expected_ping
-          );
+    t.add_cleanup(async () => {
+      if (registration) await registration.unregister();
+    });
 
-          var expected_pong = {
-              constructor: { name: 'ExtendableMessageEvent' },
-              origin: location.origin,
-              lastEventId: '',
-              source: {
-                  constructor: { name: 'ServiceWorker' },
-                  scriptURL: normalizeURL(script2),
-                  state: 'installed'
-              },
-              ports: []
-          };
-          assert_equals(results[1].pingOrPong, 'pong');
-          ExtendableMessageEventUtils.assert_equals(
-              results[1].event, expected_pong
-          );
-        });
-  }, 'Post extendable messages among service workers');
+    await wait_for_state(t, registration.installing, "activated");
+    const saw_message = new Promise(function(resolve) {
+      navigator.serviceWorker.onmessage = function(event) {
+        switch (event.data.type) {
+          case "record":
+            results.push(event.data.results);
+            break;
+          case "finish":
+            resolve(results);
+            break;
+        }
+      };
+    });
+    registration.active.postMessage({ type: "start" });
+    results = await saw_message;
+    assert_equals(results.length, 2);
+    const expected_trial_1 = {
+      constructor: { name: "ExtendableMessageEvent" },
+      origin: location.origin,
+      lastEventId: "",
+      source: {
+        constructor: { name: "ServiceWorker" },
+        scriptURL: normalizeURL(SCRIPT),
+        state: "activated"
+      },
+      ports: []
+    };
+    assert_equals(results[0].trial, 1);
+    ExtendableMessageEventUtils.assert_equals(
+      results[0].event,
+      expected_trial_1
+    );
+
+    const expected_trial_2 = {
+      constructor: { name: "ExtendableMessageEvent" },
+      origin: location.origin,
+      lastEventId: "",
+      source: {
+        constructor: { name: "ServiceWorker" },
+        scriptURL: normalizeURL(SCRIPT),
+        state: "activated"
+      },
+      ports: []
+    };
+    assert_equals(results[1].trial, 2);
+    ExtendableMessageEventUtils.assert_equals(
+      results[1].event,
+      expected_trial_2
+    );
+  }, "Post loopback extendable messages");
+
+  promise_test(async t => {
+    const SCRIPT1 = "resources/extendable-message-event-ping-worker.js";
+    const SCRIPT2 = "resources/extendable-message-event-pong-worker.js";
+    const SCOPE = "resources/scope/extendable-message-event-pingpong";
+    let results = [];
+
+    let registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT1,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, "activated");
+    const frame = await with_iframe(SCOPE);
+
+    registration = await navigator.serviceWorker.register(SCRIPT2, {
+      scope: SCOPE
+    });
+
+    t.add_cleanup(async () => {
+      if (registration) await registration.unregister();
+      if (frame) frame.remove();
+    });
+
+    await wait_for_state(t, registration.installing, "installed");
+    const saw_message = new Promise(function(resolve) {
+      navigator.serviceWorker.onmessage = function(event) {
+        switch (event.data.type) {
+          case "record":
+            results.push(event.data.results);
+            break;
+          case "finish":
+            resolve(results);
+            break;
+        }
+      };
+    });
+    registration.active.postMessage({ type: "start" });
+    results = await saw_message;
+    assert_equals(results.length, 2);
+
+    const expected_ping = {
+      constructor: { name: "ExtendableMessageEvent" },
+      origin: location.origin,
+      lastEventId: "",
+      source: {
+        constructor: { name: "ServiceWorker" },
+        scriptURL: normalizeURL(SCRIPT1),
+        state: "activated"
+      },
+      ports: []
+    };
+    assert_equals(results[0].pingOrPong, "ping");
+    ExtendableMessageEventUtils.assert_equals(results[0].event, expected_ping);
+
+    const expected_pong = {
+      constructor: { name: "ExtendableMessageEvent" },
+      origin: location.origin,
+      lastEventId: "",
+      source: {
+        constructor: { name: "ServiceWorker" },
+        scriptURL: normalizeURL(SCRIPT2),
+        state: "installed"
+      },
+      ports: []
+    };
+    assert_equals(results[1].pingOrPong, "pong");
+    ExtendableMessageEventUtils.assert_equals(results[1].event, expected_pong);
+  }, "Post extendable messages among service workers");
 </script>

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html
@@ -22,6 +22,7 @@ promise_test(async t => {
   );
   await wait_for_state(t, registration.installing, 'activated');
   const frame = await with_iframe(SCOPE);
+
   const expected_events_seen = [
     'updatefound',
     'install',
@@ -39,30 +40,29 @@ promise_test(async t => {
 }, 'Verify registration attributes on ServiceWorkerGlobalScope');
 
 promise_test(async t => {
- t.add_cleanup(async() => {
-    if (registration1)
-      await registration1.unregister();
-    if (registration2)
-      await registration2.unregister();
+  t.add_cleanup(async() => {
+    if (registration)
+      await registration.unregister();
  });
 
   const SCRIPT1 = 'resources/registration-attribute-worker.js';
   const SCRIPT2 = 'resources/registration-attribute-newer-worker.js';
   const SCOPE = 'resources/scope/registration-attribute';
-  const registration1 = await service_worker_unregister_and_register(
+  const registration = await service_worker_unregister_and_register(
     t,
     SCRIPT1,
     SCOPE
   );
-  await wait_for_state(t, registration1.installing, 'activated');
-  const registration2 = await navigator.serviceWorker.register(
+  await wait_for_state(t, registration.installing, 'activated');
+  const sameRegistration = await navigator.serviceWorker.register(
     SCRIPT2,
     {scope: SCOPE}
   );
-  assert_equals(registration1, registration2);
-  const worker = registration2.installing;
+  assert_equals(registration, sameRegistration);
+  const worker = sameRegistration.installing;
   await wait_for_state(t, worker, 'activated');
-  const channel = new MessageChannel
+
+  const channel = new MessageChannel;
   worker.postMessage({port: channel.port2}, [channel.port2]);
   const results = await new Promise(function(resolve) {
     channel.port1.onmessage = function(e) { resolve(e.data); };

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html
@@ -6,6 +6,13 @@
 <script>
 
 promise_test(async t => {
+  t.add_cleanup(async() => {
+    if (frame)
+      frame.remove();
+    if (registration)
+      await registration.unregister();
+  });
+
   const SCRIPT = 'resources/registration-attribute-worker.js';
   const SCOPE = 'resources/scope/registration-attribute';
   const registration = await service_worker_unregister_and_register(
@@ -24,14 +31,6 @@ promise_test(async t => {
     'statechange(activated)',
     'fetch',
   ];
-
-  t.add_cleanup(async() => {
-    if (frame)
-      frame.remove();
-    if (registration)
-      await registration.unregister();
-  })
-
   assert_equals(
     frame.contentDocument.body.textContent,
     expected_events_seen.toString(),
@@ -40,6 +39,13 @@ promise_test(async t => {
 }, 'Verify registration attributes on ServiceWorkerGlobalScope');
 
 promise_test(async t => {
+ t.add_cleanup(async() => {
+    if (registration1)
+      await registration1.unregister();
+    if (registration2)
+      await registration2.unregister();
+ });
+
   const SCRIPT1 = 'resources/registration-attribute-worker.js';
   const SCRIPT2 = 'resources/registration-attribute-newer-worker.js';
   const SCOPE = 'resources/scope/registration-attribute';
@@ -93,14 +99,6 @@ promise_test(async t => {
     '  waiting: empty',
     '  active: ' + newer_script_url,
   ];
-
- t.add_cleanup(async() => {
-    if (registration1)
-      await registration1.unregister();
-    if (registration2)
-      await registration2.unregister();
- })
-
   assert_array_equals(results, expectations);
 }, 'Verify registration attributes on ServiceWorkerGlobalScope of the ' +
    'newer worker');

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html
@@ -1,107 +1,103 @@
 <!DOCTYPE html>
 <title>ServiceWorkerGlobalScope: registration</title>
-<script src='/resources/testharness.js'></script>
-<script src='/resources/testharnessreport.js'></script>
-<script src='../resources/test-helpers.sub.js'></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/test-helpers.sub.js"></script>
 <script>
+  promise_test(async t => {
+    const SCRIPT = "resources/registration-attribute-worker.js";
+    const SCOPE = "resources/scope/registration-attribute";
+    const registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, "activated");
+    const frame = await with_iframe(SCOPE);
+    const expected_events_seen = [
+      "updatefound",
+      "install",
+      "statechange(installed)",
+      "statechange(activating)",
+      "activate",
+      "statechange(activated)",
+      "fetch"
+    ];
 
-promise_test(function(t) {
-    var script = 'resources/registration-attribute-worker.js';
-    var scope = 'resources/scope/registration-attribute';
-    var registration;
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(function(reg) {
-          registration = reg;
-          add_result_callback(function() { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() { return with_iframe(scope); })
-      .then(function(frame) {
-          var expected_events_seen = [
-            'updatefound',
-            'install',
-            'statechange(installed)',
-            'statechange(activating)',
-            'activate',
-            'statechange(activated)',
-            'fetch',
-          ];
+    t.add_cleanup(async () => {
+      if (frame) frame.remove();
+      if (registration) await registration.unregister();
+    });
 
-          assert_equals(
-              frame.contentDocument.body.textContent,
-              expected_events_seen.toString(),
-              'Service Worker should respond to fetch');
-          frame.remove();
-          return registration.unregister();
-        });
-  }, 'Verify registration attributes on ServiceWorkerGlobalScope');
+    assert_equals(
+      frame.contentDocument.body.textContent,
+      expected_events_seen.toString(),
+      "Service Worker should respond to fetch"
+    );
+  }, "Verify registration attributes on ServiceWorkerGlobalScope");
 
-promise_test(function(t) {
-    var script = 'resources/registration-attribute-worker.js';
-    var newer_script = 'resources/registration-attribute-newer-worker.js';
-    var scope = 'resources/scope/registration-attribute';
-    var newer_worker;
-    var registration;
+  promise_test(async t => {
+    const SCRIPT1 = "resources/registration-attribute-worker.js";
+    const SCRIPT2 = "resources/registration-attribute-newer-worker.js";
+    const SCOPE = "resources/scope/registration-attribute";
+    const registration1 = await service_worker_unregister_and_register(
+      t,
+      SCRIPT1,
+      SCOPE
+    );
+    await wait_for_state(t, registration1.installing, "activated");
+    const registration2 = await navigator.serviceWorker.register(SCRIPT2, {
+      scope: SCOPE
+    });
+    assert_equals(registration1, registration2);
+    const worker = registration2.installing;
+    await wait_for_state(t, worker, "activated");
+    const channel = new MessageChannel();
+    worker.postMessage({ port: channel.port2 }, [channel.port2]);
+    const results = await new Promise(function(resolve) {
+      channel.port1.onmessage = function(e) {
+        resolve(e.data);
+      };
+    });
+    const script_url = normalizeURL(SCRIPT1);
+    const newer_script_url = normalizeURL(SCRIPT2);
+    const expectations = [
+      "evaluate",
+      "  installing: empty",
+      "  waiting: empty",
+      "  active: " + script_url,
+      "updatefound",
+      "  installing: " + newer_script_url,
+      "  waiting: empty",
+      "  active: " + script_url,
+      "install",
+      "  installing: " + newer_script_url,
+      "  waiting: empty",
+      "  active: " + script_url,
+      "statechange(installed)",
+      "  installing: empty",
+      "  waiting: " + newer_script_url,
+      "  active: " + script_url,
+      "statechange(activating)",
+      "  installing: empty",
+      "  waiting: empty",
+      "  active: " + newer_script_url,
+      "activate",
+      "  installing: empty",
+      "  waiting: empty",
+      "  active: " + newer_script_url,
+      "statechange(activated)",
+      "  installing: empty",
+      "  waiting: empty",
+      "  active: " + newer_script_url
+    ];
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(function(reg) {
-          registration = reg;
-          add_result_callback(function() { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() {
-          return navigator.serviceWorker.register(newer_script, {scope: scope});
-        })
-      .then(function(reg) {
-          assert_equals(reg, registration);
-          newer_worker = registration.installing;
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() {
-          var channel = new MessageChannel;
-          var saw_message = new Promise(function(resolve) {
-              channel.port1.onmessage = function(e) { resolve(e.data); };
-            });
-          newer_worker.postMessage({port: channel.port2}, [channel.port2]);
-          return saw_message;
-        })
-      .then(function(results) {
-          var script_url = normalizeURL(script);
-          var newer_script_url = normalizeURL(newer_script);
-          var expectations = [
-            'evaluate',
-            '  installing: empty',
-            '  waiting: empty',
-            '  active: ' + script_url,
-            'updatefound',
-            '  installing: ' + newer_script_url,
-            '  waiting: empty',
-            '  active: ' + script_url,
-            'install',
-            '  installing: ' + newer_script_url,
-            '  waiting: empty',
-            '  active: ' + script_url,
-            'statechange(installed)',
-            '  installing: empty',
-            '  waiting: ' + newer_script_url,
-            '  active: ' + script_url,
-            'statechange(activating)',
-            '  installing: empty',
-            '  waiting: empty',
-            '  active: ' + newer_script_url,
-            'activate',
-            '  installing: empty',
-            '  waiting: empty',
-            '  active: ' + newer_script_url,
-            'statechange(activated)',
-            '  installing: empty',
-            '  waiting: empty',
-            '  active: ' + newer_script_url,
-          ];
-          assert_array_equals(results, expectations);
-          return registration.unregister();
-        });
-  }, 'Verify registration attributes on ServiceWorkerGlobalScope of the ' +
-     'newer worker');
+    //add_completion_callback(async() => {
+    t.add_cleanup(async () => {
+      if (registration1) await registration1.unregister();
+      if (registration2) await registration2.unregister();
+    });
 
+    assert_array_equals(results, expectations);
+  }, "Verify registration attributes on ServiceWorkerGlobalScope of the newer worker");
 </script>

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html
@@ -1,103 +1,108 @@
 <!DOCTYPE html>
 <title>ServiceWorkerGlobalScope: registration</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="../resources/test-helpers.sub.js"></script>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='../resources/test-helpers.sub.js'></script>
 <script>
-  promise_test(async t => {
-    const SCRIPT = "resources/registration-attribute-worker.js";
-    const SCOPE = "resources/scope/registration-attribute";
-    const registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT,
-      SCOPE
-    );
-    await wait_for_state(t, registration.installing, "activated");
-    const frame = await with_iframe(SCOPE);
-    const expected_events_seen = [
-      "updatefound",
-      "install",
-      "statechange(installed)",
-      "statechange(activating)",
-      "activate",
-      "statechange(activated)",
-      "fetch"
-    ];
 
-    t.add_cleanup(async () => {
-      if (frame) frame.remove();
-      if (registration) await registration.unregister();
-    });
+promise_test(async t => {
+  const SCRIPT = 'resources/registration-attribute-worker.js';
+  const SCOPE = 'resources/scope/registration-attribute';
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE);
+  const expected_events_seen = [
+    'updatefound',
+    'install',
+    'statechange(installed)',
+    'statechange(activating)',
+    'activate',
+    'statechange(activated)',
+    'fetch',
+  ];
 
-    assert_equals(
-      frame.contentDocument.body.textContent,
-      expected_events_seen.toString(),
-      "Service Worker should respond to fetch"
-    );
-  }, "Verify registration attributes on ServiceWorkerGlobalScope");
+  t.add_cleanup(async() => {
+    if (frame)
+      frame.remove();
+    if (registration)
+      await registration.unregister();
+  })
 
-  promise_test(async t => {
-    const SCRIPT1 = "resources/registration-attribute-worker.js";
-    const SCRIPT2 = "resources/registration-attribute-newer-worker.js";
-    const SCOPE = "resources/scope/registration-attribute";
-    const registration1 = await service_worker_unregister_and_register(
-      t,
-      SCRIPT1,
-      SCOPE
-    );
-    await wait_for_state(t, registration1.installing, "activated");
-    const registration2 = await navigator.serviceWorker.register(SCRIPT2, {
-      scope: SCOPE
-    });
-    assert_equals(registration1, registration2);
-    const worker = registration2.installing;
-    await wait_for_state(t, worker, "activated");
-    const channel = new MessageChannel();
-    worker.postMessage({ port: channel.port2 }, [channel.port2]);
-    const results = await new Promise(function(resolve) {
-      channel.port1.onmessage = function(e) {
-        resolve(e.data);
-      };
-    });
-    const script_url = normalizeURL(SCRIPT1);
-    const newer_script_url = normalizeURL(SCRIPT2);
-    const expectations = [
-      "evaluate",
-      "  installing: empty",
-      "  waiting: empty",
-      "  active: " + script_url,
-      "updatefound",
-      "  installing: " + newer_script_url,
-      "  waiting: empty",
-      "  active: " + script_url,
-      "install",
-      "  installing: " + newer_script_url,
-      "  waiting: empty",
-      "  active: " + script_url,
-      "statechange(installed)",
-      "  installing: empty",
-      "  waiting: " + newer_script_url,
-      "  active: " + script_url,
-      "statechange(activating)",
-      "  installing: empty",
-      "  waiting: empty",
-      "  active: " + newer_script_url,
-      "activate",
-      "  installing: empty",
-      "  waiting: empty",
-      "  active: " + newer_script_url,
-      "statechange(activated)",
-      "  installing: empty",
-      "  waiting: empty",
-      "  active: " + newer_script_url
-    ];
+  assert_equals(
+    frame.contentDocument.body.textContent,
+    expected_events_seen.toString(),
+    'Service Worker should respond to fetch'
+  );
+}, 'Verify registration attributes on ServiceWorkerGlobalScope');
 
-    //add_completion_callback(async() => {
-    t.add_cleanup(async () => {
-      if (registration1) await registration1.unregister();
-      if (registration2) await registration2.unregister();
-    });
+promise_test(async t => {
+  const SCRIPT1 = 'resources/registration-attribute-worker.js';
+  const SCRIPT2 = 'resources/registration-attribute-newer-worker.js';
+  const SCOPE = 'resources/scope/registration-attribute';
+  const registration1 = await service_worker_unregister_and_register(
+    t,
+    SCRIPT1,
+    SCOPE
+  );
+  await wait_for_state(t, registration1.installing, 'activated');
+  const registration2 = await navigator.serviceWorker.register(
+    SCRIPT2,
+    {scope: SCOPE}
+  );
+  assert_equals(registration1, registration2);
+  const worker = registration2.installing;
+  await wait_for_state(t, worker, 'activated');
+  const channel = new MessageChannel
+  worker.postMessage({port: channel.port2}, [channel.port2]);
+  const results = await new Promise(function(resolve) {
+    channel.port1.onmessage = function(e) { resolve(e.data); };
+  });
+  const script_url = normalizeURL(SCRIPT1);
+  const newer_script_url = normalizeURL(SCRIPT2);
+  const expectations = [
+    'evaluate',
+    '  installing: empty',
+    '  waiting: empty',
+    '  active: ' + script_url,
+    'updatefound',
+    '  installing: ' + newer_script_url,
+    '  waiting: empty',
+    '  active: ' + script_url,
+    'install',
+    '  installing: ' + newer_script_url,
+    '  waiting: empty',
+    '  active: ' + script_url,
+    'statechange(installed)',
+    '  installing: empty',
+    '  waiting: ' + newer_script_url,
+    '  active: ' + script_url,
+    'statechange(activating)',
+    '  installing: empty',
+    '  waiting: empty',
+    '  active: ' + newer_script_url,
+    'activate',
+    '  installing: empty',
+    '  waiting: empty',
+    '  active: ' + newer_script_url,
+    'statechange(activated)',
+    '  installing: empty',
+    '  waiting: empty',
+    '  active: ' + newer_script_url,
+  ];
 
-    assert_array_equals(results, expectations);
-  }, "Verify registration attributes on ServiceWorkerGlobalScope of the newer worker");
+ t.add_cleanup(async() => {
+    if (registration1)
+      await registration1.unregister();
+    if (registration2)
+      await registration2.unregister();
+ })
+
+  assert_array_equals(results, expectations);
+}, 'Verify registration attributes on ServiceWorkerGlobalScope of the ' +
+   'newer worker');
+
 </script>

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/service-worker-error-event.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/service-worker-error-event.https.html
@@ -5,6 +5,11 @@
 <script src='../resources/test-helpers.sub.js'></script>
 <script>
 promise_test(async t => {
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+  });
+
   const SCRIPT = 'resources/error-worker.js';
   const SCOPE = 'resources/scope/service-worker-error-event';
   const registration = await service_worker_unregister_and_register(
@@ -16,11 +21,6 @@ promise_test(async t => {
   const event = await new Promise(function(resolve) {
     navigator.serviceWorker.onmessage = resolve;
     worker.postMessage('');
-  });
-
-  add_completion_callback(async() => {
-    if (registration)
-      await registration.unregister();
   });
 
   assert_equals(event.data.error, 'testError', 'error type');

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/service-worker-error-event.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/service-worker-error-event.https.html
@@ -1,31 +1,35 @@
 <!DOCTYPE html>
 <title>ServiceWorkerGlobalScope: Error event error message</title>
-<script src='/resources/testharness.js'></script>
-<script src='/resources/testharnessreport.js'></script>
-<script src='../resources/test-helpers.sub.js'></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    var script = 'resources/error-worker.js';
-    var scope = 'resources/scope/service-worker-error-event';
-    var error_name = 'testError'
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(registration => {
-          var worker = registration.installing;
-          add_completion_callback(() => { registration.unregister(); });
-          return new Promise(function(resolve) {
-              navigator.serviceWorker.onmessage = resolve;
-              worker.postMessage('');
-            });
-        })
-      .then(e => {
-          assert_equals(e.data.error, error_name, 'error type');
-          assert_greater_than(
-            e.data.message.indexOf(error_name), -1, 'error message');
-          assert_greater_than(
-            e.data.filename.indexOf(script), -1, 'filename');
-          assert_equals(e.data.lineno, 5, 'error line number');
-          assert_equals(e.data.colno, 3, 'error column number');
-        });
-  }, 'Error handlers inside serviceworker should see the attributes of ' +
-     'ErrorEvent');
+  promise_test(async t => {
+    const SCRIPT = "resources/error-worker.js";
+    const SCOPE = "resources/scope/service-worker-error-event";
+    const registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT,
+      SCOPE
+    );
+    const worker = registration.installing;
+    const event = await new Promise(function(resolve) {
+      navigator.serviceWorker.onmessage = resolve;
+      worker.postMessage("");
+    });
+
+    add_completion_callback(async () => {
+      if (registration) await registration.unregister();
+    });
+
+    assert_equals(event.data.error, "testError", "error type");
+    assert_greater_than(
+      event.data.message.indexOf("testError"),
+      -1,
+      "error message"
+    );
+    assert_greater_than(event.data.filename.indexOf(SCRIPT), -1, "filename");
+    assert_equals(event.data.lineno, 5, "error line number");
+    assert_equals(event.data.colno, 3, "error column number");
+  }, "Error handlers inside serviceworker should see the attributes of ErrorEvent");
 </script>

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/service-worker-error-event.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/service-worker-error-event.https.html
@@ -1,35 +1,36 @@
 <!DOCTYPE html>
 <title>ServiceWorkerGlobalScope: Error event error message</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="../resources/test-helpers.sub.js"></script>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='../resources/test-helpers.sub.js'></script>
 <script>
-  promise_test(async t => {
-    const SCRIPT = "resources/error-worker.js";
-    const SCOPE = "resources/scope/service-worker-error-event";
-    const registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT,
-      SCOPE
-    );
-    const worker = registration.installing;
-    const event = await new Promise(function(resolve) {
-      navigator.serviceWorker.onmessage = resolve;
-      worker.postMessage("");
-    });
+promise_test(async t => {
+  const SCRIPT = 'resources/error-worker.js';
+  const SCOPE = 'resources/scope/service-worker-error-event';
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+  const worker = registration.installing;
+  const event = await new Promise(function(resolve) {
+    navigator.serviceWorker.onmessage = resolve;
+    worker.postMessage('');
+  });
 
-    add_completion_callback(async () => {
-      if (registration) await registration.unregister();
-    });
+  add_completion_callback(async() => {
+    if (registration)
+      await registration.unregister();
+  });
 
-    assert_equals(event.data.error, "testError", "error type");
-    assert_greater_than(
-      event.data.message.indexOf("testError"),
-      -1,
-      "error message"
-    );
-    assert_greater_than(event.data.filename.indexOf(SCRIPT), -1, "filename");
-    assert_equals(event.data.lineno, 5, "error line number");
-    assert_equals(event.data.colno, 3, "error column number");
-  }, "Error handlers inside serviceworker should see the attributes of ErrorEvent");
+  assert_equals(event.data.error, 'testError', 'error type');
+  assert_greater_than(
+    event.data.message.indexOf('testError'), -1, 'error message');
+  assert_greater_than(
+    event.data.filename.indexOf(SCRIPT), -1, 'filename');
+  assert_equals(event.data.lineno, 5, 'error line number');
+  assert_equals(event.data.colno, 3, 'error column number');
+
+}, 'Error handlers inside serviceworker should see the attributes of ' +
+   'ErrorEvent');
 </script>

--- a/service-workers/service-worker/clients-get-client-types.https.html
+++ b/service-workers/service-worker/clients-get-client-types.https.html
@@ -4,105 +4,134 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-var scope = 'resources/clients-get-client-types';
-var frame_url = scope + '-frame.html';
-var shared_worker_url = scope + '-shared-worker.js';
-var worker_url = scope + '-worker.js';
-var client_ids = [];
-var registration;
-var frame;
-promise_test(function(t) {
-    return service_worker_unregister_and_register(
-        t, 'resources/clients-get-worker.js', scope)
-      .then(function(r) {
-          registration = r;
-          add_completion_callback(function() { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() {
-          return with_iframe(frame_url);
-        })
-      .then(function(f) {
-          frame = f;
-          add_completion_callback(function() { frame.remove(); });
-          frame.focus();
-          return wait_for_clientId();
-        })
-      .then(function(client_id) {
-          client_ids.push(client_id);
-          return new Promise(function(resolve) {
-              var w = new SharedWorker(shared_worker_url);
-              w.port.onmessage = function(e) {
-                resolve(e.data.clientId);
-              };
-            });
-        })
-      .then(function(client_id) {
-          client_ids.push(client_id);
-          var channel = new MessageChannel();
-          var w = new Worker(worker_url);
-          w.postMessage({cmd:'GetClientId', port:channel.port2},
-              [channel.port2]);
-          return new Promise(function(resolve) {
-              channel.port1.onmessage = function(e) {
-                resolve(e.data.clientId);
-              };
-            });
-        })
-      .then(function(client_id) {
-          client_ids.push(client_id);
-          var channel = new MessageChannel();
-          frame.contentWindow.postMessage('StartWorker', '*', [channel.port2]);
-          return new Promise(function(resolve) {
-              channel.port1.onmessage = function(e) {
-                resolve(e.data.clientId);
-              };
-            });
-        })
-      .then(function(client_id) {
-          client_ids.push(client_id);
-          var saw_message = new Promise(function(resolve) {
-              navigator.serviceWorker.onmessage = resolve;
-            });
-          registration.active.postMessage({clientIds: client_ids});
-          return saw_message;
-        })
-      .then(function(e) {
-          assert_equals(e.data.length, expected.length);
-          // We use these assert_not_equals because assert_array_equals doesn't
-          // print the error description when passed an undefined value.
-          assert_not_equals(e.data[0], undefined,
-              'Window client should not be undefined');
-          assert_array_equals(e.data[0], expected[0], 'Window client');
-          assert_not_equals(e.data[1], undefined,
-              'Shared worker client should not be undefined');
-          assert_array_equals(e.data[1], expected[1], 'Shared worker client');
-          assert_not_equals(e.data[2], undefined,
-              'Worker(Started by main frame) client should not be undefined');
-          assert_array_equals(e.data[2], expected[2],
-              'Worker(Started by main frame) client');
-          assert_not_equals(e.data[3], undefined,
-              'Worker(Started by sub frame) client should not be undefined');
-          assert_array_equals(e.data[3], expected[3],
-              'Worker(Started by sub frame) client');
-        });
-  }, 'Test Clients.get() with window and worker clients');
+  const SCOPE = "resources/clients-get-client-types";
+  const SCRIPT = "resources/clients-get-worker.js";
+  const FRAME_URL = SCOPE + "-frame.html";
+  const SHARED_WORKER_URL = SCOPE + "-shared-worker.js";
+  const WORKER_URL = SCOPE + "-worker.js";
+  let client_ids = [];
 
-function wait_for_clientId() {
-  return new Promise(function(resolve) {
+  promise_test(async t => {
+    const registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, "activated");
+    const frame = await with_iframe(FRAME_URL);
+
+    t.add_cleanup(async () => {
+      if (frame) frame.remove();
+      if (registration) await registration.unregister();
+    });
+
+    frame.focus();
+    let client_id = await wait_for_clientId();
+    client_ids.push(client_id);
+
+    client_id = await new Promise(function(resolve) {
+      const sharedWorker = new SharedWorker(SHARED_WORKER_URL);
+      sharedWorker.port.onmessage = function(event) {
+        resolve(event.data.clientId);
+      };
+    });
+    client_ids.push(client_id);
+
+    let channel = new MessageChannel();
+    const worker = new Worker(WORKER_URL);
+    worker.postMessage({ cmd: "GetClientId", port: channel.port2 }, [
+      channel.port2
+    ]);
+    client_id = await new Promise(function(resolve) {
+      channel.port1.onmessage = function(event) {
+        resolve(event.data.clientId);
+      };
+    });
+    client_ids.push(client_id);
+
+    channel = new MessageChannel();
+    frame.contentWindow.postMessage("StartWorker", "*", [channel.port2]);
+    client_id = await new Promise(function(resolve) {
+      channel.port1.onmessage = function(event) {
+        resolve(event.data.clientId);
+      };
+    });
+    client_ids.push(client_id);
+
+    const e = await new Promise(function(resolve) {
+      navigator.serviceWorker.onmessage = resolve;
+      registration.active.postMessage({ clientIds: client_ids });
+    });
+    assert_equals(e.data.length, expected.length);
+    // We use these assert_not_equals because assert_array_equals doesn't
+    // print the error description when passed an undefined value.
+    assert_not_equals(
+      e.data[0],
+      undefined,
+      "Window client should not be undefined"
+    );
+    assert_array_equals(e.data[0], expected[0], "Window client");
+    assert_not_equals(
+      e.data[1],
+      undefined,
+      "Shared worker client should not be undefined"
+    );
+    assert_array_equals(e.data[1], expected[1], "Shared worker client");
+    assert_not_equals(
+      e.data[2],
+      undefined,
+      "Worker(Started by main frame) client should not be undefined"
+    );
+    assert_array_equals(
+      e.data[2],
+      expected[2],
+      "Worker(Started by main frame) client"
+    );
+    assert_not_equals(
+      e.data[3],
+      undefined,
+      "Worker(Started by sub frame) client should not be undefined"
+    );
+    assert_array_equals(
+      e.data[3],
+      expected[3],
+      "Worker(Started by sub frame) client"
+    );
+  });
+
+  function wait_for_clientId() {
+    return new Promise(function(resolve) {
       function get_client_id(e) {
-        window.removeEventListener('message', get_client_id);
+        window.removeEventListener("message", get_client_id);
         resolve(e.data.clientId);
       }
-      window.addEventListener('message', get_client_id, false);
+      window.addEventListener("message", get_client_id, false);
     });
-}
+  }
 
-var expected = [
+  const expected = [
     // visibilityState, focused, url, type, frameType
-    ['visible', true, normalizeURL(scope) + '-frame.html', 'window', 'nested'],
-    [undefined, undefined, normalizeURL(scope) + '-shared-worker.js', 'sharedworker', 'none'],
-    [undefined, undefined, normalizeURL(scope) + '-worker.js', 'worker', 'none'],
-    [undefined, undefined, normalizeURL(scope) + '-frame-worker.js', 'worker', 'none']
-];
+    ["visible", true, normalizeURL(SCOPE) + "-frame.html", "window", "nested"],
+    [
+      undefined,
+      undefined,
+      normalizeURL(SCOPE) + "-shared-worker.js",
+      "sharedworker",
+      "none"
+    ],
+    [
+      undefined,
+      undefined,
+      normalizeURL(SCOPE) + "-worker.js",
+      "worker",
+      "none"
+    ],
+    [
+      undefined,
+      undefined,
+      normalizeURL(SCOPE) + "-frame-worker.js",
+      "worker",
+      "none"
+    ]
+  ];
 </script>

--- a/service-workers/service-worker/clients-get-client-types.https.html
+++ b/service-workers/service-worker/clients-get-client-types.https.html
@@ -4,134 +4,98 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  const SCOPE = "resources/clients-get-client-types";
-  const SCRIPT = "resources/clients-get-worker.js";
-  const FRAME_URL = SCOPE + "-frame.html";
-  const SHARED_WORKER_URL = SCOPE + "-shared-worker.js";
-  const WORKER_URL = SCOPE + "-worker.js";
-  let client_ids = [];
+const SCOPE = 'resources/clients-get-client-types';
+const SCRIPT = 'resources/clients-get-worker.js';
+const FRAME_URL = SCOPE + '-frame.html';
+const SHARED_WORKER_URL = SCOPE + '-shared-worker.js';
+const WORKER_URL = SCOPE + '-worker.js';
+let client_ids = [];
 
-  promise_test(async t => {
-    const registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT,
-      SCOPE
-    );
-    await wait_for_state(t, registration.installing, "activated");
-    const frame = await with_iframe(FRAME_URL);
+promise_test(async t => {
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(FRAME_URL);
 
-    t.add_cleanup(async () => {
-      if (frame) frame.remove();
-      if (registration) await registration.unregister();
-    });
-
-    frame.focus();
-    let client_id = await wait_for_clientId();
-    client_ids.push(client_id);
-
-    client_id = await new Promise(function(resolve) {
-      const sharedWorker = new SharedWorker(SHARED_WORKER_URL);
-      sharedWorker.port.onmessage = function(event) {
-        resolve(event.data.clientId);
-      };
-    });
-    client_ids.push(client_id);
-
-    let channel = new MessageChannel();
-    const worker = new Worker(WORKER_URL);
-    worker.postMessage({ cmd: "GetClientId", port: channel.port2 }, [
-      channel.port2
-    ]);
-    client_id = await new Promise(function(resolve) {
-      channel.port1.onmessage = function(event) {
-        resolve(event.data.clientId);
-      };
-    });
-    client_ids.push(client_id);
-
-    channel = new MessageChannel();
-    frame.contentWindow.postMessage("StartWorker", "*", [channel.port2]);
-    client_id = await new Promise(function(resolve) {
-      channel.port1.onmessage = function(event) {
-        resolve(event.data.clientId);
-      };
-    });
-    client_ids.push(client_id);
-
-    const e = await new Promise(function(resolve) {
-      navigator.serviceWorker.onmessage = resolve;
-      registration.active.postMessage({ clientIds: client_ids });
-    });
-    assert_equals(e.data.length, expected.length);
-    // We use these assert_not_equals because assert_array_equals doesn't
-    // print the error description when passed an undefined value.
-    assert_not_equals(
-      e.data[0],
-      undefined,
-      "Window client should not be undefined"
-    );
-    assert_array_equals(e.data[0], expected[0], "Window client");
-    assert_not_equals(
-      e.data[1],
-      undefined,
-      "Shared worker client should not be undefined"
-    );
-    assert_array_equals(e.data[1], expected[1], "Shared worker client");
-    assert_not_equals(
-      e.data[2],
-      undefined,
-      "Worker(Started by main frame) client should not be undefined"
-    );
-    assert_array_equals(
-      e.data[2],
-      expected[2],
-      "Worker(Started by main frame) client"
-    );
-    assert_not_equals(
-      e.data[3],
-      undefined,
-      "Worker(Started by sub frame) client should not be undefined"
-    );
-    assert_array_equals(
-      e.data[3],
-      expected[3],
-      "Worker(Started by sub frame) client"
-    );
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
   });
 
-  function wait_for_clientId() {
-    return new Promise(function(resolve) {
-      function get_client_id(e) {
-        window.removeEventListener("message", get_client_id);
-        resolve(e.data.clientId);
-      }
-      window.addEventListener("message", get_client_id, false);
-    });
-  }
+  frame.focus();
+  let client_id = await wait_for_clientId();
+  client_ids.push(client_id);
 
-  const expected = [
-    // visibilityState, focused, url, type, frameType
-    ["visible", true, normalizeURL(SCOPE) + "-frame.html", "window", "nested"],
-    [
-      undefined,
-      undefined,
-      normalizeURL(SCOPE) + "-shared-worker.js",
-      "sharedworker",
-      "none"
-    ],
-    [
-      undefined,
-      undefined,
-      normalizeURL(SCOPE) + "-worker.js",
-      "worker",
-      "none"
-    ],
-    [
-      undefined,
-      undefined,
-      normalizeURL(SCOPE) + "-frame-worker.js",
-      "worker",
-      "none"
-    ]
-  ];
+  client_id = await new Promise(function(resolve) {
+    const sharedWorker = new SharedWorker(SHARED_WORKER_URL);
+    sharedWorker.port.onmessage = function(event) {
+      resolve(event.data.clientId);
+    };
+  });
+  client_ids.push(client_id);
+
+  let channel = new MessageChannel();
+  const worker = new Worker(WORKER_URL);
+  worker.postMessage({ cmd: 'GetClientId', port: channel.port2 }, [
+    channel.port2
+  ]);
+  client_id = await new Promise(function(resolve) {
+    channel.port1.onmessage = function(event) {
+      resolve(event.data.clientId);
+    };
+  });
+  client_ids.push(client_id);
+
+  channel = new MessageChannel();
+  frame.contentWindow.postMessage('StartWorker', '*', [channel.port2]);
+  client_id = await new Promise(function(resolve) {
+    channel.port1.onmessage = function(event) {
+      resolve(event.data.clientId);
+    };
+  });
+  client_ids.push(client_id);
+
+  const e = await new Promise(function(resolve) {
+    navigator.serviceWorker.onmessage = resolve;
+    registration.active.postMessage({ clientIds: client_ids });
+  });
+  assert_equals(e.data.length, expected.length);
+  // We use these assert_not_equals because assert_array_equals doesn't
+  // print the error description when passed an undefined value.
+  assert_not_equals(e.data[0], undefined,
+    'Window client should not be undefined');
+  assert_array_equals(e.data[0], expected[0], 'Window client');
+  assert_not_equals(e.data[1], undefined,
+    'Shared worker client should not be undefined');
+  assert_array_equals(e.data[1], expected[1], 'Shared worker client');
+  assert_not_equals(e.data[2], undefined,
+    'Worker(Started by main frame) client should not be undefined');
+  assert_array_equals(e.data[2], expected[2],
+    'Worker(Started by main frame) client');
+  assert_not_equals(e.data[3], undefined,
+    'Worker(Started by sub frame) client should not be undefined');
+  assert_array_equals(e.data[3], expected[3],
+    'Worker(Started by sub frame) client');
+});
+
+function wait_for_clientId() {
+  return new Promise(function(resolve) {
+    function get_client_id(e) {
+      window.removeEventListener('message', get_client_id);
+      resolve(e.data.clientId);
+    }
+    window.addEventListener('message', get_client_id, false);
+  });
+}
+
+const expected = [
+  // visibilityState, focused, url, type, frameType
+  ['visible', true, normalizeURL(SCOPE) + '-frame.html', 'window', 'nested'],
+  [undefined, undefined, normalizeURL(SCOPE) + '-shared-worker.js', 'sharedworker', 'none'],
+  [undefined, undefined, normalizeURL(SCOPE) + '-worker.js', 'worker', 'none'],
+  [undefined, undefined, normalizeURL(SCOPE) + '-frame-worker.js', 'worker', 'none']
+];
 </script>

--- a/service-workers/service-worker/clients-get-client-types.https.html
+++ b/service-workers/service-worker/clients-get-client-types.https.html
@@ -12,6 +12,11 @@ const WORKER_URL = SCOPE + '-worker.js';
 let client_ids = [];
 
 promise_test(async t => {
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+
   const registration = await service_worker_unregister_and_register(
     t,
     SCRIPT,
@@ -19,12 +24,6 @@ promise_test(async t => {
   );
   await wait_for_state(t, registration.installing, 'activated');
   const frame = await with_iframe(FRAME_URL);
-
-  t.add_cleanup(async () => {
-    if (frame) frame.remove();
-    if (registration) await registration.unregister();
-  });
-
   frame.focus();
   let client_id = await wait_for_clientId();
   client_ids.push(client_id);

--- a/service-workers/service-worker/clients-get-cross-origin.https.html
+++ b/service-workers/service-worker/clients-get-cross-origin.https.html
@@ -18,6 +18,12 @@ const other_origin_iframe =
 // foreign origin which connects to a server worker in the current origin.
 
 promise_test(async t => {
+  t.add_cleanup(async () => {
+    if (frame1) frame1.remove();
+    if (frame2) frame2.remove();
+    if (registration) await registration.unregister();
+  });
+
   const registration = await service_worker_unregister_and_register(
     t,
     SCRIPT,
@@ -44,13 +50,6 @@ promise_test(async t => {
       }
     });
   });
-
-  t.add_cleanup(async () => {
-    if (frame1) frame1.remove();
-    if (frame2) frame2.remove();
-    if (registration) await registration.unregister();
-  });
-
   assert_equals(client_id, undefined, 'iframe client ID');
 }, 'Test Clients.get() cross origin');
 </script>

--- a/service-workers/service-worker/clients-get-cross-origin.https.html
+++ b/service-workers/service-worker/clients-get-cross-origin.https.html
@@ -5,52 +5,52 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  let host_info = get_host_info();
+let host_info = get_host_info();
 
-  const SCOPE = "resources/clients-get-frame.html";
-  const SCRIPT = "resources/clients-get-worker.js";
-  const other_origin_iframe =
-    host_info["HTTPS_REMOTE_ORIGIN"] +
-    base_path() +
-    "resources/clients-get-cross-origin-frame.html";
-  // This test asserts the behavior of the Client API in cases where the client
-  // belongs to a foreign origin. It does this by creating an iframe with a
-  // foreign origin which connects to a server worker in the current origin.
+const SCOPE = 'resources/clients-get-frame.html';
+const SCRIPT = 'resources/clients-get-worker.js';
+const other_origin_iframe =
+  host_info['HTTPS_REMOTE_ORIGIN'] +
+  base_path() +
+  'resources/clients-get-cross-origin-frame.html';
+// This test asserts the behavior of the Client API in cases where the client
+// belongs to a foreign origin. It does this by creating an iframe with a
+// foreign origin which connects to a server worker in the current origin.
 
-  promise_test(async t => {
-    const registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT,
-      SCOPE
-    );
-    await wait_for_state(t, registration.installing, "activated");
-    const frame1 = await with_iframe(SCOPE);
-    let client_id = await new Promise(function(resolve, reject) {
-      function get_client_id(e) {
-        window.removeEventListener("message", get_client_id);
-        resolve(e.data.clientId);
+promise_test(async t => {
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame1 = await with_iframe(SCOPE);
+  let client_id = await new Promise(function(resolve, reject) {
+    function get_client_id(e) {
+      window.removeEventListener('message', get_client_id);
+      resolve(e.data.clientId);
+    }
+    window.addEventListener('message', get_client_id, false);
+  });
+  const frame2 = await with_iframe(other_origin_iframe);
+  frame2.contentWindow.postMessage(
+    { clientId: client_id, type: 'getClientId' },
+    host_info['HTTPS_REMOTE_ORIGIN']
+  );
+  client_id = await new Promise(function(resolve) {
+    window.addEventListener('message', function(e) {
+      if (e.data && e.data.type === 'clientId') {
+        resolve(e.data.value);
       }
-      window.addEventListener("message", get_client_id, false);
     });
-    const frame2 = await with_iframe(other_origin_iframe);
-    frame2.contentWindow.postMessage(
-      { clientId: client_id, type: "getClientId" },
-      host_info["HTTPS_REMOTE_ORIGIN"]
-    );
-    client_id = await new Promise(function(resolve) {
-      window.addEventListener("message", function(e) {
-        if (e.data && e.data.type === "clientId") {
-          resolve(e.data.value);
-        }
-      });
-    });
+  });
 
-    t.add_cleanup(async () => {
-      if (frame1) frame1.remove();
-      if (frame2) frame2.remove();
-      if (registration) await registration.unregister();
-    });
+  t.add_cleanup(async () => {
+    if (frame1) frame1.remove();
+    if (frame2) frame2.remove();
+    if (registration) await registration.unregister();
+  });
 
-    assert_equals(client_id, undefined, "iframe client ID");
-  }, "Test Clients.get() cross origin");
+  assert_equals(client_id, undefined, 'iframe client ID');
+}, 'Test Clients.get() cross origin');
 </script>

--- a/service-workers/service-worker/clients-get-cross-origin.https.html
+++ b/service-workers/service-worker/clients-get-cross-origin.https.html
@@ -30,6 +30,7 @@ promise_test(async t => {
     SCOPE
   );
   await wait_for_state(t, registration.installing, 'activated');
+
   const frame1 = await with_iframe(SCOPE);
   let client_id = await new Promise(function(resolve, reject) {
     function get_client_id(e) {
@@ -38,6 +39,7 @@ promise_test(async t => {
     }
     window.addEventListener('message', get_client_id, false);
   });
+
   const frame2 = await with_iframe(other_origin_iframe);
   frame2.contentWindow.postMessage(
     { clientId: client_id, type: 'getClientId' },

--- a/service-workers/service-worker/clients-get-cross-origin.https.html
+++ b/service-workers/service-worker/clients-get-cross-origin.https.html
@@ -5,65 +5,52 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-var host_info = get_host_info();
+  let host_info = get_host_info();
 
-var scope = 'resources/clients-get-frame.html';
-var other_origin_iframe = host_info['HTTPS_REMOTE_ORIGIN'] + base_path() +
-                          'resources/clients-get-cross-origin-frame.html';
-// The ID of a client from the same origin as us.
-var my_origin_client_id;
-// This test asserts the behavior of the Client API in cases where the client
-// belongs to a foreign origin. It does this by creating an iframe with a
-// foreign origin which connects to a server worker in the current origin.
-promise_test(function(t) {
-    return service_worker_unregister_and_register(
-        t, 'resources/clients-get-worker.js', scope)
-      .then(function(registration) {
-          add_completion_callback(function() { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() {
-          return with_iframe(scope);
-        })
-      // Create a same-origin client and use it to populate |my_origin_client_id|.
-      .then(function(frame1) {
-          add_completion_callback(function() { frame1.remove(); });
-          return new Promise(function(resolve, reject) {
-            function get_client_id(e) {
-              window.removeEventListener('message', get_client_id);
-              resolve(e.data.clientId);
-            }
-            window.addEventListener('message', get_client_id, false);
-          });
-        })
-      // Create a cross-origin client. We'll communicate with this client to
-      // test the cross-origin service worker's behavior.
-      .then(function(client_id) {
-          my_origin_client_id = client_id;
-          return with_iframe(other_origin_iframe);
-        })
-      // Post the 'getClientId' message to the cross-origin client. The client
-      // will then ask its service worker to look up |my_origin_client_id| via
-      // Clients#get. Since this client ID is for a different origin, we expect
-      // the client to not be found.
-      .then(function(frame2) {
-          add_completion_callback(function() { frame2.remove(); });
+  const SCOPE = "resources/clients-get-frame.html";
+  const SCRIPT = "resources/clients-get-worker.js";
+  const other_origin_iframe =
+    host_info["HTTPS_REMOTE_ORIGIN"] +
+    base_path() +
+    "resources/clients-get-cross-origin-frame.html";
+  // This test asserts the behavior of the Client API in cases where the client
+  // belongs to a foreign origin. It does this by creating an iframe with a
+  // foreign origin which connects to a server worker in the current origin.
 
-          frame2.contentWindow.postMessage(
-            {clientId: my_origin_client_id, type: 'getClientId'},
-            host_info['HTTPS_REMOTE_ORIGIN']
-          );
+  promise_test(async t => {
+    const registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, "activated");
+    const frame1 = await with_iframe(SCOPE);
+    let client_id = await new Promise(function(resolve, reject) {
+      function get_client_id(e) {
+        window.removeEventListener("message", get_client_id);
+        resolve(e.data.clientId);
+      }
+      window.addEventListener("message", get_client_id, false);
+    });
+    const frame2 = await with_iframe(other_origin_iframe);
+    frame2.contentWindow.postMessage(
+      { clientId: client_id, type: "getClientId" },
+      host_info["HTTPS_REMOTE_ORIGIN"]
+    );
+    client_id = await new Promise(function(resolve) {
+      window.addEventListener("message", function(e) {
+        if (e.data && e.data.type === "clientId") {
+          resolve(e.data.value);
+        }
+      });
+    });
 
-          return new Promise(function(resolve) {
-              window.addEventListener('message', function(e) {
-                  if (e.data && e.data.type === 'clientId') {
-                    resolve(e.data.value);
-                  }
-                });
-            });
-        })
-      .then(function(client_id) {
-          assert_equals(client_id, undefined, 'iframe client ID');
-        });
-  }, 'Test Clients.get() cross origin');
+    t.add_cleanup(async () => {
+      if (frame1) frame1.remove();
+      if (frame2) frame2.remove();
+      if (registration) await registration.unregister();
+    });
+
+    assert_equals(client_id, undefined, "iframe client ID");
+  }, "Test Clients.get() cross origin");
 </script>

--- a/service-workers/service-worker/clients-matchall-on-evaluation.https.html
+++ b/service-workers/service-worker/clients-matchall-on-evaluation.https.html
@@ -4,25 +4,25 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  promise_test(async t => {
-    const SCRIPT = "resources/clients-matchall-on-evaluation-worker.js";
-    const SCOPE = "resources/blank.html?clients-matchAll-on-evaluation";
+promise_test(async t => {
+  const SCRIPT = 'resources/clients-matchall-on-evaluation-worker.js';
+  const SCOPE = 'resources/blank.html?clients-matchAll-on-evaluation';
 
-    const registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT,
-      SCOPE
-    );
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
 
-    t.add_cleanup(async () => {
-      if (registration) await registration.unregister();
-    });
+  t.add_cleanup(async () => {
+    if (registration) await registration.unregister();
+  });
 
-    await new Promise(function(resolve) {
-      navigator.serviceWorker.onmessage = function(e) {
-        assert_equals(e.data, "matched");
-        resolve();
-      };
-    });
-  }, "Test Clients.matchAll() on script evaluation");
+  await new Promise(function(resolve) {
+    navigator.serviceWorker.onmessage = function(e) {
+      assert_equals(e.data, 'matched');
+      resolve();
+    };
+  });
+}, 'Test Clients.matchAll() on script evaluation');
 </script>

--- a/service-workers/service-worker/clients-matchall-on-evaluation.https.html
+++ b/service-workers/service-worker/clients-matchall-on-evaluation.https.html
@@ -17,11 +17,13 @@ promise_test(async t => {
     SCRIPT,
     SCOPE
   );
-  await new Promise(function(resolve) {
+  const saw_message = new Promise(function(resolve) {
     navigator.serviceWorker.onmessage = function(e) {
-      assert_equals(e.data, 'matched');
-      resolve();
+      resolve(e.data);
     };
   });
+
+  const results = await saw_message;
+  assert_equals(results, 'matched');
 }, 'Test Clients.matchAll() on script evaluation');
 </script>

--- a/service-workers/service-worker/clients-matchall-on-evaluation.https.html
+++ b/service-workers/service-worker/clients-matchall-on-evaluation.https.html
@@ -4,21 +4,25 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-promise_test(function(t) {
-    var script = 'resources/clients-matchall-on-evaluation-worker.js';
-    var scope = 'resources/blank.html?clients-matchAll-on-evaluation';
+  promise_test(async t => {
+    const SCRIPT = "resources/clients-matchall-on-evaluation-worker.js";
+    const SCOPE = "resources/blank.html?clients-matchAll-on-evaluation";
 
-    var saw_message = new Promise(function(resolve) {
-        navigator.serviceWorker.onmessage = function(e) {
-            assert_equals(e.data, 'matched');
-            resolve();
-          };
-      });
+    const registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT,
+      SCOPE
+    );
 
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(function(registration) {
-          add_completion_callback(function() { registration.unregister(); });
-          return saw_message;
-        });
-  }, 'Test Clients.matchAll() on script evaluation');
+    t.add_cleanup(async () => {
+      if (registration) await registration.unregister();
+    });
+
+    await new Promise(function(resolve) {
+      navigator.serviceWorker.onmessage = function(e) {
+        assert_equals(e.data, "matched");
+        resolve();
+      };
+    });
+  }, "Test Clients.matchAll() on script evaluation");
 </script>

--- a/service-workers/service-worker/clients-matchall-on-evaluation.https.html
+++ b/service-workers/service-worker/clients-matchall-on-evaluation.https.html
@@ -5,6 +5,10 @@
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 promise_test(async t => {
+  t.add_cleanup(async () => {
+    if (registration) await registration.unregister();
+  });
+
   const SCRIPT = 'resources/clients-matchall-on-evaluation-worker.js';
   const SCOPE = 'resources/blank.html?clients-matchAll-on-evaluation';
 
@@ -13,11 +17,6 @@ promise_test(async t => {
     SCRIPT,
     SCOPE
   );
-
-  t.add_cleanup(async () => {
-    if (registration) await registration.unregister();
-  });
-
   await new Promise(function(resolve) {
     navigator.serviceWorker.onmessage = function(e) {
       assert_equals(e.data, 'matched');

--- a/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
+++ b/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
@@ -1,93 +1,91 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<title>Canvas tainting due to video whose responses are fetched via a service worker including range requests</title>
+<meta charset="utf-8" />
+<title>
+  Canvas tainting due to video whose responses are fetched via a service worker
+  including range requests
+</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <body>
-<script>
-// These tests try to test canvas tainting due to a <video> element. The video
-// src URL is same-origin as the page, but the response is fetched via a service
-// worker that does tricky things like returning opaque responses from another
-// origin. Furthermore, this tests range requests so there are multiple
-// responses.
-//
-// We test range requests by having the server return 206 Partial Content to the
-// first request (which doesn't necessarily have a "Range" header or one with a
-// byte range). Then the <video> element automatically makes ranged requests
-// (the "Range" HTTP request header specifies a byte range). The server responds
-// to these with 206 Partial Content for the given range.
-function range_request_test(script, expected, description) {
-  promise_test(t => {
-      let frame;
-      let registration;
-      add_result_callback(() => {
+  <script>
+    // These tests try to test canvas tainting due to a <video> element. The video
+    // src URL is same-origin as the page, but the response is fetched via a service
+    // worker that does tricky things like returning opaque responses from another
+    // origin. Furthermore, this tests range requests so there are multiple
+    // responses.
+    //
+    // We test range requests by having the server return 206 Partial Content to the
+    // first request (which doesn't necessarily have a "Range" header or one with a
+    // byte range). Then the <video> element automatically makes ranged requests
+    // (the "Range" HTTP request header specifies a byte range). The server responds
+    // to these with 206 Partial Content for the given range.
+    function range_request_test(script, expected, description) {
+      promise_test(async t => {
+        t.add_cleanup(async () => {
           if (frame) frame.remove();
-          if (registration) registration.unregister();
+          if (registration) await registration.unregister();
         });
 
-      const scope = 'resources/fetch-canvas-tainting-iframe.html';
-      return service_worker_unregister_and_register(t, script, scope)
-        .then(r => {
-            registration = r;
-            return wait_for_state(t, registration.installing, 'activated');
-          })
-        .then(() => {
-            return with_iframe(scope);
-          })
-        .then(f => {
-            frame = f;
-            // Add "?VIDEO&PartialContent" to get a video resource from the
-            // server using range requests.
-            const video_url = 'fetch-access-control.py?VIDEO&PartialContent';
-            return frame.contentWindow.create_test_case_promise(video_url);
-          })
-        .then(result => {
-            assert_equals(result, expected);
-          });
-    }, description);
-}
+        const scope = "resources/fetch-canvas-tainting-iframe.html";
+        const registration = await service_worker_unregister_and_register(
+          t,
+          script,
+          scope
+        );
+        await wait_for_state(t, registration.installing, "activated");
+        const frame = await with_iframe(scope);
+        const video_url = "fetch-access-control.py?VIDEO&PartialContent";
+        const result = await frame.contentWindow.create_test_case_promise(
+          video_url
+        );
+        assert_equals(result, expected);
+      }, description);
+    }
 
-// We want to consider a number of scenarios:
-// (1) Range responses come from a single origin, the same-origin as the page.
-//     The canvas should not be tainted.
-range_request_test(
-  'resources/fetch-event-network-fallback-worker.js',
-  'NOT_TAINTED',
-  'range responses from single origin (same-origin)');
+    // We want to consider a number of scenarios:
+    // (1) Range responses come from a single origin, the same-origin as the page.
+    //     The canvas should not be tainted.
+    range_request_test(
+      "resources/fetch-event-network-fallback-worker.js",
+      "NOT_TAINTED",
+      "range responses from single origin (same-origin)"
+    );
 
-// (2) Range responses come from a single origin, cross-origin from the page
-//     (and without CORS sharing). This is not possible to test, since service
-//     worker can't make a request with a "Range" HTTP header in no-cors mode.
+    // (2) Range responses come from a single origin, cross-origin from the page
+    //     (and without CORS sharing). This is not possible to test, since service
+    //     worker can't make a request with a "Range" HTTP header in no-cors mode.
 
-// (3) Range responses come from multiple origins. The first response comes from
-//     cross-origin (and without CORS sharing, so is opaque). Subsequent
-//     responses come from same-origin. The canvas should be tainted (but in
-//     Chrome this is a LOAD_ERROR since it disallows range responses from
-//     multiple origins, period).
-range_request_test(
-  'resources/range-request-to-different-origins-worker.js',
-  'TAINTED',
-  'range responses from multiple origins (cross-origin first)');
+    // (3) Range responses come from multiple origins. The first response comes from
+    //     cross-origin (and without CORS sharing, so is opaque). Subsequent
+    //     responses come from same-origin. The canvas should be tainted (but in
+    //     Chrome this is a LOAD_ERROR since it disallows range responses from
+    //     multiple origins, period).
+    range_request_test(
+      "resources/range-request-to-different-origins-worker.js",
+      "TAINTED",
+      "range responses from multiple origins (cross-origin first)"
+    );
 
-// (4) Range responses come from multiple origins. The first response comes from
-//     same-origin. Subsequent responses come from cross-origin (and without
-//     CORS sharing). Like (2) this is not possible since the service worker
-//     cannot make range requests cross-origin.
+    // (4) Range responses come from multiple origins. The first response comes from
+    //     same-origin. Subsequent responses come from cross-origin (and without
+    //     CORS sharing). Like (2) this is not possible since the service worker
+    //     cannot make range requests cross-origin.
 
-// (5) Range responses come from a single origin, with a mix of opaque and
-//     non-opaque responses. The first request uses 'no-cors' mode to
-//     receive an opaque response, and subsequent range requests use 'cors'
-//     to receive non-opaque responses. The canvas should be tainted.
-range_request_test(
-  'resources/range-request-with-different-cors-modes-worker.js',
-  'TAINTED',
-  'range responses from single origin with both opaque and non-opaque responses');
+    // (5) Range responses come from a single origin, with a mix of opaque and
+    //     non-opaque responses. The first request uses 'no-cors' mode to
+    //     receive an opaque response, and subsequent range requests use 'cors'
+    //     to receive non-opaque responses. The canvas should be tainted.
+    range_request_test(
+      "resources/range-request-with-different-cors-modes-worker.js",
+      "TAINTED",
+      "range responses from single origin with both opaque and non-opaque responses"
+    );
 
-// (6) Range responses come from a single origin, with a mix of opaque and
-//     non-opaque responses. The first request uses 'cors' mode to
-//     receive an non-opaque response, and subsequent range requests use
-//     'no-cors' to receive non-opaque responses. Like (2) this is not possible.
-</script>
+    // (6) Range responses come from a single origin, with a mix of opaque and
+    //     non-opaque responses. The first request uses 'cors' mode to
+    //     receive an non-opaque response, and subsequent range requests use
+    //     'no-cors' to receive non-opaque responses. Like (2) this is not possible.
+  </script>
 </body>

--- a/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
+++ b/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
@@ -32,6 +32,7 @@ function range_request_test(script, expected, description) {
       scope
     );
     await wait_for_state(t, registration.installing, 'activated');
+
     const frame = await with_iframe(scope);
     const video_url = 'fetch-access-control.py?VIDEO&PartialContent';
     const result = await frame.contentWindow.create_test_case_promise(

--- a/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
+++ b/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html
@@ -1,91 +1,85 @@
 <!DOCTYPE html>
-<meta charset="utf-8" />
-<title>
-  Canvas tainting due to video whose responses are fetched via a service worker
-  including range requests
-</title>
+<meta charset="utf-8">
+<title>Canvas tainting due to video whose responses are fetched via a service worker including range requests</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <body>
-  <script>
-    // These tests try to test canvas tainting due to a <video> element. The video
-    // src URL is same-origin as the page, but the response is fetched via a service
-    // worker that does tricky things like returning opaque responses from another
-    // origin. Furthermore, this tests range requests so there are multiple
-    // responses.
-    //
-    // We test range requests by having the server return 206 Partial Content to the
-    // first request (which doesn't necessarily have a "Range" header or one with a
-    // byte range). Then the <video> element automatically makes ranged requests
-    // (the "Range" HTTP request header specifies a byte range). The server responds
-    // to these with 206 Partial Content for the given range.
-    function range_request_test(script, expected, description) {
-      promise_test(async t => {
-        t.add_cleanup(async () => {
-          if (frame) frame.remove();
-          if (registration) await registration.unregister();
-        });
+<script>
+// These tests try to test canvas tainting due to a <video> element. The video
+// src URL is same-origin as the page, but the response is fetched via a service
+// worker that does tricky things like returning opaque responses from another
+// origin. Furthermore, this tests range requests so there are multiple
+// responses.
+//
+// We test range requests by having the server return 206 Partial Content to the
+// first request (which doesn't necessarily have a "Range" header or one with a
+// byte range). Then the <video> element automatically makes ranged requests
+// (the "Range" HTTP request header specifies a byte range). The server responds
+// to these with 206 Partial Content for the given range.
+function range_request_test(script, expected, description) {
+  promise_test(async t => {
+    t.add_cleanup(async () => {
+      if (frame) frame.remove();
+      if (registration) await registration.unregister();
+    });
 
-        const scope = "resources/fetch-canvas-tainting-iframe.html";
-        const registration = await service_worker_unregister_and_register(
-          t,
-          script,
-          scope
-        );
-        await wait_for_state(t, registration.installing, "activated");
-        const frame = await with_iframe(scope);
-        const video_url = "fetch-access-control.py?VIDEO&PartialContent";
-        const result = await frame.contentWindow.create_test_case_promise(
-          video_url
-        );
-        assert_equals(result, expected);
-      }, description);
-    }
-
-    // We want to consider a number of scenarios:
-    // (1) Range responses come from a single origin, the same-origin as the page.
-    //     The canvas should not be tainted.
-    range_request_test(
-      "resources/fetch-event-network-fallback-worker.js",
-      "NOT_TAINTED",
-      "range responses from single origin (same-origin)"
+    const scope = 'resources/fetch-canvas-tainting-iframe.html';
+    const registration = await service_worker_unregister_and_register(
+      t,
+      script,
+      scope
     );
-
-    // (2) Range responses come from a single origin, cross-origin from the page
-    //     (and without CORS sharing). This is not possible to test, since service
-    //     worker can't make a request with a "Range" HTTP header in no-cors mode.
-
-    // (3) Range responses come from multiple origins. The first response comes from
-    //     cross-origin (and without CORS sharing, so is opaque). Subsequent
-    //     responses come from same-origin. The canvas should be tainted (but in
-    //     Chrome this is a LOAD_ERROR since it disallows range responses from
-    //     multiple origins, period).
-    range_request_test(
-      "resources/range-request-to-different-origins-worker.js",
-      "TAINTED",
-      "range responses from multiple origins (cross-origin first)"
+    await wait_for_state(t, registration.installing, 'activated');
+    const frame = await with_iframe(scope);
+    const video_url = 'fetch-access-control.py?VIDEO&PartialContent';
+    const result = await frame.contentWindow.create_test_case_promise(
+      video_url
     );
+    assert_equals(result, expected);
+  }, description);
+}
 
-    // (4) Range responses come from multiple origins. The first response comes from
-    //     same-origin. Subsequent responses come from cross-origin (and without
-    //     CORS sharing). Like (2) this is not possible since the service worker
-    //     cannot make range requests cross-origin.
+// We want to consider a number of scenarios:
+// (1) Range responses come from a single origin, the same-origin as the page.
+//     The canvas should not be tainted.
+range_request_test(
+  'resources/fetch-event-network-fallback-worker.js',
+  'NOT_TAINTED',
+  'range responses from single origin (same-origin)');
 
-    // (5) Range responses come from a single origin, with a mix of opaque and
-    //     non-opaque responses. The first request uses 'no-cors' mode to
-    //     receive an opaque response, and subsequent range requests use 'cors'
-    //     to receive non-opaque responses. The canvas should be tainted.
-    range_request_test(
-      "resources/range-request-with-different-cors-modes-worker.js",
-      "TAINTED",
-      "range responses from single origin with both opaque and non-opaque responses"
-    );
+// (2) Range responses come from a single origin, cross-origin from the page
+//     (and without CORS sharing). This is not possible to test, since service
+//     worker can't make a request with a "Range" HTTP header in no-cors mode.
 
-    // (6) Range responses come from a single origin, with a mix of opaque and
-    //     non-opaque responses. The first request uses 'cors' mode to
-    //     receive an non-opaque response, and subsequent range requests use
-    //     'no-cors' to receive non-opaque responses. Like (2) this is not possible.
-  </script>
+// (3) Range responses come from multiple origins. The first response comes from
+//     cross-origin (and without CORS sharing, so is opaque). Subsequent
+//     responses come from same-origin. The canvas should be tainted (but in
+//     Chrome this is a LOAD_ERROR since it disallows range responses from
+//     multiple origins, period).
+range_request_test(
+  'resources/range-request-to-different-origins-worker.js',
+  'TAINTED',
+  'range responses from multiple origins (cross-origin first)');
+
+// (4) Range responses come from multiple origins. The first response comes from
+//     same-origin. Subsequent responses come from cross-origin (and without
+//     CORS sharing). Like (2) this is not possible since the service worker
+//     cannot make range requests cross-origin.
+
+// (5) Range responses come from a single origin, with a mix of opaque and
+//     non-opaque responses. The first request uses 'no-cors' mode to
+//     receive an opaque response, and subsequent range requests use 'cors'
+//     to receive non-opaque responses. The canvas should be tainted.
+range_request_test(
+  'resources/range-request-with-different-cors-modes-worker.js',
+  'TAINTED',
+  'range responses from single origin with both opaque and non-opaque responses');
+
+// (6) Range responses come from a single origin, with a mix of opaque and
+//     non-opaque responses. The first request uses 'cors' mode to
+//     receive an non-opaque response, and subsequent range requests use
+//     'no-cors' to receive non-opaque responses. Like (2) this is not possible.
+</script>
 </body>

--- a/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>respondWith with a response whose body is being loaded from the network by chunks</title>
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>

--- a/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html
@@ -12,10 +12,6 @@ const WORKER = 'resources/fetch-event-respond-with-body-loaded-in-chunk-worker.j
 const SCOPE = 'resources/fetch-event-respond-with-body-loaded-in-chunk-iframe.html';
 
 promise_test(async t => {
-  const registration =
-      await service_worker_unregister_and_register(t, WORKER, SCOPE);
-  await wait_for_state(t, registration.installing, 'activated');
-  const iframe = await with_iframe(SCOPE);
   t.add_cleanup(async() => {
     if (iframe)
       iframe.remove();
@@ -23,6 +19,13 @@ promise_test(async t => {
       await registration.unregister();
   });
 
+  const registration = await service_worker_unregister_and_register(
+    t,
+    WORKER,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const iframe = await with_iframe(SCOPE);
   const response = await iframe.contentWindow.fetch('body-in-chunk');
   const result = await response.text()
   assert_equals(result, 'TEST_TRICKLE\nTEST_TRICKLE\nTEST_TRICKLE\n' +

--- a/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>respondWith with a response whose body is being loaded from the network by chunks</title>
-<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
@@ -12,13 +11,20 @@ const WORKER = 'resources/fetch-event-respond-with-body-loaded-in-chunk-worker.j
 const SCOPE = 'resources/fetch-event-respond-with-body-loaded-in-chunk-iframe.html';
 
 promise_test(async t => {
-    var reg = await service_worker_unregister_and_register(t, WORKER, SCOPE);
-    add_completion_callback(() => reg.unregister());
-    await wait_for_state(t, reg.installing, 'activated');
-    let iframe = await with_iframe(SCOPE);
-    t.add_cleanup(() => iframe.remove());
+  const registration =
+      await service_worker_unregister_and_register(t, WORKER, SCOPE);
+  await wait_for_state(t, registration.installing, 'activated');
+  const iframe = await with_iframe(SCOPE);
+  t.add_cleanup(async() => {
+    if (iframe)
+      iframe.remove();
+    if (registration)
+      await registration.unregister();
+  });
 
-    let response = await iframe.contentWindow.fetch('body-in-chunk');
-    assert_equals(await response.text(), 'TEST_TRICKLE\nTEST_TRICKLE\nTEST_TRICKLE\nTEST_TRICKLE\n');
+  const response = await iframe.contentWindow.fetch('body-in-chunk');
+  const result = await response.text()
+  assert_equals(result, 'TEST_TRICKLE\nTEST_TRICKLE\nTEST_TRICKLE\n' +
+                'TEST_TRICKLE\n');
 }, 'Respond by chunks with a Response being loaded');
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html
@@ -27,7 +27,7 @@ promise_test(async t => {
   await wait_for_state(t, registration.installing, 'activated');
   const iframe = await with_iframe(SCOPE);
   const response = await iframe.contentWindow.fetch('body-in-chunk');
-  const result = await response.text()
+  const result = await response.text();
   assert_equals(result, 'TEST_TRICKLE\nTEST_TRICKLE\nTEST_TRICKLE\n' +
                 'TEST_TRICKLE\n');
 }, 'Respond by chunks with a Response being loaded');

--- a/service-workers/service-worker/fetch-event-respond-with-custom-response.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-custom-response.https.html
@@ -1,130 +1,86 @@
 <!DOCTYPE html>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>respondWith with a new Response</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  "use strict";
+'use strict';
 
-  const WORKER = "resources/fetch-event-respond-with-custom-response-worker.js";
-  const SCOPE = "resources/blank.html";
+const WORKER = 'resources/fetch-event-respond-with-custom-response-worker.js';
+const SCOPE = 'resources/blank.html';
 
-  // Register a service worker, then create an iframe at url.
-  function iframeTest(url, callback, name) {
-    return promise_test(async t => {
-      const registration = await service_worker_unregister_and_register(
-        t,
-        WORKER,
-        SCOPE
-      );
-      await wait_for_state(t, registration.installing, "activated");
-      const iframe = await with_iframe(url);
-      const iwin = iframe.contentWindow;
-      t.add_cleanup(async () => {
-        if (iframe) iframe.remove();
-        if (registration) await registration.unregister();
-      });
-      await callback(t, iwin);
-    }, name);
-  }
+// Register a service worker, then create an iframe at url.
+function iframeTest(url, callback, name) {
+  return promise_test(async t => {
+    const registration = await service_worker_unregister_and_register(
+      t,
+      WORKER,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, 'activated');
+    const iframe = await with_iframe(url);
+    const iwin = iframe.contentWindow;
+    t.add_cleanup(async () => {
+      if (iframe) iframe.remove();
+      if (registration) await registration.unregister();
+    });
+    await callback(t, iwin);
+  }, name);
+}
 
-  iframeTest(
-    SCOPE,
-    async (t, iwin) => {
-      const response = await iwin.fetch("?type=string");
-      assert_equals(await response.text(), "PASS");
-    },
-    "Subresource built from a string"
-  );
+iframeTest(SCOPE, async (t, iwin) => {
+  const response = await iwin.fetch('?type=string');
+  assert_equals(await response.text(), 'PASS');
+}, 'Subresource built from a string');
 
-  iframeTest(
-    SCOPE,
-    async (t, iwin) => {
-      const response = await iwin.fetch("?type=blob");
-      assert_equals(await response.text(), "PASS");
-    },
-    "Subresource built from a blob"
-  );
+iframeTest(SCOPE, async (t, iwin) => {
+  const response = await iwin.fetch('?type=blob');
+  assert_equals(await response.text(), 'PASS');
+}, 'Subresource built from a blob');
 
-  iframeTest(
-    SCOPE,
-    async (t, iwin) => {
-      const response = await iwin.fetch("?type=buffer");
-      assert_equals(await response.text(), "PASS");
-    },
-    "Subresource built from a buffer"
-  );
+iframeTest(SCOPE, async (t, iwin) => {
+  const response = await iwin.fetch('?type=buffer');
+  assert_equals(await response.text(), 'PASS');
+}, 'Subresource built from a buffer');
 
-  iframeTest(
-    SCOPE,
-    async (t, iwin) => {
-      const response = await iwin.fetch("?type=buffer-view");
-      assert_equals(await response.text(), "PASS");
-    },
-    "Subresource built from a buffer-view"
-  );
+iframeTest(SCOPE, async (t, iwin) => {
+  const response = await iwin.fetch('?type=buffer-view');
+  assert_equals(await response.text(), 'PASS');
+}, 'Subresource built from a buffer-view');
 
-  iframeTest(
-    SCOPE,
-    async (t, iwin) => {
-      const response = await iwin.fetch("?type=form-data");
-      const data = await response.formData();
-      assert_equals(data.get("result"), "PASS");
-    },
-    "Subresource built from form-data"
-  );
+iframeTest(SCOPE, async (t, iwin) => {
+  const response = await iwin.fetch('?type=form-data');
+  const data = await response.formData();
+  assert_equals(data.get('result'), 'PASS');
+}, 'Subresource built from form-data');
 
-  iframeTest(
-    SCOPE,
-    async (t, iwin) => {
-      const response = await iwin.fetch("?type=search-params");
-      assert_equals(await response.text(), "result=PASS");
-    },
-    "Subresource built from search-params"
-  );
+iframeTest(SCOPE, async (t, iwin) => {
+  const response = await iwin.fetch('?type=search-params');
+  assert_equals(await response.text(), 'result=PASS');
+}, 'Subresource built from search-params');
 
-  // As above, but navigations
+// As above, but navigations
 
-  iframeTest(
-    SCOPE + "?type=string",
-    (t, iwin) => {
-      assert_equals(iwin.document.body.textContent, "PASS");
-    },
-    "Navigation resource built from a string"
-  );
+iframeTest(SCOPE + '?type=string', (t, iwin) => {
+  assert_equals(iwin.document.body.textContent, 'PASS');
+}, 'Navigation resource built from a string');
 
-  iframeTest(
-    SCOPE + "?type=blob",
-    (t, iwin) => {
-      assert_equals(iwin.document.body.textContent, "PASS");
-    },
-    "Navigation resource built from a blob"
-  );
+iframeTest(SCOPE + '?type=blob', (t, iwin) => {
+  assert_equals(iwin.document.body.textContent, 'PASS');
+}, 'Navigation resource built from a blob');
 
-  iframeTest(
-    SCOPE + "?type=buffer",
-    (t, iwin) => {
-      assert_equals(iwin.document.body.textContent, "PASS");
-    },
-    "Navigation resource built from a buffer"
-  );
+iframeTest(SCOPE + '?type=buffer', (t, iwin) => {
+  assert_equals(iwin.document.body.textContent, 'PASS');
+}, 'Navigation resource built from a buffer');
 
-  iframeTest(
-    SCOPE + "?type=buffer-view",
-    (t, iwin) => {
-      assert_equals(iwin.document.body.textContent, "PASS");
-    },
-    "Navigation resource built from a buffer-view"
-  );
+iframeTest(SCOPE + '?type=buffer-view', (t, iwin) => {
+  assert_equals(iwin.document.body.textContent, 'PASS');
+}, 'Navigation resource built from a buffer-view');
 
-  // Note: not testing form data for a navigation as the boundary header is lost.
+// Note: not testing form data for a navigation as the boundary header is lost.
 
-  iframeTest(
-    SCOPE + "?type=search-params",
-    (t, iwin) => {
-      assert_equals(iwin.document.body.textContent, "result=PASS");
-    },
-    "Navigation resource built from search-params"
-  );
+iframeTest(SCOPE + '?type=search-params', (t, iwin) => {
+  assert_equals(iwin.document.body.textContent, 'result=PASS');
+}, 'Navigation resource built from search-params');
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-custom-response.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-custom-response.https.html
@@ -13,6 +13,10 @@ const SCOPE = 'resources/blank.html';
 // Register a service worker, then create an iframe at url.
 function iframeTest(url, callback, name) {
   return promise_test(async t => {
+    t.add_cleanup(async () => {
+      if (iframe) iframe.remove();
+      if (registration) await registration.unregister();
+    });
     const registration = await service_worker_unregister_and_register(
       t,
       WORKER,
@@ -21,10 +25,6 @@ function iframeTest(url, callback, name) {
     await wait_for_state(t, registration.installing, 'activated');
     const iframe = await with_iframe(url);
     const iwin = iframe.contentWindow;
-    t.add_cleanup(async () => {
-      if (iframe) iframe.remove();
-      if (registration) await registration.unregister();
-    });
     await callback(t, iwin);
   }, name);
 }

--- a/service-workers/service-worker/fetch-event-respond-with-custom-response.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-custom-response.https.html
@@ -1,82 +1,130 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>respondWith with a new Response</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-'use strict';
+  "use strict";
 
-const WORKER =
-  'resources/fetch-event-respond-with-custom-response-worker.js';
-const SCOPE =
-  'resources/blank.html';
+  const WORKER = "resources/fetch-event-respond-with-custom-response-worker.js";
+  const SCOPE = "resources/blank.html";
 
-// Register a service worker, then create an iframe at url.
-function iframeTest(url, callback, name) {
-  return promise_test(async t => {
-    const reg = await service_worker_unregister_and_register(t, WORKER, SCOPE);
-    add_completion_callback(() => reg.unregister());
-    await wait_for_state(t, reg.installing, 'activated');
-    const iframe = await with_iframe(url);
-    const iwin = iframe.contentWindow;
-    t.add_cleanup(() => iframe.remove());
-    await callback(t, iwin);
-  }, name);
-}
+  // Register a service worker, then create an iframe at url.
+  function iframeTest(url, callback, name) {
+    return promise_test(async t => {
+      const registration = await service_worker_unregister_and_register(
+        t,
+        WORKER,
+        SCOPE
+      );
+      await wait_for_state(t, registration.installing, "activated");
+      const iframe = await with_iframe(url);
+      const iwin = iframe.contentWindow;
+      t.add_cleanup(async () => {
+        if (iframe) iframe.remove();
+        if (registration) await registration.unregister();
+      });
+      await callback(t, iwin);
+    }, name);
+  }
 
-iframeTest(SCOPE, async (t, iwin) => {
-  const response = await iwin.fetch('?type=string');
-  assert_equals(await response.text(), 'PASS');
-}, 'Subresource built from a string');
+  iframeTest(
+    SCOPE,
+    async (t, iwin) => {
+      const response = await iwin.fetch("?type=string");
+      assert_equals(await response.text(), "PASS");
+    },
+    "Subresource built from a string"
+  );
 
-iframeTest(SCOPE, async (t, iwin) => {
-  const response = await iwin.fetch('?type=blob');
-  assert_equals(await response.text(), 'PASS');
-}, 'Subresource built from a blob');
+  iframeTest(
+    SCOPE,
+    async (t, iwin) => {
+      const response = await iwin.fetch("?type=blob");
+      assert_equals(await response.text(), "PASS");
+    },
+    "Subresource built from a blob"
+  );
 
-iframeTest(SCOPE, async (t, iwin) => {
-  const response = await iwin.fetch('?type=buffer');
-  assert_equals(await response.text(), 'PASS');
-}, 'Subresource built from a buffer');
+  iframeTest(
+    SCOPE,
+    async (t, iwin) => {
+      const response = await iwin.fetch("?type=buffer");
+      assert_equals(await response.text(), "PASS");
+    },
+    "Subresource built from a buffer"
+  );
 
-iframeTest(SCOPE, async (t, iwin) => {
-  const response = await iwin.fetch('?type=buffer-view');
-  assert_equals(await response.text(), 'PASS');
-}, 'Subresource built from a buffer-view');
+  iframeTest(
+    SCOPE,
+    async (t, iwin) => {
+      const response = await iwin.fetch("?type=buffer-view");
+      assert_equals(await response.text(), "PASS");
+    },
+    "Subresource built from a buffer-view"
+  );
 
-iframeTest(SCOPE, async (t, iwin) => {
-  const response = await iwin.fetch('?type=form-data');
-  const data = await response.formData();
-  assert_equals(data.get('result'), 'PASS');
-}, 'Subresource built from form-data');
+  iframeTest(
+    SCOPE,
+    async (t, iwin) => {
+      const response = await iwin.fetch("?type=form-data");
+      const data = await response.formData();
+      assert_equals(data.get("result"), "PASS");
+    },
+    "Subresource built from form-data"
+  );
 
-iframeTest(SCOPE, async (t, iwin) => {
-  const response = await iwin.fetch('?type=search-params');
-  assert_equals(await response.text(), 'result=PASS');
-}, 'Subresource built from search-params');
+  iframeTest(
+    SCOPE,
+    async (t, iwin) => {
+      const response = await iwin.fetch("?type=search-params");
+      assert_equals(await response.text(), "result=PASS");
+    },
+    "Subresource built from search-params"
+  );
 
-// As above, but navigations
+  // As above, but navigations
 
-iframeTest(SCOPE + '?type=string', (t, iwin) => {
-  assert_equals(iwin.document.body.textContent, 'PASS');
-}, 'Navigation resource built from a string');
+  iframeTest(
+    SCOPE + "?type=string",
+    (t, iwin) => {
+      assert_equals(iwin.document.body.textContent, "PASS");
+    },
+    "Navigation resource built from a string"
+  );
 
-iframeTest(SCOPE + '?type=blob', (t, iwin) => {
-  assert_equals(iwin.document.body.textContent, 'PASS');
-}, 'Navigation resource built from a blob');
+  iframeTest(
+    SCOPE + "?type=blob",
+    (t, iwin) => {
+      assert_equals(iwin.document.body.textContent, "PASS");
+    },
+    "Navigation resource built from a blob"
+  );
 
-iframeTest(SCOPE + '?type=buffer', (t, iwin) => {
-  assert_equals(iwin.document.body.textContent, 'PASS');
-}, 'Navigation resource built from a buffer');
+  iframeTest(
+    SCOPE + "?type=buffer",
+    (t, iwin) => {
+      assert_equals(iwin.document.body.textContent, "PASS");
+    },
+    "Navigation resource built from a buffer"
+  );
 
-iframeTest(SCOPE + '?type=buffer-view', (t, iwin) => {
-  assert_equals(iwin.document.body.textContent, 'PASS');
-}, 'Navigation resource built from a buffer-view');
+  iframeTest(
+    SCOPE + "?type=buffer-view",
+    (t, iwin) => {
+      assert_equals(iwin.document.body.textContent, "PASS");
+    },
+    "Navigation resource built from a buffer-view"
+  );
 
-// Note: not testing form data for a navigation as the boundary header is lost.
+  // Note: not testing form data for a navigation as the boundary header is lost.
 
-iframeTest(SCOPE + '?type=search-params', (t, iwin) => {
-  assert_equals(iwin.document.body.textContent, 'result=PASS');
-}, 'Navigation resource built from search-params');
+  iframeTest(
+    SCOPE + "?type=search-params",
+    (t, iwin) => {
+      assert_equals(iwin.document.body.textContent, "result=PASS");
+    },
+    "Navigation resource built from search-params"
+  );
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-partial-stream.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-partial-stream.https.html
@@ -1,67 +1,64 @@
 <!DOCTYPE html>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>respondWith streams data to an intercepted fetch()</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  "use strict";
+'use strict';
 
-  const WORKER = "resources/fetch-event-respond-with-partial-stream-worker.js";
-  const SCOPE = "resources/fetch-event-respond-with-partial-stream-iframe.html";
+const WORKER = 'resources/fetch-event-respond-with-partial-stream-worker.js';
+const SCOPE = 'resources/fetch-event-respond-with-partial-stream-iframe.html';
 
-  promise_test(async t => {
-    const registration = await service_worker_unregister_and_register(
-      t,
-      WORKER,
-      SCOPE
-    );
-    await wait_for_state(t, registration.installing, "activated");
+promise_test(async t => {
+  const registration = await service_worker_unregister_and_register(
+    t,
+    WORKER,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
 
-    const frame = await with_iframe(SCOPE);
-    t.add_cleanup(async () => {
-      if (registration) await registration.unregister();
-      if (frame) frame.remove();
-    });
+  const frame = await with_iframe(SCOPE);
+  t.add_cleanup(async () => {
+    if (registration) await registration.unregister();
+    if (frame) frame.remove();
+  });
 
-    const response = await frame.contentWindow.fetch("partial-stream.txt");
+  const response = await frame.contentWindow.fetch('partial-stream.txt');
 
-    const reader = response.body.getReader();
+  const reader = response.body.getReader();
 
-    const encoder = new TextEncoder();
-    const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
 
-    const expected = "partial-stream-content";
-    const encodedExpected = encoder.encode(expected);
-    let received = "";
-    let encodedReceivedLength = 0;
+  const expected = 'partial-stream-content';
+  const encodedExpected = encoder.encode(expected);
+  let received = '';
+  let encodedReceivedLength = 0;
 
-    // Accumulate response data from the service worker.  We do this as a loop
-    // to allow the browser the flexibility of rebuffering if it chooses.  We
-    // do expect to get the partial data within the test timeout period, though.
-    // The spec is a bit vague at the moment about this, but it seems reasonable
-    // that the browser should not stall the response stream when the service
-    // worker has only written a partial result, but not closed the stream.
-    while (encodedReceivedLength < encodedExpected.length) {
-      let chunk = await reader.read();
-      assert_false(chunk.done, "partial body stream should not be closed yet");
+  // Accumulate response data from the service worker.  We do this as a loop
+  // to allow the browser the flexibility of rebuffering if it chooses.  We
+  // do expect to get the partial data within the test timeout period, though.
+  // The spec is a bit vague at the moment about this, but it seems reasonable
+  // that the browser should not stall the response stream when the service
+  // worker has only written a partial result, but not closed the stream.
+  while (encodedReceivedLength < encodedExpected.length) {
+    let chunk = await reader.read();
+    assert_false(chunk.done, 'partial body stream should not be closed yet');
 
-      encodedReceivedLength += chunk.value.length;
-      received += decoder.decode(chunk.value);
-    }
+    encodedReceivedLength += chunk.value.length;
+    received += decoder.decode(chunk.value);
+  }
 
-    // Note, the spec may allow some re-buffering between the service worker
-    // and the outer intercepted fetch.  We could relax this exact chunk value
-    // match if necessary.  The goal, though, is to ensure the outer fetch is
-    // not completely blocked until the service worker body is closed.
-    assert_equals(
-      received,
-      expected,
-      "should receive partial content through service worker interception"
-    );
+  // Note, the spec may allow some re-buffering between the service worker
+  // and the outer intercepted fetch.  We could relax this exact chunk value
+  // match if necessary.  The goal, though, is to ensure the outer fetch is
+  // not completely blocked until the service worker body is closed.
+  assert_equals(received, expected,
+                'should receive partial content through service worker interception');
 
-    registration.active.postMessage("done");
+  registration.active.postMessage('done');
 
-    await reader.closed;
-  }, "respondWith() streams data to an intercepted fetch()");
+  await reader.closed;
+}, 'respondWith() streams data to an intercepted fetch()');
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-partial-stream.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-partial-stream.https.html
@@ -1,62 +1,67 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>respondWith streams data to an intercepted fetch()</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-'use strict';
+  "use strict";
 
-const WORKER =
-  'resources/fetch-event-respond-with-partial-stream-worker.js';
-const SCOPE =
-  'resources/fetch-event-respond-with-partial-stream-iframe.html';
+  const WORKER = "resources/fetch-event-respond-with-partial-stream-worker.js";
+  const SCOPE = "resources/fetch-event-respond-with-partial-stream-iframe.html";
 
-promise_test(async t => {
-  let reg = await service_worker_unregister_and_register(t, WORKER, SCOPE)
-  add_completion_callback(() => reg.unregister());
+  promise_test(async t => {
+    const registration = await service_worker_unregister_and_register(
+      t,
+      WORKER,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, "activated");
 
-  await wait_for_state(t, reg.installing, 'activated');
+    const frame = await with_iframe(SCOPE);
+    t.add_cleanup(async () => {
+      if (registration) await registration.unregister();
+      if (frame) frame.remove();
+    });
 
-  let frame = await with_iframe(SCOPE);
-  t.add_cleanup(_ => frame.remove());
+    const response = await frame.contentWindow.fetch("partial-stream.txt");
 
-  let response = await frame.contentWindow.fetch('partial-stream.txt');
+    const reader = response.body.getReader();
 
-  let reader = response.body.getReader();
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
 
-  let encoder = new TextEncoder();
-  let decoder = new TextDecoder();
+    const expected = "partial-stream-content";
+    const encodedExpected = encoder.encode(expected);
+    let received = "";
+    let encodedReceivedLength = 0;
 
-  let expected = 'partial-stream-content';
-  let encodedExpected = encoder.encode(expected);
-  let received = '';
-  let encodedReceivedLength = 0;
+    // Accumulate response data from the service worker.  We do this as a loop
+    // to allow the browser the flexibility of rebuffering if it chooses.  We
+    // do expect to get the partial data within the test timeout period, though.
+    // The spec is a bit vague at the moment about this, but it seems reasonable
+    // that the browser should not stall the response stream when the service
+    // worker has only written a partial result, but not closed the stream.
+    while (encodedReceivedLength < encodedExpected.length) {
+      let chunk = await reader.read();
+      assert_false(chunk.done, "partial body stream should not be closed yet");
 
-  // Accumulate response data from the service worker.  We do this as a loop
-  // to allow the browser the flexibility of rebuffering if it chooses.  We
-  // do expect to get the partial data within the test timeout period, though.
-  // The spec is a bit vague at the moment about this, but it seems reasonable
-  // that the browser should not stall the response stream when the service
-  // worker has only written a partial result, but not closed the stream.
-  while (encodedReceivedLength < encodedExpected.length) {
-    let chunk = await reader.read();
-    assert_false(chunk.done, 'partial body stream should not be closed yet');
+      encodedReceivedLength += chunk.value.length;
+      received += decoder.decode(chunk.value);
+    }
 
-    encodedReceivedLength += chunk.value.length;
-    received += decoder.decode(chunk.value);
-  }
+    // Note, the spec may allow some re-buffering between the service worker
+    // and the outer intercepted fetch.  We could relax this exact chunk value
+    // match if necessary.  The goal, though, is to ensure the outer fetch is
+    // not completely blocked until the service worker body is closed.
+    assert_equals(
+      received,
+      expected,
+      "should receive partial content through service worker interception"
+    );
 
-  // Note, the spec may allow some re-buffering between the service worker
-  // and the outer intercepted fetch.  We could relax this exact chunk value
-  // match if necessary.  The goal, though, is to ensure the outer fetch is
-  // not completely blocked until the service worker body is closed.
-  assert_equals(received, expected,
-                'should receive partial content through service worker interception');
+    registration.active.postMessage("done");
 
-  reg.active.postMessage('done');
-
-  await reader.closed;
-
-  }, 'respondWith() streams data to an intercepted fetch()');
+    await reader.closed;
+  }, "respondWith() streams data to an intercepted fetch()");
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-partial-stream.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-partial-stream.https.html
@@ -11,6 +11,11 @@ const WORKER = 'resources/fetch-event-respond-with-partial-stream-worker.js';
 const SCOPE = 'resources/fetch-event-respond-with-partial-stream-iframe.html';
 
 promise_test(async t => {
+  t.add_cleanup(async () => {
+    if (registration) await registration.unregister();
+    if (frame) frame.remove();
+  });
+
   const registration = await service_worker_unregister_and_register(
     t,
     WORKER,
@@ -19,11 +24,6 @@ promise_test(async t => {
   await wait_for_state(t, registration.installing, 'activated');
 
   const frame = await with_iframe(SCOPE);
-  t.add_cleanup(async () => {
-    if (registration) await registration.unregister();
-    if (frame) frame.remove();
-  });
-
   const response = await frame.contentWindow.fetch('partial-stream.txt');
 
   const reader = response.body.getReader();

--- a/service-workers/service-worker/fetch-event-respond-with-readable-stream-chunk.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-readable-stream-chunk.https.html
@@ -7,12 +7,15 @@
 <script>
 'use strict';
 
-const WORKER =
-  'resources/fetch-event-respond-with-readable-stream-chunk-worker.js';
-const SCOPE =
-  'resources/fetch-event-respond-with-readable-stream-chunk-iframe.html';
+const WORKER = 'resources/fetch-event-respond-with-readable-stream-chunk-worker.js';
+const SCOPE = 'resources/fetch-event-respond-with-readable-stream-chunk-iframe.html';
 
 promise_test(async t => {
+  t.add_cleanup(async () => {
+    if (iframe) iframe.remove();
+    if (registration) await registration.unregister();
+  });
+
   const registration = await service_worker_unregister_and_register(
     t,
     WORKER,
@@ -20,11 +23,6 @@ promise_test(async t => {
   );
   await wait_for_state(t, registration.installing, 'activated');
   const iframe = await with_iframe(SCOPE);
-  t.add_cleanup(async () => {
-    if (iframe) iframe.remove();
-    if (registration) await registration.unregister();
-  });
-
   const response = await iframe.contentWindow.fetch('body-stream');
   assert_equals(await response.text(), 'chunk #1 chunk #2 chunk #3 chunk #4');
 }, 'Respond by chunks with a Response built from a ReadableStream');

--- a/service-workers/service-worker/fetch-event-respond-with-readable-stream-chunk.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-readable-stream-chunk.https.html
@@ -1,23 +1,31 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>respondWith with a response built from a ReadableStream</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-'use strict';
+  "use strict";
 
-const WORKER = 'resources/fetch-event-respond-with-readable-stream-chunk-worker.js';
-const SCOPE = 'resources/fetch-event-respond-with-readable-stream-chunk-iframe.html';
+  const WORKER =
+    "resources/fetch-event-respond-with-readable-stream-chunk-worker.js";
+  const SCOPE =
+    "resources/fetch-event-respond-with-readable-stream-chunk-iframe.html";
 
-promise_test(async t => {
-    var reg = await service_worker_unregister_and_register(t, WORKER, SCOPE);
-    add_completion_callback(() => reg.unregister());
-    await wait_for_state(t, reg.installing, 'activated');
-    let iframe = await with_iframe(SCOPE);
-    t.add_cleanup(() => iframe.remove());
+  promise_test(async t => {
+    const registration = await service_worker_unregister_and_register(
+      t,
+      WORKER,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, "activated");
+    const iframe = await with_iframe(SCOPE);
+    t.add_cleanup(async () => {
+      if (iframe) iframe.remove();
+      if (registration) await registration.unregister();
+    });
 
-    let response = await iframe.contentWindow.fetch('body-stream');
-    assert_equals(await response.text(), 'chunk #1 chunk #2 chunk #3 chunk #4');
-}, 'Respond by chunks with a Response built from a ReadableStream');
+    const response = await iframe.contentWindow.fetch("body-stream");
+    assert_equals(await response.text(), "chunk #1 chunk #2 chunk #3 chunk #4");
+  }, "Respond by chunks with a Response built from a ReadableStream");
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-readable-stream-chunk.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-readable-stream-chunk.https.html
@@ -1,31 +1,31 @@
 <!DOCTYPE html>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>respondWith with a response built from a ReadableStream</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  "use strict";
+'use strict';
 
-  const WORKER =
-    "resources/fetch-event-respond-with-readable-stream-chunk-worker.js";
-  const SCOPE =
-    "resources/fetch-event-respond-with-readable-stream-chunk-iframe.html";
+const WORKER =
+  'resources/fetch-event-respond-with-readable-stream-chunk-worker.js';
+const SCOPE =
+  'resources/fetch-event-respond-with-readable-stream-chunk-iframe.html';
 
-  promise_test(async t => {
-    const registration = await service_worker_unregister_and_register(
-      t,
-      WORKER,
-      SCOPE
-    );
-    await wait_for_state(t, registration.installing, "activated");
-    const iframe = await with_iframe(SCOPE);
-    t.add_cleanup(async () => {
-      if (iframe) iframe.remove();
-      if (registration) await registration.unregister();
-    });
+promise_test(async t => {
+  const registration = await service_worker_unregister_and_register(
+    t,
+    WORKER,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const iframe = await with_iframe(SCOPE);
+  t.add_cleanup(async () => {
+    if (iframe) iframe.remove();
+    if (registration) await registration.unregister();
+  });
 
-    const response = await iframe.contentWindow.fetch("body-stream");
-    assert_equals(await response.text(), "chunk #1 chunk #2 chunk #3 chunk #4");
-  }, "Respond by chunks with a Response built from a ReadableStream");
+  const response = await iframe.contentWindow.fetch('body-stream');
+  assert_equals(await response.text(), 'chunk #1 chunk #2 chunk #3 chunk #4');
+}, 'Respond by chunks with a Response built from a ReadableStream');
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html
@@ -1,82 +1,58 @@
 <!DOCTYPE html>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>respondWith with a response built from a ReadableStream</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  "use strict";
+'use strict';
 
-  const WORKER = "resources/fetch-event-respond-with-readable-stream-worker.js";
-  const SCOPE = "resources/blank.html";
+const WORKER = 'resources/fetch-event-respond-with-readable-stream-worker.js';
+const SCOPE = 'resources/blank.html';
 
-  // Register a service worker, then create an iframe at url.
-  function iframeTest(url, callback, name) {
-    return promise_test(async t => {
-      const registration = await service_worker_unregister_and_register(
-        t,
-        WORKER,
-        SCOPE
-      );
-      await wait_for_state(t, registration.installing, "activated");
-      const iframe = await with_iframe(url);
-      const contentWindow = iframe.contentWindow;
-      t.add_cleanup(async () => {
-        if (iframe) iframe.remove();
-        if (registration) await registration.unregister();
-      });
-      await callback(t, contentWindow);
-    }, name);
-  }
+// Register a service worker, then create an iframe at url.
+function iframeTest(url, callback, name) {
+  return promise_test(async t => {
+    const registration = await service_worker_unregister_and_register(
+      t,
+      WORKER,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, 'activated');
+    const iframe = await with_iframe(url);
+    const contentWindow = iframe.contentWindow;
+    t.add_cleanup(async () => {
+      if (iframe) iframe.remove();
+      if (registration) await registration.unregister();
+    });
+    await callback(t, contentWindow);
+  }, name);
+}
 
-  iframeTest(
-    SCOPE,
-    async (t, iwin) => {
-      const response = await iwin.fetch("?stream");
-      assert_equals(await response.text(), "PASS");
-    },
-    "Subresource built from a ReadableStream"
-  );
+iframeTest(SCOPE, async (t, iwin) => {
+  const response = await iwin.fetch('?stream');
+  assert_equals(await response.text(), 'PASS');
+}, 'Subresource built from a ReadableStream');
 
-  iframeTest(
-    SCOPE + "?stream",
-    (t, iwin) => {
-      assert_equals(iwin.document.body.textContent, "PASS");
-    },
-    "Main resource built from a ReadableStream"
-  );
+iframeTest(SCOPE + '?stream', (t, iwin) => {
+  assert_equals(iwin.document.body.textContent, 'PASS');
+}, 'Main resource built from a ReadableStream');
 
-  iframeTest(
-    SCOPE,
-    async (t, iwin) => {
-      const response = await iwin.fetch("?stream&delay");
-      assert_equals(await response.text(), "PASS");
-    },
-    "Subresource built from a ReadableStream - delayed"
-  );
+iframeTest(SCOPE, async (t, iwin) => {
+  const response = await iwin.fetch('?stream&delay');
+  assert_equals(await response.text(), 'PASS');
+}, 'Subresource built from a ReadableStream - delayed');
 
-  iframeTest(
-    SCOPE + "?stream&delay",
-    (t, iwin) => {
-      assert_equals(iwin.document.body.textContent, "PASS");
-    },
-    "Main resource built from a ReadableStream - delayed"
-  );
+iframeTest(SCOPE + '?stream&delay', (t, iwin) => {
+  assert_equals(iwin.document.body.textContent, 'PASS');
+}, 'Main resource built from a ReadableStream - delayed');
 
-  iframeTest(
-    SCOPE,
-    async (t, iwin) => {
-      const response = await iwin.fetch("?stream&use-fetch-stream");
-      assert_equals(await response.text(), "PASS\n");
-    },
-    "Subresource built from a ReadableStream - fetch stream"
-  );
+iframeTest(SCOPE, async (t, iwin) => {
+  const response = await iwin.fetch('?stream&use-fetch-stream');
+  assert_equals(await response.text(), 'PASS\n');
+}, 'Subresource built from a ReadableStream - fetch stream');
 
-  iframeTest(
-    SCOPE + "?stream&use-fetch-stream",
-    (t, iwin) => {
-      assert_equals(iwin.document.body.textContent, "PASS\n");
-    },
-    "Main resource built from a ReadableStream - fetch stream"
-  );
+iframeTest(SCOPE + '?stream&use-fetch-stream', (t, iwin) => {
+  assert_equals(iwin.document.body.textContent, 'PASS\n');
+}, 'Main resource built from a ReadableStream - fetch stream');
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html
@@ -1,54 +1,82 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>respondWith with a response built from a ReadableStream</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-'use strict';
+  "use strict";
 
-const WORKER =
-  'resources/fetch-event-respond-with-readable-stream-worker.js';
-const SCOPE =
-  'resources/blank.html';
+  const WORKER = "resources/fetch-event-respond-with-readable-stream-worker.js";
+  const SCOPE = "resources/blank.html";
 
-// Register a service worker, then create an iframe at url.
-function iframeTest(url, callback, name) {
-  return promise_test(async t => {
-    const reg = await service_worker_unregister_and_register(t, WORKER, SCOPE);
-    add_completion_callback(() => reg.unregister());
-    await wait_for_state(t, reg.installing, 'activated');
-    const iframe = await with_iframe(url);
-    const iwin = iframe.contentWindow;
-    t.add_cleanup(() => iframe.remove());
-    await callback(t, iwin);
-  }, name);
-}
+  // Register a service worker, then create an iframe at url.
+  function iframeTest(url, callback, name) {
+    return promise_test(async t => {
+      const registration = await service_worker_unregister_and_register(
+        t,
+        WORKER,
+        SCOPE
+      );
+      await wait_for_state(t, registration.installing, "activated");
+      const iframe = await with_iframe(url);
+      const contentWindow = iframe.contentWindow;
+      t.add_cleanup(async () => {
+        if (iframe) iframe.remove();
+        if (registration) await registration.unregister();
+      });
+      await callback(t, contentWindow);
+    }, name);
+  }
 
-iframeTest(SCOPE, async (t, iwin) => {
-  const response = await iwin.fetch('?stream');
-  assert_equals(await response.text(), 'PASS');
-}, 'Subresource built from a ReadableStream');
+  iframeTest(
+    SCOPE,
+    async (t, iwin) => {
+      const response = await iwin.fetch("?stream");
+      assert_equals(await response.text(), "PASS");
+    },
+    "Subresource built from a ReadableStream"
+  );
 
-iframeTest(SCOPE + '?stream', (t, iwin) => {
-  assert_equals(iwin.document.body.textContent, 'PASS');
-}, 'Main resource built from a ReadableStream');
+  iframeTest(
+    SCOPE + "?stream",
+    (t, iwin) => {
+      assert_equals(iwin.document.body.textContent, "PASS");
+    },
+    "Main resource built from a ReadableStream"
+  );
 
-iframeTest(SCOPE, async (t, iwin) => {
-  const response = await iwin.fetch('?stream&delay');
-  assert_equals(await response.text(), 'PASS');
-}, 'Subresource built from a ReadableStream - delayed');
+  iframeTest(
+    SCOPE,
+    async (t, iwin) => {
+      const response = await iwin.fetch("?stream&delay");
+      assert_equals(await response.text(), "PASS");
+    },
+    "Subresource built from a ReadableStream - delayed"
+  );
 
-iframeTest(SCOPE + '?stream&delay', (t, iwin) => {
-  assert_equals(iwin.document.body.textContent, 'PASS');
-}, 'Main resource built from a ReadableStream - delayed');
+  iframeTest(
+    SCOPE + "?stream&delay",
+    (t, iwin) => {
+      assert_equals(iwin.document.body.textContent, "PASS");
+    },
+    "Main resource built from a ReadableStream - delayed"
+  );
 
-iframeTest(SCOPE, async (t, iwin) => {
-  const response = await iwin.fetch('?stream&use-fetch-stream');
-  assert_equals(await response.text(), 'PASS\n');
-}, 'Subresource built from a ReadableStream - fetch stream');
+  iframeTest(
+    SCOPE,
+    async (t, iwin) => {
+      const response = await iwin.fetch("?stream&use-fetch-stream");
+      assert_equals(await response.text(), "PASS\n");
+    },
+    "Subresource built from a ReadableStream - fetch stream"
+  );
 
-iframeTest(SCOPE + '?stream&use-fetch-stream', (t, iwin) => {
-  assert_equals(iwin.document.body.textContent, 'PASS\n');
-}, 'Main resource built from a ReadableStream - fetch stream');
+  iframeTest(
+    SCOPE + "?stream&use-fetch-stream",
+    (t, iwin) => {
+      assert_equals(iwin.document.body.textContent, "PASS\n");
+    },
+    "Main resource built from a ReadableStream - fetch stream"
+  );
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html
@@ -24,8 +24,7 @@ function iframeTest(url, callback, name) {
     );
     await wait_for_state(t, registration.installing, 'activated');
     const iframe = await with_iframe(url);
-    const contentWindow = iframe.contentWindow;
-    await callback(t, contentWindow);
+    await callback(t, iframe.contentWindow);
   }, name);
 }
 

--- a/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html
@@ -13,6 +13,10 @@ const SCOPE = 'resources/blank.html';
 // Register a service worker, then create an iframe at url.
 function iframeTest(url, callback, name) {
   return promise_test(async t => {
+    t.add_cleanup(async () => {
+      if (iframe) iframe.remove();
+      if (registration) await registration.unregister();
+    });
     const registration = await service_worker_unregister_and_register(
       t,
       WORKER,
@@ -21,10 +25,6 @@ function iframeTest(url, callback, name) {
     await wait_for_state(t, registration.installing, 'activated');
     const iframe = await with_iframe(url);
     const contentWindow = iframe.contentWindow;
-    t.add_cleanup(async () => {
-      if (iframe) iframe.remove();
-      if (registration) await registration.unregister();
-    });
     await callback(t, contentWindow);
   }, name);
 }

--- a/service-workers/service-worker/fetch-event-respond-with-response-body-with-invalid-chunk.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-response-body-with-invalid-chunk.https.html
@@ -1,34 +1,37 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>respondWith with response body having invalid chunks</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-'use strict';
+  "use strict";
 
-const WORKER =
-  'resources/fetch-event-respond-with-response-body-with-invalid-chunk-worker.js';
-const SCOPE =
-  'resources/fetch-event-respond-with-response-body-with-invalid-chunk-iframe.html';
-// Called by the iframe when done.
-var done;
-var done_was_called = new Promise(resolve => done = resolve);
+  const WORKER =
+    "resources/fetch-event-respond-with-response-body-with-invalid-chunk-worker.js";
+  const SCOPE =
+    "resources/fetch-event-respond-with-response-body-with-invalid-chunk-iframe.html";
+  // Called by the iframe when done.
+  const done_was_called = new Promise(resolve => (done = resolve));
 
-// This test creates an controlled iframe that makes a fetch request. The
-// service worker returns a response with a body stream containing an invalid
-// chunk.
-promise_test(t => {
-    return service_worker_unregister_and_register(t, WORKER, SCOPE)
-      .then(reg => {
-           add_completion_callback(() => reg.unregister());
-           return wait_for_state(t, reg.installing, 'activated');
-         })
-      .then(() => with_iframe(SCOPE))
-      .then(frame => {
-          t.add_cleanup(() => frame.remove())
-        })
-      .then(() => done_was_called)
-      .then(result => assert_equals(result, 'PASS'));
-  }, 'Response with a ReadableStream having non-Uint8Array chunks should be transferred as errored');
+  // This test creates an controlled iframe that makes a fetch request. The
+  // service worker returns a response with a body stream containing an invalid
+  // chunk.
+  promise_test(async t => {
+    const registration = await service_worker_unregister_and_register(
+      t,
+      WORKER,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, "activated");
+    const frame = await with_iframe(SCOPE);
+
+    t.add_cleanup(async () => {
+      if (frame) frame.remove();
+      if (registration) await registration.unregister();
+    });
+
+    const result = await done_was_called;
+    assert_equals(result, "PASS");
+  }, "Response with a ReadableStream having non-Uint8Array chunks should be transferred as errored");
 </script>

--- a/service-workers/service-worker/fetch-event-respond-with-response-body-with-invalid-chunk.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-response-body-with-invalid-chunk.https.html
@@ -1,37 +1,37 @@
 <!DOCTYPE html>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>respondWith with response body having invalid chunks</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  "use strict";
+'use strict';
 
-  const WORKER =
-    "resources/fetch-event-respond-with-response-body-with-invalid-chunk-worker.js";
-  const SCOPE =
-    "resources/fetch-event-respond-with-response-body-with-invalid-chunk-iframe.html";
-  // Called by the iframe when done.
-  const done_was_called = new Promise(resolve => (done = resolve));
+const WORKER =
+  'resources/fetch-event-respond-with-response-body-with-invalid-chunk-worker.js';
+const SCOPE =
+  'resources/fetch-event-respond-with-response-body-with-invalid-chunk-iframe.html';
+// Called by the iframe when done.
+const done_was_called = new Promise(resolve => (done = resolve));
 
-  // This test creates an controlled iframe that makes a fetch request. The
-  // service worker returns a response with a body stream containing an invalid
-  // chunk.
-  promise_test(async t => {
-    const registration = await service_worker_unregister_and_register(
-      t,
-      WORKER,
-      SCOPE
-    );
-    await wait_for_state(t, registration.installing, "activated");
-    const frame = await with_iframe(SCOPE);
+// This test creates an controlled iframe that makes a fetch request. The
+// service worker returns a response with a body stream containing an invalid
+// chunk.
+promise_test(async t => {
+  const registration = await service_worker_unregister_and_register(
+    t,
+    WORKER,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE);
 
-    t.add_cleanup(async () => {
-      if (frame) frame.remove();
-      if (registration) await registration.unregister();
-    });
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
 
-    const result = await done_was_called;
-    assert_equals(result, "PASS");
-  }, "Response with a ReadableStream having non-Uint8Array chunks should be transferred as errored");
+  const result = await done_was_called;
+  assert_equals(result, 'PASS');
+}, 'Response with a ReadableStream having non-Uint8Array chunks should be transferred as errored');
 </script>

--- a/service-workers/service-worker/fetch-request-xhr-sync-on-worker.https.html
+++ b/service-workers/service-worker/fetch-request-xhr-sync-on-worker.https.html
@@ -7,6 +7,11 @@
 'use strict';
 
 promise_test(async t => {
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+
   const SCRIPT = 'resources/fetch-request-xhr-sync-on-worker-worker.js';
   const SCOPE = 'resources/fetch-request-xhr-sync-on-worker-scope/';
   const NON_EXISTENT_FILE = 'non-existent-file.txt';
@@ -25,11 +30,6 @@ promise_test(async t => {
   const result = await frame.contentWindow.performSyncXHROnWorker(
     NON_EXISTENT_FILE
   );
-
-  t.add_cleanup(async () => {
-    if (frame) frame.remove();
-    if (registration) await registration.unregister();
-  });
 
   assert_equals(
     result.status,

--- a/service-workers/service-worker/fetch-request-xhr-sync-on-worker.https.html
+++ b/service-workers/service-worker/fetch-request-xhr-sync-on-worker.https.html
@@ -4,38 +4,42 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-'use strict';
+  "use strict";
 
-promise_test((t) => {
-    const url = 'resources/fetch-request-xhr-sync-on-worker-worker.js';
-    const scope = 'resources/fetch-request-xhr-sync-on-worker-scope/';
-    const non_existent_file = 'non-existent-file.txt';
+  promise_test(async t => {
+    const SCRIPT = "resources/fetch-request-xhr-sync-on-worker-worker.js";
+    const SCOPE = "resources/fetch-request-xhr-sync-on-worker-scope/";
+    const NON_EXISTENT_FILE = "non-existent-file.txt";
 
     // In Chromium, the service worker scope matching for workers is based on
     // the URL of the parent HTML. So this test creates an iframe which is
     // controlled by the service worker first, and creates a worker from the
     // iframe.
-    return service_worker_unregister_and_register(t, url, scope)
-      .then((registration) => {
-          t.add_cleanup(() => registration.unregister());
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(() => { return with_iframe(scope + 'iframe_page'); })
-      .then((frame) => {
-          t.add_cleanup(() => frame.remove());
-          return frame.contentWindow.performSyncXHROnWorker(non_existent_file);
-        })
-      .then((result) => {
-          assert_equals(
-              result.status,
-              200,
-              'HTTP response status code for intercepted request'
-            );
-          assert_equals(
-            result.responseText,
-              'Response from service worker',
-              'HTTP response text for intercepted request'
-            );
-        });
-  }, 'Verify SyncXHR on Worker is intercepted');
+    const registration = await service_worker_unregister_and_register(
+      t,
+      SCRIPT,
+      SCOPE
+    );
+    await wait_for_state(t, registration.installing, "activated");
+    const frame = await with_iframe(SCOPE + "iframe_page");
+    const result = await frame.contentWindow.performSyncXHROnWorker(
+      NON_EXISTENT_FILE
+    );
+
+    t.add_cleanup(async () => {
+      if (frame) frame.remove();
+      if (registration) await registration.unregister();
+    });
+
+    assert_equals(
+      result.status,
+      200,
+      "HTTP response status code for intercepted request"
+    );
+    assert_equals(
+      result.responseText,
+      "Response from service worker",
+      "HTTP response text for intercepted request"
+    );
+  }, "Verify SyncXHR on Worker is intercepted");
 </script>

--- a/service-workers/service-worker/fetch-request-xhr-sync-on-worker.https.html
+++ b/service-workers/service-worker/fetch-request-xhr-sync-on-worker.https.html
@@ -4,42 +4,42 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  "use strict";
+'use strict';
 
-  promise_test(async t => {
-    const SCRIPT = "resources/fetch-request-xhr-sync-on-worker-worker.js";
-    const SCOPE = "resources/fetch-request-xhr-sync-on-worker-scope/";
-    const NON_EXISTENT_FILE = "non-existent-file.txt";
+promise_test(async t => {
+  const SCRIPT = 'resources/fetch-request-xhr-sync-on-worker-worker.js';
+  const SCOPE = 'resources/fetch-request-xhr-sync-on-worker-scope/';
+  const NON_EXISTENT_FILE = 'non-existent-file.txt';
 
-    // In Chromium, the service worker scope matching for workers is based on
-    // the URL of the parent HTML. So this test creates an iframe which is
-    // controlled by the service worker first, and creates a worker from the
-    // iframe.
-    const registration = await service_worker_unregister_and_register(
-      t,
-      SCRIPT,
-      SCOPE
-    );
-    await wait_for_state(t, registration.installing, "activated");
-    const frame = await with_iframe(SCOPE + "iframe_page");
-    const result = await frame.contentWindow.performSyncXHROnWorker(
-      NON_EXISTENT_FILE
-    );
+  // In Chromium, the service worker scope matching for workers is based on
+  // the URL of the parent HTML. So this test creates an iframe which is
+  // controlled by the service worker first, and creates a worker from the
+  // iframe.
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE + 'iframe_page');
+  const result = await frame.contentWindow.performSyncXHROnWorker(
+    NON_EXISTENT_FILE
+  );
 
-    t.add_cleanup(async () => {
-      if (frame) frame.remove();
-      if (registration) await registration.unregister();
-    });
+  t.add_cleanup(async () => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
 
-    assert_equals(
-      result.status,
-      200,
-      "HTTP response status code for intercepted request"
-    );
-    assert_equals(
-      result.responseText,
-      "Response from service worker",
-      "HTTP response text for intercepted request"
-    );
-  }, "Verify SyncXHR on Worker is intercepted");
+  assert_equals(
+    result.status,
+    200,
+    'HTTP response status code for intercepted request'
+  );
+  assert_equals(
+    result.responseText,
+    'Response from service worker',
+    'HTTP response text for intercepted request'
+  );
+}, 'Verify SyncXHR on Worker is intercepted');
 </script>

--- a/service-workers/service-worker/request-end-to-end.https.html
+++ b/service-workers/service-worker/request-end-to-end.https.html
@@ -4,48 +4,41 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-  "use strict";
+'use strict';
 
-  promise_test(async t => {
-    const url = "resources/request-end-to-end-worker.js";
-    const scope = "resources/blank.html";
+promise_test(async t => {
+  const url = 'resources/request-end-to-end-worker.js';
+  const scope = 'resources/blank.html';
 
-    const registration = await service_worker_unregister_and_register(
-      t,
-      url,
-      scope
-    );
-    await wait_for_state(t, registration.installing, "activated");
-    const frame = await with_iframe(scope);
-    const result = JSON.parse(frame.contentDocument.body.textContent);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    url,
+    scope
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(scope);
+  const result = JSON.parse(frame.contentDocument.body.textContent);
 
-    t.add_cleanup(async () => {
-      if (frame) await frame.remove();
-      if (registration) await registration.unregister();
-    });
+  t.add_cleanup(async () => {
+    if (frame) await frame.remove();
+    if (registration) await registration.unregister();
+  });
 
-    assert_equals(result.url, frame.src, "request.url");
-    assert_equals(result.method, "GET", "request.method");
-    assert_equals(result.referrer, location.href, "request.referrer");
-    assert_equals(result.mode, "navigate", "request.mode");
-    assert_equals(
-      result.request_construct_error,
-      "",
-      "Constructing a Request with a Request whose mode " +
-        "is navigate and non-empty RequestInit must not throw a " +
-        "TypeError."
-    );
-    assert_equals(result.credentials, "include", "request.credentials");
-    assert_equals(result.redirect, "manual", "request.redirect");
-    assert_equals(
-      result.headers["user-agent"],
-      undefined,
-      "Default User-Agent header should not be passed to " + "onfetch event."
-    );
-    assert_equals(
-      result.append_header_error,
-      "TypeError",
-      "Appending a new header to the request must throw a " + "TypeError."
-    );
-  }, "Test FetchEvent.request passed to onfetch");
+  assert_equals(result.url, frame.src, 'request.url');
+  assert_equals(result.method, 'GET', 'request.method');
+  assert_equals(result.referrer, location.href, 'request.referrer');
+  assert_equals(result.mode, 'navigate', 'request.mode');
+  assert_equals(result.request_construct_error, '',
+                'Constructing a Request with a Request whose mode ' +
+                'is navigate and non-empty RequestInit must not throw a ' +
+                'TypeError.');
+  assert_equals(result.credentials, 'include', 'request.credentials');
+  assert_equals(result.redirect, 'manual', 'request.redirect');
+  assert_equals(result.headers['user-agent'], undefined,
+                'Default User-Agent header should not be passed to ' +
+                'onfetch event.');
+  assert_equals(result.append_header_error, 'TypeError',
+                'Appending a new header to the request must throw a ' +
+                'TypeError.');
+}, 'Test FetchEvent.request passed to onfetch');
 </script>

--- a/service-workers/service-worker/request-end-to-end.https.html
+++ b/service-workers/service-worker/request-end-to-end.https.html
@@ -4,37 +4,48 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-'use strict';
+  "use strict";
 
-promise_test(t => {
-    var url = 'resources/request-end-to-end-worker.js';
-    var scope = 'resources/blank.html';
-    return service_worker_unregister_and_register(t, url, scope)
-      .then(r => {
-          add_completion_callback(() => { r.unregister(); });
-          return wait_for_state(t, r.installing, 'activated');
-        })
-      .then(() => { return with_iframe(scope); })
-      .then(frame => {
-          add_completion_callback(() => { frame.remove(); });
+  promise_test(async t => {
+    const url = "resources/request-end-to-end-worker.js";
+    const scope = "resources/blank.html";
 
-          var result = JSON.parse(frame.contentDocument.body.textContent);
-          assert_equals(result.url, frame.src, 'request.url');
-          assert_equals(result.method, 'GET', 'request.method');
-          assert_equals(result.referrer, location.href, 'request.referrer');
-          assert_equals(result.mode, 'navigate', 'request.mode');
-          assert_equals(result.request_construct_error, '',
-                        'Constructing a Request with a Request whose mode ' +
-                        'is navigate and non-empty RequestInit must not throw a ' +
-                        'TypeError.')
-          assert_equals(result.credentials, 'include', 'request.credentials');
-          assert_equals(result.redirect, 'manual', 'request.redirect');
-          assert_equals(result.headers['user-agent'], undefined,
-                        'Default User-Agent header should not be passed to ' +
-                        'onfetch event.')
-          assert_equals(result.append_header_error, 'TypeError',
-                        'Appending a new header to the request must throw a ' +
-                        'TypeError.')
-        });
-  }, 'Test FetchEvent.request passed to onfetch');
+    const registration = await service_worker_unregister_and_register(
+      t,
+      url,
+      scope
+    );
+    await wait_for_state(t, registration.installing, "activated");
+    const frame = await with_iframe(scope);
+    const result = JSON.parse(frame.contentDocument.body.textContent);
+
+    t.add_cleanup(async () => {
+      if (frame) await frame.remove();
+      if (registration) await registration.unregister();
+    });
+
+    assert_equals(result.url, frame.src, "request.url");
+    assert_equals(result.method, "GET", "request.method");
+    assert_equals(result.referrer, location.href, "request.referrer");
+    assert_equals(result.mode, "navigate", "request.mode");
+    assert_equals(
+      result.request_construct_error,
+      "",
+      "Constructing a Request with a Request whose mode " +
+        "is navigate and non-empty RequestInit must not throw a " +
+        "TypeError."
+    );
+    assert_equals(result.credentials, "include", "request.credentials");
+    assert_equals(result.redirect, "manual", "request.redirect");
+    assert_equals(
+      result.headers["user-agent"],
+      undefined,
+      "Default User-Agent header should not be passed to " + "onfetch event."
+    );
+    assert_equals(
+      result.append_header_error,
+      "TypeError",
+      "Appending a new header to the request must throw a " + "TypeError."
+    );
+  }, "Test FetchEvent.request passed to onfetch");
 </script>

--- a/service-workers/service-worker/request-end-to-end.https.html
+++ b/service-workers/service-worker/request-end-to-end.https.html
@@ -7,6 +7,11 @@
 'use strict';
 
 promise_test(async t => {
+  t.add_cleanup(async () => {
+    if (frame) await frame.remove();
+    if (registration) await registration.unregister();
+  });
+
   const url = 'resources/request-end-to-end-worker.js';
   const scope = 'resources/blank.html';
 
@@ -18,12 +23,6 @@ promise_test(async t => {
   await wait_for_state(t, registration.installing, 'activated');
   const frame = await with_iframe(scope);
   const result = JSON.parse(frame.contentDocument.body.textContent);
-
-  t.add_cleanup(async () => {
-    if (frame) await frame.remove();
-    if (registration) await registration.unregister();
-  });
-
   assert_equals(result.url, frame.src, 'request.url');
   assert_equals(result.method, 'GET', 'request.method');
   assert_equals(result.referrer, location.href, 'request.referrer');

--- a/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html
+++ b/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html
@@ -4,484 +4,412 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
-  <script>
-    let lastCallbackId = 0;
-    let callbacks = {};
-    function doTest(frame, type) {
-      return new Promise(function(resolve) {
-        let id = ++lastCallbackId;
-        callbacks[id] = resolve;
-        frame.contentWindow.postMessage({ id: id, type: type }, "*");
-      });
-    }
+<script>
+let lastCallbackId = 0;
+let callbacks = {};
+function doTest(frame, type) {
+  return new Promise(function(resolve) {
+    let id = ++lastCallbackId;
+    callbacks[id] = resolve;
+    frame.contentWindow.postMessage({ id: id, type: type }, '*');
+  });
+}
 
-    // Asks the service worker for data about requests and clients seen. The
-    // worker posts a message back with |data| where:
-    // |data.requests|: the requests the worker received FetchEvents for
-    // |data.clients|: the URLs of all the worker's clients
-    // The worker clears its data after responding.
-    function getResultsFromWorker(worker) {
-      return new Promise(resolve => {
-        const channel = new MessageChannel();
-        channel.port1.onmessage = msg => {
-          resolve(msg.data);
-        };
-        worker.postMessage({ port: channel.port2 }, [channel.port2]);
-      });
-    }
-
-    window.onmessage = function(e) {
-      message = e.data;
-      const id = message["id"];
-      const callback = callbacks[id];
-      delete callbacks[id];
-      callback(message["result"]);
+// Asks the service worker for data about requests and clients seen. The
+// worker posts a message back with |data| where:
+// |data.requests|: the requests the worker received FetchEvents for
+// |data.clients|: the URLs of all the worker's clients
+// The worker clears its data after responding.
+function getResultsFromWorker(worker) {
+  return new Promise(resolve => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = msg => {
+      resolve(msg.data);
     };
+    worker.postMessage({ port: channel.port2 }, [channel.port2]);
+  });
+}
 
-    const SCOPE = "resources/sandboxed-iframe-fetch-event-iframe.py";
-    const SCRIPT = "resources/sandboxed-iframe-fetch-event-worker.js";
-    const expected_base_url = new URL(SCOPE, location.href);
-    // Service worker controlling |SCOPE|.
-    let worker;
-    // A normal iframe.
-    // This should be controlled by a service worker.
-    let normal_frame;
-    // An iframe created by <iframe sandbox='allow-scripts'>.
-    // This should NOT be controlled by a service worker.
-    let sandboxed_frame;
-    // An iframe created by <iframe sandbox='allow-scripts allow-same-origin'>.
-    // This should be controlled by a service worker.
-    let sandboxed_same_origin_frame;
-    // An iframe whose response header has
-    // 'Content-Security-Policy: allow-scripts'.
-    // This should NOT be controlled by a service worker.
-    let sandboxed_frame_by_header;
-    // An iframe whose response header has
-    // 'Content-Security-Policy: allow-scripts allow-same-origin'.
-    // This should be controlled by a service worker.
-    let sandboxed_same_origin_frame_by_header;
+window.onmessage = function(e) {
+  message = e.data;
+  const id = message['id'];
+  const callback = callbacks[id];
+  delete callbacks[id];
+  callback(message['result']);
+};
 
-    promise_test(async t => {
-      const registration = await service_worker_unregister_and_register(
-        t,
-        SCRIPT,
-        SCOPE
-      );
+const SCOPE = 'resources/sandboxed-iframe-fetch-event-iframe.py';
+const SCRIPT = 'resources/sandboxed-iframe-fetch-event-worker.js';
+const expected_base_url = new URL(SCOPE, location.href);
+// Service worker controlling |SCOPE|.
+let worker;
+// A normal iframe.
+// This should be controlled by a service worker.
+let normal_frame;
+// An iframe created by <iframe sandbox='allow-scripts'>.
+// This should NOT be controlled by a service worker.
+let sandboxed_frame;
+// An iframe created by <iframe sandbox='allow-scripts allow-same-origin'>.
+// This should be controlled by a service worker.
+let sandboxed_same_origin_frame;
+// An iframe whose response header has
+// 'Content-Security-Policy: allow-scripts'.
+// This should NOT be controlled by a service worker.
+let sandboxed_frame_by_header;
+// An iframe whose response header has
+// 'Content-Security-Policy: allow-scripts allow-same-origin'.
+// This should be controlled by a service worker.
+let sandboxed_same_origin_frame_by_header;
 
-      add_completion_callback(async () => {
-        if (registration) await registration.unregister();
-      });
+promise_test(async t => {
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
 
-      worker = registration.installing;
-      await wait_for_state(t, registration.installing, "activated");
-    }, "Prepare a service worker.");
+  add_completion_callback(async () => {
+    if (registration) await registration.unregister();
+  });
 
-    promise_test(async t => {
-      normal_frame = await with_iframe(SCOPE + "?iframe");
-      add_completion_callback(() => normal_frame.remove());
-      const data = await getResultsFromWorker(worker);
-      const requests = data.requests;
-      assert_equals(requests.length, 1);
-      assert_equals(requests[0], expected_base_url + "?iframe");
-      assert_true(data.clients.includes(expected_base_url + "?iframe"));
-    }, "Prepare a normal iframe.");
+  worker = registration.installing;
+  await wait_for_state(t, registration.installing, 'activated');
+}, 'Prepare a service worker.');
 
-    promise_test(async t => {
-      sandboxed_frame = await with_sandboxed_iframe(
-        SCOPE + "?sandboxed-iframe",
-        "allow-scripts"
-      );
-      add_completion_callback(() => sandboxed_frame.remove());
-      const data = await getResultsFromWorker(worker);
-      assert_equals(data.requests.length, 0);
-      assert_false(
-        data.clients.includes(expected_base_url + "?sandboxed-iframe")
-      );
-    }, 'Prepare an iframe sandboxed by <iframe sandbox="allow-scripts">.');
+promise_test(async t => {
+  normal_frame = await with_iframe(SCOPE + '?iframe');
+  add_completion_callback(() => normal_frame.remove());
+  const data = await getResultsFromWorker(worker);
+  const requests = data.requests;
+  assert_equals(requests.length, 1);
+  assert_equals(requests[0], expected_base_url + '?iframe');
+  assert_true(data.clients.includes(expected_base_url + '?iframe'));
+}, 'Prepare a normal iframe.');
 
-    promise_test(async t => {
-      sandboxed_same_origin_frame = await with_sandboxed_iframe(
-        SCOPE + "?sandboxed-iframe-same-origin",
-        "allow-scripts allow-same-origin"
-      );
-      add_completion_callback(() => sandboxed_same_origin_frame.remove());
-      const data = await getResultsFromWorker(worker);
-      const requests = data.requests;
-      assert_equals(requests.length, 1);
-      assert_equals(
-        requests[0],
-        expected_base_url + "?sandboxed-iframe-same-origin"
-      );
-      assert_true(
-        data.clients.includes(
-          expected_base_url + "?sandboxed-iframe-same-origin"
-        )
-      );
-    }, "Prepare an iframe sandboxed by '<iframe sandbox=\"allow-scripts allow-same-origin\">'");
+promise_test(async t => {
+  sandboxed_frame = await with_sandboxed_iframe(
+    SCOPE + '?sandboxed-iframe',
+    'allow-scripts'
+  );
+  add_completion_callback(() => sandboxed_frame.remove());
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0);
+  assert_false(
+    data.clients.includes(expected_base_url + '?sandboxed-iframe')
+  );
+}, 'Prepare an iframe sandboxed by <iframe sandbox="allow-scripts">.');
 
-    promise_test(async t => {
-      const iframe_full_url =
-        expected_base_url +
-        "?sandbox=allow-scripts&" +
-        "sandboxed-frame-by-header";
-      sandboxed_frame_by_header = await with_iframe(iframe_full_url);
-      add_completion_callback(() => sandboxed_frame_by_header.remove());
-      const data = await getResultsFromWorker(worker);
-      const requests = data.requests;
-      assert_equals(
-        requests.length,
-        1,
-        "Service worker should provide the response"
-      );
-      assert_equals(requests[0], iframe_full_url);
-      assert_false(
-        data.clients.includes(iframe_full_url),
-        "Service worker should NOT control the sandboxed page"
-      );
-    }, "Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.");
+promise_test(async t => {
+  sandboxed_same_origin_frame = await with_sandboxed_iframe(
+    SCOPE + '?sandboxed-iframe-same-origin',
+    'allow-scripts allow-same-origin'
+  );
+  add_completion_callback(() => sandboxed_same_origin_frame.remove());
+  const data = await getResultsFromWorker(worker);
+  const requests = data.requests;
+  assert_equals(requests.length, 1);
+  assert_equals(
+    requests[0],
+    expected_base_url + '?sandboxed-iframe-same-origin'
+  );
+  assert_true(
+    data.clients.includes(
+      expected_base_url + '?sandboxed-iframe-same-origin'
+    )
+  );
+}, 'Prepare an iframe sandboxed by <iframe sandbox="allow-scripts allow-same-origin">');
 
-    promise_test(async t => {
-      const iframe_full_url =
-        expected_base_url +
-        "?sandbox=allow-scripts%20allow-same-origin&" +
-        "sandboxed-iframe-same-origin-by-header";
-      sandboxed_same_origin_frame_by_header = await with_iframe(
-        iframe_full_url
-      );
-      add_completion_callback(() =>
-        sandboxed_same_origin_frame_by_header.remove()
-      );
-      const data = await getResultsFromWorker(worker);
-      const requests = data.requests;
-      assert_equals(requests.length, 1);
-      assert_equals(requests[0], iframe_full_url);
-      assert_true(data.clients.includes(iframe_full_url));
-    }, "Prepare an iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin.");
+promise_test(async t => {
+  const iframe_full_url = expected_base_url + '?sandbox=allow-scripts&' +
+                          'sandboxed-frame-by-header';
+  sandboxed_frame_by_header = await with_iframe(iframe_full_url);
+  add_completion_callback(() => sandboxed_frame_by_header.remove());
+  const data = await getResultsFromWorker(worker);
+  const requests = data.requests;
+  assert_equals(requests.length, 1,
+                'Service worker should provide the response');
+  assert_equals(requests[0], iframe_full_url);
+  assert_false(data.clients.includes(iframe_full_url),
+              'Service worker should NOT control the sandboxed page');
+}, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.');
 
-    promise_test(async t => {
-      const result = await doTest(normal_frame, "fetch");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The fetch request should be handled by SW."
-      );
-      assert_equals(data.requests[0], normal_frame.src + "&test=fetch");
-    }, "Fetch request from a normal iframe");
+promise_test(async t => {
+  const iframe_full_url =
+    expected_base_url + '?sandbox=allow-scripts%20allow-same-origin&' +
+    'sandboxed-iframe-same-origin-by-header';
+  sandboxed_same_origin_frame_by_header = await with_iframe(iframe_full_url);
+  add_completion_callback(() =>
+    sandboxed_same_origin_frame_by_header.remove()
+  );
+  const data = await getResultsFromWorker(worker);
+  const requests = data.requests;
+  assert_equals(requests.length, 1);
+  assert_equals(requests[0], iframe_full_url);
+  assert_true(data.clients.includes(iframe_full_url));
+}, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts ' +
+   'and allow-same-origin.');
 
-    promise_test(async t => {
-      const result = await doTest(normal_frame, "fetch-from-worker");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The fetch request should be handled by SW."
-      );
-      assert_equals(
-        data.requests[0],
-        normal_frame.src + "&test=fetch-from-worker"
-      );
-    }, "Fetch request from a worker in a normal iframe");
+promise_test(async t => {
+  const result = await doTest(normal_frame, 'fetch');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+    'The fetch request should be handled by SW.');
+  assert_equals(data.requests[0], normal_frame.src + '&test=fetch');
+}, 'Fetch request from a normal iframe');
 
-    promise_test(async t => {
-      const result = await doTest(normal_frame, "iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The request should be handled by SW."
-      );
-      assert_equals(data.requests[0], normal_frame.src + "&test=iframe");
-      assert_true(data.clients.includes(normal_frame.src + "&test=iframe"));
-    }, "Request for an iframe in the normal iframe");
+promise_test(async t => {
+  const result = await doTest(normal_frame, 'fetch-from-worker');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  const requests = data.requests;
+  assert_equals(requests.length, 1,
+                'The fetch request should be handled by SW.');
+  assert_equals(requests[0], normal_frame.src + '&test=fetch-from-worker');
+}, 'Fetch request from a worker in a normal iframe');
 
-    promise_test(async t => {
-      const result = await doTest(normal_frame, "sandboxed-iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-      assert_false(
-        data.clients.includes(normal_frame.src + "&test=sandboxed-iframe")
-      );
-    }, "Request for an sandboxed iframe with allow-scripts flag in the normal iframe");
+promise_test(async t => {
+  const result = await doTest(normal_frame, 'iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The request should be handled by SW.');
+  assert_equals(data.requests[0], normal_frame.src + '&test=iframe');
+  assert_true(data.clients.includes(normal_frame.src + '&test=iframe'));
+}, 'Request for an iframe in the normal iframe');
 
-    promise_test(async t => {
-      const result = await doTest(normal_frame, "sandboxed-iframe-same-origin");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The request should be handled by SW."
-      );
-      assert_equals(
-        data.requests[0],
-        normal_frame.src + "&test=sandboxed-iframe-same-origin"
-      );
-      assert_true(
-        data.clients.includes(
-          normal_frame.src + "&test=sandboxed-iframe-same-origin"
-        )
-      );
-    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the normal iframe");
+promise_test(async t => {
+  const result = await doTest(normal_frame, 'sandboxed-iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+  assert_false(data.clients.includes(
+    normal_frame.src + '&test=sandboxed-iframe'));
+}, 'Request for an sandboxed iframe with allow-scripts flag in the normal ' +
+   'iframe');
 
-    promise_test(async t => {
-      const result = await doTest(sandboxed_frame, "fetch");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The fetch request should NOT be handled by SW."
-      );
-    }, "Fetch request from iframe sandboxed by an attribute with allow-scripts flag");
+promise_test(async t => {
+  const frame = normal_frame;
+  const result = await doTest(frame, 'sandboxed-iframe-same-origin');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  const requests = data.requests;
+  assert_equals(requests.length, 1,
+                'The request should be handled by SW.');
+  assert_equals(requests[0],
+                frame.src + '&test=sandboxed-iframe-same-origin');
+  assert_true(data.clients.includes(
+              frame.src + '&test=sandboxed-iframe-same-origin'));
+}, 'Request for an sandboxed iframe with allow-scripts and ' +
+   'allow-same-origin flag in the normal iframe');
 
-    promise_test(async t => {
-      const result = await doTest(sandboxed_frame, "fetch-from-worker");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The fetch request should NOT be handled by SW."
-      );
-    }, "Fetch request from a worker in iframe sandboxed by an attribute with allow-scripts flag");
+promise_test(async t => {
+  const result = await doTest(sandboxed_frame, 'fetch');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The fetch request should NOT be handled by SW.');
+}, 'Fetch request from iframe sandboxed by an attribute with allow-scripts ' +
+   'flag');
 
-    promise_test(async t => {
-      const result = await doTest(sandboxed_frame, "iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-      assert_false(data.clients.includes(sandboxed_frame.src + "&test=iframe"));
-    }, "Request for an iframe in the iframe sandboxed by an attribute with allow-scripts flag");
+promise_test(async t => {
+  const result = await doTest(sandboxed_frame, 'fetch-from-worker');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The fetch request should NOT be handled by SW.');
+}, 'Fetch request from a worker in iframe sandboxed by an attribute with ' +
+   'allow-scripts flag');
 
-    promise_test(async t => {
-      const result = await doTest(sandboxed_frame, "sandboxed-iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-      assert_false(
-        data.clients.includes(sandboxed_frame.src + "&test=sandboxed-iframe")
-      );
-    }, "Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by an attribute with allow-scripts flag");
+promise_test(async t => {
+  const result = await doTest(sandboxed_frame, 'iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+  assert_false(data.clients.includes(sandboxed_frame.src + '&test=iframe'));
+}, 'Request for an iframe in the iframe sandboxed by an attribute with ' +
+   'allow-scripts flag');
 
-    promise_test(async t => {
-      const result = await doTest(
-        sandboxed_frame,
-        "sandboxed-iframe-same-origin"
-      );
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-      assert_false(
-        data.clients.includes(
-          sandboxed_frame.src + "&test=sandboxed-iframe-same-origin"
-        )
-      );
-    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by an attribute with allow-scripts flag");
+promise_test(async t => {
+  const result = await doTest(sandboxed_frame, 'sandboxed-iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+  assert_false(data.clients.includes(
+    sandboxed_frame.src + '&test=sandboxed-iframe'));
+}, 'Request for an sandboxed iframe with allow-scripts flag in the iframe ' +
+   'sandboxed by an attribute with allow-scripts flag');
 
-    promise_test(async t => {
-      const result = await doTest(sandboxed_same_origin_frame, "fetch");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The fetch request should be handled by SW."
-      );
-      assert_equals(
-        data.requests[0],
-        sandboxed_same_origin_frame.src + "&test=fetch"
-      );
-    }, "Fetch request from iframe sandboxed by an attribute with allow-scripts and allow-same-origin flag");
+promise_test(async t => {
+  const result = await doTest(
+    sandboxed_frame,
+    'sandboxed-iframe-same-origin'
+  );
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+  assert_false(data.clients.includes(
+    sandboxed_frame.src + '&test=sandboxed-iframe-same-origin'));
+}, 'Request for an sandboxed iframe with allow-scripts and ' +
+   'allow-same-origin flag in the iframe sandboxed by an attribute with ' +
+   'allow-scripts flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_same_origin_frame;
-      const result = await doTest(frame, "fetch-from-worker");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The fetch request should be handled by SW."
-      );
-      assert_equals(data.requests[0], frame.src + "&test=fetch-from-worker");
-    }, "Fetch request from a worker in iframe sandboxed by an attribute with allow-scripts and allow-same-origin flag");
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame;
+  const result = await doTest(frame, 'fetch');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The fetch request should be handled by SW.');
+  assert_equals(data.requests[0], frame.src + '&test=fetch');
+}, 'Fetch request from iframe sandboxed by an attribute with allow-scripts '+
+   'and allow-same-origin flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_same_origin_frame;
-      const result = await doTest(frame, "iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The request should be handled by SW."
-      );
-      assert_equals(data.requests[0], frame.src + "&test=iframe");
-      assert_true(data.clients.includes(frame.src + "&test=iframe"));
-    }, "Request for an iframe in the iframe sandboxed by an attribute with allow-scripts and allow-same-origin flag");
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame;
+  const result = await doTest(frame, 'fetch-from-worker');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The fetch request should be handled by SW.');
+  assert_equals(data.requests[0], frame.src + '&test=fetch-from-worker');
+}, 'Fetch request from a worker in iframe sandboxed by an attribute with '+
+   'allow-scripts and allow-same-origin flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_same_origin_frame;
-      const result = await doTest(frame, "sandboxed-iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-      assert_false(data.clients.includes(frame.src + "&test=sandboxed-iframe"));
-    }, "Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by attribute with allow-scripts and allow-same-origin flag");
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame;
+  const result = await doTest(frame, 'iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The request should be handled by SW.');
+  assert_equals(data.requests[0], frame.src + '&test=iframe');
+  assert_true(data.clients.includes(frame.src + '&test=iframe'));
+}, 'Request for an iframe in the iframe sandboxed by an attribute with '+
+   'allow-scripts and allow-same-origin flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_same_origin_frame;
-      const result = await doTest(frame, "sandboxed-iframe-same-origin");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The request should be handled by SW."
-      );
-      assert_equals(
-        data.requests[0],
-        frame.src + "&test=sandboxed-iframe-same-origin"
-      );
-      assert_true(
-        data.clients.includes(frame.src + "&test=sandboxed-iframe-same-origin")
-      );
-    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by attribute with allow-scripts and allow-same-origin flag");
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame;
+  const result = await doTest(frame, 'sandboxed-iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+  assert_false(data.clients.includes(frame.src + '&test=sandboxed-iframe'));
+}, 'Request for an sandboxed iframe with allow-scripts flag in the iframe '+
+   'sandboxed by attribute with allow-scripts and allow-same-origin flag');
 
-    promise_test(async t => {
-      const result = await doTest(sandboxed_frame_by_header, "fetch");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-    }, "Fetch request from iframe sandboxed by CSP HTTP header with allow-scripts flag");
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame;
+  const result = await doTest(frame, 'sandboxed-iframe-same-origin');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The request should be handled by SW.');
+  assert_equals(data.requests[0],
+                frame.src + '&test=sandboxed-iframe-same-origin');
+  assert_true(data.clients.includes(
+    frame.src + '&test=sandboxed-iframe-same-origin'));
+}, 'Request for an sandboxed iframe with allow-scripts and '+
+   'allow-same-origin flag in the iframe sandboxed by attribute with '+
+   'allow-scripts and allow-same-origin flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_frame_by_header;
-      const result = await doTest(frame, "iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-      assert_false(data.clients.includes(frame.src + "&test=iframe"));
-    }, "Request for an iframe in the iframe sandboxed by CSP HTTP header with allow-scripts flag");
+promise_test(async t => {
+  const result = await doTest(sandboxed_frame_by_header, 'fetch');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+}, 'Fetch request from iframe sandboxed by CSP HTTP header with '+
+   'allow-scripts flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_frame_by_header;
-      const result = await doTest(frame, "sandboxed-iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-      assert_false(data.clients.includes(frame.src + "&test=sandboxed-iframe"));
-    }, "Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by CSP HTTP header with allow-scripts flag");
+promise_test(async t => {
+  const frame = sandboxed_frame_by_header;
+  const result = await doTest(frame, 'iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+    'The request should NOT be handled by SW.');
+  assert_false(data.clients.includes(frame.src + '&test=iframe'));
+}, 'Request for an iframe in the iframe sandboxed by CSP HTTP header with '+
+   'allow-scripts flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_frame_by_header;
-      const result = await doTest(frame, "sandboxed-iframe-same-origin");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-      assert_false(
-        data.clients.includes(frame.src + "&test=sandboxed-iframe-same-origin")
-      );
-    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by CSP HTTP header with allow-scripts flag");
+promise_test(async t => {
+  const frame = sandboxed_frame_by_header;
+  const result = await doTest(frame, 'sandboxed-iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+  assert_false(data.clients.includes(frame.src + '&test=sandboxed-iframe'));
+}, 'Request for an sandboxed iframe with allow-scripts flag in the iframe '+
+   'sandboxed by CSP HTTP header with allow-scripts flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_same_origin_frame_by_header;
-      const result = await doTest(frame, "fetch");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The request should be handled by SW."
-      );
-      assert_equals(data.requests[0], frame.src + "&test=fetch");
-    }, "Fetch request from iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
+promise_test(async t => {
+  const frame = sandboxed_frame_by_header;
+  const result = await doTest(frame, 'sandboxed-iframe-same-origin');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+  assert_false(data.clients.includes(
+    frame.src + '&test=sandboxed-iframe-same-origin'));
+}, 'Request for an sandboxed iframe with allow-scripts and '+
+   'allow-same-origin flag in the iframe sandboxed by CSP HTTP header with '+
+   'allow-scripts flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_same_origin_frame_by_header;
-      const result = await doTest(frame, "iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The request should be handled by SW."
-      );
-      assert_equals(data.requests[0], frame.src + "&test=iframe");
-      assert_true(data.clients.includes(frame.src + "&test=iframe"));
-    }, "Request for an iframe in the iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame_by_header;
+  const result = await doTest(frame, 'fetch');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The request should be handled by SW.');
+  assert_equals(data.requests[0], frame.src + '&test=fetch');
+}, 'Fetch request from iframe sandboxed by CSP HTTP header with '+
+   'allow-scripts and allow-same-origin flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_same_origin_frame_by_header;
-      const result = await doTest(frame, "sandboxed-iframe");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-      assert_false(data.clients.includes(frame.src + "&test=sandboxed-iframe"));
-    }, "Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame_by_header;
+  const result = await doTest(frame, 'iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The request should be handled by SW.');
+  assert_equals(data.requests[0], frame.src + '&test=iframe');
+  assert_true(data.clients.includes(frame.src + '&test=iframe'));
+}, 'Request for an iframe in the iframe sandboxed by CSP HTTP header with '+
+   'allow-scripts and allow-same-origin flag');
 
-    promise_test(async t => {
-      const frame = sandboxed_same_origin_frame_by_header;
-      const result = await doTest(frame, "sandboxed-iframe-same-origin");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The request should be handled by SW."
-      );
-      assert_equals(
-        data.requests[0],
-        frame.src + "&test=sandboxed-iframe-same-origin"
-      );
-      assert_true(
-        data.clients.includes(frame.src + "&test=sandboxed-iframe-same-origin")
-      );
-    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
-  </script>
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame_by_header;
+  const result = await doTest(frame, 'sandboxed-iframe');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+  assert_false(data.clients.includes(frame.src + '&test=sandboxed-iframe'));
+}, 'Request for an sandboxed iframe with allow-scripts flag in the ' +
+   'iframe sandboxed by CSP HTTP header with allow-scripts and '+
+   'allow-same-origin flag');
+
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame_by_header;
+  const result = await doTest(frame, 'sandboxed-iframe-same-origin');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The request should be handled by SW.');
+  assert_equals(data.requests[0],
+                frame.src + '&test=sandboxed-iframe-same-origin');
+  assert_true(data.clients.includes(
+    frame.src + '&test=sandboxed-iframe-same-origin'));
+}, 'Request for an sandboxed iframe with allow-scripts and '+
+   'allow-same-origin flag in the iframe sandboxed by CSP HTTP header with '+
+   'allow-scripts and allow-same-origin flag');
+</script>
 </body>

--- a/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html
+++ b/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html
@@ -72,7 +72,6 @@ promise_test(async t => {
     SCOPE
   );
 
-  worker = registration.installing;
   await wait_for_state(t, registration.installing, 'activated');
 }, 'Prepare a service worker.');
 

--- a/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html
+++ b/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html
@@ -4,532 +4,484 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
-<script>
-var lastCallbackId = 0;
-var callbacks = {};
-function doTest(frame, type) {
-  return new Promise(function(resolve) {
-    var id = ++lastCallbackId;
-    callbacks[id] = resolve;
-    frame.contentWindow.postMessage({id: id, type: type}, '*');
-  });
-}
+  <script>
+    let lastCallbackId = 0;
+    let callbacks = {};
+    function doTest(frame, type) {
+      return new Promise(function(resolve) {
+        let id = ++lastCallbackId;
+        callbacks[id] = resolve;
+        frame.contentWindow.postMessage({ id: id, type: type }, "*");
+      });
+    }
 
-// Asks the service worker for data about requests and clients seen. The
-// worker posts a message back with |data| where:
-// |data.requests|: the requests the worker received FetchEvents for
-// |data.clients|: the URLs of all the worker's clients
-// The worker clears its data after responding.
-function getResultsFromWorker(worker) {
-  return new Promise(resolve => {
-    let channel = new MessageChannel();
-    channel.port1.onmessage = msg => {
-      resolve(msg.data);
+    // Asks the service worker for data about requests and clients seen. The
+    // worker posts a message back with |data| where:
+    // |data.requests|: the requests the worker received FetchEvents for
+    // |data.clients|: the URLs of all the worker's clients
+    // The worker clears its data after responding.
+    function getResultsFromWorker(worker) {
+      return new Promise(resolve => {
+        const channel = new MessageChannel();
+        channel.port1.onmessage = msg => {
+          resolve(msg.data);
+        };
+        worker.postMessage({ port: channel.port2 }, [channel.port2]);
+      });
+    }
+
+    window.onmessage = function(e) {
+      message = e.data;
+      const id = message["id"];
+      const callback = callbacks[id];
+      delete callbacks[id];
+      callback(message["result"]);
     };
-    worker.postMessage({port: channel.port2}, [channel.port2]);
-  });
-}
 
-window.onmessage = function (e) {
-  message = e.data;
-  var id = message['id'];
-  var callback = callbacks[id];
-  delete callbacks[id];
-  callback(message['result']);
-};
+    const SCOPE = "resources/sandboxed-iframe-fetch-event-iframe.py";
+    const SCRIPT = "resources/sandboxed-iframe-fetch-event-worker.js";
+    const expected_base_url = new URL(SCOPE, location.href);
+    // Service worker controlling |SCOPE|.
+    let worker;
+    // A normal iframe.
+    // This should be controlled by a service worker.
+    let normal_frame;
+    // An iframe created by <iframe sandbox='allow-scripts'>.
+    // This should NOT be controlled by a service worker.
+    let sandboxed_frame;
+    // An iframe created by <iframe sandbox='allow-scripts allow-same-origin'>.
+    // This should be controlled by a service worker.
+    let sandboxed_same_origin_frame;
+    // An iframe whose response header has
+    // 'Content-Security-Policy: allow-scripts'.
+    // This should NOT be controlled by a service worker.
+    let sandboxed_frame_by_header;
+    // An iframe whose response header has
+    // 'Content-Security-Policy: allow-scripts allow-same-origin'.
+    // This should be controlled by a service worker.
+    let sandboxed_same_origin_frame_by_header;
 
-const SCOPE = 'resources/sandboxed-iframe-fetch-event-iframe.py';
-const SCRIPT = 'resources/sandboxed-iframe-fetch-event-worker.js';
-const expected_base_url = new URL(SCOPE, location.href);
-// Service worker controlling |SCOPE|.
-let worker;
-// A normal iframe.
-// This should be controlled by a service worker.
-let normal_frame;
-// An iframe created by <iframe sandbox='allow-scripts'>.
-// This should NOT be controlled by a service worker.
-let sandboxed_frame;
-// An iframe created by <iframe sandbox='allow-scripts allow-same-origin'>.
-// This should be controlled by a service worker.
-let sandboxed_same_origin_frame;
-// An iframe whose response header has
-// 'Content-Security-Policy: allow-scripts'.
-// This should NOT be controlled by a service worker.
-let sandboxed_frame_by_header;
-// An iframe whose response header has
-// 'Content-Security-Policy: allow-scripts allow-same-origin'.
-// This should be controlled by a service worker.
-let sandboxed_same_origin_frame_by_header;
+    promise_test(async t => {
+      const registration = await service_worker_unregister_and_register(
+        t,
+        SCRIPT,
+        SCOPE
+      );
 
-promise_test(t => {
-  return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
-    .then(function(registration) {
-      add_completion_callback(() => registration.unregister());
+      add_completion_callback(async () => {
+        if (registration) await registration.unregister();
+      });
+
       worker = registration.installing;
-      return wait_for_state(t, registration.installing, 'activated');
-    });
-}, 'Prepare a service worker.');
+      await wait_for_state(t, registration.installing, "activated");
+    }, "Prepare a service worker.");
 
-promise_test(t => {
-  return with_iframe(SCOPE + '?iframe')
-    .then(f => {
-      normal_frame = f;
-      add_completion_callback(() => f.remove());
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
+    promise_test(async t => {
+      normal_frame = await with_iframe(SCOPE + "?iframe");
+      add_completion_callback(() => normal_frame.remove());
+      const data = await getResultsFromWorker(worker);
+      const requests = data.requests;
       assert_equals(requests.length, 1);
-      assert_equals(requests[0], expected_base_url + '?iframe');
-      assert_true(data.clients.includes(expected_base_url + '?iframe'));
-    });
-}, 'Prepare a normal iframe.');
+      assert_equals(requests[0], expected_base_url + "?iframe");
+      assert_true(data.clients.includes(expected_base_url + "?iframe"));
+    }, "Prepare a normal iframe.");
 
-promise_test(t => {
-  return with_sandboxed_iframe(SCOPE + '?sandboxed-iframe', 'allow-scripts')
-    .then(f => {
-      sandboxed_frame = f;
-      add_completion_callback(() => f.remove());
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
+    promise_test(async t => {
+      sandboxed_frame = await with_sandboxed_iframe(
+        SCOPE + "?sandboxed-iframe",
+        "allow-scripts"
+      );
+      add_completion_callback(() => sandboxed_frame.remove());
+      const data = await getResultsFromWorker(worker);
       assert_equals(data.requests.length, 0);
-      assert_false(data.clients.includes(expected_base_url +
-                                         '?sandboxed-iframe'));
-    });
-}, 'Prepare an iframe sandboxed by <iframe sandbox="allow-scripts">.');
+      assert_false(
+        data.clients.includes(expected_base_url + "?sandboxed-iframe")
+      );
+    }, 'Prepare an iframe sandboxed by <iframe sandbox="allow-scripts">.');
 
-promise_test(t => {
-  return with_sandboxed_iframe(SCOPE + '?sandboxed-iframe-same-origin',
-                               'allow-scripts allow-same-origin')
-    .then(f => {
-      sandboxed_same_origin_frame = f;
-      add_completion_callback(() => f.remove());
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
+    promise_test(async t => {
+      sandboxed_same_origin_frame = await with_sandboxed_iframe(
+        SCOPE + "?sandboxed-iframe-same-origin",
+        "allow-scripts allow-same-origin"
+      );
+      add_completion_callback(() => sandboxed_same_origin_frame.remove());
+      const data = await getResultsFromWorker(worker);
+      const requests = data.requests;
       assert_equals(requests.length, 1);
-      assert_equals(requests[0],
-                    expected_base_url + '?sandboxed-iframe-same-origin');
-      assert_true(data.clients.includes(
-        expected_base_url + '?sandboxed-iframe-same-origin'));
-    })
-}, 'Prepare an iframe sandboxed by ' +
-   '<iframe sandbox="allow-scripts allow-same-origin">.');
+      assert_equals(
+        requests[0],
+        expected_base_url + "?sandboxed-iframe-same-origin"
+      );
+      assert_true(
+        data.clients.includes(
+          expected_base_url + "?sandboxed-iframe-same-origin"
+        )
+      );
+    }, "Prepare an iframe sandboxed by '<iframe sandbox=\"allow-scripts allow-same-origin\">'");
 
-promise_test(t => {
-  const iframe_full_url = expected_base_url + '?sandbox=allow-scripts&' +
-                          'sandboxed-frame-by-header';
-  return with_iframe(iframe_full_url)
-    .then(f => {
-      sandboxed_frame_by_header = f;
-      add_completion_callback(() => f.remove());
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'Service worker should provide the response');
+    promise_test(async t => {
+      const iframe_full_url =
+        expected_base_url +
+        "?sandbox=allow-scripts&" +
+        "sandboxed-frame-by-header";
+      sandboxed_frame_by_header = await with_iframe(iframe_full_url);
+      add_completion_callback(() => sandboxed_frame_by_header.remove());
+      const data = await getResultsFromWorker(worker);
+      const requests = data.requests;
+      assert_equals(
+        requests.length,
+        1,
+        "Service worker should provide the response"
+      );
       assert_equals(requests[0], iframe_full_url);
-      assert_false(data.clients.includes(iframe_full_url),
-                   'Service worker should NOT control the sandboxed page');
-    });
-}, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.');
+      assert_false(
+        data.clients.includes(iframe_full_url),
+        "Service worker should NOT control the sandboxed page"
+      );
+    }, "Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.");
 
-promise_test(t => {
-  const iframe_full_url =
-    expected_base_url + '?sandbox=allow-scripts%20allow-same-origin&' +
-    'sandboxed-iframe-same-origin-by-header';
-  return with_iframe(iframe_full_url)
-    .then(f => {
-      sandboxed_same_origin_frame_by_header = f;
-      add_completion_callback(() => f.remove());
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
+    promise_test(async t => {
+      const iframe_full_url =
+        expected_base_url +
+        "?sandbox=allow-scripts%20allow-same-origin&" +
+        "sandboxed-iframe-same-origin-by-header";
+      sandboxed_same_origin_frame_by_header = await with_iframe(
+        iframe_full_url
+      );
+      add_completion_callback(() =>
+        sandboxed_same_origin_frame_by_header.remove()
+      );
+      const data = await getResultsFromWorker(worker);
+      const requests = data.requests;
       assert_equals(requests.length, 1);
       assert_equals(requests[0], iframe_full_url);
       assert_true(data.clients.includes(iframe_full_url));
-    })
-}, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts and ' +
-   'allow-same-origin.');
+    }, "Prepare an iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin.");
 
-promise_test(t => {
-  let frame = normal_frame;
-  return doTest(frame, 'fetch')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The fetch request should be handled by SW.');
-      assert_equals(requests[0], frame.src + '&test=fetch');
-    });
-}, 'Fetch request from a normal iframe');
+    promise_test(async t => {
+      const result = await doTest(normal_frame, "fetch");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The fetch request should be handled by SW."
+      );
+      assert_equals(data.requests[0], normal_frame.src + "&test=fetch");
+    }, "Fetch request from a normal iframe");
 
-promise_test(t => {
-  let frame = normal_frame;
-  return doTest(frame, 'fetch-from-worker')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The fetch request should be handled by SW.');
-      assert_equals(requests[0], frame.src + '&test=fetch-from-worker');
-    });
-}, 'Fetch request from a worker in a normal iframe');
+    promise_test(async t => {
+      const result = await doTest(normal_frame, "fetch-from-worker");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The fetch request should be handled by SW."
+      );
+      assert_equals(
+        data.requests[0],
+        normal_frame.src + "&test=fetch-from-worker"
+      );
+    }, "Fetch request from a worker in a normal iframe");
 
-promise_test(t => {
-  let frame = normal_frame;
-  return doTest(frame, 'iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The request should be handled by SW.');
-      assert_equals(requests[0], frame.src + '&test=iframe');
-      assert_true(data.clients.includes(frame.src + '&test=iframe'));
+    promise_test(async t => {
+      const result = await doTest(normal_frame, "iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The request should be handled by SW."
+      );
+      assert_equals(data.requests[0], normal_frame.src + "&test=iframe");
+      assert_true(data.clients.includes(normal_frame.src + "&test=iframe"));
+    }, "Request for an iframe in the normal iframe");
 
-    });
-}, 'Request for an iframe in the normal iframe');
-
-promise_test(t => {
-  let frame = normal_frame;
-  return doTest(frame, 'sandboxed-iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-      assert_false(data.clients.includes(
-        frame.src + '&test=sandboxed-iframe'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts flag in the normal ' +
-   'iframe');
-
-promise_test(t => {
-  let frame = normal_frame;
-  return doTest(frame, 'sandboxed-iframe-same-origin')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The request should be handled by SW.');
-      assert_equals(requests[0],
-                    frame.src + '&test=sandboxed-iframe-same-origin');
-      assert_true(data.clients.includes(
-        frame.src + '&test=sandboxed-iframe-same-origin'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts and ' +
-   'allow-same-origin flag in the normal iframe');
-
-promise_test(t => {
-  let frame = sandboxed_frame;
-  return doTest(frame, 'fetch')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The fetch request should NOT be handled by SW.');
-    });
-}, 'Fetch request from iframe sandboxed by an attribute with allow-scripts ' +
-   'flag');
-
-promise_test(t => {
-  let frame = sandboxed_frame;
-  return doTest(frame, 'fetch-from-worker')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The fetch request should NOT be handled by SW.');
-    });
-}, 'Fetch request from a worker in iframe sandboxed by an attribute with ' +
-   'allow-scripts flag');
-
-promise_test(t => {
-  let frame = sandboxed_frame;
-  return doTest(frame, 'iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-      assert_false(data.clients.includes(frame.src + '&test=iframe'));
-    });
-}, 'Request for an iframe in the iframe sandboxed by an attribute with ' +
-   'allow-scripts flag');
-
-promise_test(t => {
-  let frame = sandboxed_frame;
-  return doTest(frame, 'sandboxed-iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-      assert_false(data.clients.includes(
-        frame.src + '&test=sandboxed-iframe'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts flag in the iframe ' +
-   'sandboxed by an attribute with allow-scripts flag');
-
-promise_test(t => {
-  let frame = sandboxed_frame;
-  return doTest(frame, 'sandboxed-iframe-same-origin')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-      assert_false(data.clients.includes(
-        frame.src + '&test=sandboxed-iframe-same-origin'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts and ' +
-   'allow-same-origin flag in the iframe sandboxed by an attribute with ' +
-   'allow-scripts flag');
-
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame;
-  return doTest(frame, 'fetch')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The fetch request should be handled by SW.');
-      assert_equals(requests[0], frame.src + '&test=fetch');
-    });
-}, 'Fetch request from iframe sandboxed by an attribute with allow-scripts ' +
-   'and allow-same-origin flag');
-
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame;
-  return doTest(frame, 'fetch-from-worker')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The fetch request should be handled by SW.');
-      assert_equals(requests[0],
-                    frame.src + '&test=fetch-from-worker');
-    });
-}, 'Fetch request from a worker in iframe sandboxed by an attribute with ' +
-   'allow-scripts and allow-same-origin flag');
-
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame;
-  return doTest(frame, 'iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The request should be handled by SW.');
-      assert_equals(requests[0], frame.src + '&test=iframe');
-      assert_true(data.clients.includes(frame.src + '&test=iframe'));
-    });
-}, 'Request for an iframe in the iframe sandboxed by an attribute with ' +
-   'allow-scripts and allow-same-origin flag');
-
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame;
-  return doTest(frame, 'sandboxed-iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-      assert_false(data.clients.includes(
-        frame.src + '&test=sandboxed-iframe'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts flag in the iframe ' +
-   'sandboxed by attribute with allow-scripts and allow-same-origin flag');
-
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame;
-  return doTest(frame, 'sandboxed-iframe-same-origin')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The request should be handled by SW.');
-      assert_equals(requests[0],
-                    frame.src + '&test=sandboxed-iframe-same-origin');
-      assert_true(data.clients.includes(
-        frame.src + '&test=sandboxed-iframe-same-origin'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts and ' +
-   'allow-same-origin flag in the iframe sandboxed by attribute with ' +
-   'allow-scripts and allow-same-origin flag');
-
-promise_test(t => {
-  let frame = sandboxed_frame_by_header;
-  return doTest(frame, 'fetch')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-    });
-}, 'Fetch request from iframe sandboxed by CSP HTTP header with ' +
-   'allow-scripts flag');
-
-promise_test(t => {
-  let frame = sandboxed_frame_by_header;
-  return doTest(frame, 'iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-      assert_false(data.clients.includes(frame.src + '&test=iframe'));
-    });
-}, 'Request for an iframe in the iframe sandboxed by CSP HTTP header with ' +
-   'allow-scripts flag');
-
-promise_test(t => {
-  let frame = sandboxed_frame_by_header;
-  return doTest(frame, 'sandboxed-iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-      assert_false(data.clients.includes(
-        frame.src + '&test=sandboxed-iframe'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts flag in the iframe ' +
-   'sandboxed by CSP HTTP header with allow-scripts flag');
-
-promise_test(t => {
-  let frame = sandboxed_frame_by_header;
-  return doTest(frame, 'sandboxed-iframe-same-origin')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-      assert_false(data.clients.includes(
-        frame.src + '&test=sandboxed-iframe-same-origin'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts and ' +
-   'allow-same-origin flag in the iframe sandboxed by CSP HTTP header with ' +
-   'allow-scripts flag');
-
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame_by_header;
-  return doTest(frame, 'fetch')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The request should be handled by SW.');
-      assert_equals(requests[0], frame.src + '&test=fetch');
-    });
-}, 'Fetch request from iframe sandboxed by CSP HTTP header with ' +
-   'allow-scripts and allow-same-origin flag');
-
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame_by_header;
-  return doTest(frame, 'iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The request should be handled by SW.');
-      assert_equals(requests[0], frame.src + '&test=iframe');
-      assert_true(data.clients.includes(frame.src + '&test=iframe'));
-    });
-}, 'Request for an iframe in the iframe sandboxed by CSP HTTP header with ' +
-   'allow-scripts and allow-same-origin flag');
-
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame_by_header;
-  return doTest(frame, 'sandboxed-iframe')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
+    promise_test(async t => {
+      const result = await doTest(normal_frame, "sandboxed-iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
       assert_false(
-        data.clients.includes(frame.src + '&test=sandboxed-iframe'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts flag in the ' +
-   'iframe sandboxed by CSP HTTP header with allow-scripts and ' +
-   'allow-same-origin flag');
+        data.clients.includes(normal_frame.src + "&test=sandboxed-iframe")
+      );
+    }, "Request for an sandboxed iframe with allow-scripts flag in the normal iframe");
 
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame_by_header;
-  return doTest(frame, 'sandboxed-iframe-same-origin')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The request should be handled by SW.');
-      assert_equals(requests[0],
-                    frame.src + '&test=sandboxed-iframe-same-origin');
-      assert_true(data.clients.includes(
-        frame.src + '&test=sandboxed-iframe-same-origin'));
-    });
-}, 'Request for an sandboxed iframe with allow-scripts and ' +
-   'allow-same-origin flag in the iframe sandboxed by CSP HTTP header with ' +
-   'allow-scripts and allow-same-origin flag');
-</script>
+    promise_test(async t => {
+      const result = await doTest(normal_frame, "sandboxed-iframe-same-origin");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The request should be handled by SW."
+      );
+      assert_equals(
+        data.requests[0],
+        normal_frame.src + "&test=sandboxed-iframe-same-origin"
+      );
+      assert_true(
+        data.clients.includes(
+          normal_frame.src + "&test=sandboxed-iframe-same-origin"
+        )
+      );
+    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the normal iframe");
+
+    promise_test(async t => {
+      const result = await doTest(sandboxed_frame, "fetch");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The fetch request should NOT be handled by SW."
+      );
+    }, "Fetch request from iframe sandboxed by an attribute with allow-scripts flag");
+
+    promise_test(async t => {
+      const result = await doTest(sandboxed_frame, "fetch-from-worker");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The fetch request should NOT be handled by SW."
+      );
+    }, "Fetch request from a worker in iframe sandboxed by an attribute with allow-scripts flag");
+
+    promise_test(async t => {
+      const result = await doTest(sandboxed_frame, "iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+      assert_false(data.clients.includes(sandboxed_frame.src + "&test=iframe"));
+    }, "Request for an iframe in the iframe sandboxed by an attribute with allow-scripts flag");
+
+    promise_test(async t => {
+      const result = await doTest(sandboxed_frame, "sandboxed-iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+      assert_false(
+        data.clients.includes(sandboxed_frame.src + "&test=sandboxed-iframe")
+      );
+    }, "Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by an attribute with allow-scripts flag");
+
+    promise_test(async t => {
+      const result = await doTest(
+        sandboxed_frame,
+        "sandboxed-iframe-same-origin"
+      );
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+      assert_false(
+        data.clients.includes(
+          sandboxed_frame.src + "&test=sandboxed-iframe-same-origin"
+        )
+      );
+    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by an attribute with allow-scripts flag");
+
+    promise_test(async t => {
+      const result = await doTest(sandboxed_same_origin_frame, "fetch");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The fetch request should be handled by SW."
+      );
+      assert_equals(
+        data.requests[0],
+        sandboxed_same_origin_frame.src + "&test=fetch"
+      );
+    }, "Fetch request from iframe sandboxed by an attribute with allow-scripts and allow-same-origin flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_same_origin_frame;
+      const result = await doTest(frame, "fetch-from-worker");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The fetch request should be handled by SW."
+      );
+      assert_equals(data.requests[0], frame.src + "&test=fetch-from-worker");
+    }, "Fetch request from a worker in iframe sandboxed by an attribute with allow-scripts and allow-same-origin flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_same_origin_frame;
+      const result = await doTest(frame, "iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The request should be handled by SW."
+      );
+      assert_equals(data.requests[0], frame.src + "&test=iframe");
+      assert_true(data.clients.includes(frame.src + "&test=iframe"));
+    }, "Request for an iframe in the iframe sandboxed by an attribute with allow-scripts and allow-same-origin flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_same_origin_frame;
+      const result = await doTest(frame, "sandboxed-iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+      assert_false(data.clients.includes(frame.src + "&test=sandboxed-iframe"));
+    }, "Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by attribute with allow-scripts and allow-same-origin flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_same_origin_frame;
+      const result = await doTest(frame, "sandboxed-iframe-same-origin");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The request should be handled by SW."
+      );
+      assert_equals(
+        data.requests[0],
+        frame.src + "&test=sandboxed-iframe-same-origin"
+      );
+      assert_true(
+        data.clients.includes(frame.src + "&test=sandboxed-iframe-same-origin")
+      );
+    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by attribute with allow-scripts and allow-same-origin flag");
+
+    promise_test(async t => {
+      const result = await doTest(sandboxed_frame_by_header, "fetch");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+    }, "Fetch request from iframe sandboxed by CSP HTTP header with allow-scripts flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_frame_by_header;
+      const result = await doTest(frame, "iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+      assert_false(data.clients.includes(frame.src + "&test=iframe"));
+    }, "Request for an iframe in the iframe sandboxed by CSP HTTP header with allow-scripts flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_frame_by_header;
+      const result = await doTest(frame, "sandboxed-iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+      assert_false(data.clients.includes(frame.src + "&test=sandboxed-iframe"));
+    }, "Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by CSP HTTP header with allow-scripts flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_frame_by_header;
+      const result = await doTest(frame, "sandboxed-iframe-same-origin");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+      assert_false(
+        data.clients.includes(frame.src + "&test=sandboxed-iframe-same-origin")
+      );
+    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by CSP HTTP header with allow-scripts flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_same_origin_frame_by_header;
+      const result = await doTest(frame, "fetch");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The request should be handled by SW."
+      );
+      assert_equals(data.requests[0], frame.src + "&test=fetch");
+    }, "Fetch request from iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_same_origin_frame_by_header;
+      const result = await doTest(frame, "iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The request should be handled by SW."
+      );
+      assert_equals(data.requests[0], frame.src + "&test=iframe");
+      assert_true(data.clients.includes(frame.src + "&test=iframe"));
+    }, "Request for an iframe in the iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_same_origin_frame_by_header;
+      const result = await doTest(frame, "sandboxed-iframe");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+      assert_false(data.clients.includes(frame.src + "&test=sandboxed-iframe"));
+    }, "Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
+
+    promise_test(async t => {
+      const frame = sandboxed_same_origin_frame_by_header;
+      const result = await doTest(frame, "sandboxed-iframe-same-origin");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The request should be handled by SW."
+      );
+      assert_equals(
+        data.requests[0],
+        frame.src + "&test=sandboxed-iframe-same-origin"
+      );
+      assert_true(
+        data.clients.includes(frame.src + "&test=sandboxed-iframe-same-origin")
+      );
+    }, "Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
+  </script>
 </body>

--- a/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html
+++ b/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html
@@ -62,23 +62,23 @@ let sandboxed_frame_by_header;
 let sandboxed_same_origin_frame_by_header;
 
 promise_test(async t => {
+  add_completion_callback(async () => {
+    if (registration) await registration.unregister();
+  });
+
   const registration = await service_worker_unregister_and_register(
     t,
     SCRIPT,
     SCOPE
   );
 
-  add_completion_callback(async () => {
-    if (registration) await registration.unregister();
-  });
-
   worker = registration.installing;
   await wait_for_state(t, registration.installing, 'activated');
 }, 'Prepare a service worker.');
 
 promise_test(async t => {
-  normal_frame = await with_iframe(SCOPE + '?iframe');
   add_completion_callback(() => normal_frame.remove());
+  normal_frame = await with_iframe(SCOPE + '?iframe');
   const data = await getResultsFromWorker(worker);
   const requests = data.requests;
   assert_equals(requests.length, 1);
@@ -87,11 +87,11 @@ promise_test(async t => {
 }, 'Prepare a normal iframe.');
 
 promise_test(async t => {
+  add_completion_callback(() => sandboxed_frame.remove());
   sandboxed_frame = await with_sandboxed_iframe(
     SCOPE + '?sandboxed-iframe',
     'allow-scripts'
   );
-  add_completion_callback(() => sandboxed_frame.remove());
   const data = await getResultsFromWorker(worker);
   assert_equals(data.requests.length, 0);
   assert_false(
@@ -100,11 +100,11 @@ promise_test(async t => {
 }, 'Prepare an iframe sandboxed by <iframe sandbox="allow-scripts">.');
 
 promise_test(async t => {
+  add_completion_callback(() => sandboxed_same_origin_frame.remove());
   sandboxed_same_origin_frame = await with_sandboxed_iframe(
     SCOPE + '?sandboxed-iframe-same-origin',
     'allow-scripts allow-same-origin'
   );
-  add_completion_callback(() => sandboxed_same_origin_frame.remove());
   const data = await getResultsFromWorker(worker);
   const requests = data.requests;
   assert_equals(requests.length, 1);
@@ -120,10 +120,10 @@ promise_test(async t => {
 }, 'Prepare an iframe sandboxed by <iframe sandbox="allow-scripts allow-same-origin">');
 
 promise_test(async t => {
+  add_completion_callback(() => sandboxed_frame_by_header.remove());
   const iframe_full_url = expected_base_url + '?sandbox=allow-scripts&' +
                           'sandboxed-frame-by-header';
   sandboxed_frame_by_header = await with_iframe(iframe_full_url);
-  add_completion_callback(() => sandboxed_frame_by_header.remove());
   const data = await getResultsFromWorker(worker);
   const requests = data.requests;
   assert_equals(requests.length, 1,
@@ -134,13 +134,13 @@ promise_test(async t => {
 }, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.');
 
 promise_test(async t => {
+  add_completion_callback(() =>
+    sandboxed_same_origin_frame_by_header.remove()
+  );
   const iframe_full_url =
     expected_base_url + '?sandbox=allow-scripts%20allow-same-origin&' +
     'sandboxed-iframe-same-origin-by-header';
   sandboxed_same_origin_frame_by_header = await with_iframe(iframe_full_url);
-  add_completion_callback(() =>
-    sandboxed_same_origin_frame_by_header.remove()
-  );
   const data = await getResultsFromWorker(worker);
   const requests = data.requests;
   assert_equals(requests.length, 1);

--- a/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
+++ b/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
@@ -63,7 +63,6 @@ promise_test(async t => {
     if (registration) await registration.unregister();
   });
 
-  worker = registration.installing;
   await wait_for_state(t, registration.installing, 'activated');
 }, 'Prepare a service worker.');
 

--- a/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
+++ b/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
@@ -1,132 +1,140 @@
 <!DOCTYPE html>
-<title>ServiceWorker FetchEvent issued from workers in an iframe sandboxed via CSP HTTP response header.</title>
+<title>
+  ServiceWorker FetchEvent issued from workers in an iframe sandboxed via CSP
+  HTTP response header.
+</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
-<script>
-let lastCallbackId = 0;
-let callbacks = {};
-function doTest(frame, type) {
-  return new Promise(function(resolve) {
-    var id = ++lastCallbackId;
-    callbacks[id] = resolve;
-    frame.contentWindow.postMessage({id: id, type: type}, '*');
-  });
-}
+  <script>
+    let lastCallbackId = 0;
+    let callbacks = {};
+    function doTest(frame, type) {
+      return new Promise(function(resolve) {
+        var id = ++lastCallbackId;
+        callbacks[id] = resolve;
+        frame.contentWindow.postMessage({ id: id, type: type }, "*");
+      });
+    }
 
-// Asks the service worker for data about requests and clients seen. The
-// worker posts a message back with |data| where:
-// |data.requests|: the requests the worker received FetchEvents for
-// |data.clients|: the URLs of all the worker's clients
-// The worker clears its data after responding.
-function getResultsFromWorker(worker) {
-  return new Promise(resolve => {
-    let channel = new MessageChannel();
-    channel.port1.onmessage = msg => {
-      resolve(msg.data);
+    // Asks the service worker for data about requests and clients seen. The
+    // worker posts a message back with |data| where:
+    // |data.requests|: the requests the worker received FetchEvents for
+    // |data.clients|: the URLs of all the worker's clients
+    // The worker clears its data after responding.
+    function getResultsFromWorker(worker) {
+      return new Promise(resolve => {
+        let channel = new MessageChannel();
+        channel.port1.onmessage = msg => {
+          resolve(msg.data);
+        };
+        worker.postMessage({ port: channel.port2 }, [channel.port2]);
+      });
+    }
+
+    window.onmessage = function(e) {
+      message = e.data;
+      let id = message["id"];
+      let callback = callbacks[id];
+      delete callbacks[id];
+      callback(message["result"]);
     };
-    worker.postMessage({port: channel.port2}, [channel.port2]);
-  });
-}
 
-window.onmessage = function (e) {
-  message = e.data;
-  let id = message['id'];
-  let callback = callbacks[id];
-  delete callbacks[id];
-  callback(message['result']);
-};
+    const SCOPE = "resources/sandboxed-iframe-fetch-event-iframe.py";
+    const SCRIPT = "resources/sandboxed-iframe-fetch-event-worker.js";
+    const expected_base_url = new URL(SCOPE, location.href);
+    // A service worker controlling |SCOPE|.
+    let worker;
+    // An iframe whose response header has
+    // 'Content-Security-Policy: allow-scripts'.
+    // This should NOT be controlled by a service worker.
+    let sandboxed_frame_by_header;
+    // An iframe whose response header has
+    // 'Content-Security-Policy: allow-scripts allow-same-origin'.
+    // This should be controlled by a service worker.
+    let sandboxed_same_origin_frame_by_header;
 
-const SCOPE = 'resources/sandboxed-iframe-fetch-event-iframe.py';
-const SCRIPT = 'resources/sandboxed-iframe-fetch-event-worker.js';
-const expected_base_url = new URL(SCOPE, location.href);
-// A service worker controlling |SCOPE|.
-let worker;
-// An iframe whose response header has
-// 'Content-Security-Policy: allow-scripts'.
-// This should NOT be controlled by a service worker.
-let sandboxed_frame_by_header;
-// An iframe whose response header has
-// 'Content-Security-Policy: allow-scripts allow-same-origin'.
-// This should be controlled by a service worker.
-let sandboxed_same_origin_frame_by_header;
+    promise_test(async t => {
+      const registration = await service_worker_unregister_and_register(
+        t,
+        SCRIPT,
+        SCOPE
+      );
 
-promise_test(t => {
-  return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
-    .then(function(registration) {
-      add_completion_callback(() => registration.unregister());
+      add_completion_callback(async () => {
+        if (registration) await registration.unregister();
+      });
+
       worker = registration.installing;
-      return wait_for_state(t, registration.installing, 'activated');
-    });
-}, 'Prepare a service worker.');
+      await wait_for_state(t, registration.installing, "activated");
+    }, "Prepare a service worker.");
 
-promise_test(t => {
-  const iframe_full_url = expected_base_url + '?sandbox=allow-scripts&' +
-                          'sandboxed-frame-by-header';
-  return with_iframe(iframe_full_url)
-    .then(f => {
-      sandboxed_frame_by_header = f;
-      add_completion_callback(() => f.remove());
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'Service worker should provide the response');
-      assert_equals(requests[0], iframe_full_url);
-      assert_false(data.clients.includes(iframe_full_url),
-                   'Service worker should NOT control the sandboxed page');
-    });
-}, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.');
+    promise_test(async t => {
+      const iframe_full_url =
+        expected_base_url +
+        "?sandbox=allow-scripts&" +
+        "sandboxed-frame-by-header";
+      const frame = await with_iframe(iframe_full_url);
+      sandboxed_frame_by_header = frame;
+      const data = await getResultsFromWorker(worker);
+      const requests = data.requests;
 
-promise_test(t => {
-  const iframe_full_url =
-    expected_base_url + '?sandbox=allow-scripts%20allow-same-origin&' +
-    'sandboxed-iframe-same-origin-by-header';
-  return with_iframe(iframe_full_url)
-    .then(f => {
-      sandboxed_same_origin_frame_by_header = f;
-      add_completion_callback(() => f.remove());
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1);
+      add_completion_callback(() => frame.remove());
+
+      assert_equals(
+        requests.length,
+        1,
+        "Service worker should provide the response"
+      );
       assert_equals(requests[0], iframe_full_url);
+      assert_false(
+        data.clients.includes(iframe_full_url),
+        "Service worker should NOT control the sandboxed page"
+      );
+    }, "Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.");
+
+    promise_test(async t => {
+      const iframe_full_url =
+        expected_base_url +
+        "?sandbox=allow-scripts%20allow-same-origin&" +
+        "sandboxed-iframe-same-origin-by-header";
+      const frame = await with_iframe(iframe_full_url);
+      sandboxed_same_origin_frame_by_header = frame;
+      const data = await getResultsFromWorker(worker);
+
+      add_completion_callback(() => f.remove());
+
+      assert_equals(data.requests.length, 1);
+      assert_equals(data.requests[0], iframe_full_url);
       assert_true(data.clients.includes(iframe_full_url));
-    })
-}, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts and ' +
-   'allow-same-origin.');
+    }, "Prepare an iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin.");
 
-promise_test(t => {
-  let frame = sandboxed_frame_by_header;
-  return doTest(frame, 'fetch-from-worker')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-    });
-}, 'Fetch request from a worker in iframe sandboxed by CSP HTTP header ' +
-   'allow-scripts flag');
+    promise_test(async t => {
+      const result = await doTest(
+        sandboxed_frame_by_header,
+        "fetch-from-worker"
+      );
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        0,
+        "The request should NOT be handled by SW."
+      );
+    }, "Fetch request from a worker in iframe sandboxed by CSP HTTP header allow-scripts flag");
 
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame_by_header;
-  return doTest(frame, 'fetch-from-worker')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The request should be handled by SW.');
-      assert_equals(requests[0], frame.src + '&test=fetch-from-worker');
-    });
-}, 'Fetch request from a worker in iframe sandboxed by CSP HTTP header ' +
-   'with allow-scripts and allow-same-origin flag');
-</script>
+    promise_test(async t => {
+      let frame = sandboxed_same_origin_frame_by_header;
+      const result = await doTest(frame, "fetch-from-worker");
+      assert_equals(result, "done");
+      const data = await getResultsFromWorker(worker);
+      assert_equals(
+        data.requests.length,
+        1,
+        "The request should be handled by SW."
+      );
+      assert_equals(data.requests[0], frame.src + "&test=fetch-from-worker");
+    }, "Fetch request from a worker in iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
+  </script>
 </body>

--- a/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
+++ b/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
@@ -68,6 +68,7 @@ promise_test(async t => {
 }, 'Prepare a service worker.');
 
 promise_test(async t => {
+  add_completion_callback(() => frame.remove());
   const iframe_full_url =
     expected_base_url +
     '?sandbox=allow-scripts&' +
@@ -76,8 +77,6 @@ promise_test(async t => {
   sandboxed_frame_by_header = frame;
   const data = await getResultsFromWorker(worker);
   const requests = data.requests;
-
-  add_completion_callback(() => frame.remove());
 
   assert_equals(
     requests.length,
@@ -92,6 +91,7 @@ promise_test(async t => {
 }, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.');
 
 promise_test(async t => {
+  add_completion_callback(() => f.remove());
   const iframe_full_url =
     expected_base_url +
     '?sandbox=allow-scripts%20allow-same-origin&' +
@@ -99,8 +99,6 @@ promise_test(async t => {
   const frame = await with_iframe(iframe_full_url);
   sandboxed_same_origin_frame_by_header = frame;
   const data = await getResultsFromWorker(worker);
-
-  add_completion_callback(() => f.remove());
 
   assert_equals(data.requests.length, 1);
   assert_equals(data.requests[0], iframe_full_url);

--- a/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
+++ b/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
@@ -1,140 +1,134 @@
 <!DOCTYPE html>
-<title>
-  ServiceWorker FetchEvent issued from workers in an iframe sandboxed via CSP
-  HTTP response header.
-</title>
+<title>ServiceWorker FetchEvent issued from workers in an iframe sandboxed via CSP HTTP response header.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
-  <script>
-    let lastCallbackId = 0;
-    let callbacks = {};
-    function doTest(frame, type) {
-      return new Promise(function(resolve) {
-        var id = ++lastCallbackId;
-        callbacks[id] = resolve;
-        frame.contentWindow.postMessage({ id: id, type: type }, "*");
-      });
-    }
+<script>
+let lastCallbackId = 0;
+let callbacks = {};
+function doTest(frame, type) {
+  return new Promise(function(resolve) {
+    var id = ++lastCallbackId;
+    callbacks[id] = resolve;
+    frame.contentWindow.postMessage({id: id, type: type}, '*');
+  });
+}
 
-    // Asks the service worker for data about requests and clients seen. The
-    // worker posts a message back with |data| where:
-    // |data.requests|: the requests the worker received FetchEvents for
-    // |data.clients|: the URLs of all the worker's clients
-    // The worker clears its data after responding.
-    function getResultsFromWorker(worker) {
-      return new Promise(resolve => {
-        let channel = new MessageChannel();
-        channel.port1.onmessage = msg => {
-          resolve(msg.data);
-        };
-        worker.postMessage({ port: channel.port2 }, [channel.port2]);
-      });
-    }
-
-    window.onmessage = function(e) {
-      message = e.data;
-      let id = message["id"];
-      let callback = callbacks[id];
-      delete callbacks[id];
-      callback(message["result"]);
+// Asks the service worker for data about requests and clients seen. The
+// worker posts a message back with |data| where:
+// |data.requests|: the requests the worker received FetchEvents for
+// |data.clients|: the URLs of all the worker's clients
+// The worker clears its data after responding.
+function getResultsFromWorker(worker) {
+  return new Promise(resolve => {
+    let channel = new MessageChannel();
+    channel.port1.onmessage = msg => {
+      resolve(msg.data);
     };
+    worker.postMessage({port: channel.port2}, [channel.port2]);
+  });
+}
 
-    const SCOPE = "resources/sandboxed-iframe-fetch-event-iframe.py";
-    const SCRIPT = "resources/sandboxed-iframe-fetch-event-worker.js";
-    const expected_base_url = new URL(SCOPE, location.href);
-    // A service worker controlling |SCOPE|.
-    let worker;
-    // An iframe whose response header has
-    // 'Content-Security-Policy: allow-scripts'.
-    // This should NOT be controlled by a service worker.
-    let sandboxed_frame_by_header;
-    // An iframe whose response header has
-    // 'Content-Security-Policy: allow-scripts allow-same-origin'.
-    // This should be controlled by a service worker.
-    let sandboxed_same_origin_frame_by_header;
+window.onmessage = function(e) {
+  message = e.data;
+  let id = message['id'];
+  let callback = callbacks[id];
+  delete callbacks[id];
+  callback(message['result']);
+};
 
-    promise_test(async t => {
-      const registration = await service_worker_unregister_and_register(
-        t,
-        SCRIPT,
-        SCOPE
-      );
+const SCOPE = 'resources/sandboxed-iframe-fetch-event-iframe.py';
+const SCRIPT = 'resources/sandboxed-iframe-fetch-event-worker.js';
+const expected_base_url = new URL(SCOPE, location.href);
+// A service worker controlling |SCOPE|.
+let worker;
+// An iframe whose response header has
+// 'Content-Security-Policy: allow-scripts'.
+// This should NOT be controlled by a service worker.
+let sandboxed_frame_by_header;
+// An iframe whose response header has
+// 'Content-Security-Policy: allow-scripts allow-same-origin'.
+// This should be controlled by a service worker.
+let sandboxed_same_origin_frame_by_header;
 
-      add_completion_callback(async () => {
-        if (registration) await registration.unregister();
-      });
+promise_test(async t => {
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
 
-      worker = registration.installing;
-      await wait_for_state(t, registration.installing, "activated");
-    }, "Prepare a service worker.");
+  add_completion_callback(async () => {
+    if (registration) await registration.unregister();
+  });
 
-    promise_test(async t => {
-      const iframe_full_url =
-        expected_base_url +
-        "?sandbox=allow-scripts&" +
-        "sandboxed-frame-by-header";
-      const frame = await with_iframe(iframe_full_url);
-      sandboxed_frame_by_header = frame;
-      const data = await getResultsFromWorker(worker);
-      const requests = data.requests;
+  worker = registration.installing;
+  await wait_for_state(t, registration.installing, 'activated');
+}, 'Prepare a service worker.');
 
-      add_completion_callback(() => frame.remove());
+promise_test(async t => {
+  const iframe_full_url =
+    expected_base_url +
+    '?sandbox=allow-scripts&' +
+    'sandboxed-frame-by-header';
+  const frame = await with_iframe(iframe_full_url);
+  sandboxed_frame_by_header = frame;
+  const data = await getResultsFromWorker(worker);
+  const requests = data.requests;
 
-      assert_equals(
-        requests.length,
-        1,
-        "Service worker should provide the response"
-      );
-      assert_equals(requests[0], iframe_full_url);
-      assert_false(
-        data.clients.includes(iframe_full_url),
-        "Service worker should NOT control the sandboxed page"
-      );
-    }, "Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.");
+  add_completion_callback(() => frame.remove());
 
-    promise_test(async t => {
-      const iframe_full_url =
-        expected_base_url +
-        "?sandbox=allow-scripts%20allow-same-origin&" +
-        "sandboxed-iframe-same-origin-by-header";
-      const frame = await with_iframe(iframe_full_url);
-      sandboxed_same_origin_frame_by_header = frame;
-      const data = await getResultsFromWorker(worker);
+  assert_equals(
+    requests.length,
+    1,
+    'Service worker should provide the response'
+  );
+  assert_equals(requests[0], iframe_full_url);
+  assert_false(
+    data.clients.includes(iframe_full_url),
+    'Service worker should NOT control the sandboxed page'
+  );
+}, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.');
 
-      add_completion_callback(() => f.remove());
+promise_test(async t => {
+  const iframe_full_url =
+    expected_base_url +
+    '?sandbox=allow-scripts%20allow-same-origin&' +
+    'sandboxed-iframe-same-origin-by-header';
+  const frame = await with_iframe(iframe_full_url);
+  sandboxed_same_origin_frame_by_header = frame;
+  const data = await getResultsFromWorker(worker);
 
-      assert_equals(data.requests.length, 1);
-      assert_equals(data.requests[0], iframe_full_url);
-      assert_true(data.clients.includes(iframe_full_url));
-    }, "Prepare an iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin.");
+  add_completion_callback(() => f.remove());
 
-    promise_test(async t => {
-      const result = await doTest(
-        sandboxed_frame_by_header,
-        "fetch-from-worker"
-      );
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        0,
-        "The request should NOT be handled by SW."
-      );
-    }, "Fetch request from a worker in iframe sandboxed by CSP HTTP header allow-scripts flag");
+  assert_equals(data.requests.length, 1);
+  assert_equals(data.requests[0], iframe_full_url);
+  assert_true(data.clients.includes(iframe_full_url));
+}, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts ' +
+   'and allow-same-origin.');
 
-    promise_test(async t => {
-      let frame = sandboxed_same_origin_frame_by_header;
-      const result = await doTest(frame, "fetch-from-worker");
-      assert_equals(result, "done");
-      const data = await getResultsFromWorker(worker);
-      assert_equals(
-        data.requests.length,
-        1,
-        "The request should be handled by SW."
-      );
-      assert_equals(data.requests[0], frame.src + "&test=fetch-from-worker");
-    }, "Fetch request from a worker in iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag");
-  </script>
+promise_test(async t => {
+  const result = await doTest(
+    sandboxed_frame_by_header,
+    'fetch-from-worker'
+  );
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
+}, 'Fetch request from a worker in iframe sandboxed by CSP HTTP header ' +
+   'allow-scripts flag');
+
+promise_test(async t => {
+  let frame = sandboxed_same_origin_frame_by_header;
+  const result = await doTest(frame, 'fetch-from-worker');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The request should be handled by SW.');
+  assert_equals(data.requests[0], frame.src + '&test=fetch-from-worker');
+}, 'Fetch request from a worker in iframe sandboxed by CSP HTTP header ' +
+   'with allow-scripts and allow-same-origin flag');
+</script>
 </body>


### PR DESCRIPTION
- Fix a couple of tests with function t.add_cleanup() as it supports promise, see detail in #8748.
- The usage of unregister() method in some tests is not rigorous.  As [spec]\(https://w3c.github.io/ServiceWorker/#dom-serviceworkerregistration-unregister):
>>   [NewObject] Promise<boolean> unregister();
  unregister() method must run these steps:
>> 1. Let promise be a promise.
...
>> 4. Return promise.
- Following mattto's recommendation format these tests using prettier.io