### PR TITLE
[css-text-decor] Add text-emphasis-position tests

### DIFF
--- a/css/css-text-decor/text-emphasis-position-005-manual.html
+++ b/css/css-text-decor/text-emphasis-position-005-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-position: over right</title>
+<meta name="assert" content="text-emphasis:dot; text-emphasis-position:over right; the dot appears OVER horizontally set characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-position-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+text-emphasis-position:over right;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the dot appears OVER horizontally set characters.</p>
+<div id="htmlsrc" style="writing-mode:horizontal-tb">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-position-006-manual.html
+++ b/css/css-text-decor/text-emphasis-position-006-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-position: over left</title>
+<meta name="assert" content="text-emphasis:dot; text-emphasis-position:over left; the dot appears OVER horizontally set characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-position-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+text-emphasis-position:over left;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the dot appears OVER horizontally set characters.</p>
+<div id="htmlsrc" style="writing-mode:horizontal-tb">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-position-007-manual.html
+++ b/css/css-text-decor/text-emphasis-position-007-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-position: under right</title>
+<meta name="assert" content="text-emphasis:dot; text-emphasis-position:under right; the dot appears UNDER horizontally set characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-position-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+text-emphasis-position:under right;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the dot appears UNDER horizontally set characters.</p>
+<div id="htmlsrc" style="writing-mode:horizontal-tb">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-position-008-manual.html
+++ b/css/css-text-decor/text-emphasis-position-008-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-position: under left</title>
+<meta name="assert" content="text-emphasis:dot; text-emphasis-position:under left; the dot appears UNDER horizontally set characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-position-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+text-emphasis-position:under left;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the dot appears UNDER horizontally set characters.</p>
+<div id="htmlsrc" style="writing-mode:horizontal-tb">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-position-009-manual.html
+++ b/css/css-text-decor/text-emphasis-position-009-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-position: over right (vertical)</title>
+<meta name="assert" content="text-emphasis:dot; text-emphasis-position:over right; the dot appears to the RIGHT of vertically set characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-position-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+text-emphasis-position:over right;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the dot appears to the RIGHT of vertically set characters.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-position-010-manual.html
+++ b/css/css-text-decor/text-emphasis-position-010-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-position: under right (vertical)</title>
+<meta name="assert" content="text-emphasis:dot; text-emphasis-position:under right; the dot appears to the RIGHT of vertically set characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-position-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+text-emphasis-position:under right;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the dot appears to the RIGHT of vertically set characters.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-position-011-manual.html
+++ b/css/css-text-decor/text-emphasis-position-011-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-position: over left (vertical)</title>
+<meta name="assert" content="text-emphasis:dot; text-emphasis-position:over left; the dot appears to the LEFT of vertically set characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-position-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+text-emphasis-position:over left;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the dot appears to the LEFT of vertically set characters.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>

--- a/css/css-text-decor/text-emphasis-position-012-manual.html
+++ b/css/css-text-decor/text-emphasis-position-012-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-emphasis-position: under left (vertical)</title>
+<meta name="assert" content="text-emphasis:dot; text-emphasis-position:under left; the dot appears to the LEFT of vertically set characters">
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-position-property">
+<!-- cosmetic styling -->
+<style>
+#htmlsrc { margin: 2em; }
+#htmlsrc p {
+	font-size: 28px;
+	border-radius: 5px;
+	line-height: 1.5;
+	}
+</style>
+<!-- the test -->
+<style>
+div span {
+text-emphasis:dot;
+text-emphasis-position:under left;
+}</style>
+</head>
+<body>
+<p class="instructions">Test passes if the dot appears to the LEFT of vertically set characters.</p>
+<div id="htmlsrc" style="writing-mode:vertical-rl">
+
+<div>
+<p lang="zh-hans"><span>引发网络的全部潜能</span></p>
+<p lang="zh-hant"><span>引發網絡的全部潛能</span></p>
+<p lang="ja"><span>可能性を最大限に導き出すために</span></p>
+</div>  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR ports https://w3c.github.io/i18n-tests/results/emphasis-marks#text_emphasis_posn to WPT. Currently, the tests are manual tests, since we're unable to come up with a way to automate them.

Tests from `005` to `008` are in horizontal writing mode, and tests from `009` to `012` are in `vertical-rl`.

I didn't include the exploratory tests.

/cc @r12a
