### PR TITLE
service workers: Simplified tests with async/await - Part 3

### DIFF
--- a/service-workers/service-worker/activation.https.html
+++ b/service-workers/service-worker/activation.https.html
@@ -10,154 +10,97 @@
 // waiting worker. The active worker controls |iframe| and has an inflight
 // message event that can be finished by calling
 // |registration.active.postMessage('go')|.
-function setup_activation_test(t, scope, worker_url) {
-  var registration;
-  var iframe;
-  return navigator.serviceWorker.getRegistration(scope)
-    .then(r => {
-        if (r)
-          return r.unregister();
-      })
-    .then(() => {
-        // Create an in-scope iframe. Do this prior to registration to avoid
-        // racing between an update triggered by navigation and the update()
-        // call below.
-        return with_iframe(scope);
-      })
-    .then(f => {
-        iframe = f;
-        // Create an active worker.
-        return navigator.serviceWorker.register(worker_url, { scope: scope });
-      })
-    .then(r => {
-        registration = r;
-        add_result_callback(() => registration.unregister());
-        return wait_for_state(t, r.installing, 'activated');
-      })
-    .then(() => {
-        // Check that the frame was claimed.
-        assert_not_equals(
-            iframe.contentWindow.navigator.serviceWorker.controller, null);
-        // Create an in-flight request.
-        registration.active.postMessage('wait');
-        // Now there is both a controllee and an in-flight request.
-        // Initiate an update.
-        return registration.update();
-      })
-    .then(() => {
-        // Wait for a waiting worker.
-        return wait_for_state(t, registration.installing, 'installed');
-      })
-    .then(() => {
-        return wait_for_activation_on_dummy_scope(t, self);
-      })
-    .then(() => {
-        assert_not_equals(registration.waiting, null);
-        assert_not_equals(registration.active, null);
-        return Promise.resolve({registration: registration, iframe: iframe});
-      });
+async function setup_activation_test(t, scope, worker_url) {
+  let registration = await navigator.serviceWorker.getRegistration(scope);
+  const iframe = await with_iframe(scope);
+  registration = await navigator.serviceWorker.register(worker_url, {
+    scope: scope
+  });
+  t.add_cleanup(async () => {
+    if (iframe) iframe.remove();
+    if (registration) await registration.unregister();
+  });
+
+  await wait_for_state(t, registration.installing, 'activated');
+  // Check that the frame was claimed.
+  assert_not_equals(
+    iframe.contentWindow.navigator.serviceWorker.controller, null);
+  // Create an in-flight request.
+  registration.active.postMessage('wait');
+  // Now there is both a controllee and an in-flight request.
+  // Initiate an update.
+  await registration.update();
+  // Wait for a waiting worker.
+  await wait_for_state(t, registration.installing, 'installed');
+  await wait_for_activation_on_dummy_scope(t, self);
+  assert_not_equals(registration.waiting, null);
+  assert_not_equals(registration.active, null);
+  return Promise.resolve({registration: registration, iframe: iframe});
 }
-promise_test(t => {
-    var scope = 'resources/no-controllee';
-    var worker_url = 'resources/mint-new-worker.py';
-    var registration;
-    var iframe;
-    var new_worker;
-    return setup_activation_test(t, scope, worker_url)
-      .then(result => {
-          registration = result.registration;
-          iframe = result.iframe;
-          // Finish the in-flight request.
-          registration.active.postMessage('go');
-          return wait_for_activation_on_dummy_scope(t, self);
-        })
-      .then(() => {
-          // The new worker is still waiting. Remove the frame and it should
-          // activate.
-          new_worker = registration.waiting;
-          assert_equals(new_worker.state, 'installed');
-          var reached_active = wait_for_state(t, new_worker, 'activating');
-          iframe.remove();
-          return reached_active;
-        })
-      .then(() => {
-          assert_equals(new_worker, registration.active);
-        });
-  }, 'loss of controllees triggers activation');
-promise_test(t => {
-    var scope = 'resources/no-request';
-    var worker_url = 'resources/mint-new-worker.py';
-    var registration;
-    var iframe;
-    var new_worker;
-    return setup_activation_test(t, scope, worker_url)
-      .then(result => {
-          registration = result.registration;
-          iframe = result.iframe;
-          // Remove the iframe.
-          iframe.remove();
-          return new Promise(resolve => setTimeout(resolve, 0));
-        })
-      .then(() => {
-          // Finish the request.
-          new_worker = registration.waiting;
-          var reached_active = wait_for_state(t, new_worker, 'activating');
-          registration.active.postMessage('go');
-          return reached_active;
-        })
-      .then(() => {
-          assert_equals(registration.active, new_worker);
-        });
-  }, 'finishing a request triggers activation');
-promise_test(t => {
-    var scope = 'resources/skip-waiting';
-    var worker_url = 'resources/mint-new-worker.py?skip-waiting';
-    var registration;
-    var new_worker;
-    return setup_activation_test(t, scope, worker_url)
-      .then(result => {
-          registration = result.registration;
-          // Finish the request. The iframe does not need to be removed because
-          // skipWaiting() was called.
-          new_worker = registration.waiting;
-          var reached_active = wait_for_state(t, new_worker, 'activating');
-          registration.active.postMessage('go');
-          return reached_active;
-        })
-      .then(() => {
-          assert_equals(registration.active, new_worker);
-        });
-  }, 'skipWaiting bypasses no controllee requirement');
+promise_test(async t => {
+  const SCOPE = 'resources/no-controllee';
+  const WORKER_URL = 'resources/mint-new-worker.py';
+  const result = await setup_activation_test(t, SCOPE, WORKER_URL);
+  const registration = result.registration;
+  const iframe = result.iframe;
+  // Finish the in-flight request.
+  registration.active.postMessage('go');
+  await wait_for_activation_on_dummy_scope(t, self);
+  // The new worker is still waiting. Remove the frame and it should activate.
+  const new_worker = registration.waiting;
+  iframe.remove();
+  assert_equals(new_worker.state, 'installed');
+  await wait_for_state(t, new_worker, 'activating');
+  assert_equals(new_worker, registration.active);
+}, 'loss of controllees triggers activation');
+
+promise_test(async t => {
+  const SCOPE = 'resources/no-request';
+  const WORKER_URL = 'resources/mint-new-worker.py';
+  const result = await setup_activation_test(t, SCOPE, WORKER_URL);
+  const registration = result.registration;
+  const iframe = result.iframe;
+  // Remove the iframe.
+  iframe.remove();
+  await new Promise(resolve => setTimeout(resolve, 0));
+  const new_worker = registration.waiting;
+  registration.active.postMessage('go');
+  await wait_for_state(t, new_worker, 'activating');
+  assert_equals(registration.active, new_worker);
+}, 'finishing a request triggers activation');
+
+promise_test(async t => {
+  const SCOPE = 'resources/skip-waiting';
+  const WORKER_URL = 'resources/mint-new-worker.py?skip-waiting';
+  const result = await setup_activation_test(t, SCOPE, WORKER_URL);
+  const registration = result.registration;
+  // Finish the request. The iframe does not need to be removed because
+  // skipWaiting() was called.
+  const new_worker = registration.waiting;
+  registration.active.postMessage('go');
+  await wait_for_state(t, new_worker, 'activating');
+  assert_equals(registration.active, new_worker);
+}, 'skipWaiting bypasses no controllee requirement');
 
 // This test is not really about activation, but otherwise is very
 // similar to the other tests here.
-promise_test(t => {
-    var scope = 'resources/unregister';
-    var worker_url = 'resources/mint-new-worker.py';
-    var registration;
-    var iframe;
-    var new_worker;
-    return setup_activation_test(t, scope, worker_url)
-      .then(result => {
-          registration = result.registration;
-          iframe = result.iframe;
-          // Remove the iframe.
-          iframe.remove();
-          return registration.unregister();
-        })
-      .then(() => {
-          // The unregister operation should wait for the active worker to
-          // finish processing its events before clearing the registration.
-          new_worker = registration.waiting;
-          var reached_redundant = wait_for_state(t, new_worker, 'redundant');
-          registration.active.postMessage('go');
-          return reached_redundant;
-        })
-      .then(() => {
-          assert_equals(registration.installing, null);
-          assert_equals(registration.waiting, null);
-          assert_equals(registration.active, null);
-        });
-  }, 'finishing a request triggers unregister');
+promise_test(async t => {
+  const SCOPE = 'resources/unregister';
+  const WORKER_URL = 'resources/mint-new-worker.py';
+  const result = await setup_activation_test(t, SCOPE, WORKER_URL);
+  const registration = result.registration;
+  const iframe = result.iframe;
+  // Remove the iframe.
+  iframe.remove();
+  await registration.unregister();
+  // The unregister operation should wait for the active worker to
+  // finish processing its events before clearing the registration.
+  const new_worker = registration.waiting;
+  registration.active.postMessage('go');
+  await wait_for_state(t, new_worker, 'redundant');
+  assert_equals(registration.installing, null);
+  assert_equals(registration.waiting, null);
+  assert_equals(registration.active, null);
+}, 'finishing a request triggers unregister');
 </script>
 </body>

--- a/service-workers/service-worker/dedicated-worker-service-worker-interception.https.html
+++ b/service-workers/service-worker/dedicated-worker-service-worker-interception.https.html
@@ -4,37 +4,47 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-
 // Note that Chrome cannot pass these tests because of https://crbug.com/731599.
 
 function service_worker_interception_test(url, description) {
   promise_test(async t => {
     // Register a service worker whose scope includes |url|.
     const kServiceWorkerScriptURL =
-        'resources/service-worker-interception-service-worker.js';
+      'resources/service-worker-interception-service-worker.js';
     const registration = await service_worker_unregister_and_register(
-        t, kServiceWorkerScriptURL, url);
-    add_result_callback(() => registration.unregister());
+      t,
+      kServiceWorkerScriptURL,
+      url
+    );
+
+    t.add_cleanup(async () => {
+      if (registration) await registration.unregister();
+    });
+
     await wait_for_state(t, registration.installing, 'activated');
 
     // Start a dedicated worker for |url|. The top-level script request and any
     // module imports should be intercepted by the service worker.
     const worker = new Worker(url, { type: 'module' });
-    const msg_event = await new Promise(resolve => worker.onmessage = resolve);
+    const msg_event = await new Promise(
+      resolve => (worker.onmessage = resolve)
+    );
     assert_equals(msg_event.data, 'LOADED_FROM_SERVICE_WORKER');
   }, description);
 }
 
 service_worker_interception_test(
-    'resources/service-worker-interception-network-worker.js',
-    'Top-level module loading should be intercepted by a service worker.');
+  'resources/service-worker-interception-network-worker.js',
+  'Top-level module loading should be intercepted by a service worker.'
+);
 
 service_worker_interception_test(
-    'resources/service-worker-interception-static-import-worker.js',
-    'Static import should be intercepted by a service worker.');
+  'resources/service-worker-interception-static-import-worker.js',
+  'Static import should be intercepted by a service worker.'
+);
 
 service_worker_interception_test(
-    'resources/service-worker-interception-dynamic-import-worker.js',
-    'Dynamic import should be intercepted by a service worker.');
-
+  'resources/service-worker-interception-dynamic-import-worker.js',
+  'Dynamic import should be intercepted by a service worker.'
+);
 </script>

--- a/service-workers/service-worker/detached-context.https.html
+++ b/service-workers/service-worker/detached-context.https.html
@@ -10,128 +10,129 @@
 // NOTE: This file tests corner case behavior that might not be defined in the
 // spec. See https://github.com/w3c/ServiceWorker/issues/1221
 
+promise_test(async t => {
+  const url = 'resources/blank.html';
+  const scope_for_iframe = 'removed-registration'
+  const scope_for_main = 'resources/' + scope_for_iframe;
+  const script = 'resources/empty-worker.js';
+  let resolvedCount = 0;
+
+  await service_worker_unregister(t, scope_for_main)
+  const frame = await with_iframe(url);
+  let registration = await navigator.serviceWorker.register(
+    script,
+    {scope: scope_for_main}
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  registration = await frame.contentWindow.navigator.serviceWorker.getRegistration(
+    scope_for_iframe
+  );
+  frame.remove();
+
+  //add_completion_callback(async() => {
+  add_completion_callback(async() => {
+    if (registration) await registration.unregister();
+    if (frame) frame.remove();
+  })
+
+  assert_equals(registration.installing, null);
+  assert_equals(registration.waiting, null);
+  assert_equals(registration.active.state, 'activated');
+  assert_equals(registration.scope, normalizeURL(scope_for_main));
+  registration.onupdatefound = () => { /* empty */ };
+
+  // We want to verify that unregister() and update() do not
+  // resolve on a detached registration.  We can't check for
+  // an explicit rejection, though, because not all browsers
+  // fire rejection callbacks on detached promises.  Instead
+  // we wait for a dummy scope to install, activate, and
+  // unregister before declaring that the promises did not
+  // resolve.
+  registration.unregister().then(() => resolvedCount += 1,
+                      () => {});
+  registration.update().then(() => resolvedCount += 1,
+                  () => {});
+  await wait_for_activation_on_dummy_scope(t, window);
+  assert_equals(resolvedCount, 0,
+                'methods called on a detached registration should not ' +
+                'resolve');
+}, 'accessing a ServiceWorkerRegistration from a removed iframe');
+
+promise_test(async t => {
+  const script = 'resources/empty-worker.js';
+  const scope = 'resources/scope/serviceworker-from-detached';
+
+  const registration = await service_worker_unregister_and_register(
+    t,
+    script,
+    scope
+  );
+
+  //add_completion_callback(async() => {
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+  });
+
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(scope);
+  const worker = frame.contentWindow.navigator.serviceWorker.controller;
+  frame.remove();
+  assert_equals(worker.scriptURL, normalizeURL(script));
+  assert_equals(worker.state, 'activated');
+  worker.onstatechange = () => { /* empty */ };
+  assert_throws({ name: 'InvalidStateError' },
+                () => { worker.postMessage(''); },
+                'postMessage on a detached client should throw an ' +
+                'exception.');
+}, 'accessing a ServiceWorker object from a removed iframe');
+
 promise_test(t => {
-    const url = 'resources/blank.html';
-    const scope_for_iframe = 'removed-registration'
-    const scope_for_main = 'resources/' + scope_for_iframe;
-    const script = 'resources/empty-worker.js';
-    let frame;
-    let resolvedCount = 0;
-
-    return service_worker_unregister(t, scope_for_main)
-      .then(() => {
-          return with_iframe(url);
-        })
-      .then(f => {
-          frame = f;
-          return navigator.serviceWorker.register(script,
-                                                  {scope: scope_for_main});
-        })
-      .then(r => {
-          add_completion_callback(() => { r.unregister(); });
-          return wait_for_state(t, r.installing, 'activated');
-        })
-      .then(() => {
-          return frame.contentWindow.navigator.serviceWorker.getRegistration(
-            scope_for_iframe);
-        })
-      .then(r => {
-          frame.remove();
-          assert_equals(r.installing, null);
-          assert_equals(r.waiting, null);
-          assert_equals(r.active.state, 'activated');
-          assert_equals(r.scope, normalizeURL(scope_for_main));
-          r.onupdatefound = () => { /* empty */ };
-
-          // We want to verify that unregister() and update() do not
-          // resolve on a detached registration.  We can't check for
-          // an explicit rejection, though, because not all browsers
-          // fire rejection callbacks on detached promises.  Instead
-          // we wait for a dummy scope to install, activate, and
-          // unregister before declaring that the promises did not
-          // resolve.
-          r.unregister().then(() => resolvedCount += 1,
-                              () => {});
-          r.update().then(() => resolvedCount += 1,
-                          () => {});
-          return wait_for_activation_on_dummy_scope(t, window);
-        })
-      .then(() => {
-          assert_equals(resolvedCount, 0,
-                        'methods called on a detached registration should not resolve');
-        })
-  }, 'accessing a ServiceWorkerRegistration from a removed iframe');
-
-promise_test(t => {
-    const script = 'resources/empty-worker.js';
-    const scope = 'resources/scope/serviceworker-from-detached';
-
-    return service_worker_unregister_and_register(t, script, scope)
-      .then(registration => {
-          add_completion_callback(() => { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(() => { return with_iframe(scope); })
-      .then(frame => {
-          const worker = frame.contentWindow.navigator.serviceWorker.controller;
-          frame.remove();
-          assert_equals(worker.scriptURL, normalizeURL(script));
-          assert_equals(worker.state, 'activated');
-          worker.onstatechange = () => { /* empty */ };
-          assert_throws(
-              { name: 'InvalidStateError' },
-              () => { worker.postMessage(''); },
-              'postMessage on a detached client should throw an exception.');
-        });
-  }, 'accessing a ServiceWorker object from a removed iframe');
-
-promise_test(t => {
-    const iframe = document.createElement('iframe');
-    iframe.src = 'resources/blank.html';
-    document.body.appendChild(iframe);
-    const f = iframe.contentWindow.Function;
-    function get_navigator() {
-      return f('return navigator')();
-    }
-    return new Promise(resolve => {
-        assert_equals(iframe.contentWindow.navigator, get_navigator());
-        iframe.src = 'resources/blank.html?navigate-to-new-url';
-        iframe.onload = resolve;
-      }).then(function() {
-        assert_not_equals(get_navigator().serviceWorker, null);
-        assert_equals(
-            get_navigator().serviceWorker,
-            iframe.contentWindow.navigator.serviceWorker);
-      });
-  }, 'accessing navigator.serviceWorker on a detached iframe');
+  const iframe = document.createElement('iframe');
+  iframe.src = 'resources/blank.html';
+  document.body.appendChild(iframe);
+  const f = iframe.contentWindow.Function;
+  function get_navigator() {
+    return f('return navigator')();
+  }
+  return new Promise(resolve => {
+    assert_equals(iframe.contentWindow.navigator, get_navigator());
+    iframe.src = 'resources/blank.html?navigate-to-new-url';
+    iframe.onload = resolve;
+  }).then(function() {
+    assert_not_equals(get_navigator().serviceWorker, null);
+    assert_equals(
+      get_navigator().serviceWorker,
+      iframe.contentWindow.navigator.serviceWorker);
+  });
+}, 'accessing navigator.serviceWorker on a detached iframe');
 
 test(t => {
-    const iframe = document.createElement('iframe');
-    iframe.src = 'resources/blank.html';
-    document.body.appendChild(iframe);
-    const f = iframe.contentWindow.Function;
-    function get_navigator() {
-      return f('return navigator')();
-    }
-    assert_not_equals(get_navigator().serviceWorker, null);
-    iframe.remove();
-    assert_throws({name: 'TypeError'}, () => get_navigator());
-  }, 'accessing navigator on a removed frame');
+  const iframe = document.createElement('iframe');
+  iframe.src = 'resources/blank.html';
+  document.body.appendChild(iframe);
+  const f = iframe.contentWindow.Function;
+  function get_navigator() {
+    return f('return navigator')();
+  }
+  assert_not_equals(get_navigator().serviceWorker, null);
+  iframe.remove();
+  assert_throws({name: 'TypeError'}, () => get_navigator());
+}, 'accessing navigator on a removed frame');
 
 // It seems weird that about:blank and blank.html (the test above) have
 // different behavior. These expectations are based on Chromium behavior, which
 // might not be right.
 test(t => {
-    const iframe = document.createElement('iframe');
-    iframe.src = 'about:blank';
-    document.body.appendChild(iframe);
-    const f = iframe.contentWindow.Function;
-    function get_navigator() {
-      return f('return navigator')();
-    }
-    assert_not_equals(get_navigator().serviceWorker, null);
-    iframe.remove();
-    assert_equals(get_navigator().serviceWorker, null);
-  }, 'accessing navigator.serviceWorker on a removed about:blank frame');
+  const iframe = document.createElement('iframe');
+  iframe.src = 'about:blank';
+  document.body.appendChild(iframe);
+  const f = iframe.contentWindow.Function;
+  function get_navigator() {
+    return f('return navigator')();
+  }
+  assert_not_equals(get_navigator().serviceWorker, null);
+  iframe.remove();
+  assert_equals(get_navigator().serviceWorker, null);
+}, 'accessing navigator.serviceWorker on a removed about:blank frame');
 
 </script>

--- a/service-workers/service-worker/import-scripts-updated-flag.https.html
+++ b/service-workers/service-worker/import-scripts-updated-flag.https.html
@@ -10,74 +10,65 @@
 // service worker lifetime. The sub-tests trigger subsequent `importScript`
 // invocations via the `message` event.
 
-var register;
+let register;
 
 function post_and_wait_for_reply(worker, message) {
   return new Promise(resolve => {
-      navigator.serviceWorker.onmessage = e => { resolve(e.data); };
-      worker.postMessage(message);
-    });
+    navigator.serviceWorker.onmessage = e => {
+      resolve(e.data);
+    };
+    worker.postMessage(message);
+  });
 }
 
-promise_test(function(t) {
-    const scope = 'resources/import-scripts-updated-flag';
-    let registration;
+promise_test(async t => {
+  const SCOPE = 'resources/import-scripts-updated-flag';
+  const SCRIPT = 'resources/import-scripts-updated-flag-worker.js';
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
 
-    register = service_worker_unregister_and_register(
-        t, 'resources/import-scripts-updated-flag-worker.js', scope)
-      .then(r => {
-          registration = r;
-          add_completion_callback(() => { registration.unregister(); });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(() => {
-          // This test should not be considered complete until after the
-          // service worker has been unregistered. Currently, `testharness.js`
-          // does not support asynchronous global "tear down" logic, so this
-          // must be expressed using a dedicated `promise_test`. Because the
-          // other sub-tests in this file are declared synchronously, this test
-          // will be the final test executed.
-          promise_test(function(t) {
-              return registration.unregister();
-            });
+  add_completion_callback(async () => {
+    if (registration) await registration.unregister();
+  });
 
-          return registration.active;
-        });
+  await wait_for_state(t, registration.installing, 'activated');
+  // This test should not be considered complete until after the
+  // service worker has been unregistered. Currently, `testharness.js`
+  // does not support asynchronous global "tear down" logic, so this
+  // must be expressed using a dedicated `promise_test`. Because the
+  // other sub-tests in this file are declared synchronously, this test
+  // will be the final test executed.
+  promise_test(async () => {
+    await registration.unregister();
+  });
+  register = registration.active;
+}, 'initialize global state');
 
-    return register;
-  }, 'initialize global state');
+promise_test(async t => {
+  const result = await post_and_wait_for_reply(
+    register,
+    'root-and-message'
+  );
+  assert_equals(result.error, null);
+  assert_equals(result.value, 'root-and-message');
+}, 'import script previously imported at worker evaluation time');
 
-promise_test(t => {
-    return register
-      .then(function(worker) {
-          return post_and_wait_for_reply(worker, 'root-and-message');
-        })
-      .then(result => {
-          assert_equals(result.error, null);
-          assert_equals(result.value, 'root-and-message');
-        });
-  }, 'import script previously imported at worker evaluation time');
+promise_test(async t => {
+  const result = await post_and_wait_for_reply(
+    register,
+    'install-and-message'
+  );
+  assert_equals(result.error, null);
+  assert_equals(result.value, 'install-and-message');
+}, 'import script previously imported at worker install time');
 
-promise_test(t => {
-    return register
-      .then(function(worker) {
-          return post_and_wait_for_reply(worker, 'install-and-message');
-        })
-      .then(result => {
-          assert_equals(result.error, null);
-          assert_equals(result.value, 'install-and-message');
-        });
-  }, 'import script previously imported at worker install time');
-
-promise_test(t => {
-    return register
-      .then(function(worker) {
-          return post_and_wait_for_reply(worker, 'message');
-        })
-      .then(result => {
-          assert_equals(result.error, 'NetworkError');
-          assert_equals(result.value, null);
-        });
-  }, 'import script not previously imported');
+promise_test(async t => {
+  const result = await post_and_wait_for_reply(register, 'message');
+  assert_equals(result.error, 'NetworkError');
+  assert_equals(result.value, null);
+}, 'import script not previously imported');
 </script>
 </body>

--- a/service-workers/service-worker/local-url-inherit-controller.https.html
+++ b/service-workers/service-worker/local-url-inherit-controller.https.html
@@ -14,13 +14,17 @@ const SCOPE = 'resources/local-url-inherit-controller-frame.html';
 async function doAsyncTest(t, opts) {
   let name = `${opts.scheme}-${opts.child}-${opts.check}`;
   let scope = SCOPE + '?name=' + name;
-  let reg = await service_worker_unregister_and_register(t, SCRIPT, scope);
-  add_completion_callback(_ => reg.unregister());
-  await wait_for_state(t, reg.installing, 'activated');
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, scope);
+  await wait_for_state(t, registration.installing, 'activated');
 
-  let frame = await with_iframe(scope);
-  add_completion_callback(_ => frame.remove());
-  assert_not_equals(frame.contentWindow.navigator.serviceWorker.controller, null,
+  const frame = await with_iframe(scope);
+  add_completion_callback(async() => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+  assert_not_equals(frame.contentWindow.navigator.serviceWorker.controller,
+                    null,
                     'frame should be controlled');
 
   let result = await frame.contentWindow.checkChildController(opts);

--- a/service-workers/service-worker/mime-sniffing.https.html
+++ b/service-workers/service-worker/mime-sniffing.https.html
@@ -5,20 +5,23 @@
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    const SCOPE = 'resources/blank.html?mime-sniffing';
-    const SCRIPT = 'resources/mime-sniffing-worker.js';
-    return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
-      .then(registration => {
-          add_completion_callback(() => registration.unregister());
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(_ => with_iframe(SCOPE))
-      .then(frame => {
-          add_completion_callback(() => frame.remove());
-          assert_equals(frame.contentWindow.document.body.innerText, 'test');
-          const h1 = frame.contentWindow.document.getElementById('testid');
-          assert_equals(h1.innerText,'test');
-        });
-  }, 'The response from service worker should be correctly MIME siniffed.');
+promise_test(async t => {
+  const SCOPE = 'resources/blank.html?mime-sniffing';
+  const SCRIPT = 'resources/mime-sniffing-worker.js';
+  const registration =
+      await service_worker_unregister_and_register(t, SCRIPT, SCOPE);
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE);
+
+  t.add_cleanup(async() => {
+    if (registration)
+      await registration.unregister();
+    if (frame)
+      frame.remove();
+  });
+
+  assert_equals(frame.contentWindow.document.body.innerText, 'test');
+  const h1 = frame.contentWindow.document.getElementById('testid');
+  assert_equals(h1.innerText,'test');
+}, 'The response from service worker should be correctly MIME siniffed.');
 </script>

--- a/service-workers/service-worker/opaque-response-preloaded.https.html
+++ b/service-workers/service-worker/opaque-response-preloaded.https.html
@@ -5,8 +5,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-const WORKER =
-  'resources/opaque-response-preloaded-worker.js';
+const WORKER = 'resources/opaque-response-preloaded-worker.js';
 
 var done;
 
@@ -15,36 +14,40 @@ var done;
 // iframe that uses link rel=preload to issue a same-origin no-cors request.
 // The service worker responds to the request with an opaque response. Then the
 // iframe does an XHR (not no-cors) to that URL again. The request should fail.
-promise_test(t => {
-    const SCOPE =
-      'resources/opaque-response-being-preloaded-xhr.html';
-    const promise = new Promise(resolve => done = resolve);
+promise_test(async t => {
+  const SCOPE = 'resources/opaque-response-being-preloaded-xhr.html';
+  const promise = new Promise(resolve => done = resolve);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    WORKER,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE);
+  const result = await promise;
+  t.add_cleanup(async() => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+  assert_equals(result, 'PASS');
+}, 'Opaque responses should not be reused for XHRs, loading case');
 
-    return service_worker_unregister_and_register(t, WORKER, SCOPE)
-      .then(reg => {
-           add_completion_callback(() => reg.unregister());
-           return wait_for_state(t, reg.installing, 'activated');
-         })
-      .then(() => with_iframe(SCOPE))
-      .then(frame => t.add_cleanup(() => frame.remove() ))
-      .then(() => promise)
-      .then(result => assert_equals(result, 'PASS'));
-  }, 'Opaque responses should not be reused for XHRs, loading case');
-
-promise_test(t => {
-    const SCOPE =
-      'resources/opaque-response-preloaded-xhr.html';
-    const promise = new Promise(resolve => done = resolve);
-
-    return service_worker_unregister_and_register(t, WORKER, SCOPE)
-      .then(reg => {
-           add_completion_callback(() => reg.unregister());
-           return wait_for_state(t, reg.installing, 'activated');
-         })
-      .then(() => with_iframe(SCOPE))
-      .then(frame => t.add_cleanup(() => frame.remove() ))
-      .then(() => promise)
-      .then(result => assert_equals(result, 'PASS'));
-  }, 'Opaque responses should not be reused for XHRs, done case');
+promise_test(async t => {
+  const SCOPE = 'resources/opaque-response-preloaded-xhr.html';
+  const promise = new Promise(resolve => done = resolve);
+  const registration = await service_worker_unregister_and_register(
+    t,
+    WORKER,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE);
+  const result = await promise;
+  t.add_cleanup(async() => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
+  assert_equals(result, 'PASS');
+}, 'Opaque responses should not be reused for XHRs, done case');
 
 </script>

--- a/service-workers/service-worker/ready.https.html
+++ b/service-workers/service-worker/ready.https.html
@@ -3,298 +3,256 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
-<body>
 <script>
 test(function() {
-    var promise = navigator.serviceWorker.ready;
-    assert_equals(promise, navigator.serviceWorker.ready,
-                  'repeated access to ready without intervening ' +
-                  'registrations should return the same Promise object');
+  const promise = navigator.serviceWorker.ready;
+  assert_equals(promise, navigator.serviceWorker.ready,
+                'repeated access to ready without intervening ' +
+                'registrations should return the same Promise object');
   }, 'ready returns the same Promise object');
 
-promise_test(function(t) {
-    return with_iframe('resources/blank.html?uncontrolled')
-      .then(t.step_func(function(frame) {
-          var promise = frame.contentWindow.navigator.serviceWorker.ready;
-          t.add_cleanup(function() {
-              frame.remove();
-            });
+promise_test(async t => {
+  const SCRIPT = 'resources/empty-worker.js';
+  const SCOPE = 'resources/blank.html?ready-installing';
+  await service_worker_unregister(t, SCOPE);
+  const frame = await with_iframe(SCOPE);
 
-          assert_equals(Object.getPrototypeOf(promise),
-                        frame.contentWindow.Promise.prototype,
-                        'the Promise should be in the context of the ' +
-                        'related document');
-        }));
-  }, 'ready returns a Promise object in the context of the related document');
+  let registration = await navigator.serviceWorker.register(
+    SCRIPT,
+    {scope: SCOPE}
+  );
+  await frame.contentWindow.navigator.serviceWorker.ready;
 
-promise_test(function(t) {
-    var url = 'resources/empty-worker.js';
-    var scope = 'resources/blank.html?ready-controlled';
-    var expected_url = normalizeURL(url);
-    var frame;
+  t.add_cleanup(async() => {
+    if (frame) frame.remove();
+    if (registration) await registration.unregister();
+  });
 
-    return service_worker_unregister_and_register(t, url, scope)
-      .then(function(registration) {
-          add_completion_callback(function() {
-              registration.unregister();
-            });
-          return wait_for_state(t, registration.installing, 'activated');
-        })
-      .then(function() { return with_iframe(scope); })
-      .then(function(f) {
-          t.add_cleanup(function() {
-              f.remove();
-            });
-          frame = f;
-          return frame.contentWindow.navigator.serviceWorker.ready;
-        })
-      .then(function(registration) {
-          assert_equals(registration.installing, null,
-                        'installing should be null');
-          assert_equals(registration.waiting, null,
-                        'waiting should be null');
-          assert_equals(registration.active.scriptURL, expected_url,
-                        'active after ready should not be null');
-          assert_equals(frame.contentWindow.navigator.serviceWorker.controller,
-                        registration.active,
-                        'the controller should be the active worker');
-          assert_in_array(registration.active.state,
-                          ['activating', 'activated'],
-                          '.ready should be resolved when the registration ' +
-                          'has an active worker');
-        });
-  }, 'ready on a controlled document');
+  assert_equals(registration.installing, null, 'installing should be null');
+  assert_equals(registration.waiting, null, 'waiting should be null');
+  assert_not_equals(registration.active, null,
+                    'active after ready should not be null');
+  assert_in_array(registration.active.state, ['activating', 'activated'],
+                  '.ready should be resolved when the registration ' +
+                  'has an active worker');
 
-promise_test(function(t) {
-    var url = 'resources/empty-worker.js';
-    var scope = 'resources/blank.html?ready-potential-controlled';
-    var expected_url = normalizeURL(url);
-    var frame;
-
-    return with_iframe(scope)
-      .then(function(f) {
-          t.add_cleanup(function() {
-              f.remove();
-            });
-          frame = f;
-          return navigator.serviceWorker.register(url, {scope:scope});
-        })
-      .then(function(r) {
-          add_completion_callback(function() {
-              r.unregister();
-            });
-          return frame.contentWindow.navigator.serviceWorker.ready;
-        })
-      .then(function(registration) {
-          assert_equals(registration.installing, null,
-                        'installing should be null');
-          assert_equals(registration.waiting, null,
-                        'waiting should be null.')
-          assert_equals(registration.active.scriptURL, expected_url,
-                        'active after ready should not be null');
-          assert_in_array(registration.active.state,
-                          ['activating', 'activated'],
-                          '.ready should be resolved when the registration ' +
-                          'has an active worker');
-          assert_equals(frame.contentWindow.navigator.serviceWorker.controller,
-                        null,
-                        'uncontrolled document should not have a controller');
-        });
-  }, 'ready on a potential controlled document');
-
-promise_test(function(t) {
-    var url = 'resources/empty-worker.js';
-    var scope = 'resources/blank.html?ready-installing';
-
-    return service_worker_unregister(t, scope)
-      .then(function() {
-          return with_iframe(scope);
-        })
-      .then(function(f) {
-          var promise = f.contentWindow.navigator.serviceWorker.ready;
-          t.add_cleanup(function() {
-              f.remove();
-            });
-          navigator.serviceWorker.register(url, {scope: scope});
-          return promise;
-        })
-      .then(function(registration) {
-          add_completion_callback(function() {
-              registration.unregister();
-            });
-
-          assert_equals(registration.installing, null,
-                        'installing should be null');
-          assert_equals(registration.waiting, null, 'waiting should be null');
-          assert_not_equals(registration.active, null,
-                            'active after ready should not be null');
-          assert_in_array(registration.active.state,
-                          ['activating', 'activated'],
-                          '.ready should be resolved when the registration ' +
-                          'has an active worker');
-       });
  }, 'ready on an iframe whose parent registers a new service worker');
 
-promise_test(function(t) {
-    var url = 'resources/empty-worker.js';
-    var scope = 'resources/register-iframe.html';
-    var expected_url = normalizeURL(url);
+promise_test(async t => {
+  const frame = await with_iframe('resources/blank.html?uncontrolled');
+  const registration = frame.contentWindow.navigator.serviceWorker.ready;
 
-    return with_iframe(scope)
-      .then(function(f) {
-          t.add_cleanup(function() {
-              f.remove();
-            });
-          return f.contentWindow.navigator.serviceWorker.ready;
-        })
-      .then(function(registration) {
-          add_completion_callback(function() {
-              registration.unregister();
-            });
+  t.add_cleanup(function() {
+    if (frame) frame.remove();
+  });
 
-          assert_equals(registration.installing, null,
-                        'installing should be null');
-          assert_equals(registration.waiting, null, 'waiting should be null');
-          assert_not_equals(registration.active, null,
-                            'active after ready should not be null');
-          assert_in_array(registration.active.state,
-                          ['activating', 'activated'],
-                          '.ready should be resolved with "active worker"');
-       });
+  assert_equals(Object.getPrototypeOf(registration),
+                frame.contentWindow.Promise.prototype,
+                'the Promise should be in the context of the ' +
+                'related document');
+}, 'ready returns a Promise object in the context of the related document');
+
+promise_test(async t => {
+  const SCRIPT = 'resources/empty-worker.js';
+  const SCOPE = 'resources/blank.html?ready-controlled';
+  const expected_url = normalizeURL(SCRIPT);
+
+  let registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(SCOPE);
+  registration = await frame.contentWindow.navigator.serviceWorker.ready;
+
+  t.add_cleanup(async() => {
+    if (registration)
+      await registration.unregister();
+    if (frame)
+      frame.remove();
+  });
+
+  assert_equals(registration.installing, null, 'installing should be null');
+  assert_equals(registration.waiting, null, 'waiting should be null');
+  assert_equals(registration.active.scriptURL, expected_url,
+                'active after ready should not be null');
+  assert_equals(frame.contentWindow.navigator.serviceWorker.controller,
+                registration.active,
+                'the controller should be the active worker');
+  assert_in_array(registration.active.state, ['activating', 'activated'],
+                  '.ready should be resolved when the registration ' +
+                  'has an active worker');
+
+}, 'ready on a controlled document');
+
+promise_test(async t => {
+  const SCRIPT = 'resources/empty-worker.js';
+  const SCOPE = 'resources/blank.html?ready-potential-controlled';
+  const expected_url = normalizeURL(SCRIPT);
+
+  const frame = await with_iframe(SCOPE);
+  let registration = await navigator.serviceWorker.register(
+    SCRIPT,
+    {scope:SCOPE}
+  );
+
+  registration = await frame.contentWindow.navigator.serviceWorker.ready;
+
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+    if (frame) frame.remove();
+  });
+
+  assert_equals(registration.installing, null, 'installing should be null');
+  assert_equals(registration.waiting, null, 'waiting should be null.');
+  assert_equals(registration.active.scriptURL, expected_url,
+                'active after ready should not be null');
+  assert_in_array(registration.active.state,
+                  ['activating', 'activated'],
+                  '.ready should be resolved when the registration ' +
+                  'has an active worker');
+  assert_equals(frame.contentWindow.navigator.serviceWorker.controller,
+                null,
+                'uncontrolled document should not have a controller');
+
+  }, 'ready on a potential controlled document');
+
+
+promise_test(async t => {
+  const SCRIPT = 'resources/empty-worker.js';
+  const SCOPE = 'resources/register-iframe.html';
+  const expected_url = normalizeURL(SCRIPT);
+  const frame = await with_iframe(SCOPE);
+  const registration = await frame.contentWindow.navigator.serviceWorker.ready;
+
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+    if (frame) frame.remove();
+  });
+
+  assert_equals(registration.installing, null, 'installing should be null');
+  assert_equals(registration.waiting, null, 'waiting should be null');
+  assert_not_equals(registration.active, null,
+                    'active after ready should not be null');
+  assert_in_array(registration.active.state, ['activating', 'activated'],
+                  '.ready should be resolved with "active worker"');
+
  }, 'ready on an iframe that installs a new service worker');
 
-promise_test(function(t) {
-    var url = 'resources/empty-worker.js';
-    var matched_scope = 'resources/blank.html?ready-after-match';
-    var longer_matched_scope = 'resources/blank.html?ready-after-match-longer';
-    var frame, registration;
+promise_test(async t => {
+  const SCRIPT = 'resources/empty-worker.js';
+  const MATCHED_SCOPE = 'resources/blank.html?ready-after-resolve';
+  const LONGER_MATCHED_SCOPE =
+      'resources/blank.html?ready-after-resolve-longer';
 
-    return Promise.all([service_worker_unregister(t, matched_scope),
-                        service_worker_unregister(t, longer_matched_scope)])
-      .then(function() {
-          return with_iframe(longer_matched_scope);
-        })
-      .then(function(f) {
-          t.add_cleanup(function() {
-              f.remove();
-            });
-          frame = f;
-          return navigator.serviceWorker.register(url, {scope: matched_scope});
-        })
-      .then(function(r) {
-          add_completion_callback(function() {
-              r.unregister();
-            });
-          registration = r;
-          return wait_for_state(t, r.installing, 'activated');
-        })
-      .then(function() {
-          return navigator.serviceWorker.register(
-              url, {scope: longer_matched_scope});
-        })
-      .then(function(r) {
-          add_completion_callback(function() {
-              r.unregister();
-            });
-          return frame.contentWindow.navigator.serviceWorker.ready;
-        })
-      .then(function(r) {
-          assert_equals(r.scope, normalizeURL(longer_matched_scope),
-                        'longer matched registration should be returned');
-          assert_equals(frame.contentWindow.navigator.serviceWorker.controller,
-                        null, 'controller should be null');
-        });
-  }, 'ready after a longer matched registration registered');
+  let registration =
+      await service_worker_unregister_and_register(t, SCRIPT, MATCHED_SCOPE);
+  await wait_for_state(t, registration.installing, 'activated');
+  const frame = await with_iframe(LONGER_MATCHED_SCOPE);
+  registration = await frame.contentWindow.navigator.serviceWorker.ready;
 
-promise_test(function(t) {
-    var url = 'resources/empty-worker.js';
-    var matched_scope = 'resources/blank.html?ready-after-resolve';
-    var longer_matched_scope =
-        'resources/blank.html?ready-after-resolve-longer';
-    var frame, registration;
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+  });
 
-    return service_worker_unregister_and_register(t, url, matched_scope)
-      .then(function(r) {
-          add_completion_callback(function() {
-              r.unregister();
-            });
-          registration = r;
-          return wait_for_state(t, r.installing, 'activated');
-        })
-      .then(function() {
-          return with_iframe(longer_matched_scope);
-        })
-      .then(function(f) {
-          t.add_cleanup(function() {
-              f.remove();
-            });
-          frame = f;
-          return f.contentWindow.navigator.serviceWorker.ready;
-        })
-      .then(function(r) {
-          assert_equals(r.scope, normalizeURL(matched_scope),
-                        'matched registration should be returned');
-          return navigator.serviceWorker.register(
-              url, {scope: longer_matched_scope});
-        })
-      .then(function(r) {
-          add_completion_callback(function() {
-              r.unregister();
-            });
-          return frame.contentWindow.navigator.serviceWorker.ready;
-        })
-      .then(function(r) {
-          assert_equals(r.scope, normalizeURL(matched_scope),
-                        'ready should only be resolved once');
-        });
+  assert_equals(registration.scope, normalizeURL(MATCHED_SCOPE),
+                'matched registration should be returned');
+  registration = await navigator.serviceWorker.register(
+      SCRIPT, {scope: LONGER_MATCHED_SCOPE});
+  registration = await frame.contentWindow.navigator.serviceWorker.ready;
+
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+    if (frame) frame.remove();
+  });
+
+  assert_equals(registration.scope, normalizeURL(MATCHED_SCOPE),
+                'ready should only be resolved once');
+
   }, 'access ready after it has been resolved');
 
-promise_test(async function(t) {
-    var url = 'resources/empty-worker.js';
-    var matched_scope = 'resources/blank.html?ready-after-resurrect';
+promise_test(async t => {
+  const SCRIPT = 'resources/empty-worker.js';
+  const MATCHED_SCOPE = 'resources/blank.html?ready-after-match';
+  const LONGER_MATCHED_SCOPE = 'resources/blank.html?ready-after-match-longer';
 
-    let reg1 = await service_worker_unregister_and_register(t, url, matched_scope);
-    add_completion_callback(function() {
-        reg1.unregister();
-      });
-    await wait_for_state(t, reg1.installing, 'activated');
+  await service_worker_unregister(t, MATCHED_SCOPE);
+  await service_worker_unregister(t, LONGER_MATCHED_SCOPE);
+  const frame = await with_iframe(LONGER_MATCHED_SCOPE);
+  let registration = await navigator.serviceWorker.register(
+    SCRIPT,
+    {scope: MATCHED_SCOPE}
+  );
+  await wait_for_state(t, registration.installing, 'activated');
+  registration = await navigator.serviceWorker.register(
+    SCRIPT,
+    {scope: LONGER_MATCHED_SCOPE}
+  );
+  registration = await frame.contentWindow.navigator.serviceWorker.ready;
 
-    // Hold the worker alive with a controlled worker
-    let frame = await with_iframe(matched_scope);
-    add_completion_callback(function() {
-        frame.remove();
-      });
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+    if (frame) frame.remove();
+  });
 
-    // Doom the registration as uninstalling.
-    await reg1.unregister();
+  assert_equals(registration.scope, normalizeURL(LONGER_MATCHED_SCOPE),
+                'longer matched registration should be returned');
+  assert_equals(frame.contentWindow.navigator.serviceWorker.controller,
+                null, 'controller should be null');
 
-    // Access the ready promise while the registration is doomed.
-    let readyPromise = frame.contentWindow.navigator.serviceWorker.ready;
+  }, 'ready after a longer matched registration registered');
 
-    // Resurrect the doomed registration;
-    let reg2 = await service_worker_unregister_and_register(t, url, matched_scope);
-    assert_equals(reg1, reg2, 'existing registration should be resurrected');
 
-    // We are trying to test if the ready promise ever resolves here.  Use
-    // an explicit timeout check here rather than forcing a full infrastructure
-    // level timeout.
-    let timeoutId;
-    let timeoutPromise = new Promise(resolve => {
-      timeoutId = setTimeout(_ => {
-        timeoutId = null;
-        resolve();
-      }, 500);
-    });
+promise_test(async t => {
+  const SCRIPT = 'resources/empty-worker.js';
+  const MATCHED_SCOPE = 'resources/blank.html?ready-after-resurrect';
 
-    // This should resolve immediately since there is an alive registration
-    // with an active promise for the matching scope.
-    await Promise.race([readyPromise, timeoutPromise]);
+  const registration1 = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    MATCHED_SCOPE
+  );
 
-    assert_not_equals(timeoutId, null,
-                      'ready promise should resolve before timeout');
-    clearTimeout(timeoutId);
+  t.add_cleanup(async()  => {
+    if (frame) frame.remove();
+    if (registration1) await registration1.unregister();
+    if (registration2) await registration1.unregister();
+  });
 
-    // We should get here and not time out.
+  await wait_for_state(t, registration1.installing, 'activated');
 
-  }, 'access ready on uninstalling registration that is resurrected');
+  // Hold the worker alive with a controlled worker
+  const frame = await with_iframe(MATCHED_SCOPE);
+
+  // Access the ready promise while the registration is doomed.
+  const readyPromise = await frame.contentWindow.navigator.serviceWorker.ready;
+
+  // Resurrect the doomed registration;
+  const registration2 = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    MATCHED_SCOPE
+  );
+  assert_equals(registration1, registration2,
+                'existing registration should be resurrected');
+
+  // We are trying to test if the ready promise ever resolves here.  Use
+  // an explicit timeout check here rather than forcing a full infrastructure
+  // level timeout.
+  let timeoutId;
+  const timeoutPromise = new Promise(resolve => {
+    timeoutId = setTimeout(_ => {
+      timeoutId = null;
+      resolve();
+    }, 500);
+  });
+
+  // This should resolve immediately since there is an alive registration
+  // with an active promise for the matching scope.
+  await Promise.race([readyPromise, timeoutPromise]);
+  assert_not_equals(timeoutId, null,
+                    'ready promise should resolve before timeout');
+  clearTimeout(timeoutId);
+}, 'access ready on uninstalling registration that is resurrected');
 </script>

--- a/service-workers/service-worker/registration-end-to-end.https.html
+++ b/service-workers/service-worker/registration-end-to-end.https.html
@@ -4,93 +4,92 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-var t = async_test('Registration: end-to-end');
-t.step(function() {
+promise_test(async t => {
+  const SCOPE = 'resources/in-scope/';
+  const SCRIPT = 'resources/end-to-end-worker.js';
+  let serviceWorkerStates = [];
+  const currentChangeCount = 0;
 
-    var scope = 'resources/in-scope/';
-    var serviceWorkerStates = [];
-    var lastServiceWorkerState = '';
-    var receivedMessageFromPort = '';
-    var currentChangeCount = 0;
+  assert_true(navigator.serviceWorker instanceof ServiceWorkerContainer);
+  assert_equals(typeof navigator.serviceWorker.register, 'function');
+  assert_equals(typeof navigator.serviceWorker.getRegistration, 'function');
 
-    assert_true(navigator.serviceWorker instanceof ServiceWorkerContainer);
-    assert_equals(typeof navigator.serviceWorker.register, 'function');
-    assert_equals(typeof navigator.serviceWorker.getRegistration, 'function');
+  navigator.serviceWorker.oncurrentchange = function() {
+    ++currentChangeCount;
+  };
 
-    navigator.serviceWorker.oncurrentchange = function() {
-        ++currentChangeCount;
-    };
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
 
-    service_worker_unregister_and_register(
-        t, 'resources/end-to-end-worker.js', scope)
-      .then(onRegister)
-      .catch(unreached_rejection(t));
+  function sendMessagePort(worker, from) {
+    const messageChannel = new MessageChannel();
+    worker.postMessage({from:from, port:messageChannel.port2}, [messageChannel.port2]);
+    return messageChannel.port1;
+  }
 
-    function sendMessagePort(worker, from) {
-        var messageChannel = new MessageChannel();
-        worker.postMessage({from:from, port:messageChannel.port2}, [messageChannel.port2]);
-        return messageChannel.port1;
-    }
+  async function onRegister(registration) {
+    const sw = registration.installing;
+    serviceWorkerStates.push(sw.state);
+    lastServiceWorkerState = sw.state;
 
-    function onRegister(registration) {
-        var sw = registration.installing;
+    const sawMessage =  new Promise(resolve => {
+      sendMessagePort(sw, 'registering doc').onmessage = function (e) {
+        receivedMessageFromPort = e.data;
+        resolve();
+      };
+    });
+
+    const sawActive = new Promise(resolve => {
+      sw.onstatechange = function() {
         serviceWorkerStates.push(sw.state);
+
+        switch (sw.state) {
+        case 'installed':
+          assert_equals(lastServiceWorkerState, "installing");
+          break;
+        case 'activating':
+          assert_equals(lastServiceWorkerState, "installed");
+          break;
+        case 'activated':
+          assert_equals(lastServiceWorkerState, "activating");
+          break;
+        default:
+          // We won't see "redundant" because onstatechange is
+          // overwritten before calling unregister.
+          assert_unreached("Unexpected state: " + sw.state);
+        };
+
         lastServiceWorkerState = sw.state;
+        if (sw.state === 'activated')
+          resolve();
+      };
+    });
 
-        var sawMessage = new Promise(t.step_func(function(resolve) {
-            sendMessagePort(sw, 'registering doc').onmessage = t.step_func(function (e) {
-                receivedMessageFromPort = e.data;
-                resolve();
-            });
-        }));
+    await Promise.all([sawMessage, sawActive]);
 
-        var sawActive = new Promise(t.step_func(function(resolve) {
-            sw.onstatechange = t.step_func(function() {
-                serviceWorkerStates.push(sw.state);
+    t.add_cleanup(async() => {
+      if (registration)  await registration.unregister();
+    });
 
-                switch (sw.state) {
-                case 'installed':
-                    assert_equals(lastServiceWorkerState, 'installing');
-                    break;
-                case 'activating':
-                    assert_equals(lastServiceWorkerState, 'installed');
-                    break;
-                case 'activated':
-                    assert_equals(lastServiceWorkerState, 'activating');
-                    break;
-                default:
-                    // We won't see 'redundant' because onstatechange is
-                    // overwritten before calling unregister.
-                    assert_unreached('Unexpected state: ' + sw.state);
-                }
+    assert_array_equals(serviceWorkerStates,
+                        ['installing', "installed", "activating", "activated"],
+                        "Service worker should pass through all states");
 
-                lastServiceWorkerState = sw.state;
-                if (sw.state === 'activated')
-                    resolve();
-            });
-        }));
+    assert_equals(currentChangeCount, 0,
+                  "Should not see current changes since document is out of scope");
 
-        Promise.all([sawMessage, sawActive]).then(t.step_func(function() {
-            assert_array_equals(serviceWorkerStates,
-                                ['installing', 'installed', 'activating', 'activated'],
-                                'Service worker should pass through all states');
+    assert_equals(receivedMessageFromPort, "Ack for: registering doc");
 
-            assert_equals(currentChangeCount, 0,
-                          'Should not see current changes since document is out of scope');
-
-            assert_equals(receivedMessageFromPort, 'Ack for: registering doc');
-
-            var sawRedundant = new Promise(t.step_func(function(resolve) {
-                sw.onstatechange = t.step_func(function() {
-                    assert_equals(sw.state, 'redundant');
-                    resolve();
-                });
-            }));
-            registration.unregister();
-            sawRedundant.then(t.step_func(function() {
-                t.done();
-            }));
-        }));
-    }
+    await new Promise(resolve => {
+      sw.onstatechange = function() {
+        assert_equals(sw.state, "redundant");
+        resolve();
+      };
+    });
+  };
 });
+
 </script>

--- a/service-workers/service-worker/websocket-in-service-worker.https.html
+++ b/service-workers/service-worker/websocket-in-service-worker.https.html
@@ -4,24 +4,27 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
-promise_test(t => {
-    const SCRIPT = 'resources/websocket-worker.js?pipe=sub';
-    const SCOPE = 'resources/blank.html';
-    let registration;
-    return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
-      .then(r => {
-          add_completion_callback(() => { r.unregister(); });
-          registration = r;
-          return wait_for_state(t, r.installing, 'activated');
-        })
-      .then(() => {
-          return new Promise(resolve => {
-              navigator.serviceWorker.onmessage = t.step_func(msg => {
-                  assert_equals(msg.data, 'PASS');
-                  resolve();
-              });
-              registration.active.postMessage({});
-          });
-        });
-  }, 'Verify WebSockets can be created in a Service Worker');
+promise_test(async t => {
+  const SCRIPT = 'resources/websocket-worker.js?pipe=sub';
+  const SCOPE = 'resources/blank.html';
+
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+
+  t.add_cleanup(async() => {
+    if (registration) await registration.unregister();
+  });
+
+  await wait_for_state(t, registration.installing, 'activated');
+  await new Promise(resolve => {
+    navigator.serviceWorker.onmessage = t.step_func(msg => {
+      assert_equals(msg.data, 'PASS');
+      resolve();
+    });
+    registration.active.postMessage({});
+  });
+}, 'Verify WebSockets can be created in a Service Worker');
 </script>

--- a/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
+++ b/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html
@@ -52,80 +52,71 @@ let sandboxed_frame_by_header;
 // This should be controlled by a service worker.
 let sandboxed_same_origin_frame_by_header;
 
-promise_test(t => {
-  return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
-    .then(function(registration) {
-      add_completion_callback(() => registration.unregister());
-      worker = registration.installing;
-      return wait_for_state(t, registration.installing, 'activated');
-    });
+promise_test(async t => {
+  const registration = await service_worker_unregister_and_register(
+    t,
+    SCRIPT,
+    SCOPE
+  );
+
+  add_completion_callback(async() => {
+    if (registration) await registration.unregister();
+  });
+
+  worker = registration.installing;
+  await wait_for_state(t, registration.installing, 'activated');
 }, 'Prepare a service worker.');
 
-promise_test(t => {
+promise_test(async t => {
   const iframe_full_url = expected_base_url + '?sandbox=allow-scripts&' +
                           'sandboxed-frame-by-header';
-  return with_iframe(iframe_full_url)
-    .then(f => {
-      sandboxed_frame_by_header = f;
-      add_completion_callback(() => f.remove());
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'Service worker should provide the response');
-      assert_equals(requests[0], iframe_full_url);
-      assert_false(data.clients.includes(iframe_full_url),
-                   'Service worker should NOT control the sandboxed page');
-    });
+  const frame = await with_iframe(iframe_full_url);
+  sandboxed_frame_by_header = frame;
+  const data = await getResultsFromWorker(worker);
+  const requests = data.requests;
+
+  add_completion_callback(() => frame.remove());
+
+  assert_equals(requests.length, 1,
+                'Service worker should provide the response');
+  assert_equals(requests[0], iframe_full_url);
+  assert_false(data.clients.includes(iframe_full_url),
+                'Service worker should NOT control the sandboxed page');
 }, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.');
 
-promise_test(t => {
-  const iframe_full_url =
-    expected_base_url + '?sandbox=allow-scripts%20allow-same-origin&' +
+promise_test(async t => {
+  const iframe_full_url = expected_base_url +
+    '?sandbox=allow-scripts%20allow-same-origin&' +
     'sandboxed-iframe-same-origin-by-header';
-  return with_iframe(iframe_full_url)
-    .then(f => {
-      sandboxed_same_origin_frame_by_header = f;
-      add_completion_callback(() => f.remove());
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1);
-      assert_equals(requests[0], iframe_full_url);
-      assert_true(data.clients.includes(iframe_full_url));
-    })
+  const frame = await with_iframe(iframe_full_url);
+  sandboxed_same_origin_frame_by_header = frame;
+  const data = await getResultsFromWorker(worker);
+
+  add_completion_callback(() => frame.remove());
+
+  assert_equals(data.requests.length, 1);
+  assert_equals(data.requests[0], iframe_full_url);
+  assert_true(data.clients.includes(iframe_full_url));
 }, 'Prepare an iframe sandboxed by CSP HTTP header with allow-scripts and ' +
    'allow-same-origin.');
 
-promise_test(t => {
-  let frame = sandboxed_frame_by_header;
-  return doTest(frame, 'fetch-from-worker')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      assert_equals(data.requests.length, 0,
-                    'The request should NOT be handled by SW.');
-    });
+promise_test(async t => {
+  const result = await doTest(sandboxed_frame_by_header, 'fetch-from-worker');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 0,
+                'The request should NOT be handled by SW.');
 }, 'Fetch request from a worker in iframe sandboxed by CSP HTTP header ' +
    'allow-scripts flag');
 
-promise_test(t => {
-  let frame = sandboxed_same_origin_frame_by_header;
-  return doTest(frame, 'fetch-from-worker')
-    .then(result => {
-      assert_equals(result, 'done');
-      return getResultsFromWorker(worker);
-    })
-    .then(data => {
-      let requests = data.requests;
-      assert_equals(requests.length, 1,
-                    'The request should be handled by SW.');
-      assert_equals(requests[0], frame.src + '&test=fetch-from-worker');
-    });
+promise_test(async t => {
+  const frame = sandboxed_same_origin_frame_by_header;
+  const result = await doTest(frame, 'fetch-from-worker');
+  assert_equals(result, 'done');
+  const data = await getResultsFromWorker(worker);
+  assert_equals(data.requests.length, 1,
+                'The request should be handled by SW.');
+  assert_equals(data.requests[0], frame.src + '&test=fetch-from-worker');
 }, 'Fetch request from a worker in iframe sandboxed by CSP HTTP header ' +
    'with allow-scripts and allow-same-origin flag');
 </script>


### PR DESCRIPTION
- Fix a couple of tests with function t.add_cleanup() as it supports promise, see detail in #8748.
- The usage of unregister() method in some tests is not rigorous.  As [spec]\(https://w3c.github.io/ServiceWorker/#dom-serviceworkerregistration-unregister):
>>   [NewObject] Promise<boolean> unregister();
  unregister() method must run these steps:
>> 1. Let promise be a promise.
...
>> 4. Return promise.