### PR TITLE
[IndexedDB] Promote test isolation

### DIFF
--- a/IndexedDB/idbfactory_open2.htm
+++ b/IndexedDB/idbfactory_open2.htm
@@ -6,12 +6,13 @@
 <script src=support.js></script>
 
 <script>
-    var open_rq = createdb(async_test(), 'database_name_open2', 13);
+    var database_name = document.location + '-database_name';
+    var open_rq = createdb(async_test(), database_name, 13);
 
     open_rq.onupgradeneeded = function(e) {};
     open_rq.onsuccess = function(e) {
         var db = e.target.result;
-        assert_equals(db.name, 'database_name_open2', 'db.name');
+        assert_equals(db.name, database_name, 'db.name');
         assert_equals(db.version, 13, 'db.version');
         this.done();
     }

--- a/IndexedDB/idbfactory_open2.htm
+++ b/IndexedDB/idbfactory_open2.htm
@@ -6,12 +6,12 @@
 <script src=support.js></script>
 
 <script>
-    var open_rq = createdb(async_test(), 'database_name', 13);
+    var open_rq = createdb(async_test(), 'database_name_open2', 13);
 
     open_rq.onupgradeneeded = function(e) {};
     open_rq.onsuccess = function(e) {
         var db = e.target.result;
-        assert_equals(db.name, 'database_name', 'db.name');
+        assert_equals(db.name, 'database_name_open2', 'db.name');
         assert_equals(db.version, 13, 'db.version');
         this.done();
     }

--- a/IndexedDB/idbfactory_open4.htm
+++ b/IndexedDB/idbfactory_open4.htm
@@ -6,7 +6,7 @@
 <script src=support.js></script>
 
 <script>
-    var open_rq = createdb(async_test(), 'database_name');
+    var open_rq = createdb(async_test(), 'database_name_open4');
 
     open_rq.onupgradeneeded = function(e) {
         assert_equals(e.target.result.version, 1, "db.version");

--- a/IndexedDB/idbfactory_open4.htm
+++ b/IndexedDB/idbfactory_open4.htm
@@ -6,7 +6,7 @@
 <script src=support.js></script>
 
 <script>
-    var open_rq = createdb(async_test(), 'database_name_open4');
+    var open_rq = createdb(async_test(), document.location + '-database_name');
 
     open_rq.onupgradeneeded = function(e) {
         assert_equals(e.target.result.version, 1, "db.version");

--- a/IndexedDB/idbfactory_open5.htm
+++ b/IndexedDB/idbfactory_open5.htm
@@ -6,7 +6,7 @@
 <script src=support.js></script>
 
 <script>
-    var open_rq = createdb(async_test(), 'database_name_open5');
+    var open_rq = createdb(async_test(), document.location + '-database_name');
 
     open_rq.onupgradeneeded = function() {};
     open_rq.onsuccess = function(e) {

--- a/IndexedDB/idbfactory_open5.htm
+++ b/IndexedDB/idbfactory_open5.htm
@@ -6,7 +6,7 @@
 <script src=support.js></script>
 
 <script>
-    var open_rq = createdb(async_test(), 'database_name');
+    var open_rq = createdb(async_test(), 'database_name_open5');
 
     open_rq.onupgradeneeded = function() {};
     open_rq.onsuccess = function(e) {


### PR DESCRIPTION
Use distinct database names for each test so that failure to clean up
from one test does not influence the result of another.