### PR TITLE
Fix hanging

### DIFF
--- a/css/css-text/white-space/reference/white-space-intrinsic-size-004-ref.html
+++ b/css/css-text/white-space/reference/white-space-intrinsic-size-004-ref.html
@@ -3,20 +3,16 @@
 <title>test reference</title>
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
 <style>
-aside {
-  float: left;
-  background: blue;
-}
 div {
   color: transparent;
   font-family: Ahem;
   font-size: 50px;
-  width: 5ch;
+  width: 3ch;
+  height: 2ch;
+  background: green;
 }
 </style>
 
-<p>Test passes if there is a single blue rectangle below.
+<p>Test passes if there is a single green rectangle below and no red.
 <div>
-  <aside class=own>X</aside>
-  <aside class=owbw>X</aside>
 </div>

--- a/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-002-ref.html
+++ b/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-002-ref.html
@@ -3,6 +3,6 @@
 <title>CSS test Reference</title>
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
 
-<p>This test passes if you can see the word PASS below, without any extra spaces.
+<p>This test passes if the letters below are spaced equally.
 
-<div>PASS</div>
+<div>X X X X</div>

--- a/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-003-ref.html
+++ b/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-003-ref.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS test Reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+
+<style>
+div {
+  font: 25px/1 Ahem;
+  color: green;
+}
+</style>
+
+<p>This test passes if there is a green rectangle and no red.
+
+<div>X<br>X<br>X<br>X</div>

--- a/css/css-text/white-space/white-space-intrinsic-size-004.html
+++ b/css/css-text/white-space/white-space-intrinsic-size-004.html
@@ -6,25 +6,25 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
 <meta name="flags" content="">
 <link rel="match" href="reference/white-space-intrinsic-size-004-ref.html">
-<meta name="assert" content="Preserved spaces at the end of the line do not affect the intrinsic max-content size when white-space is pre-wrap. The value of overflow-wrap makes no difference.">
+<meta name="assert" content="Preserved spaces at the end of the line do affect the intrinsic max-content size when white-space is pre-wrap, as hanging does not prevent contributing to the max-content size. The value of overflow-wrap makes no difference.">
 <style>
 aside {
   float: left;
   white-space: pre-wrap;
-  background: blue;
-  margin-bottom: 1em;
+  background: green;
 }
 aside:last-of-type { overflow-wrap: break-word; }
 div {
+  background: red;
   color: transparent;
   font-family: Ahem;
   font-size: 50px;
-  width: 3ch; /* enough room for both floats if their max-content size does not include the preserved spaces,
-		 but not enough if they do, causing a line break in that case. */
+  width: 3ch;
+  height: 2em;
 }
 </style>
 
-<p>Test passes if there is a single blue rectangle below.
+<p>Test passes if there is a single green rectangle below and no red.
 <div>
   <aside>X  </aside>
   <aside>X  </aside>

--- a/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-002.html
+++ b/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-002.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
 <link rel="match" href="reference/white-space-pre-wrap-trailing-spaces-002-ref.html">
-<meta name="assert" content="Preserved white space at the end of the line is hanged when white-space is pre-wrap, and therefore does not count when computing the (maximum) intrinsic size.">
+<meta name="assert" content="Hanging preserved white space at the end of the line when white-space is pre-wrap has no effect on the max-content size.">
 
 <style>
 span {
@@ -15,6 +15,6 @@ span {
 #s2 { text-align: center; }
 </style>
 
-<p>This test passes if you can see the word PASS below, without any extra spaces.
+<p>This test passes if the letters below are spaced equally.
 
-<div><span id=s1>P                                 </span><span id=s2>A                                    </span>SS</div>
+<div><span id=s1>X </span><span id=s2>X </span>X X</div>

--- a/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-003.html
+++ b/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-003.html
@@ -3,25 +3,19 @@
 <title>CSS Text test: intrinsic minimum sizing of trailing spaces with white-space:pre-wrap</title>
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/white-space-pre-wrap-trailing-spaces-002-ref.html">
+<link rel="match" href="reference/white-space-pre-wrap-trailing-spaces-003-ref.html">
 <meta name="assert" content="Preserved white space at the end of the line is hanged when white-space is pre-wrap, and therefore does not count when computing the (minimum) intrinsic size.">
 
 <style>
-/* Make the table invisible */
-table { border-collapse: collapse; }
-td { padding: 0; }
-
-/* for the content of the table to be sized to their mininum intrinsic size */
-table { width: 0; }
-
-span {
-  display: inline-block;
+div {
+  font: 25px/1 Ahem;
   white-space: pre-wrap;
+  width: min-content;
+  color: green;
+  background: red;
 }
-#s1 { text-align: right; }
-#s2 { text-align: center; }
 </style>
 
-<p>This test passes if you can see the word PASS below, without any extra spaces.
+<p>This test passes if there is a green rectangle and no red.
 
-<table><td><span id=s1>P                                 </span><td><span id=s2>A                                    </span><td>SS</table>
+<div>X    X X X</div>


### PR DESCRIPTION
Some hanging white-space test were wrong:
* using tables when testing something else than tables is a bad idea, they're weird and unreliable
* hanging things doesn't take them out of max content calculations.