### PR TITLE
[websockets] Correct failure case

### DIFF
--- a/websockets/unload-a-document/001-1.html
+++ b/websockets/unload-a-document/001-1.html
@@ -6,7 +6,6 @@
 <script>
 var controller = opener || parent;
 var t = controller.t;
-var assert_equals = controller.asset_equals;
 var assert_unreached = controller.assert_unreached;
 var uuid = controller.uuid;
 t.add_cleanup(function() {delete sessionStorage[uuid];});

--- a/websockets/unload-a-document/002-1.html
+++ b/websockets/unload-a-document/002-1.html
@@ -12,7 +12,7 @@ t.add_cleanup(function() {delete sessionStorage[uuid];});
 t.step(function() {
   // this test can fail if the document is unloaded on navigation e.g. due to OOM
   if (sessionStorage[uuid]) {
-    assert_unreached('document was discarded');
+    t.done();
   } else {
     sessionStorage[uuid] = 'true';
     var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo');

--- a/websockets/unload-a-document/002-1.html
+++ b/websockets/unload-a-document/002-1.html
@@ -7,7 +7,7 @@
 var controller = opener || parent;
 var t = controller.t;
 var assert_unreached = controller.assert_unreached ;
-var uuid = controller.token;
+var uuid = controller.uuid;
 t.add_cleanup(function() {delete sessionStorage[uuid];});
 t.step(function() {
   // this test can fail if the document is unloaded on navigation e.g. due to OOM

--- a/websockets/unload-a-document/002-1.html
+++ b/websockets/unload-a-document/002-1.html
@@ -6,7 +6,6 @@
 <script>
 var controller = opener || parent;
 var t = controller.t;
-var assert_equals = controller.asset_equals;
 var assert_unreached = controller.assert_unreached ;
 var uuid = controller.token;
 t.add_cleanup(function() {delete sessionStorage[uuid];});
@@ -20,8 +19,7 @@ t.step(function() {
     ws.onopen = t.step_func(function(e) {
 
       t.step_timeout(function() {
-        assert_equals(ws.readyState, ws.CLOSED, 'ws.readyState');
-        t.done();
+        assert_unreached('document was not discarded');
       }, 4000);
       ws.close();
       ws.onclose = t.step_func(function() {


### PR DESCRIPTION
The test titled `002.html` includes a document which references an
undefined property, `asset_equals`. Correcting this typo would allow
tests to pass spuriously (that is: when the document is not discarded).
Replace the assertion that was originally intended with
`assert_unreached` so that user agents which execute this code path
report a test failure.

The test titled `001.html` also includes a misspelled reference, but it
does not rely on the value. Remove the reference.