### PR TITLE
[css-text-decor] Add text-emphasis tests

### DIFF
--- a/css/css-text-decor/text-emphasis-001-manual.html
+++ b/css/css-text-decor/text-emphasis-001-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: dot</title>
 <meta name="assert" content="text-emphasis:dot; a dot appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-001-manual.html
+++ b/css/css-text-decor/text-emphasis-001-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:dot; a dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled dot appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-002-manual.html
+++ b/css/css-text-decor/text-emphasis-002-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: circle</title>
 <meta name="assert" content="text-emphasis:circle; a circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-002-manual.html
+++ b/css/css-text-decor/text-emphasis-002-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:circle; a circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-003-manual.html
+++ b/css/css-text-decor/text-emphasis-003-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: double-circle</title>
 <meta name="assert" content="text-emphasis:double-circle; a double-circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-003-manual.html
+++ b/css/css-text-decor/text-emphasis-003-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:double-circle; a double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled double-circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-004-manual.html
+++ b/css/css-text-decor/text-emphasis-004-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: triangle</title>
 <meta name="assert" content="text-emphasis:triangle; a triangle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-004-manual.html
+++ b/css/css-text-decor/text-emphasis-004-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:triangle; a triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled triangle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-005-manual.html
+++ b/css/css-text-decor/text-emphasis-005-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: sesame</title>
 <meta name="assert" content="text-emphasis:sesame; a sesame mark appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-005-manual.html
+++ b/css/css-text-decor/text-emphasis-005-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:sesame; a sesame mark appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled sesame mark appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-006-manual.html
+++ b/css/css-text-decor/text-emphasis-006-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: filled dot</title>
 <meta name="assert" content="text-emphasis:filled dot; a filled dot appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-006-manual.html
+++ b/css/css-text-decor/text-emphasis-006-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:filled dot; a filled dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled dot appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-007-manual.html
+++ b/css/css-text-decor/text-emphasis-007-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: filled circle</title>
 <meta name="assert" content="text-emphasis:filled circle; a filled circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-007-manual.html
+++ b/css/css-text-decor/text-emphasis-007-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:filled circle; a filled circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-008-manual.html
+++ b/css/css-text-decor/text-emphasis-008-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: filled double-circle</title>
 <meta name="assert" content="text-emphasis:filled double-circle; a filled double-circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-008-manual.html
+++ b/css/css-text-decor/text-emphasis-008-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:filled double-circle; a filled double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled double-circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-009-manual.html
+++ b/css/css-text-decor/text-emphasis-009-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: filled triangle</title>
 <meta name="assert" content="text-emphasis:filled triangle; a filled triangle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-009-manual.html
+++ b/css/css-text-decor/text-emphasis-009-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:filled triangle; a filled triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled triangle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-010-manual.html
+++ b/css/css-text-decor/text-emphasis-010-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: filled sesame</title>
 <meta name="assert" content="text-emphasis:filled sesame; a filled sesame appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-010-manual.html
+++ b/css/css-text-decor/text-emphasis-010-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:filled sesame; a filled sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled sesame appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-011-manual.html
+++ b/css/css-text-decor/text-emphasis-011-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: open dot</title>
 <meta name="assert" content="text-emphasis:open dot; an open dot appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-011-manual.html
+++ b/css/css-text-decor/text-emphasis-011-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:open dot; an open dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open dot appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-012-manual.html
+++ b/css/css-text-decor/text-emphasis-012-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: open circle</title>
 <meta name="assert" content="text-emphasis:open circle; an open circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-012-manual.html
+++ b/css/css-text-decor/text-emphasis-012-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:open circle; an open circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-014-manual.html
+++ b/css/css-text-decor/text-emphasis-014-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: open double-circle</title>
 <meta name="assert" content="text-emphasis:open double-circle; an open double-circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-014-manual.html
+++ b/css/css-text-decor/text-emphasis-014-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:open double-circle; an open double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open double-circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-015-manual.html
+++ b/css/css-text-decor/text-emphasis-015-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: open triangle</title>
 <meta name="assert" content="text-emphasis:open triangle; an open triangle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-015-manual.html
+++ b/css/css-text-decor/text-emphasis-015-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:open triangle; an open triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open triangle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-016-manual.html
+++ b/css/css-text-decor/text-emphasis-016-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: open sesame</title>
 <meta name="assert" content="text-emphasis:open sesame; an open sesame appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-016-manual.html
+++ b/css/css-text-decor/text-emphasis-016-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:open sesame; an open sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open sesame appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-017-manual.html
+++ b/css/css-text-decor/text-emphasis-017-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis: 'string'</title>
 <meta name="assert" content="text-emphasis:'x'; an 'x' appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-017-manual.html
+++ b/css/css-text-decor/text-emphasis-017-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:'x'; an 'x' appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:'x';
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an 'x' appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-018-manual.html
+++ b/css/css-text-decor/text-emphasis-018-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis-style</title>
+<title>text-emphasis: filled</title>
 <meta name="assert" content="text-emphasis:filled; a filled circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-018-manual.html
+++ b/css/css-text-decor/text-emphasis-018-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style</title>
+<meta name="assert" content="text-emphasis:filled; a filled circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:horizontal-tb">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-019-manual.html
+++ b/css/css-text-decor/text-emphasis-019-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis-style</title>
+<title>text-emphasis: open</title>
 <meta name="assert" content="text-emphasis:open; an open circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-019-manual.html
+++ b/css/css-text-decor/text-emphasis-019-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style</title>
+<meta name="assert" content="text-emphasis:open; an open circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:horizontal-tb">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-020-manual.html
+++ b/css/css-text-decor/text-emphasis-020-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis</title>
+<title>text-emphasis and space</title>
 <meta name="assert" content="text-emphasis:dot; no dot appears next to the space (Zs) characters">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-020-manual.html
+++ b/css/css-text-decor/text-emphasis-020-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis</title>
+<meta name="assert" content="text-emphasis:dot; no dot appears next to the space (Zs) characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if no dot appears next to the space (Zs) characters.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引 发 网 络 的 全 部 潜 能　</span></p>
+<p lang="zh-hant"><span>引 發 網 絡 的 全 部 潛 能　</span></p>
+<p lang="ja"><span>可 能 性 を 最 大 限 に 導　き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-001-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-001-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: dot (tbrl)</title>
 <meta name="assert" content="text-emphasis:dot; a dot appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-001-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-001-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:dot; a dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled dot appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-002-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-002-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: circle (tbrl)</title>
 <meta name="assert" content="text-emphasis:circle; a circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-002-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-002-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:circle; a circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-003-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-003-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: double-circle (tbrl)</title>
 <meta name="assert" content="text-emphasis:double-circle; a double-circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-003-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-003-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:double-circle; a double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled double-circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-004-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-004-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: triangle (tbrl)</title>
 <meta name="assert" content="text-emphasis:triangle; a triangle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-004-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-004-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:triangle; a triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, filled triangle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-005-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-005-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: sesame (tbrl)</title>
 <meta name="assert" content="text-emphasis:sesame; a sesame mark appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-005-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-005-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:sesame; a sesame mark appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, filled sesame mark appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-006-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-006-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: filled dot (tbrl)</title>
 <meta name="assert" content="text-emphasis:filled dot; a filled dot appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-006-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-006-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:filled dot; a filled dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled dot appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-007-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-007-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: filled circle (tbrl)</title>
 <meta name="assert" content="text-emphasis:filled circle; a filled circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-007-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-007-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:filled circle; a filled circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-008-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-008-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: filled double-circle (tbrl)</title>
 <meta name="assert" content="text-emphasis:filled double-circle; a filled double-circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-008-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-008-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:filled double-circle; a filled double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled double-circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-009-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-009-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: filled triangle (tbrl)</title>
 <meta name="assert" content="text-emphasis:filled triangle; a filled triangle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-009-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-009-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:filled triangle; a filled triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, filled triangle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-010-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-010-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: filled sesame (tbrl)</title>
 <meta name="assert" content="text-emphasis:filled sesame; a filled sesame appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-010-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-010-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:filled sesame; a filled sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, filled sesame appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-011-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-011-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: open dot (tbrl)</title>
 <meta name="assert" content="text-emphasis:open dot; an open dot appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-011-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-011-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:open dot; an open dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open dot appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-012-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-012-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: open circle (tbrl)</title>
 <meta name="assert" content="text-emphasis:open circle; an open circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-012-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-012-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:open circle; an open circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-014-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-014-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: open double-circle (tbrl)</title>
 <meta name="assert" content="text-emphasis:open double-circle; an open double-circle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-014-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-014-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:open double-circle; an open double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open double-circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-015-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-015-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: open triangle (tbrl)</title>
 <meta name="assert" content="text-emphasis:open triangle; an open triangle appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-015-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-015-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:open triangle; an open triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, open triangle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-016-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-016-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: open sesame (tbrl)</title>
 <meta name="assert" content="text-emphasis:open sesame; an open sesame appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-016-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-016-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:open sesame; an open sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, open sesame appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-017-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-017-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: 'string' (tbrl)</title>
 <meta name="assert" content="text-emphasis:'x'; an 'x' appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-017-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-017-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:'x'; an 'x' appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:'x';
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, 'x' appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-018-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-018-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: filled (tbrl)</title>
 <meta name="assert" content="text-emphasis:filled; a filled sesame appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-018-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-018-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:filled; a filled sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:filled;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled sesame appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-019-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-019-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis: open (tbrl)</title>
 <meta name="assert" content="text-emphasis:open; an open sesame appears next to each character">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-019-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-019-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:open; an open sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:open;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open sesame appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-tbrl-020-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-020-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>text-emphasis tbrl</title>
+<title>text-emphasis and space (tbrl)</title>
 <meta name="assert" content="text-emphasis:dot; no dot appears next to the space (Zs) characters">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
 <!-- cosmetic styling -->
 <style>
 #htmlsrc { margin: 2em; }

--- a/css/css-text-decor/text-emphasis-tbrl-020-manual.html
+++ b/css/css-text-decor/text-emphasis-tbrl-020-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis tbrl</title>
+<meta name="assert" content="text-emphasis:dot; no dot appears next to the space (Zs) characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if no dot appears next to the space (Zs) characters.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引 发 网 络 的 全 部 潜 能　</span></p>
+<p lang="zh-hant"><span>引 發 網 絡 的 全 部 潛 能　</span></p>
+<p lang="ja"><span>可 能 性 を 最 大 限 に 導　き出すために</span></p>
+</div>  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR ports https://w3c.github.io/i18n-tests/results/emphasis-marks#text_emph and https://w3c.github.io/i18n-tests/results/emphasis-marks#text_emph_v to WPT. Currently, the tests are manual tests, since we're unable to come up with a way to automate them.

These are simple tests designed to check basic functionality.

/cc @r12a
