### PR TITLE
[css-text] Verifying the effect of ZERO WIDTH SPACE on Arabic shaping

### DIFF
--- a/css/css-text/text-encoding/reference/shaping-zwsp-001-ref.html
+++ b/css/css-text/text-encoding/reference/shaping-zwsp-001-ref.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: zero width space and text-shaping</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<style>
+  table {
+    font-size: 3em;
+    border-spacing: 0 3px;
+  }
+  td {
+    padding: 0 0.5ch;
+    line-height: 1;
+    border: 1px solid;
+  }
+  @font-face {
+    font-family: 'csstest_noto';
+    src: url('/fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
+  }
+  table {
+    font-family: 'csstest_noto';
+  }
+</style>
+
+<p>Test passes if both halves of each of the pairs below are identical:
+
+<table dir=rtl lang=ar>
+<tr><!-- alef, final -->
+  <td>&#x640;&#xFE8E;
+  <td>&#x640;&#xFE8E;
+<tr><!-- beh, initial -->
+  <td>&#xFE91;&#x640;
+  <td>&#xFE91;&#x640;
+<tr><!-- beh,  medial -->
+  <td>&#x640;&#xFE92;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, medial -->
+  <td>&#x640;&#xFE92;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, medial -->
+  <td>&#x640;&#xFE92;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, final -->
+  <td>&#x640;&#xFE90;
+  <td>&#x640;&#xFE90;
+</table>

--- a/css/css-text/text-encoding/shaping-zwsp-001.html
+++ b/css/css-text/text-encoding/shaping-zwsp-001.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: zero width space and text-shaping</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-encoding">
+<link rel="help" href="https://www.unicode.org/versions/Unicode11.0.0/ch23.pdf">
+<link rel="help" href="https://www.unicode.org/versions/Unicode11.0.0/ch09.pdf">
+<link rel="help" href="https://www.unicode.org/Public/UCD/latest/ucd/ArabicShaping.txt">
+<link rel="help" href="https://www.w3.org/TR/alreq/#h_disjoining_enforcement">
+<link rel="help" href="https://www.w3.org/TR/alreq/#h_joining_enforcement">
+<link rel="match" href="reference/shaping-zwsp-001-ref.html">
+<meta name="assert" content="ZERO WIDTH SPACE between Arabic characters must not break shaping, as ZWSP has joining type T.">
+<style>
+  table {
+    font-size: 3em;
+    border-spacing: 0 3px;
+  }
+  td {
+    padding: 0 0.5ch;
+    line-height: 1;
+    border: 1px solid;
+  }
+  @font-face {
+    font-family: 'csstest_noto';
+    src: url('/fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
+  }
+  table {
+    font-family: 'csstest_noto';
+  }
+</style>
+
+<p>Test passes if both halves of each of the pairs below are identical:
+
+<table dir=rtl lang=ar>
+<tr><!-- alef, final -->
+  <td>&#x640;&#xfeff;&#x0627;
+  <td>&#x640;&#xFE8E;
+<tr><!-- beh, initial -->
+  <td>&#x0628;&#xfeff;&#x640;
+  <td>&#xFE91;&#x640;
+<tr><!-- beh,  medial -->
+  <td>&#x640;&#x0628;&#xfeff;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, medial -->
+  <td>&#x640;&#xfeff;&#x0628;&#xfeff;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, medial -->
+  <td>&#x640;&#xfeff;&#x0628;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, final -->
+  <td>&#x640;&#xfeff;&#x0628;
+  <td>&#x640;&#xFE90;
+</table>

--- a/css/css-text/text-encoding/shaping-zwsp-002.html
+++ b/css/css-text/text-encoding/shaping-zwsp-002.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: zero width space and text-shaping, cross font, fallback</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-encoding">
+<link rel="help" href="https://www.unicode.org/versions/Unicode11.0.0/ch23.pdf">
+<link rel="help" href="https://www.unicode.org/versions/Unicode11.0.0/ch09.pdf">
+<link rel="help" href="https://www.unicode.org/Public/UCD/latest/ucd/ArabicShaping.txt">
+<link rel="help" href="https://www.w3.org/TR/alreq/#h_disjoining_enforcement">
+<link rel="help" href="https://www.w3.org/TR/alreq/#h_joining_enforcement">
+<link rel="match" href="reference/shaping-zwsp-001-ref.html">
+<meta name="assert" content="ZERO WIDTH SPACE between Arabic characters must not break shaping, as ZWSP has joining type T, even if the ZWNJ comes from a differnt font due to font fallback.">
+<style>
+  table {
+    font-size: 3em;
+    border-spacing: 0 3px;
+  }
+  td {
+    padding: 0 0.5ch;
+    line-height: 1;
+    border: 1px solid;
+  }
+  @font-face {
+    font-family: 'primary';
+    src: url('/fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
+    unicode-range: U+20;
+  }
+  @font-face {
+    font-family: 'joiners';
+    src: url('/fonts/noto/noto-sans-v8-latin-regular.woff') format('woff');
+    unicode-range: U+FEFF;
+  }
+  @font-face {
+    font-family: 'csstest_noto';
+    src: url('/fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
+  }
+  table {
+    /*using a primary font with just U+20 (space) to get the baseline right*/
+    font-family: 'primary', 'joiners', 'csstest_noto';
+  }
+</style>
+
+<p>Test passes if both halves of each of the pairs below are identical:
+
+<table dir=rtl lang=ar>
+<tr><!-- alef, final -->
+  <td>&#x640;&#xfeff;&#x0627;
+  <td>&#x640;&#xFE8E;
+<tr><!-- beh, initial -->
+  <td>&#x0628;&#xfeff;&#x640;
+  <td>&#xFE91;&#x640;
+<tr><!-- beh,  medial -->
+  <td>&#x640;&#x0628;&#xfeff;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, medial -->
+  <td>&#x640;&#xfeff;&#x0628;&#xfeff;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, medial -->
+  <td>&#x640;&#xfeff;&#x0628;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, final -->
+  <td>&#x640;&#xfeff;&#x0628;
+  <td>&#x640;&#xFE90;
+</table>

--- a/css/css-text/text-encoding/shaping-zwsp-003.html
+++ b/css/css-text/text-encoding/shaping-zwsp-003.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: zero width space and text-shaping, cross font, explicit</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-encoding">
+<link rel="help" href="https://www.unicode.org/versions/Unicode11.0.0/ch23.pdf">
+<link rel="help" href="https://www.unicode.org/versions/Unicode11.0.0/ch09.pdf">
+<link rel="help" href="https://www.unicode.org/Public/UCD/latest/ucd/ArabicShaping.txt">
+<link rel="help" href="https://www.w3.org/TR/alreq/#h_disjoining_enforcement">
+<link rel="help" href="https://www.w3.org/TR/alreq/#h_joining_enforcement">
+<link rel="match" href="reference/shaping-zwsp-001-ref.html">
+<meta name="assert" content="ZERO WIDTH SPACE between Arabic characters must not break shaping, as ZWSP has joining type T, even if the ZWNJ comes from a differnt font due to being in a different element with an explicit different font.">
+<style>
+  table {
+    font-size: 3em;
+    border-spacing: 0 3px;
+  }
+  td {
+    padding: 0 0.5ch;
+    line-height: 1;
+    border: 1px solid;
+  }
+  @font-face {
+    font-family: 'joiners';
+    src: url('/fonts/noto/noto-sans-v8-latin-regular.woff') format('woff');
+  }
+  @font-face {
+    font-family: 'csstest_noto';
+    src: url('/fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
+  }
+  span {
+    font-family: 'joiners';
+    line-height: 0;
+  }
+  table {
+    font-family: 'csstest_noto';
+  }
+</style>
+
+<p>Test passes if both halves of each of the pairs below are identical:
+
+<table dir=rtl lang=ar>
+<tr><!-- alef, final -->
+  <td>&#x640;<span>&#xfeff;</span>&#x0627;
+  <td>&#x640;&#xFE8E;
+<tr><!-- beh, initial -->
+  <td>&#x0628;<span>&#xfeff;</span>&#x640;
+  <td>&#xFE91;&#x640;
+<tr><!-- beh, medial -->
+  <td>&#x640;&#x0628;<span>&#xfeff;</span>&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, medial -->
+  <td>&#x640;<span>&#xfeff;</span>&#x0628;<span>&#xfeff;</span>&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, medial -->
+  <td>&#x640;<span>&#xfeff;</span>&#x0628;&#x640;
+  <td>&#x640;&#xFE92;&#x640;
+<tr><!-- beh, final -->
+  <td>&#x640;<span>&#xfeff;</span>&#x0628;
+  <td>&#x640;&#xFE90;
+</table>


### PR DESCRIPTION
The tests as written check that the behavior required by css-text + unicode, but there are doubts as to whether unicode is actually right on that topic. Do not merge until https://github.com/w3c/csswg-drafts/issues/3861 is figured out.