### PR TITLE
[css-text] Incorrectly characterized some tests as MUST insted of SHOULD

### DIFF
--- a/css/css-text/shaping/shaping-001.html
+++ b/css/css-text/shaping/shaping-001.html
@@ -3,10 +3,11 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: colour</title>
-<meta name="assert" content="Arabic shaping must not be broken across inline box boundaries for changes to colour.">
+<meta name="assert" content="Arabic shaping should not be broken across inline box boundaries for changes to colour.">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="match" href="reference/shaping-001-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';

--- a/css/css-text/shaping/shaping-002.html
+++ b/css/css-text/shaping/shaping-002.html
@@ -3,10 +3,11 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: font-weight</title>
-<meta name="assert" content="Arabic shaping must not be broken across inline box boundaries for changes in font weight.">
+<meta name="assert" content="Arabic shaping should not be broken across inline box boundaries for changes in font weight.">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="match" href="reference/shaping-002-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';

--- a/css/css-text/shaping/shaping-003.html
+++ b/css/css-text/shaping/shaping-003.html
@@ -3,10 +3,11 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: font-style</title>
-<meta name="assert" content="Arabic shaping must not be broken across inline box boundaries for changes in font style.">
+<meta name="assert" content="Arabic shaping should not be broken across inline box boundaries for changes in font style.">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="match" href="reference/shaping-003-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';

--- a/css/css-text/shaping/shaping-008.html
+++ b/css/css-text/shaping/shaping-008.html
@@ -3,10 +3,11 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: font size 120%</title>
-<meta name="assert" content="Arabic shaping must not be broken across inline box boundaries for changes to font-size.">
+<meta name="assert" content="Arabic shaping should not be broken across inline box boundaries for changes to font-size.">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="match" href="reference/shaping-008-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';

--- a/css/css-text/shaping/shaping-017.html
+++ b/css/css-text/shaping/shaping-017.html
@@ -3,10 +3,11 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: em element</title>
-<meta name="assert" content="Arabic shaping must not be broken across inline box boundaries for the em element.">
+<meta name="assert" content="Arabic shaping should not be broken across inline box boundaries for the em element.">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="match" href="reference/shaping-003-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';

--- a/css/css-text/shaping/shaping-018.html
+++ b/css/css-text/shaping/shaping-018.html
@@ -3,10 +3,11 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: b element</title>
-<meta name="assert" content="Arabic shaping must not be broken across inline box boundaries for the b element.">
+<meta name="assert" content="Arabic shaping should not be broken across inline box boundaries for the b element.">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="match" href="reference/shaping-002-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';

--- a/css/css-text/shaping/shaping-020.html
+++ b/css/css-text/shaping/shaping-020.html
@@ -3,11 +3,12 @@
 <head>
 <meta charset="utf-8">
 <title>n'ko, colour</title>
-<meta name="assert" content="Shaping must not be broken across inline box boundaries for changes to colour in N'Ko.">
+<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to colour in N'Ko.">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="help" href="http://www.unicode.org/versions/Unicode12.0.0/ch19.pdf">
 <link rel="match" href="reference/shaping-020-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';

--- a/css/css-text/shaping/shaping-021.html
+++ b/css/css-text/shaping/shaping-021.html
@@ -3,10 +3,11 @@
 <head>
 <meta charset="utf-8">
 <title>n'ko, font-style</title>
-<meta name="assert" content="Shaping must not be broken across inline box boundaries for changes to font-style in N'Ko.">
+<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to font-style in N'Ko.">
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="match" href="reference/shaping-021-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';

--- a/css/css-text/shaping/shaping-023.html
+++ b/css/css-text/shaping/shaping-023.html
@@ -7,6 +7,7 @@
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="match" href="reference/shaping-023-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';

--- a/css/css-text/shaping/shaping-024.html
+++ b/css/css-text/shaping/shaping-024.html
@@ -7,6 +7,7 @@
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
 <link rel="match" href="reference/shaping-024-ref.html">
+<meta name="flags" content="should">
 <style type="text/css">
 @font-face {
     font-family: 'csstest_noto';


### PR DESCRIPTION
Missed some fixes in https://github.com/web-platform-tests/wpt/pull/16393. Sorry about not catching everything in the first pass. This makes no functional changes to the tests, but classifies some of them as "should", in agreement with the strictness of the requirement in the spec.