### PR TITLE
Fix get-host-info.sub.js so workers can use it.

### DIFF
--- a/common/get-host-info.sub.js
+++ b/common/get-host-info.sub.js
@@ -3,7 +3,7 @@ function get_host_info() {
   var HTTP_PORT = '{{ports[http][0]}}';
   var HTTP_PORT2 = '{{ports[http][1]}}';
   var HTTPS_PORT = '{{ports[https][0]}}';
-  var PROTOCOL = window.location.protocol;
+  var PROTOCOL = self.location.protocol;
   var IS_HTTPS = (PROTOCOL == "https:");
   var HTTP_PORT_ELIDED = HTTP_PORT == "80" ? "" : (":" + HTTP_PORT);
   var HTTP_PORT2_ELIDED = HTTP_PORT2 == "80" ? "" : (":" + HTTP_PORT2);


### PR DESCRIPTION
Access self.location instead of window.location. Fixes #13518 (see https://crbug.com/953873).