### PR TITLE
[docs] Restructure explanations of test types

### DIFF
--- a/docs/_writing-tests/index.md
+++ b/docs/_writing-tests/index.md
@@ -11,42 +11,46 @@ There's also a load of [general guidelines][] that apply to all tests.
 
 ## Test Type
 
-There are four main test types:
+Tests in this project use a few different approaches to verify expected
+behavior. The tests can be classified based on the way they express
+expectations:
 
-* [Reftests][] should be used to test rendering and layout. They
-  consist of two or more pages with assertions as to whether they
-  render identically or not.
+* Rendering tests should be used to verify that the browser graphically
+  displays pages as expected. See the [rendering test guidelines][rendering]
+  for tips on how to write great rendering tests. There are a few different
+  ways to write rendering tests:
 
-* [testharness.js][] tests should be used (where
-  possible!) for testing everything else. They are built with the
-  testharness.js unit testing framework, and consist of assertions
-  written in JavaScript.
+  * [Reftests][] should be used to test rendering and layout. They consist of
+    two or more pages with assertions as to whether they render identically or
+    not.
 
-* [Visual tests][visual] should be used for checking rendering where
-  there is a large number of conforming renderings such that reftests
-  are impractical. They consist of a page that renders to final state
-  at which point a screenshot can be taken and compared to an expected
-  rendering for that user agent on that platform.
+  * [Visual tests][visual] should be used for checking rendering where there is
+    a large number of conforming renderings such that reftests are impractical.
+    They consist of a page that renders to final state at which point a
+    screenshot can be taken and compared to an expected rendering for that user
+    agent on that platform.
 
-* [Manual tests][manual] are used as a last resort for anything
-  that can't be tested using any of the above. They consist of a page
-  that needs manual interaction or verification of the final result.
+* [testharness.js][] tests should be used (where possible!) for testing
+  everything else. They are built with the testharness.js unit testing
+  framework, and consist of assertions written in JavaScript.
 
-In general, there is a strong preference towards the first two test
-types (as they can be easily run without human interaction), so they
+* WebDriver tests are written in Python and test [the WebDriver browser
+  automation protocol](https://w3c.github.io/webdriver/)
+
+* [Manual tests][manual] are used as a last resort for anything that can't be
+  tested using any of the above. They consist of a page that needs manual
+  interaction or verification of the final result.
+
+In general, there is a strong preference towards reftests and testharness.js
+tests types (as they can be easily run without human interaction), so they
 should be used in preference to the others even if it results in a
 somewhat cumbersome test; there is a far weaker preference between the
-first two, and it is at times advisable to use testharness.js tests
+two test types, and it is at times advisable to use testharness.js tests
 for things which would typically be tested using reftests but for
 which it would be overly cumbersome.
 
 See [file names][] for test types and features determined by the file names,
 and [server features][] for advanced testing features.
-
-In addition to the four main test types, there are also WebDriver
-tests, which are used exclusively for testing the WebDriver protocol
-itself. There is currently no documentation about these tests,
-however.
 
 ## Submitting Tests
 
@@ -58,6 +62,7 @@ make sure you run the [`lint` script][lint-tool] before opening a pull request!
 [file names]: {{ site.baseurl }}{% link _writing-tests/file-names.md %}
 [general guidelines]: {{ site.baseurl }}{% link _writing-tests/general-guidelines.md %}
 [reftests]: {{ site.baseurl }}{% link _writing-tests/reftests.md %}
+[rendering]: {{ site.baseurl }}{% link _writing-tests/rendering.md %}
 [server features]: {{ site.baseurl }}{% link _writing-tests/server-features.md %}
 [testharness.js]: {{ site.baseurl }}{% link _writing-tests/testharness.md %}
 [visual]: {{ site.baseurl }}{% link _writing-tests/visual.md %}

--- a/docs/_writing-tests/index.md
+++ b/docs/_writing-tests/index.md
@@ -34,7 +34,8 @@ expectations:
   everything else. They are built with the testharness.js unit testing
   framework, and consist of assertions written in JavaScript.
 
-* WebDriver tests are written in Python and test [the WebDriver browser
+* WebDriver tests are written in Python using
+  [pytest](https://docs.pytest.org/en/latest/) and test [the WebDriver browser
   automation protocol](https://w3c.github.io/webdriver/)
 
 * [Manual tests][manual] are used as a last resort for anything that can't be

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -58,27 +58,32 @@ the filesystem, and is preferred for larger specifications.
 
 ## Test Types
 
-The testsuite has a few types of tests, outlined below:
+Tests in this project use a few different approaches to verify expected
+behavior. The tests can be classified based on the way they express
+expectations:
 
-* [testharness.js][] tests, which are run
-  through a JS harness and report their result back with JS.
+* Rendering tests ensure that the browser graphically displays pages as
+  expected. There are a few different ways this is done:
 
-* [Reftests][], which render two (or more) web
-  pages and combine them with equality assertions about their
-  rendering (e.g., `A.html` and `B.html` must render identically), run
-  either by the user switching between tabs/windows and trying to
-  observe differences or through automated scripts.
+  * [Reftests][] render two (or more) web pages and combine them with equality
+    assertions about their rendering (e.g., `A.html` and `B.html` must render
+    identically), run either by the user switching between tabs/windows and
+    trying to observe differences or through [automated
+    scripts][running-from-local-system].
 
-* [Visual tests][visual] which display a page where the
-  result is determined either by a human looking at it or by comparing
-  it with a saved screenshot for that user agent on that platform.
+  * [Visual tests][visual] display a page where the result is determined either
+    by a human looking at it or by comparing it with a saved screenshot for
+    that user agent on that platform.
 
-* [Manual tests][manual], which rely on a human to run
-  them and determine their result.
+* [testharness.js][] tests verify that JavaScript interfaces behave as
+  expected. They get their name from the JavaScript harness that's used to
+  execute them.
 
-* WebDriver tests, which are used for testing the WebDriver protocol
-  itself.
+* WebDriver tests are written in Python and test [the WebDriver browser
+  automation protocol](https://w3c.github.io/webdriver/)
 
+* [Manual tests][manual] rely on a human to run them and determine their
+  result.
 
 ## GitHub
 
@@ -108,3 +113,4 @@ free to add yourself to the META.yml file!
 [visual]: {{ site.baseurl }}{% link _writing-tests/visual.md %}
 [manual]: {{ site.baseurl }}{% link _writing-tests/manual.md %}
 [github-intro]: {{ site.baseurl }}{% link _appendix/github-intro.md %}
+[running-from-local-system]: {{ site.baseurl}}{% link _running-tests/from-local-system.md %}


### PR DESCRIPTION
The project documentation includes two lists of WPT's various test
types. Update these lists in the interest of helping readers orient
themselves to the project.

- Present reftests and visual tests under a generic "rendering test"
  item in recognition of the related nature of those two test types. Use
  the new item in the "Writing Tests" document to recommend the
  rendering test guidelines.
- Consistently introduce WebDriver tests in both lists

---

This is an attempt to resolve [bocoup/wpt-docs#5](https://github.com/bocoup/wpt-docs/issues/5). It's a little less ambitious than the plan outlined there because it only changes the structure of the table of contents--not the documents themselves. This doesn't reduce the number of concepts we present, but I'm hoping it still helps readers build an understanding.