### PR TITLE
[tools] Document unintuitive branch

### DIFF
--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -9,6 +9,8 @@ from six import iteritems
 
 from .sourcefile import SourceFile
 
+# This variable is interpreted as `True` when the source code is being
+# type-checked by Mypy.
 MYPY = False
 if MYPY:
     from typing import Dict, Optional

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -9,10 +9,9 @@ from six import iteritems
 
 from .sourcefile import SourceFile
 
-# This variable is interpreted as `True` when the source code is being
-# type-checked by Mypy.
 MYPY = False
 if MYPY:
+    # MYPY is set to True when run under Mypy.
     from typing import Dict, Optional
 
 


### PR DESCRIPTION
Although this pattern is endorsed by the Mypy type checker, it appears
to include an unreachable statement. Contributors lacking familiarity
with Mypy may assume it is spurious debugging logic. Add a comment to
document the special feature provided by the type checker.

---

@gsnedders At some point, we have to take familiarity with the tooling for
granted, but this feature seems particularly likely to trip up the casual
observer (e.g. me, 10 minutes ago).