### PR TITLE
Attempt to handle ChromeDriver versions better

### DIFF
--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -25,7 +25,7 @@ main() {
     for PRODUCT in "${PRODUCTS[@]}"; do
         if [[ "$PRODUCT" == "chrome" ]]; then
             add_wpt_hosts
-            test_infrastructure "--binary=$(which google-chrome-unstable)"
+            test_infrastructure "--binary=$(which google-chrome-unstable) --channel dev"
         else
             test_infrastructure
         fi

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -461,35 +461,47 @@ class Chrome(Browser):
     def find_webdriver(self, channel=None):
         return find_executable("chromedriver")
 
-    def _latest_chromedriver_url(self, browser_binary=None):
-        latest = None
-        chrome_version = self.version(browser_binary)
-        assert chrome_version, "Cannot detect the version of Chrome"
-
-        # Remove channel suffixes (e.g. " dev").
-        chrome_version = chrome_version.split(' ')[0]
+    def _official_chromedriver_url(self, chrome_version):
+        # http://chromedriver.chromium.org/downloads/version-selection
         parts = chrome_version.split(".")
-        if len(parts) == 4:
-            latest_url = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_%s.%s.%s" % tuple(parts[:-1])
+        assert len(parts) == 4
+        latest_url = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_%s.%s.%s" % tuple(parts[:-1])
+        try:
+            latest = get(latest_url).text.strip()
+        except requests.RequestException:
+            latest_url = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_%s" % parts[0]
             try:
                 latest = get(latest_url).text.strip()
             except requests.RequestException:
-                latest_url = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_%s" % parts[0]
-                try:
-                    latest = get(latest_url).text.strip()
-                except requests.RequestException:
-                    pass
-        if latest is None:
-            # Fall back to *Chromium* build archives.
+                return None
+        return "https://chromedriver.storage.googleapis.com/%s/chromedriver_%s.zip" % (
+            latest, self.platform_string())
+
+    def _chromium_chromedriver_url(self, chrome_version):
+        try:
+            # Try to find the Chromium build with the same revision.
             omaha = get("https://omahaproxy.appspot.com/deps.json?version=" + chrome_version).json()
             revision = omaha['chromium_base_position']
             url = "https://storage.googleapis.com/chromium-browser-snapshots/%s/%s/chromedriver_%s.zip" % (
                 self.chromium_platform_string(), revision, self.platform_string())
-        else:
-            url = "https://chromedriver.storage.googleapis.com/%s/chromedriver_%s.zip" % (
-                latest, self.platform_string())
-
+            # Check the status without downloading the content (this is a streaming request).
+            get(url)
+        except requests.RequestException:
+            # Fall back to the tip-of-tree Chromium build.
+            revision_url = "https://storage.googleapis.com/chromium-browser-snapshots/%s/LAST_CHANGE" % (
+                self.chromium_platform_string())
+            revision = get(revision_url).text.strip()
+            url = "https://storage.googleapis.com/chromium-browser-snapshots/%s/%s/chromedriver_%s.zip" % (
+                self.chromium_platform_string(), revision, self.platform_string())
         return url
+
+    def _latest_chromedriver_url(self, browser_binary=None):
+        chrome_version = self.version(browser_binary)
+        assert chrome_version, "Cannot detect the version of Chrome"
+        # Remove channel suffixes (e.g. " dev").
+        chrome_version = chrome_version.split(' ')[0]
+        return (self._official_chromedriver_url(chrome_version) or
+                self._chromium_chromedriver_url(chrome_version))
 
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):
         if dest is None:

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -277,6 +277,8 @@ class Chrome(BrowserSetup):
         if kwargs["browser_channel"] == "dev":
             logger.info("Automatically turning on experimental features for Chrome Dev")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
+            # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
+            kwargs["webdriver_args"].append("--disable-build-check")
 
 
 class ChromeAndroid(BrowserSetup):

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -102,7 +102,8 @@ def test_list_tests(manifest_dir):
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--metadata", manifest_dir, "--list-tests",
-                       "--yes", "chrome", "/dom/nodes/Element-tagName.html"])
+                       "--channel", "dev", "--yes", "chrome",
+                       "/dom/nodes/Element-tagName.html"])
     assert excinfo.value.code == 0
 
 
@@ -173,12 +174,13 @@ def test_run_zero_tests():
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--binary-arg", "headless",
-                       "chrome", "/non-existent-dir/non-existent-file.html"])
+                       "--channel", "dev", "chrome",
+                       "/non-existent-dir/non-existent-file.html"])
     assert excinfo.value.code != 0
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--binary-arg", "headless",
-                       "--no-fail-on-unexpected",
+                       "--no-fail-on-unexpected", "--channel", "dev",
                        "chrome", "/non-existent-dir/non-existent-file.html"])
     assert excinfo.value.code != 0
 
@@ -197,12 +199,12 @@ def test_run_failing_test():
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--binary-arg", "headless",
-                       "chrome", failing_test])
+                       "--channel", "dev", "chrome", failing_test])
     assert excinfo.value.code != 0
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--binary-arg", "headless",
-                       "--no-fail-on-unexpected",
+                       "--no-fail-on-unexpected", "--channel", "dev",
                        "chrome", failing_test])
     assert excinfo.value.code == 0
 
@@ -228,14 +230,14 @@ def test_run_verify_unstable(temp_test):
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--verify", "--binary-arg", "headless",
-                       "chrome", unstable_test])
+                       "--channel", "dev", "chrome", unstable_test])
     assert excinfo.value.code != 0
 
     stable_test = temp_test("test(function() {}, 'my test');")
 
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--verify", "--binary-arg", "headless",
-                       "chrome", stable_test])
+                       "--channel", "dev", "chrome", stable_test])
     assert excinfo.value.code == 0
 
 


### PR DESCRIPTION
Previous fix (#16454) was insufficient; see
https://crbug.com/chromedriver/2656#c21

This time the fix is two-fold: 1. use the tip-of-tree build of
ChromeDriver as the final fall back; 2. when running Chrome Dev, disable
ChromeDriver's version check (which might make results a bit unreliable
when 1 is in effect).

This should finally fix #16448.