### PR TITLE
[cookie-store] Promote stability in test results

### DIFF
--- a/cookie-store/serviceworker_cookieStore_subscriptions.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions.js
@@ -9,12 +9,18 @@ self.addEventListener('install', (event) => {
     // The subscribeToChanges calls are not done in parallel on purpose. Having
     // multiple in-flight requests introduces failure modes aside from the
     // cookie change logic that this test aims to cover.
-    await cookieStore.subscribeToChanges([
-      { name: 'cookie-name1', matchType: 'equals', url: '/scope/path1' }]);
-    await cookieStore.subscribeToChanges([
-      { },  // Test the default values for subscription properties.
-      { name: 'cookie-prefix', matchType: 'starts-with' },
-    ]);
+    try {
+      await cookieStore.subscribeToChanges([
+        { name: 'cookie-name1', matchType: 'equals', url: '/scope/path1' }]);
+      await cookieStore.subscribeToChanges([
+        { },  // Test the default values for subscription properties.
+        { name: 'cookie-prefix', matchType: 'starts-with' },
+      ]);
+
+    // If the worker enters the "redundant" state, the UA may terminate it
+    // before all tests have been reported to the client. Stifle errors in
+    // order to avoid this and ensure all tests are consistently reported.
+    } catch (err) {}
   })());
 });
 

--- a/cookie-store/serviceworker_cookieStore_subscriptions.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions.js
@@ -17,9 +17,9 @@ self.addEventListener('install', (event) => {
         { name: 'cookie-prefix', matchType: 'starts-with' },
       ]);
 
-    // If the worker enters the "redundant" state, the UA may terminate it
-    // before all tests have been reported to the client. Stifle errors in
-    // order to avoid this and ensure all tests are consistently reported.
+      // If the worker enters the "redundant" state, the UA may terminate it
+      // before all tests have been reported to the client. Stifle errors in
+      // order to avoid this and ensure all tests are consistently reported.
     } catch (err) {}
   })());
 });

--- a/cookie-store/serviceworker_cookieStore_subscriptions_basic.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_basic.js
@@ -6,8 +6,14 @@ importScripts("/resources/testharness.js");
 
 self.addEventListener('install', (event) => {
   event.waitUntil((async () => {
-    await cookieStore.subscribeToChanges([
-      { name: 'cookie-name', matchType: 'equals', url: '/scope/path' }]);
+    try {
+      await cookieStore.subscribeToChanges([
+        { name: 'cookie-name', matchType: 'equals', url: '/scope/path' }]);
+
+    // If the worker enters the "redundant" state, the UA may terminate it
+    // before all tests have been reported to the client. Stifle errors in
+    // order to avoid this and ensure all tests are consistently reported.
+    } catch (err) {}
   })());
 });
 

--- a/cookie-store/serviceworker_cookieStore_subscriptions_basic.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_basic.js
@@ -10,9 +10,9 @@ self.addEventListener('install', (event) => {
       await cookieStore.subscribeToChanges([
         { name: 'cookie-name', matchType: 'equals', url: '/scope/path' }]);
 
-    // If the worker enters the "redundant" state, the UA may terminate it
-    // before all tests have been reported to the client. Stifle errors in
-    // order to avoid this and ensure all tests are consistently reported.
+      // If the worker enters the "redundant" state, the UA may terminate it
+      // before all tests have been reported to the client. Stifle errors in
+      // order to avoid this and ensure all tests are consistently reported.
     } catch (err) {}
   })());
 });

--- a/cookie-store/serviceworker_cookieStore_subscriptions_empty.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_empty.js
@@ -6,7 +6,13 @@ importScripts("/resources/testharness.js");
 
 self.addEventListener('install', (event) => {
   event.waitUntil((async () => {
-    await cookieStore.subscribeToChanges([]);
+    try {
+      await cookieStore.subscribeToChanges([]);
+
+    // If the worker enters the "redundant" state, the UA may terminate it
+    // before all tests have been reported to the client. Stifle errors in
+    // order to avoid this and ensure all tests are consistently reported.
+    } catch (err) {}
   })());
 });
 

--- a/cookie-store/serviceworker_cookieStore_subscriptions_empty.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_empty.js
@@ -9,9 +9,9 @@ self.addEventListener('install', (event) => {
     try {
       await cookieStore.subscribeToChanges([]);
 
-    // If the worker enters the "redundant" state, the UA may terminate it
-    // before all tests have been reported to the client. Stifle errors in
-    // order to avoid this and ensure all tests are consistently reported.
+      // If the worker enters the "redundant" state, the UA may terminate it
+      // before all tests have been reported to the client. Stifle errors in
+      // order to avoid this and ensure all tests are consistently reported.
     } catch (err) {}
   })());
 });

--- a/cookie-store/serviceworker_cookieStore_subscriptions_eventhandler_attribute.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_eventhandler_attribute.js
@@ -6,8 +6,14 @@ importScripts("/resources/testharness.js");
 
 self.addEventListener('install', (event) => {
   event.waitUntil((async () => {
-    await cookieStore.subscribeToChanges([
-      { name: 'cookie-name', matchType: 'equals', url: '/scope/path' }]);
+    try {
+      await cookieStore.subscribeToChanges([
+        { name: 'cookie-name', matchType: 'equals', url: '/scope/path' }]);
+
+    // If the worker enters the "redundant" state, the UA may terminate it
+    // before all tests have been reported to the client. Stifle errors in
+    // order to avoid this and ensure all tests are consistently reported.
+    } catch (err) {}
   })());
 });
 

--- a/cookie-store/serviceworker_cookieStore_subscriptions_eventhandler_attribute.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_eventhandler_attribute.js
@@ -10,9 +10,9 @@ self.addEventListener('install', (event) => {
       await cookieStore.subscribeToChanges([
         { name: 'cookie-name', matchType: 'equals', url: '/scope/path' }]);
 
-    // If the worker enters the "redundant" state, the UA may terminate it
-    // before all tests have been reported to the client. Stifle errors in
-    // order to avoid this and ensure all tests are consistently reported.
+      // If the worker enters the "redundant" state, the UA may terminate it
+      // before all tests have been reported to the client. Stifle errors in
+      // order to avoid this and ensure all tests are consistently reported.
     } catch (err) {}
   })());
 });

--- a/cookie-store/serviceworker_cookieStore_subscriptions_mismatch.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_mismatch.js
@@ -6,8 +6,14 @@ importScripts("/resources/testharness.js");
 
 self.addEventListener('install', (event) => {
   event.waitUntil((async () => {
-    await cookieStore.subscribeToChanges([
-      { name: 'cookie-name', matchType: 'equals', url: '/scope/path' }]);
+    try{
+      await cookieStore.subscribeToChanges([
+        { name: 'cookie-name', matchType: 'equals', url: '/scope/path' }]);
+
+    // If the worker enters the "redundant" state, the UA may terminate it
+    // before all tests have been reported to the client. Stifle errors in
+    // order to avoid this and ensure all tests are consistently reported.
+    } catch (err) {}
   })());
 });
 

--- a/cookie-store/serviceworker_cookieStore_subscriptions_mismatch.js
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_mismatch.js
@@ -6,13 +6,13 @@ importScripts("/resources/testharness.js");
 
 self.addEventListener('install', (event) => {
   event.waitUntil((async () => {
-    try{
+    try {
       await cookieStore.subscribeToChanges([
         { name: 'cookie-name', matchType: 'equals', url: '/scope/path' }]);
 
-    // If the worker enters the "redundant" state, the UA may terminate it
-    // before all tests have been reported to the client. Stifle errors in
-    // order to avoid this and ensure all tests are consistently reported.
+      // If the worker enters the "redundant" state, the UA may terminate it
+      // before all tests have been reported to the client. Stifle errors in
+      // order to avoid this and ensure all tests are consistently reported.
     } catch (err) {}
   })());
 });


### PR DESCRIPTION
Allow service worker activation to proceed in the absence of the API
under test. This prevents the workers in failing implementations from
entering the "redundant" state, which can interfere with the harness's
ability to detect all tests.

---

I've observed inconsistent test results from these tests in Safari Technology
Preview 80. This change stabilizes the results and also makes the tests fail
immediately (instead of timing out).

In general, it seems preferable to defer all fallible logic until after the
service worker's been activated. I'm not familiar with the cookie-store draft,
so I've assumed that these operations have to be done during installation.

For cases like that, it might be nice if the harness could be more resilient.
For instance, it might react to the "redundant" state by discarding all tests
(given that it's suspect whether all tests have been transmitted back to the
client) and reporting the "ERROR" status. However, I imagine doing so would
interfere with the service-workers tests that concern redundant workers.
@mattto / @mkruisselbrink do you have any thoughts about that?