### PR TITLE
[fetch] Partially fix test instability in Safari

### DIFF
--- a/fetch/api/credentials/cookies.any.js
+++ b/fetch/api/credentials/cookies.any.js
@@ -5,9 +5,9 @@ function cookies(desc, credentials1, credentials2 ,cookies) {
   var urlParameters = "";
   var urlCleanParameters = "";
   if (cookies) {
-    urlParameters +="?pipe=header(Set-Cookie,";
+    urlParameters +="?pipe=header(Vary,*)|header(Set-Cookie,";
     urlParameters += cookies.join(",True)|header(Set-Cookie,") +  ",True)";
-    urlCleanParameters +="?pipe=header(Set-Cookie,";
+    urlCleanParameters +="?pipe=header(Vary,*)|header(Set-Cookie,";
     urlCleanParameters +=  cookies.join("%3B%20max-age=0,True)|header(Set-Cookie,") +  "%3B%20max-age=0,True)";
   }
 

--- a/fetch/api/credentials/cookies3.any.js
+++ b/fetch/api/credentials/cookies3.any.js
@@ -1,0 +1,35 @@
+// META: script=../resources/utils.js
+'use strict';
+
+var index = -1;
+
+while (index++ < 10) {
+  (function(name) {
+    promise_test(function(t) {
+      var url = RESOURCES_DIR + 'top.txt'
+      var setUrl = url + '?pipe=header(Set-Cookie,' + name + '=1,True)|header(Vary,*)';
+      var unsetUrl = url + '?pipe=header(Set-Cookie,' + name + '=0%3B%20max-age=0,True)|header(Vary,*)';
+      var getUrl = RESOURCES_DIR + 'inspect-headers.py?headers=cookie';
+      var opts = { credentials: 'include' };
+
+      t.add_cleanup(function() {
+        return fetch(unsetUrl, opts);
+      });
+
+      return fetch(setUrl)
+        .then(function() {
+            return fetch(getUrl, opts);
+          })
+        .then(function(response) {
+            assert_equals(response.headers.get('x-request-cookie'), name + '=1', 'first set');
+            return fetch(unsetUrl, opts);
+          })
+        .then(function() {
+            return fetch(getUrl, opts);
+          })
+        .then(function(response) {
+            assert_equals(response.headers.get('x-request-cookie'), null, 'first unset');
+          });
+    }, name);
+  })(String.fromCharCode(97 + index));
+}

--- a/fetch/api/resources/inspect-headers.py
+++ b/fetch/api/resources/inspect-headers.py
@@ -21,4 +21,6 @@ def main(request, response):
             headers.append(("Access-Control-Allow-Headers", ", ".join(request.headers)))
 
     headers.append(("content-type", "text/plain"))
+    headers.append(("Cache-Control", "no-cache"))
+    headers.append(("Vary", "*"))
     return headers, ""


### PR DESCRIPTION
Safari reports inconsistent results for this test, [as demonstrated on wpt.fyi](https://wpt.fyi/results/fetch/api/credentials/cookies.any.html?label=master&product=chrome%5Bexperimental%5D&product=edge&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&aligned):

![2019-04-19-safari-history](https://user-images.githubusercontent.com/677252/56450370-a701d180-62f3-11e9-856f-7d9823168056.png)

This is partially due to the browser's more aggressive caching strategy, as can be seen in the "Network" tab of the developer's console:

![2019-04-19-safari-cache](https://user-images.githubusercontent.com/677252/56450371-aa955880-62f3-11e9-9664-1381e141d8ad.png)

The caching can be disabled by using a combination of HTTP headers (both `Cache-Control` and `Vary` appear to be necessary). Unfortunately, it looks like there's further instability that remains even after caching has been disabled. I've included a new test (not really fit for `master`) which demonstrates the instability. Here's a screenshot of the kind of results I have in mind:

![2019-04-19-safari-unstable](https://user-images.githubusercontent.com/677252/56450373-aec17600-62f3-11e9-8d4c-1acb2ce2d3b2.png)

The initial sub-test failure isn't too concerning--some cookies could be lingering from a previous test. I can't explain the second sub-test failure, though. While the absence of the cookie named `a` is expected (it is removed by the cleanup logic of the first sub-test), the absence of the cookie named `k` surprises me.

@burg or @eric-carlson can you verify this?