### PR TITLE
[css-text-3] Fix incorrect test

### DIFF
--- a/css/css-text/white-space/break-spaces-008.html
+++ b/css/css-text/white-space/break-spaces-008.html
@@ -8,7 +8,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-break-all">
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="flags" content="ahem">
-<meta name="assert" content="White spaces are preserved, honoring the 'white-space: break-spaces', which may lead to overfow. However, we can break before the first white-space after the word honoring the 'break-all' value.">
+<meta name="assert" content="White spaces are preserved, honoring the 'white-space: break-spaces', which may lead to overfow. However, we can break before the las letter in the word honoring the 'break-all' value.">
 <style>
 div {
   position: relative;
@@ -30,6 +30,6 @@ span { color: green; }
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div class="fail">XXXX<br><span>X</span>XX<span>X</span><br><span>XXXX</span><br><span>XXXX</span></div>
+  <div class="fail">XXX<span>X</span><br>X<span>X</span>XX<br><span>XXXX</span><br><span>XXXX</span></div>
   <div class="test">XXXX XX</div>
 </body>


### PR DESCRIPTION
If we can break between letters and after spaces, but not before spaces
or after letters, then the break will be before the last letter of the
word.

(see also: https://github.com/w3c/csswg-drafts/issues/3701)