### PR TITLE
Drop meta_filters support

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -26,13 +26,6 @@ class ManifestVersionMismatch(ManifestError):
     pass
 
 
-def iterfilter(filters, iter):
-    for f in filters:
-        iter = f(iter)
-    for item in iter:
-        yield item
-
-
 item_classes = {"testharness": TestharnessTest,
                 "reftest": RefTest,
                 "reftest_node": RefTestNode,
@@ -45,7 +38,7 @@ item_classes = {"testharness": TestharnessTest,
 
 
 class TypeData(object):
-    def __init__(self, manifest, type_cls, meta_filters):
+    def __init__(self, manifest, type_cls):
         """Dict-like object containing the TestItems for each test type.
 
         Loading an actual Item class for each test is unnecessarily
@@ -61,7 +54,6 @@ class TypeData(object):
         self.json_data = {}
         self.tests_root = None
         self.data = {}
-        self.meta_filters = meta_filters or []
 
     def __getitem__(self, key):
         if key not in self.data:
@@ -134,7 +126,7 @@ class TypeData(object):
         if self.json_data is not None:
             data = set()
             path = from_os_path(key)
-            for test in iterfilter(self.meta_filters, self.json_data.get(path, [])):
+            for test in self.json_data.get(path, []):
                 manifest_item = self.type_cls.from_json(self.manifest, path, test)
                 data.add(manifest_item)
             try:
@@ -153,7 +145,7 @@ class TypeData(object):
                 if key in self.data:
                     continue
                 data = set()
-                for test in iterfilter(self.meta_filters, self.json_data.get(path, [])):
+                for test in self.json_data.get(path, []):
                     manifest_item = self.type_cls.from_json(self.manifest, path, test)
                     data.add(manifest_item)
                 self.data[key] = data
@@ -190,12 +182,12 @@ class TypeData(object):
 
 
 class ManifestData(dict):
-    def __init__(self, manifest, meta_filters=None):
+    def __init__(self, manifest):
         """Dictionary subclass containing a TypeData instance for each test type,
         keyed by type name"""
         self.initialized = False
         for key, value in iteritems(item_classes):
-            self[key] = TypeData(manifest, value, meta_filters=meta_filters)
+            self[key] = TypeData(manifest, value)
         self.initialized = True
         self.json_obj = None
 
@@ -214,10 +206,10 @@ class ManifestData(dict):
 
 
 class Manifest(object):
-    def __init__(self, tests_root=None, url_base="/", meta_filters=None):
+    def __init__(self, tests_root=None, url_base="/"):
         assert url_base is not None
         self._path_hash = {}
-        self._data = ManifestData(self, meta_filters)
+        self._data = ManifestData(self)
         self._reftest_nodes_by_url = None
         self.tests_root = tests_root
         self.url_base = url_base
@@ -396,12 +388,12 @@ class Manifest(object):
         return rv
 
     @classmethod
-    def from_json(cls, tests_root, obj, types=None, meta_filters=None):
+    def from_json(cls, tests_root, obj, types=None):
         version = obj.get("version")
         if version != CURRENT_VERSION:
             raise ManifestVersionMismatch
 
-        self = cls(tests_root, url_base=obj.get("url_base", "/"), meta_filters=meta_filters)
+        self = cls(tests_root, url_base=obj.get("url_base", "/"))
         if not hasattr(obj, "items") and hasattr(obj, "paths"):
             raise ManifestError
 
@@ -419,17 +411,17 @@ class Manifest(object):
         return self
 
 
-def load(tests_root, manifest, types=None, meta_filters=None):
+def load(tests_root, manifest, types=None):
     logger = get_logger()
 
     logger.warning("Prefer load_and_update instead")
-    return _load(logger, tests_root, manifest, types, meta_filters)
+    return _load(logger, tests_root, manifest, types)
 
 
 __load_cache = {}
 
 
-def _load(logger, tests_root, manifest, types=None, meta_filters=None, allow_cached=True):
+def _load(logger, tests_root, manifest, types=None, allow_cached=True):
     # "manifest" is a path or file-like object.
     manifest_path = (manifest if isinstance(manifest, string_types)
                      else manifest.name)
@@ -445,8 +437,7 @@ def _load(logger, tests_root, manifest, types=None, meta_filters=None, allow_cac
             with open(manifest) as f:
                 rv = Manifest.from_json(tests_root,
                                         fast_json.load(f),
-                                        types=types,
-                                        meta_filters=meta_filters)
+                                        types=types)
         except IOError:
             return None
         except ValueError:
@@ -455,8 +446,7 @@ def _load(logger, tests_root, manifest, types=None, meta_filters=None, allow_cac
     else:
         rv = Manifest.from_json(tests_root,
                                 fast_json.load(manifest),
-                                types=types,
-                                meta_filters=meta_filters)
+                                types=types)
 
     if allow_cached:
         __load_cache[manifest_path] = rv
@@ -472,7 +462,6 @@ def load_and_update(tests_root,
                     cache_root=None,
                     working_copy=True,
                     types=None,
-                    meta_filters=None,
                     write_manifest=True,
                     allow_cached=True):
     logger = get_logger()
@@ -484,7 +473,6 @@ def load_and_update(tests_root,
                              tests_root,
                              manifest_path,
                              types=types,
-                             meta_filters=meta_filters,
                              allow_cached=allow_cached)
         except ManifestVersionMismatch:
             logger.info("Manifest version changed, rebuilding")
@@ -493,7 +481,7 @@ def load_and_update(tests_root,
             logger.info("Manifest url base did not match, rebuilding")
 
     if manifest is None:
-        manifest = Manifest(tests_root, url_base, meta_filters=meta_filters)
+        manifest = Manifest(tests_root, url_base)
         update = True
 
     if update:

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -298,34 +298,6 @@ def test_iterpath():
     assert set(m.iterpath("missing")) == set()
 
 
-def test_filter():
-    m = manifest.Manifest()
-
-    sources = [SourceFileWithTest("test1", "0"*40, item.RefTestNode, references=[("/test1-ref", "==")]),
-               SourceFileWithTests("test2", "0"*40, item.TestharnessTest, [("test2-1.html",),
-                                                                           ("test2-2.html",)]),
-               SourceFileWithTest("test3", "0"*40, item.TestharnessTest)]
-    m.update([(s, True) for s in sources])
-
-    json = m.to_json()
-
-    def filter(it):
-        for test in it:
-            if test[0] in ["test2-2.html", "test3"]:
-                yield test
-
-    filtered_manifest = manifest.Manifest.from_json("/", json, types=["testharness"], meta_filters=[filter])
-
-    actual = [
-        (ty, path, [test.id for test in tests])
-        for (ty, path, tests) in filtered_manifest
-    ]
-    assert actual == [
-        ("testharness", "test2", ["/test2-2.html"]),
-        ("testharness", "test3", ["/test3"]),
-    ]
-
-
 def test_reftest_node_by_url():
     m = manifest.Manifest()
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -110,14 +110,13 @@ class TagFilter(object):
 
 class ManifestLoader(object):
     def __init__(self, test_paths, force_manifest_update=False, manifest_download=False,
-                 types=None, meta_filters=None):
+                 types=None):
         do_delayed_imports()
         self.test_paths = test_paths
         self.force_manifest_update = force_manifest_update
         self.manifest_download = manifest_download
         self.types = types
         self.logger = structured.get_default_logger()
-        self.meta_filters = meta_filters
         if self.logger is None:
             self.logger = structured.structuredlog.StructuredLogger("ManifestLoader")
 
@@ -137,7 +136,7 @@ class ManifestLoader(object):
             download_from_github(manifest_path, tests_path)
         return manifest.load_and_update(tests_path, manifest_path, url_base,
                                         cache_root=cache_root, update=self.force_manifest_update,
-                                        meta_filters=self.meta_filters, types=self.types)
+                                        types=self.types)
 
 
 def iterfilter(filters, iter):


### PR DESCRIPTION
This exposes JSON objects to our public API, which should really be an implementation detail.

The original usage of this is already gone, as it turned out to be super fragile and got broken quite quickly. Loading items is now much quicker than it once was, and if we want to optimise the `jstest` case again we should probably do it with a more specific optimisation (probably adding a list of paths to the manifest with the flag?).