### PR TITLE
Add submissions/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ scratch
 /css/dist_last
 /css/tools/cache
 /webaudio/idl/*
+
+# w3c-test.org PR-branch mirroring
+submissions/

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -64,6 +64,9 @@ TRAILING WHITESPACE, INDENT TABS, CR AT EOL: *.sxg
 
 TRAILING WHITESPACE: xhr/resources/headers-some-are-empty.asis
 
+## .gitignore
+W3C-TEST.ORG: .gitignore
+
 ## Documentation ##
 
 W3C-TEST.ORG: README.md


### PR DESCRIPTION
https://w3c-test.org/submissions/ is served from a subdirectory of the wpt clone on the w3c-test.org and at any given time that subdirectory holds about 25GB+ of clones of wpt PR branches.

Without this change, the manifest generator apparently now tries to walk all 25GB+ of test files in the clones in that submissions/ directory.