### PR TITLE
[css-text-decor] Add text-emphasis-style tests

### DIFF
--- a/css/css-text-decor/text-emphasis-style-001-manual.html
+++ b/css/css-text-decor/text-emphasis-style-001-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: dot</title>
+<meta name="assert" content="text-emphasis-style:dot; a dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled dot appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-002-manual.html
+++ b/css/css-text-decor/text-emphasis-style-002-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: circle</title>
+<meta name="assert" content="text-emphasis-style:circle; a circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-003-manual.html
+++ b/css/css-text-decor/text-emphasis-style-003-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: double-circle</title>
+<meta name="assert" content="text-emphasis-style:double-circle; a double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled double-circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-004-manual.html
+++ b/css/css-text-decor/text-emphasis-style-004-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: triangle</title>
+<meta name="assert" content="text-emphasis-style:triangle; a triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled triangle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-005-manual.html
+++ b/css/css-text-decor/text-emphasis-style-005-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: sesame</title>
+<meta name="assert" content="text-emphasis-style:sesame; a sesame mark appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled sesame mark appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-006-manual.html
+++ b/css/css-text-decor/text-emphasis-style-006-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled dot</title>
+<meta name="assert" content="text-emphasis-style:filled dot; a filled dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled dot appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-007-manual.html
+++ b/css/css-text-decor/text-emphasis-style-007-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled circle</title>
+<meta name="assert" content="text-emphasis-style:filled circle; a filled circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-008-manual.html
+++ b/css/css-text-decor/text-emphasis-style-008-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled double-circle</title>
+<meta name="assert" content="text-emphasis-style:filled double-circle; a filled double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled double-circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-009-manual.html
+++ b/css/css-text-decor/text-emphasis-style-009-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled triangle</title>
+<meta name="assert" content="text-emphasis-style:filled triangle; a filled triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled triangle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-010-manual.html
+++ b/css/css-text-decor/text-emphasis-style-010-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled sesame</title>
+<meta name="assert" content="text-emphasis-style:filled sesame; a filled sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled sesame appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-011-manual.html
+++ b/css/css-text-decor/text-emphasis-style-011-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open dot</title>
+<meta name="assert" content="text-emphasis-style:open dot; an open dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open dot appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-012-manual.html
+++ b/css/css-text-decor/text-emphasis-style-012-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open circle</title>
+<meta name="assert" content="text-emphasis-style:open circle; an open circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-014-manual.html
+++ b/css/css-text-decor/text-emphasis-style-014-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open double-circle</title>
+<meta name="assert" content="text-emphasis-style:open double-circle; an open double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open double-circle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-015-manual.html
+++ b/css/css-text-decor/text-emphasis-style-015-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open triangle</title>
+<meta name="assert" content="text-emphasis-style:open triangle; an open triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open triangle appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-016-manual.html
+++ b/css/css-text-decor/text-emphasis-style-016-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open sesame</title>
+<meta name="assert" content="text-emphasis-style:open sesame; an open sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open sesame appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-017-manual.html
+++ b/css/css-text-decor/text-emphasis-style-017-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: 'string'</title>
+<meta name="assert" content="text-emphasis-style:'x'; an 'x' appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:'x';
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an 'x' appears next to each character.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-018-manual.html
+++ b/css/css-text-decor/text-emphasis-style-018-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled</title>
+<meta name="assert" content="text-emphasis-style:filled; a filled circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:horizontal-tb">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-019-manual.html
+++ b/css/css-text-decor/text-emphasis-style-019-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open</title>
+<meta name="assert" content="text-emphasis-style:open; an open circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:horizontal-tb">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-020-manual.html
+++ b/css/css-text-decor/text-emphasis-style-020-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style and space</title>
+<meta name="assert" content="text-emphasis-style:dot; no dot appears next to the space (Zs) characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if no dot appears next to the space (Zs) characters.</p>
+<div id="htmlsrc" style="">
+
+<div>
+<p lang="zh-hans"><span>引 发 网 络 的 全 部 潜 能　</span></p>
+<p lang="zh-hant"><span>引 發 網 絡 的 全 部 潛 能　</span></p>
+<p lang="ja"><span>可 能 性 を 最 大 限 に 導　き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-001-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-001-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: dot (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:dot; a dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled dot appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-002-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-002-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: circle (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:circle; a circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-003-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-003-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: double-circle (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:double-circle; a double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled double-circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-004-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-004-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: triangle (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:triangle; a triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, filled triangle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-005-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-005-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: sesame (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:sesame; a sesame mark appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, filled sesame mark appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-006-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-006-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled dot (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:filled dot; a filled dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled dot appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-007-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-007-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled circle (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:filled circle; a filled circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-008-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-008-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled double-circle (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:filled double-circle; a filled double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled double-circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-009-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-009-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled triangle (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:filled triangle; a filled triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, filled triangle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-010-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-010-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled sesame (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:filled sesame; a filled sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, filled sesame appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-011-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-011-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open dot (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:open dot; an open dot appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open dot appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-012-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-012-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open circle (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:open circle; an open circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-014-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-014-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open double-circle (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:open double-circle; an open double-circle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open double-circle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open double-circle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-015-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-015-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open triangle (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:open triangle; an open triangle appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open triangle;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, open triangle appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-016-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-016-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open sesame (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:open sesame; an open sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open sesame;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, open sesame appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-017-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-017-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: 'string' (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:'x'; an 'x' appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:'x';
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an upright, 'x' appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-018-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-018-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: filled (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:filled; a filled sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:filled;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if a filled sesame appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-019-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-019-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style: open (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:open; an open sesame appears next to each character">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:open;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if an open sesame appears next to each character.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-style-tbrl-020-manual.html
+++ b/css/css-text-decor/text-emphasis-style-tbrl-020-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-style and space (tbrl)</title>
+<meta name="assert" content="text-emphasis-style:dot; no dot appears next to the space (Zs) characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-style-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis-style:dot;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if no dot appears next to the space (Zs) characters.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引 发 网 络 的 全 部 潜 能　</span></p>
+<p lang="zh-hant"><span>引 發 網 絡 的 全 部 潛 能　</span></p>
+<p lang="ja"><span>可 能 性 を 最 大 限 に 導　き出すために</span></p>
+</div>  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR ports https://w3c.github.io/i18n-tests/results/emphasis-marks#text_emphasis_style to WPT. Currently, the tests are manual tests, since we're unable to come up with a way to automate them.

These are simple tests designed to check basic functionality.

**Note:** There are some [existing](https://github.com/web-platform-tests/wpt/tree/master/css/css-text-decor) tests for `text-emphasis-style`. These tests were originally from [Test the Web Forward Tokyo](https://github.com/w3c/csswg-test/tree/1c79416ac54464acdc6518ca285799730068dbda/contributors/ttwf_tokyo). Similar to the tests in this PR, these tests aim to check basic functionality of `text-emphasis-style`.

However, some of the pre-exsisting tests are dubious, such as using ruby markup for reference (e.g., see [text-emphasis-style-002.html](http://w3c-test.org/css/css-text-decor/text-emphasis-style-002.html) and the [reference file](http://w3c-test.org/css/css-text-decor/reference/text-emphasis-style-002-ref.html)).

/cc @r12a
