### PR TITLE
[docs] Reorganize information on Ahem

### DIFF
--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -48,6 +48,16 @@ python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -E
 If you are behind a proxy, you also need to make sure the domains above are
 excluded from your proxy lookups.
 
+[The Ahem font](../writing-tests/ahem) is used to test precise rendering
+behavior. [Download the font][download-ahem] and install it using the
+appropriate steps for your platform:
+
+- On Windows, right-click the downloaded file in File Explorer/Windows Explorer
+  (depending on Windows version) and select "Install" from the menu.
+- On macOS, open the downloaded file in Font Book (the default application for
+  font files) and then click install.
+- On Linux, copy the file to `~/.local/share/fonts` and then run `fc-cache`.
+
 ### Windows Notes
 
 Generally Windows Subsystem for Linux will provide the smoothest user
@@ -124,3 +134,5 @@ Additional browser-specific documentation:
   chrome_android
   safari
 ```
+
+[download-ahem]: https://github.com/web-platform-tests/wpt/raw/master/fonts/Ahem.ttf

--- a/docs/writing-tests/ahem.md
+++ b/docs/writing-tests/ahem.md
@@ -2,7 +2,9 @@
 
 A font called [Ahem][ahem-readme] has been developed which consists of
 some very well defined glyphs of precise sizes and shapes; it is
-especially useful for testing font and text properties.
+especially useful for testing font and text properties. Installation
+instructions are available in [Running Tests from the Local
+System](../running-tests/from-local-system).
 
 The font's em-square is exactly square. Its ascent and descent
 combined is exactly the size of the em square; this means that the
@@ -73,20 +75,4 @@ div {
 }
 ```
 
-## Installing Ahem
-
-After [downloading][download-ahem] the font, installation instructions
-vary between platforms:
-
-On Windows, right-click the downloaded file in File Explorer/Windows
-Explorer (depending on Windows version) and select "Install" from the
-menu.
-
-On macOS, open the downloaded file in Font Book (the default
-application for font files) and then click install.
-
-On Linux, copy the file to `~/.local/share/fonts` and then run
-`fc-cache`.
-
 [ahem-readme]: https://www.w3.org/Style/CSS/Test/Fonts/Ahem/README
-[download-ahem]: https://github.com/web-platform-tests/wpt/raw/master/fonts/Ahem.ttf


### PR DESCRIPTION
WPT maintains a document dedicated to configuring systems to run the
tests. Relocate the instructions on installing Ahem to this document,
and reference them from their original location (an explanation of how
to use the font to author tests).