### PR TITLE
Add test for Joint session state manipulation

### DIFF
--- a/html/browsers/history/joint-session-history/joint-session-history-iframe-state.html
+++ b/html/browsers/history/joint-session-history/joint-session-history-iframe-state.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Joint session history should not override parent's state.</title>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<iframe id="frame" src="about:blank"></iframe>
+<script>
+async_test(function(t) {
+    t.step_timeout(() => {
+        // Setup.
+        var initialState = {foo: 'bar'};
+        var newStateFromChild = {foo: 'baz'};
+        var child = document.getElementById("frame");
+
+        // Perform navigation in the top-level container to set the state.
+        window.history.pushState(initialState, 'title');
+
+        // Validate initial state was properly set.
+        assert_object_equals(window.history.state, initialState);
+
+        child.onload = t.step_func_done(() => {
+            // Child's initial state should be `null`.
+            assert_equals(child.contentWindow.history.state, null);
+
+            // Navigate in the child.
+            child.contentWindow.history.pushState(newStateFromChild, 'title');
+
+            // Child's state should now equal the new state.
+            assert_object_equals(child.contentWindow.history.state, newStateFromChild);
+            // Parent's state should still be preserved, having exactly the same state as it
+            // had before parent navigated.
+            assert_object_equals(window.history.state, initialState);
+        })
+        child.src = "joint-session-history-filler.html";
+    }, 1000);
+});
+</script>
+</body>

--- a/html/browsers/history/joint-session-history/joint-session-history-iframe-state.html
+++ b/html/browsers/history/joint-session-history/joint-session-history-iframe-state.html
@@ -14,6 +14,9 @@ async_test(function(t) {
         var newStateFromChild = {foo: 'baz'};
         var child = document.getElementById("frame");
 
+        // Child's initial state should be a default empty state.
+        assert_equals(child.contentWindow.history.state, null);
+
         // Perform navigation in the top-level container to set the state.
         window.history.pushState(initialState, 'title');
 

--- a/html/browsers/history/joint-session-history/joint-session-history-iframe-state.html
+++ b/html/browsers/history/joint-session-history/joint-session-history-iframe-state.html
@@ -8,36 +8,34 @@
 <iframe id="frame" src="about:blank"></iframe>
 <script>
 async_test(function(t) {
-    t.step_timeout(() => {
-        // Setup.
-        var initialState = {foo: 'bar'};
-        var newStateFromChild = {foo: 'baz'};
-        var child = document.getElementById("frame");
+    // Setup.
+    var initialState = {foo: 'bar'};
+    var newStateFromChild = {foo: 'baz'};
+    var child = document.getElementById("frame");
 
-        // Child's initial state should be a default empty state.
+    // Child's initial state should be a default empty state.
+    assert_equals(child.contentWindow.history.state, null);
+
+    // Perform navigation in the top-level container to set the state.
+    window.history.pushState(initialState, 'title');
+
+    // Validate initial state was properly set.
+    assert_object_equals(window.history.state, initialState);
+
+    child.onload = t.step_func_done(() => {
+        // Child's initial state should be `null`.
         assert_equals(child.contentWindow.history.state, null);
 
-        // Perform navigation in the top-level container to set the state.
-        window.history.pushState(initialState, 'title');
+        // Navigate in the child.
+        child.contentWindow.history.pushState(newStateFromChild, 'title');
 
-        // Validate initial state was properly set.
+        // Child's state should now equal the new state.
+        assert_object_equals(child.contentWindow.history.state, newStateFromChild);
+        // Parent's state should still be preserved, having exactly the same state as it
+        // had before parent navigated.
         assert_object_equals(window.history.state, initialState);
-
-        child.onload = t.step_func_done(() => {
-            // Child's initial state should be `null`.
-            assert_equals(child.contentWindow.history.state, null);
-
-            // Navigate in the child.
-            child.contentWindow.history.pushState(newStateFromChild, 'title');
-
-            // Child's state should now equal the new state.
-            assert_object_equals(child.contentWindow.history.state, newStateFromChild);
-            // Parent's state should still be preserved, having exactly the same state as it
-            // had before parent navigated.
-            assert_object_equals(window.history.state, initialState);
-        })
-        child.src = "joint-session-history-filler.html";
-    }, 1000);
+    })
+    child.src = "joint-session-history-filler.html";
 });
 </script>
 </body>


### PR DESCRIPTION
Some browsers don't seem to agree on how top-level container should handle the navigation of the child, particularly around if the state should be overwritten by the child or not. This is particularly prominent in WebKit based browsers, such as Safari.

As far as I've tested this, it appears that these browsers pass the test:

- Chrome 73.0.3683.103
- Chrome Canary 75.0.3767.0
- Firefox ESR 60

These browsers don't pass the test:

- Safari 12.1 (14607.1.40.1.4)
- Safari TP (Safari 12.2, WebKit 14608.1.14)

This leads me to believe that Chrome & Firefox's implementation is correct, thus this test is geared to pass in these browsers. Ideally we'd follow the [`history` spec](https://www.w3.org/TR/html50/browsers.html#the-history-interface), but as far as I'm aware, it does not specify how browsers should work in this particular scenario.

Looking at this pragmatically as well, it appears that keeping the `window.history.state` in the navigation makes sense, as the top window did not actually change it's state, just the child iframe, even if navigation occurred and  going back in history means that child iframe _will_ navigate back. That, however, does not alter the state of the parent window, which is why it appears that implementation in Chrome/Firefox seems correct.


## References

- There is a bug report opened in Webkit repo for this issue https://bugs.webkit.org/show_bug.cgi?id=196990