### PR TITLE
[html] Add test for history traversal

### DIFF
--- a/html/browsers/browsing-the-web/history-traversal/api-availability.html
+++ b/html/browsers/browsing-the-web/history-traversal/api-availability.html
@@ -11,7 +11,7 @@ var hasNavigated = false;
 var child;
 t.step(function() {
   child = window.open("resources/api-availability-1.html");
-  add_result_callback(function() {
+  t.add_cleanup(function() {
     child.close();
   });
 });

--- a/html/browsers/browsing-the-web/history-traversal/api-availability.html
+++ b/html/browsers/browsing-the-web/history-traversal/api-availability.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>API availability following history traversal</title>
+<meta charset=utf-8>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<p>Test requires popup blocker disabled</p>
+<div id=log></div>
+<script>
+var t = async_test();
+var hasNavigated = false;
+var child;
+t.step(function() {
+  child = window.open("resources/api-availability-1.html");
+  add_result_callback(function() {
+    child.close();
+  });
+});
+navigate = t.step_func(function() {
+  hasNavigated = true;
+  child.location = child.location.href.replace("api-availability-1.html", "api-availability-2.html");
+});
+</script>

--- a/html/browsers/browsing-the-web/history-traversal/resources/api-availability-1.html
+++ b/html/browsers/browsing-the-web/history-traversal/resources/api-availability-1.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>API availability following history traversal - 1</title>
+<script>
+var controller = opener || parent;
+var t = controller.t;
+var assert_not_equals = controller.assert_not_equals;
+
+t.step(function() {
+  // If this document is discarded as a result of navigation, then this script
+  // will be executed a second time. The semantics this test intends to verify
+  // cannot be observed under these conditions, the discarding is not itself a
+  // violation. Silently pass the test in that case.
+  if (controller.hasNavigated) {
+    t.done();
+    return;
+  }
+
+  t.step_timeout(function() {
+    assert_not_equals(navigator, null);
+    t.done();
+  }, 1000);
+
+  controller.navigate();
+});
+</script>

--- a/html/browsers/browsing-the-web/history-traversal/resources/api-availability-1.html
+++ b/html/browsers/browsing-the-web/history-traversal/resources/api-availability-1.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>API availability following history traversal - 1</title>
 <script>
-var controller = opener || parent;
+var controller = opener;
 var t = controller.t;
 var assert_not_equals = controller.assert_not_equals;
 
@@ -16,7 +16,7 @@ t.step(function() {
   }
 
   t.step_timeout(function() {
-    assert_not_equals(navigator, null);
+    assert_not_equals(window.navigator, null);
     t.done();
   }, 1000);
 

--- a/html/browsers/browsing-the-web/history-traversal/resources/api-availability-1.html
+++ b/html/browsers/browsing-the-web/history-traversal/resources/api-availability-1.html
@@ -16,7 +16,13 @@ t.step(function() {
   }
 
   t.step_timeout(function() {
-    assert_not_equals(window.navigator, null);
+    assert_not_equals(window.history, null, 'history');
+    assert_not_equals(window.localStorage, null, 'localStorage');
+    assert_not_equals(window.location, null, 'location');
+    assert_not_equals(window.navigator, null, 'navigator');
+    assert_not_equals(window.opener, null, 'opener');
+    assert_not_equals(window.sessionStorage, null, 'sessionStorage');
+
     t.done();
   }, 1000);
 

--- a/html/browsers/browsing-the-web/history-traversal/resources/api-availability-2.html
+++ b/html/browsers/browsing-the-web/history-traversal/resources/api-availability-2.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>API availability following history traversal - 2</title>
+<body onload="history.back()"></body>


### PR DESCRIPTION
This test fails in Safari 12. I discovered the behavior while reviewing [`websockets/unload-a-document/002.html`](https://github.com/web-platform-tests/wpt/blob/a81e0ccf8fce2f5765cb2ca548cd095969909915/websockets/unload-a-document/002.html), where it intermittently triggers a harness error.

I've reviewed the specification, and I haven't found any text that would explain this. I also can't find any existing tests for this. With all of that said, I'm not well-versed in this area, so I could use a hand verifying if this test is valid. Any suggestions for improvements are very welcome.