### PR TITLE
[css-test] Handle U+00C0 as other control characters

### DIFF
--- a/css/css-text/white-space/control-chars-00C.html
+++ b/css/css-text/white-space/control-chars-00C.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Control charcters must be visible: U+000C</title>
+<link rel=author title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-processing">
+<link rel=mismatch href="reference/control-chars-000-ref.html">
+<meta name=flags content="">
+<meta name=assert content="U+000C, which is in the unicode category CC, must be visible">
+<style>
+div {
+  font-size: 4em;
+}
+div::after { content: "\000C" } /* Injecting via CSS, to avoid any mangling by the html parser */
+</style>
+
+<p>Test passes if there is a visible character below.
+
+<div></div>


### PR DESCRIPTION
As per https://github.com/w3c/csswg-drafts/issues/855