### PR TITLE
Update noopener tests to match spec rules for choosing a browsing con…

### DIFF
--- a/html/browsers/the-window-object/window-open-noopener.html
+++ b/html/browsers/the-window-object/window-open-noopener.html
@@ -12,27 +12,30 @@
 <script src=/resources/testharnessreport.js></script>
 <script>
 var testData = [
-  { testDescription: "window.open() with 'noopener' should not reuse existing target",
+  { testDescription: "window.open() with 'noopener' should reuse existing target",
     secondWindowFeatureString: "noopener",
-    shouldReuse: false },
+    shouldHaveOpener: false },
   { testDescription: "noopener=1 means the same as noopener",
     secondWindowFeatureString: "noopener=1",
-    shouldReuse: false },
+    shouldHaveOpener: false },
   { testDescription: "noopener=0 means lack of noopener",
     secondWindowFeatureString: "noopener=0",
-    shouldReuse: true },
-  { testDescription: "noopener needs to be present as a token on its own",
+    shouldHaveOpener: true },
+  { testDescription: "noopener separated only by spaces should work",
     secondWindowFeatureString: "make me noopener",
-    shouldReuse: true },
+    shouldHaveOpener: false },
   { testDescription: "Trailing noopener should work",
     secondWindowFeatureString: "abc def,  \n\r noopener",
-    shouldReuse: false },
+    shouldHaveOpener: false },
   { testDescription: "Leading noopener should work",
     secondWindowFeatureString: "noopener \f\t , hey, there",
-    shouldReuse: false },
+    shouldHaveOpener: false },
   { testDescription: "Interior noopener should work",
     secondWindowFeatureString: "and now, noopener   , hey, there",
-    shouldReuse: false },
+    shouldHaveOpener: false },
+  { testDescription: "noreferrer should also suppress opener when reusing existing target",
+    secondWindowFeatureString: "noreferrer",
+    shouldHaveOpener: false },
 ];
 
 /**
@@ -54,7 +57,7 @@ function indexedTests() {
     t.secondWindowFeatureString = test.secondWindowFeatureString;
     t.windowName = "someuniquename" + i;
 
-    if (test.shouldReuse) {
+    if (test.shouldHaveOpener) {
       t.step(function() {
         var windowName = this.windowName;
 
@@ -83,9 +86,9 @@ function indexedTests() {
         channel.onmessage = this.step_func_done(function(e) {
           var data = e.data;
           assert_equals(data.name, windowName, "Should have the right name");
-          assert_equals(data.haveOpener, false, "Should not have opener");
+          assert_equals(data.haveOpener, true, "Should still have opener");
           assert_equals(w1.opener, window);
-          assert_equals(w1.location.href, "about:blank");
+          assert_not_equals(w1.location.href, "about:blank", "Should have navigated");
         });
 
         w1 = window.open("", windowName);

--- a/html/browsers/the-window-object/window-open-noopener.html
+++ b/html/browsers/the-window-object/window-open-noopener.html
@@ -14,28 +14,28 @@
 var testData = [
   { testDescription: "window.open() with 'noopener' should reuse existing target",
     secondWindowFeatureString: "noopener",
-    shouldHaveOpener: false },
+    shouldReturnWindow: false },
   { testDescription: "noopener=1 means the same as noopener",
     secondWindowFeatureString: "noopener=1",
-    shouldHaveOpener: false },
+    shouldReturnWindow: false },
   { testDescription: "noopener=0 means lack of noopener",
     secondWindowFeatureString: "noopener=0",
-    shouldHaveOpener: true },
+    shouldReturnWindow: true },
   { testDescription: "noopener separated only by spaces should work",
     secondWindowFeatureString: "make me noopener",
-    shouldHaveOpener: false },
+    shouldReturnWindow: false },
   { testDescription: "Trailing noopener should work",
     secondWindowFeatureString: "abc def,  \n\r noopener",
-    shouldHaveOpener: false },
+    shouldReturnWindow: false },
   { testDescription: "Leading noopener should work",
     secondWindowFeatureString: "noopener \f\t , hey, there",
-    shouldHaveOpener: false },
+    shouldReturnWindow: false },
   { testDescription: "Interior noopener should work",
     secondWindowFeatureString: "and now, noopener   , hey, there",
-    shouldHaveOpener: false },
+    shouldReturnWindow: false },
   { testDescription: "noreferrer should also suppress opener when reusing existing target",
     secondWindowFeatureString: "noreferrer",
-    shouldHaveOpener: false },
+    shouldReturnWindow: false },
 ];
 
 /**
@@ -57,7 +57,7 @@ function indexedTests() {
     t.secondWindowFeatureString = test.secondWindowFeatureString;
     t.windowName = "someuniquename" + i;
 
-    if (test.shouldHaveOpener) {
+    if (test.shouldReturnWindow) {
       t.step(function() {
         var windowName = this.windowName;
 

--- a/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html
+++ b/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html
@@ -36,7 +36,7 @@ for (var target of ["self", "parent", "top"]) {
 
 /**
  * And now check that a noopener load targeted at something other than one of
- * the three special targets above in fact ignores existing things with the
+ * the three special targets above is still able to reuse existing things with the
  * given name.  We do this in two ways.  First, by opening a window named
  * "ourpopup" and then doing a load via <a rel="noopener" target="ourpopup"> and
  * verifying that the load happens in a window with a null opener, etc, while
@@ -44,17 +44,17 @@ for (var target of ["self", "parent", "top"]) {
  * <a rel="noopener"> at a name that an existing subframe has, and ensuring that
  * this subframe is not navigated.
  */
-var t1 = async_test("Check that targeting of rel=noopener with a given name ignores an existing window with that name");
+var t1 = async_test("Check that targeting of rel=noopener with a given name reuses an existing window with that name");
 var w;
 t1.add_cleanup(function() { w.close(); });
 var channel = new BroadcastChannel("ourpopup");
 channel.onmessage = t1.step_func_done(function(e) {
   var data = e.data;
-  assert_false(data.hasOpener);
+  assert_true(data.hasOpener);
   assert_false(data.hasParent);
   assert_equals(data.name, "ourpopup");
   assert_equals(w.opener, window);
-  assert_equals(w.location.href, "about:blank");
+  assert_not_equals(w.location.href, "about:blank");
 });
 t1.step(function() {
   w = window.open("", "ourpopup");
@@ -62,15 +62,15 @@ t1.step(function() {
   document.querySelectorAll("a")[0].click();
 });
 
-var t2 = async_test("Check that targeting of rel=noopener with a given name ignores an existing subframe with that name");
+var t2 = async_test("Check that targeting of rel=noopener with a given name reuses an existing subframe with that name");
 var channel = new BroadcastChannel("oursubframe");
 channel.onmessage = t2.step_func_done(function(e) {
   var data = e.data;
   assert_false(data.hasOpener);
-  assert_false(data.hasParent);
+  assert_true(data.hasParent);
   assert_equals(data.name, "oursubframe");
-  assert_equals(document.querySelector("iframe").contentWindow.location.href,
-                "about:blank");
+  assert_not_equals(document.querySelector("iframe").contentWindow.location.href,
+                    "about:blank");
 });
 t2.step(function() {
   document.querySelectorAll("a")[1].click();


### PR DESCRIPTION
Per https://github.com/whatwg/html/issues/1826, a few tests are out of date with https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name

html/browsers/the-window-object/window-open-noopener.html?indexed and
html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html
both assert that specifying noopener will prevent reuse of an existing named browser context, but the spec does not include this special case.