### PR TITLE
[generic-sensor] Avoid unhandled promise rejection

### DIFF
--- a/generic-sensor/generic-sensor-tests.js
+++ b/generic-sensor/generic-sensor-tests.js
@@ -7,7 +7,7 @@
 //
 //   --enable-blink-features=MojoJS,MojoJSTest
 let loadChromiumResources = Promise.resolve().then(() => {
-  if (!MojoInterfaceInterceptor) {
+  if (!window.MojoInterfaceInterceptor) {
     // Do nothing on non-Chromium-based browsers or when the Mojo bindings are
     // not present in the global namespace.
     return;
@@ -37,7 +37,10 @@ async function initialize_generic_sensor_tests() {
   if (typeof GenericSensorTest === 'undefined') {
     await loadChromiumResources;
   }
-  assert_true(typeof GenericSensorTest !== 'undefined');
+  assert_true(
+    typeof GenericSensorTest !== 'undefined',
+    'Mojo testing interface is not available.'
+  );
   let sensorTest = new GenericSensorTest();
   await sensorTest.initialize();
   return sensorTest;


### PR DESCRIPTION
By testing for a global binding via an unqualified IdentifierReference,
the Generic Sensor utility file produces a rejected promise which is not
handled. If testharness.js has not yet determined that testing is
complete, this unhandled rejection will cause a harness-level error.
Such errors will occur based on relative timing of asynchronous
operations, and this has been observed to be unstable in Apple Safari as
hosted on Azure Pipelines.

Update the feature detection logic to avoid generating an unhandled
rejection by instead referencing a property of the global object.

---

I have not been able to reproduce the harness error locally, but the issue is clear from the results collected via Azure Pipelines and uploaded to wpt.fyi. [The most recent results for
`ambient-light/AmbientLightSensor_insecure_context.html`](https://wpt.fyi/results/ambient-light/AmbientLightSensor_insecure_context.html?run_id=6206214895566848) demonstrate the problem

> ERROR message: Can't find variable: MojoInterfaceInterceptor

The "history" feature on that page shows that this is intermittent in that environment. The same problem affects all tests which do not use the `sensor_test` function, that is: all of the `_insecure_context.html` tests.

In addition to promoting determinism in those specific tests, this change improves failure messages for all tests in browsers which don't define the Mojo interface. Currently, the tests fail with the message: "ReferenceError: MojoInterfaceInterceptor is not defined". With this patch applied, they instead fail with the message, "assert_true: Mojo testing interface is not available. expected true got false"