### PR TITLE
[xhr] Promote determinism in test for invalid HTTP

### DIFF
--- a/xhr/resources/echo-method.py
+++ b/xhr/resources/echo-method.py
@@ -1,6 +1,18 @@
+# This handler is designed to verify that UAs correctly discard the body of
+# responses to HTTP HEAD requests. If the response body is written to a
+# separate TCP packet, then this behavior cannot be verified. This handler uses
+# the response writer to ensure that the body is tranmitted in the same packet
+# as the headers. In this way, non-conforming UAs will consistently fail the
+# associated test.
+
 def main(request, response):
-    response.send_body_for_head_request = True
     headers = [("Content-type", "text/plain")]
     content = request.method
 
-    return headers, content
+    response.add_required_headers = False
+    response.writer.write('''HTTP/1.1 200 OK
+Content-type: text/plain
+Content-Length: {}
+
+{}'''.format(len(content), content))
+    response.writer.flush()

--- a/xhr/resources/echo-method.py
+++ b/xhr/resources/echo-method.py
@@ -1,7 +1,7 @@
 # This handler is designed to verify that UAs correctly discard the body of
 # responses to HTTP HEAD requests. If the response body is written to a
 # separate TCP packet, then this behavior cannot be verified. This handler uses
-# the response writer to ensure that the body is tranmitted in the same packet
+# the response writer to ensure that the body is transmitted in the same packet
 # as the headers. In this way, non-conforming UAs will consistently fail the
 # associated test.
 

--- a/xhr/resources/echo-method.py
+++ b/xhr/resources/echo-method.py
@@ -6,7 +6,6 @@
 # associated test.
 
 def main(request, response):
-    headers = [("Content-type", "text/plain")]
     content = request.method
 
     response.add_required_headers = False


### PR DESCRIPTION
`xhr/response-method.htm` attempts to verify how the body of responses
to HEAD requests is interpreted. Although this is in direct violation of
HTTP [1], the Fetch specification includes instruction for how browsers
should handle it [2].

As originally written, the server script uses a high-level interface to
define the invalid response. As a result, no guarantee could be made
about how the data was segmented into TCP packets. This allowed the test
to violate HTTP in a distinct and unintentional way: data intended to be
interpreted as the body of a HEAD response could instead be interpreted
as the beginning of the response to the subsequent POST request.

Although some UAs happen to tolerate such data, others (e.g. Apple
Safari at the time of this writing) do not. In those contexts, the test
would fail inconsistently. Because this test is not intended to verify
how UAs interpret invalid bytes which *precede* an HTTP response, these
failures do  not indicate non-conformance.

Update the server to more precisely control how bytes are written to the
connection.

[1] https://tools.ietf.org/html/rfc7231#section-4.3.2
[2] https://fetch.spec.whatwg.org/#main-fetch

---

I don't know if we can actually make any guarantee about packet segmentation, even when using the ResponseWriter. That said, curl indicates that this approach produces the required traffic much more reliably:

    $ git checkout master
    $ for i in $(seq 9); do curl --head http://web-platform.test:8000/xhr/resources/echo-method.py -v 2>&1 | grep Excess | xargs echo $i; done
    1
    2
    3
    4 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    5
    6 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    7
    8
    9 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    $ git checkout bocoup/xhr-flaky-invalid-http
    $ for i in $(seq 9); do curl --head http://web-platform.test:8000/xhr/resources/echo-method.py -v 2>&1 | grep Excess | xargs echo $i; done
    1 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    2 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    3 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    4 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    5 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    6 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    7 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    8 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)
    9 * Excess found in a non pipelined read: excess = 4 url = /xhr/resources/echo-method.py (zero-length body)