### PR TITLE
DOM/HTML: remove "Shadow DOM v0" leftovers

### DIFF
--- a/html/semantics/forms/the-label-element/label-attributes.sub.html
+++ b/html/semantics/forms/the-label-element/label-attributes.sub.html
@@ -271,16 +271,7 @@
   }, "A labelable element not in a document can label element in the same tree.");
 
   test(function () {
-    var isShadowDOMV0;
-    if ("createShadowRoot" in document.getElementById('content')) {
-      isShadowDOMV0 = true;
-    }
-    var root1;
-    if (isShadowDOMV0) {
-      root1 = document.getElementById('content').createShadowRoot();
-    } else {
-      root1 = document.getElementById('content').attachShadow({mode: 'open'});
-    }
+    var root1 = document.getElementById('content').attachShadow({mode: 'open'});
     assert_true(root1 instanceof DocumentFragment,
                 "ShadowRoot should be an instance of DocumentFragment.");
     // <label><input id="shadow1"/></label><div id="div1"></div>
@@ -293,12 +284,7 @@
     var div1 = document.createElement('div');
     label1.appendChild(div1);
     // <label for="shadow2"></label><input id="shadow2"/>
-    var root2;
-    if (isShadowDOMV0) {
-      root2 = div1.createShadowRoot();
-    } else {
-      root2 = div1.attachShadow({mode: 'open'});
-    }
+    var root2 = div1.attachShadow({mode: 'open'});
 
     assert_true(root2 instanceof DocumentFragment,
                 "ShadowRoot should be an instance of DocumentFragment.");

--- a/shadow-dom/resources/shadow-dom.js
+++ b/shadow-dom/resources/shadow-dom.js
@@ -21,13 +21,7 @@ function createTestTree(node) {
   function attachShadowFromTemplate(template) {
     let parent = template.parentNode;
     parent.removeChild(template);
-    let shadowRoot;
-    if (template.getAttribute('data-mode') === 'v0') {
-      // For legacy Shadow DOM
-      shadowRoot = parent.createShadowRoot();
-    } else {
-      shadowRoot = parent.attachShadow({mode: template.getAttribute('data-mode')});
-    }
+    let shadowRoot = parent.attachShadow({mode: template.getAttribute('data-mode')});
     let id = template.id;
     if (id) {
       shadowRoot.id = id;


### PR DESCRIPTION
FWIW, this is the result of running `grep -r createShadowRoot *` on WPT and cleaning up relevant callers, except for the historical test.