### PR TITLE
[PageLifecycle] Get page lifecycle freeze test working on Chrome

### DIFF
--- a/infrastructure/testdriver/freeze.html
+++ b/infrastructure/testdriver/freeze.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver freeze method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+var is_child_frozen = false;
+var test = async_test('Test freeze callback.');
+window.open('freeze_child.html', 'Child Window');
+
+function set_child_frozen(is_frozen) {
+  is_child_frozen = is_frozen;
+}
+
+function freeze_child(child_window) {
+  test_driver
+    .freeze(child_window)
+    .then(() => {
+      assert_true(is_child_frozen);
+      test.done();
+    })
+    .catch(t.unreached_func("freeze failed"));
+}
+
+</script>

--- a/infrastructure/testdriver/freeze_child.html
+++ b/infrastructure/testdriver/freeze_child.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Frozen Window</title>
+<h1>This window will be frozen</h1>
+<script>
+
+window.document.addEventListener("freeze", () => {
+  window.opener.set_child_frozen(true);
+});
+
+window.document.addEventListener("resume", () => {
+  window.opener.set_child_frozen(false);
+});
+
+onload = function() {
+  window.opener.freeze_child(window);
+};
+
+</script>

--- a/lifecycle/freeze.html
+++ b/lifecycle/freeze.html
@@ -3,6 +3,8 @@
 <title>TestDriver freeze method</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 
 <script>
 var test = async_test('Test freeze callback.');
@@ -44,6 +46,10 @@ test.step_timeout(() => {
       test.step(() => assert_unreached('During onfreeze: ' + step + ' never finshed.'));
   }
 }, 1000);
+
+function freeze_child(child_window) {
+  test_driver.freeze(child_window);
+}
 
 </script>
 

--- a/lifecycle/resources/window.html
+++ b/lifecycle/resources/window.html
@@ -1,9 +1,7 @@
-<!doctype html>
-<html>
-<head><title>Frozen Window</title></head>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<body>
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Frozen Window</title>
+
 <h1>This window will be frozen</h1>
 <script>
 
@@ -68,9 +66,7 @@ window.document.addEventListener("freeze", () => {
 
 onload = function() {
   window.opener.add_step(freezingStepName);
-  test_driver.freeze();
+  window.opener.freeze_child(window);
 };
 
 </script>
-</body>
-</html>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -159,18 +159,20 @@
         },
 
         /**
-         * Freeze the current page
+         * Freeze a page
          *
          * The freeze function transitions the page from the HIDDEN state to
          * the FROZEN state as described in {@link
          * https://github.com/WICG/page-lifecycle/blob/master/README.md|Lifecycle API
          * for Web Pages}
          *
+         * @param {Window} - the window corresponding to the page to freeze.
+         *
          * @returns {Promise} fulfilled after the freeze request is sent, or rejected
          *                    in case the WebDriver command errors
          */
-        freeze: function() {
-            return window.test_driver_internal.freeze();
+        freeze: function(window_to_freeze) {
+            return window.test_driver_internal.freeze(window_to_freeze);
         },
 
         /**
@@ -278,12 +280,14 @@
         },
 
         /**
-         * Freeze the current page
+         * Freeze a page
+         *
+         * @param {Window} - the window corresponding to the page to freeze.
          *
          * @returns {Promise} fulfilled after freeze request is sent, otherwise
          * it gets rejected
          */
-        freeze: function() {
+        freeze: function(window_to_freeze) {
             return Promise.reject(new Error("unimplemented"));
         },
 

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -589,7 +589,8 @@ class CallbackHandler(object):
             "click": ClickAction(self.logger, self.protocol),
             "send_keys": SendKeysAction(self.logger, self.protocol),
             "action_sequence": ActionSequenceAction(self.logger, self.protocol),
-            "generate_test_report": GenerateTestReportAction(self.logger, self.protocol)
+            "generate_test_report": GenerateTestReportAction(self.logger, self.protocol),
+            "freeze": FreezeAction(self.logger, self.protocol)
         }
 
     def __call__(self, result):
@@ -683,3 +684,13 @@ class GenerateTestReportAction(object):
         message = payload["message"]
         self.logger.debug("Generating test report: %s" % message)
         self.protocol.generate_test_report.generate_test_report(message)
+
+class FreezeAction(object):
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        if "title" not in payload:
+          raise ValueError("Freeze requires a document title")
+        self.protocol.freeze.freeze(payload["title"])

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -21,7 +21,8 @@ from .protocol import (BaseProtocolPart,
                        SendKeysProtocolPart,
                        ActionSequenceProtocolPart,
                        TestDriverProtocolPart,
-                       GenerateTestReportProtocolPart)
+                       GenerateTestReportProtocolPart,
+                       FreezeProtocolPart)
 from ..testrunner import Stop
 
 import webdriver as client
@@ -174,6 +175,25 @@ class WebDriverActionSequenceProtocolPart(ActionSequenceProtocolPart):
     def send_actions(self, actions):
         self.webdriver.actions.perform(actions['actions'])
 
+class WebDriverFreezeProtocolPart(FreezeProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def switch_to_window(self, document_title):
+        handles = self.webdriver.handles;
+        for handle in handles:
+            self.webdriver.window_handle = handle
+            if self.webdriver.send_session_command("GET", "title") == document_title:
+                return True
+        return False
+
+    def freeze(self, document_title):
+        cur_window = self.webdriver.window_handle
+        if not self.switch_to_window(document_title):
+            raise Exception("Could not find window with top-level document named %s" % document_title)
+        res = self.webdriver.send_session_command("POST", "goog/page/freeze")
+        self.webdriver.window_handle = cur_window
+        return res
 
 class WebDriverTestDriverProtocolPart(TestDriverProtocolPart):
     def setup(self):
@@ -206,7 +226,8 @@ class WebDriverProtocol(Protocol):
                   WebDriverSendKeysProtocolPart,
                   WebDriverActionSequenceProtocolPart,
                   WebDriverTestDriverProtocolPart,
-                  WebDriverGenerateTestReportProtocolPart]
+                  WebDriverGenerateTestReportProtocolPart,
+                  WebDriverFreezeProtocolPart]
 
     def __init__(self, executor, browser, capabilities, **kwargs):
         super(WebDriverProtocol, self).__init__(executor, browser)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -308,6 +308,16 @@ class ActionSequenceProtocolPart(ProtocolPart):
         :param actions: A protocol-specific handle to an array of actions."""
         pass
 
+class FreezeProtocolPart(ProtocolPart):
+    """Protocol part for performing trusted freeze"""
+    __metaclass__ = ABCMeta
+
+    name = "freeze"
+
+    @abstractmethod
+    def freeze(self):
+        """Freeze the page."""
+        pass
 
 class TestDriverProtocolPart(ProtocolPart):
     """Protocol part that implements the basic functionality required for

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -99,4 +99,13 @@
         window.__wptrunner_message_queue.push({"type": "action", "action": "generate_test_report", "message": message});
         return pending_promise;
     };
+
+    window.test_driver_internal.freeze = function(window_to_freeze) {
+        const pending_promise = new Promise(function(resolve, reject) {
+            pending_resolve = resolve;
+            pending_reject = reject;
+        });
+        window.__wptrunner_message_queue.push({"type": "action", "action": "freeze", "title": window_to_freeze.document.title});
+        return pending_promise;
+    };
 })();


### PR DESCRIPTION
This adds page freeze support for the WebDriver executor to get the
existing lifecycle freeze test to work. This also adds a testdriver
infrastructure test for the freeze.

Addionally, this changes freeze tests to freeze the child from
the parent. Previously, the child window interacted with test_driver
directly which broke some functionality, i.e. the promise returned by
test_driver.freeze(). All interactions with the test harness and driver
now take place in the parent window, with the child window passed to
functions as necessary.