### PR TITLE
Update referrer policy tests to use hosts[alt] instead of hardcoded www1

### DIFF
--- a/common/security-features/resources/common.js
+++ b/common/security-features/resources/common.js
@@ -975,7 +975,7 @@ for (const workletType of ['animation', 'audio', 'layout', 'paint']) {
          The fetch result of `assertUrl` should indicate whether
          `testUrl` is actually sent to the server or not.
 */
-function getRequestURLs(subresourceType, originType, redirectionType) {
+function getRequestURLs(subresourceType, originType, redirectionType, redirectionOrigin) {
   const key = guid();
   const value = guid();
 
@@ -984,13 +984,16 @@ function getRequestURLs(subresourceType, originType, redirectionType) {
 
   const stashEndpoint = "/common/security-features/subresource/xhr.py?key=" +
                         key + "&path=" + stashPath;
-  return {
-    testUrl:
-      getSubresourceOrigin(originType) +
+  let testUrl = getSubresourceOrigin(originType) +
         subresourceMap[subresourceType].path +
         "?redirection=" + encodeURIComponent(redirectionType) +
         "&action=purge&key=" + key +
-        "&path=" + stashPath,
+        "&path=" + stashPath;
+  if (redirectionOrigin)
+    testUrl += "&redirection-origin=" + encodeURIComponent(redirectionOrigin);
+
+  return {
+    testUrl: testUrl,
     announceUrl: stashEndpoint + "&action=put&value=" + value,
     assertUrl: stashEndpoint + "&action=take",
   };

--- a/referrer-policy/css-integration/child-css/external-import-stylesheet.html
+++ b/referrer-policy/css-integration/child-css/external-import-stylesheet.html
@@ -19,7 +19,7 @@
     <script>
       promise_test(function(css_test) {
         let id = token();
-        let url_prefix = location.protocol + "//www1." + location.hostname + ":" + location.port;
+        let url_prefix = crossOriginBaseURL();
         let css_url = url_prefix +
           "/common/security-features/subresource/stylesheet.py?id=" + id +
           "&import-rule" + "&referrer-policy=no-referrer";

--- a/referrer-policy/css-integration/child-css/internal-import-stylesheet.html
+++ b/referrer-policy/css-integration/child-css/internal-import-stylesheet.html
@@ -19,7 +19,7 @@
     <script>
       promise_test(function(css_test) {
         let id = token();
-        let url_prefix = location.protocol + "//www1." + location.hostname + ":" + location.port;
+        let url_prefix = crossOriginBaseURL();
         let css_url = url_prefix + "/common/security-features/subresource/stylesheet.py?id=" + id + "&import-rule";
         let check_url = url_prefix + "/common/security-features/subresource/stylesheet.py" +
                         "?id=" + id + "&report-headers";

--- a/referrer-policy/css-integration/child-css/processing-instruction.html
+++ b/referrer-policy/css-integration/child-css/processing-instruction.html
@@ -18,8 +18,7 @@
     <script>
       promise_test(function(css_test) {
         let id = token();
-        let url_prefix = location.protocol + "//www1." + location.hostname + ":" +
-                         location.port +
+        let url_prefix = crossOriginBaseURL() +
                          "/common/security-features/subresource/stylesheet.py?id=" +
                          id;
         let css_url = url_prefix + "&amp;import-rule";

--- a/referrer-policy/css-integration/font-face/external-import-stylesheet.html
+++ b/referrer-policy/css-integration/font-face/external-import-stylesheet.html
@@ -20,8 +20,7 @@
     <script>
       promise_test(function(css_test) {
         let id = token();
-        let css_url = location.protocol + "//www1." + location.hostname + ":" +
-          location.port +
+        let css_url = crossOriginBaseURL() +
           "/common/security-features/subresource/stylesheet.py?id=" + id +
           "&import-rule" + "&type=font";
         let url_prefix = location.protocol + "//" + location.hostname + ":" + location.port;

--- a/referrer-policy/css-integration/font-face/external-stylesheet.html
+++ b/referrer-policy/css-integration/font-face/external-stylesheet.html
@@ -19,7 +19,7 @@
     <script>
       promise_test(function(css_test) {
         let id = token();
-        let url_prefix = location.protocol + "//www1." + location.hostname + ":" + location.port;
+        let url_prefix = crossOriginBaseURL();
         let css_url = url_prefix + "/common/security-features/subresource/stylesheet.py?id=" + id + "&type=font";
         let font_url = url_prefix + "/common/security-features/subresource/font.py" +
                       "?id=" + id + "&report-headers";

--- a/referrer-policy/css-integration/font-face/internal-import-stylesheet.html
+++ b/referrer-policy/css-integration/font-face/internal-import-stylesheet.html
@@ -20,8 +20,7 @@
     <script>
       promise_test(function(css_test) {
         let id = token();
-        let url_prefix = location.protocol + "//www1." + location.hostname + ":" +
-                         location.port + "/common/security-features/subresource/";
+        let url_prefix = crossOriginBaseURL() + "/common/security-features/subresource/";
         let css_url = url_prefix + "stylesheet.py?id=" + id + "&type=font";
         let font_url = url_prefix + "font.py?report-headers&id=" + id;
 

--- a/referrer-policy/css-integration/font-face/internal-stylesheet.html
+++ b/referrer-policy/css-integration/font-face/internal-stylesheet.html
@@ -19,8 +19,7 @@
     <script>
       promise_test(function(css_test) {
         let id = token();
-        let css_url = location.protocol + "//www1." + location.hostname + ":" +
-                      location.port +
+        let css_url = crossOriginBaseURL() +
                       "/common/security-features/subresource/font.py" + "?id=" +
                       id + "&type=font";
         let font_url = css_url + "&report-headers";

--- a/referrer-policy/css-integration/font-face/processing-instruction.html
+++ b/referrer-policy/css-integration/font-face/processing-instruction.html
@@ -20,7 +20,7 @@
     <script>
       promise_test(function(css_test) {
         let id = token();
-        let url_prefix = location.protocol + "//www1." + location.hostname + ":" + location.port;
+        let url_prefix = crossOriginBaseURL();
         let css_url = url_prefix +
                       "/common/security-features/subresource/stylesheet.py?id=" +
                       id + "&amp;type=font";

--- a/referrer-policy/css-integration/image/external-import-stylesheet.html
+++ b/referrer-policy/css-integration/image/external-import-stylesheet.html
@@ -20,7 +20,7 @@
     <script>
       promise_test(function(css_test) {
         var id = token();
-        var css_url = location.protocol + "//www1." + location.hostname + ":" + location.port +
+        var css_url = crossOriginBaseURL() +
           "/common/security-features/subresource/stylesheet.py?id=" + id +
           "&import-rule" + "&type=image";
         var url_prefix = location.protocol + "//" + location.hostname + ":" + location.port;

--- a/referrer-policy/css-integration/image/external-stylesheet.html
+++ b/referrer-policy/css-integration/image/external-stylesheet.html
@@ -19,7 +19,7 @@
     <script>
       promise_test(function(css_test) {
         var id = token();
-        var url_prefix = location.protocol + "//www1." + location.hostname + ":" + location.port;
+        var url_prefix = crossOriginBaseURL();
         var css_url = url_prefix + "/common/security-features/subresource/stylesheet.py?id=" + id;
         var img_url = url_prefix + "/common/security-features/subresource/image.py" +
                       "?id=" + id + "&report-headers";

--- a/referrer-policy/css-integration/image/inline-style.html
+++ b/referrer-policy/css-integration/image/inline-style.html
@@ -19,7 +19,7 @@
     <script>
       promise_test(function(css_test) {
         var id = token();
-        var css_url = location.protocol + "//www1." + location.hostname + ":" + location.port + "/common/security-features/subresource/image.py" + "?id=" + id;
+        var css_url = crossOriginBaseURL() + "/common/security-features/subresource/image.py" + "?id=" + id;
         var img_url = css_url + "&report-headers";
 
         var div = document.querySelector("div.styled");

--- a/referrer-policy/css-integration/image/internal-import-stylesheet.html
+++ b/referrer-policy/css-integration/image/internal-import-stylesheet.html
@@ -20,7 +20,7 @@
     <script>
       promise_test(function(css_test) {
         var id = token();
-        var url_prefix =  location.protocol + "//www1." + location.hostname + ":" + location.port + "/common/security-features/subresource/";
+        var url_prefix =  crossOriginBaseURL() + "/common/security-features/subresource/";
         var css_url = url_prefix + "stylesheet.py?id=" + id;
         var img_url = url_prefix + "image.py?report-headers&id=" + id;
 

--- a/referrer-policy/css-integration/image/internal-stylesheet.html
+++ b/referrer-policy/css-integration/image/internal-stylesheet.html
@@ -19,7 +19,7 @@
     <script>
       promise_test(function(css_test) {
         var id = token();
-        var css_url = location.protocol + "//www1." + location.hostname + ":" + location.port + "/common/security-features/subresource/image.py" + "?id=" + id;
+        var css_url = crossOriginBaseURL() + "/common/security-features/subresource/image.py" + "?id=" + id;
         var img_url = css_url + "&report-headers";
 
         var style = document.createElement("style");

--- a/referrer-policy/css-integration/image/presentation-attribute.html
+++ b/referrer-policy/css-integration/image/presentation-attribute.html
@@ -17,7 +17,7 @@
     <script>
       promise_test(function(css_test) {
         var id = token();
-        var css_url = location.protocol + "//www1." + location.hostname + ":" + location.port + "/common/security-features/subresource/image.py" + "?id=" + id;
+        var css_url = crossOriginBaseURL() + "/common/security-features/subresource/image.py" + "?id=" + id;
         var img_url = css_url + "&report-headers";
 
         document.body.background = css_url;

--- a/referrer-policy/css-integration/image/processing-instruction.html
+++ b/referrer-policy/css-integration/image/processing-instruction.html
@@ -20,7 +20,7 @@
     <script>
       promise_test(function(css_test) {
         var id = token();
-        var url_prefix = location.protocol + "//www1." + location.hostname + ":" + location.port;
+        var url_prefix = crossOriginBaseURL();
         var css_url = url_prefix + "/common/security-features/subresource/stylesheet.py?id=" + id;
         var img_url = url_prefix + "/common/security-features/subresource/image.py" +
                       "?id=" + id + "&report-headers";

--- a/referrer-policy/generic/iframe-inheritance.html
+++ b/referrer-policy/generic/iframe-inheritance.html
@@ -29,7 +29,7 @@
             <script src = "/referrer-policy/generic/referrer-policy-test-case.sub.js"></` + `script>
             <script>
               var urlPath = "/common/security-features/subresource/xhr.py";
-              var url = "${location.protocol}//www1.${location.hostname}:${location.port}" + urlPath;
+              var url = crossOriginBaseURL() + urlPath;
               requestViaXhr(url).then((msg) => {
                   parent.postMessage({referrer: msg.referrer}, "*")})
                 .catch((e) => {

--- a/referrer-policy/generic/multiple-headers-and-values.html
+++ b/referrer-policy/generic/multiple-headers-and-values.html
@@ -17,8 +17,7 @@
     <script>
       promise_test(() => {
         var urlPath = '/common/security-features/subresource/image.py?cache_destroyer=' + (new Date()).getTime();
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaImage(url, null, 'no-referrer')
           .then(function(message) {
               assert_equals(message.referrer, document.location.origin + "/");

--- a/referrer-policy/generic/multiple-headers-combined.html
+++ b/referrer-policy/generic/multiple-headers-combined.html
@@ -17,8 +17,7 @@
     <script>
       promise_test(() => {
         var urlPath = '/common/security-features/subresource/image.py?cache_destroyer=' + (new Date()).getTime();
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaImage(url, null, 'no-referrer')
           .then(function(message) {
               assert_equals(message.referrer, document.location.origin + "/");

--- a/referrer-policy/generic/multiple-headers-one-invalid.html
+++ b/referrer-policy/generic/multiple-headers-one-invalid.html
@@ -17,8 +17,7 @@
     <script>
       promise_test(() => {
         var urlPath = '/common/security-features/subresource/image.py?cache_destroyer=' + (new Date()).getTime();
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaImage(url, null, 'no-referrer')
           .then(function(message) {
               assert_equals(message.referrer, document.location.href);

--- a/referrer-policy/generic/multiple-headers-one-unknown-token.html
+++ b/referrer-policy/generic/multiple-headers-one-unknown-token.html
@@ -17,8 +17,7 @@
     <script>
       promise_test(() => {
         var urlPath = '/common/security-features/subresource/image.py?cache_destroyer=' + (new Date()).getTime();
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaImage(url, null, 'no-referrer')
           .then(function(message) {
               assert_equals(message.referrer, document.location.origin + "/");

--- a/referrer-policy/generic/multiple-headers.html
+++ b/referrer-policy/generic/multiple-headers.html
@@ -17,8 +17,7 @@
     <script>
       promise_test(() => {
         var urlPath = '/common/security-features/subresource/image.py?cache_destroyer=' + (new Date()).getTime();
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaImage(url, null, 'no-referrer')
           .then(function(message) {
               assert_equals(message.referrer, document.location.origin + "/");

--- a/referrer-policy/generic/referrer-policy-test-case.sub.js
+++ b/referrer-policy/generic/referrer-policy-test-case.sub.js
@@ -2,14 +2,24 @@
 // - mixed-content/generic/mixed-content-test-case.js
 // - referrer-policy/generic/referrer-policy-test-case.sub.js
 // but should be moved to /common/security-features/resources/common.js.
+
+function crossOriginBaseURL()
+{
+    return getSubresourceOrigin("cross-" + location.protocol.substring(0, location.protocol.length - 1));
+}
+
+function getOriginHosts()
+{
+    return { sameOriginHost: "{{host}}", crossOriginHost: "{{hosts[alt][]}}" };
+}
+
 function getSubresourceOrigin(originType) {
   const httpProtocol = "http";
   const httpsProtocol = "https";
   const wsProtocol = "ws";
   const wssProtocol = "wss";
 
-  const sameOriginHost = "{{host}}";
-  const crossOriginHost = "{{domains[www1]}}";
+  const { sameOriginHost, crossOriginHost } = getOriginHosts();
 
   // These values can evaluate to either empty strings or a ":port" string.
   const httpPort = getNormalizedPort(parseInt("{{ports[http][0]}}", 10));
@@ -72,10 +82,17 @@ function ReferrerPolicyTestCase(scenario, testDescription, sanityChecker) {
     "cross-origin-http": "cross-http",
     "cross-origin-https": "cross-https"
   };
+
+  let redirectionOrigin;
+  if (scenario.redirection === "swap-origin-redirect") {
+    const { sameOriginHost, crossOriginHost } = getOriginHosts();
+    redirectionOrigin = scenario.origin === "same-origin" ? crossOriginHost : sameOriginHost;
+  }
+
   const urls = getRequestURLs(
       scenario.subresource,
       originTypeConversion[scenario.origin + '-' + scenario.target_protocol],
-      scenario.redirection);
+      scenario.redirection, redirectionOrigin);
 
   const referrerUrlResolver = {
     "omitted": function(sourceUrl) {

--- a/referrer-policy/generic/sandboxed-iframe-with-opaque-origin.html
+++ b/referrer-policy/generic/sandboxed-iframe-with-opaque-origin.html
@@ -30,7 +30,7 @@
               <script src = "/referrer-policy/generic/referrer-policy-test-case.sub.js"></` + `script>
               <script>
                 var urlPath = "/common/security-features/subresource/xhr.py";
-                var url = "${location.protocol}//www1.${location.hostname}:${location.port}" + urlPath;
+                var url = crossOriginBaseURL() + urlPath;
                 requestViaXhr(url).then((msg) => {
                     parent.postMessage({referrer: msg.referrer, description: "${description}"}, "*")
                   })

--- a/referrer-policy/generic/subresource-test/area-navigate.html
+++ b/referrer-policy/generic/subresource-test/area-navigate.html
@@ -19,8 +19,7 @@
     <script>
       promise_test(function() {
           var urlPath = '/common/security-features/subresource/document.py';
-          var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                    urlPath;
+          var url = crossOriginBaseURL() + urlPath;
           return requestViaArea(url)
             .then(function(message) {
               var pre = document.getElementById('received_message')

--- a/referrer-policy/generic/subresource-test/iframe-messaging.html
+++ b/referrer-policy/generic/subresource-test/iframe-messaging.html
@@ -19,8 +19,7 @@
     <script>
       promise_test(function() {
         var urlPath = '/common/security-features/subresource/document.py';
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaIframe(url)
           .then(function(message) {
             var pre = document.getElementById('received_message')

--- a/referrer-policy/generic/subresource-test/image-decoding.html
+++ b/referrer-policy/generic/subresource-test/image-decoding.html
@@ -19,7 +19,7 @@
     <script>
       promise_test(function() {
         var urlPath = '/common/security-features/subresource/image.py';
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
+        var url = crossOriginBaseURL() +
                   urlPath + "?cache_destroyer=" + (new Date()).getTime();
         return requestViaImage(url, undefined, "always")
           .then(function(message) {

--- a/referrer-policy/generic/subresource-test/link-navigate.html
+++ b/referrer-policy/generic/subresource-test/link-navigate.html
@@ -19,8 +19,7 @@
     <script>
       promise_test(function() {
         var urlPath = '/common/security-features/subresource/document.py';
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaAnchor(url)
           .then(function(message) {
               var pre = document.getElementById('received_message')

--- a/referrer-policy/generic/subresource-test/script-messaging.html
+++ b/referrer-policy/generic/subresource-test/script-messaging.html
@@ -19,8 +19,7 @@
     <script>
       promise_test(function() {
         var urlPath = '/common/security-features/subresource/script.py';
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaScript(url)
           .then(function(message) {
               var pre = document.getElementById('received_message')

--- a/referrer-policy/generic/subresource-test/xhr-messaging.html
+++ b/referrer-policy/generic/subresource-test/xhr-messaging.html
@@ -19,8 +19,7 @@
     <script>
       promise_test(function() {
         var urlPath = '/common/security-features/subresource/xhr.py';
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaXhr(url)
           .then(function(message) {
               var pre = document.getElementById('received_message')

--- a/referrer-policy/generic/unsupported-csp-referrer-directive.html
+++ b/referrer-policy/generic/unsupported-csp-referrer-directive.html
@@ -18,8 +18,7 @@
     <script>
       promise_test(function() {
         var urlPath = '/common/security-features/subresource/image.py?cache_destroyer=' + (new Date()).getTime();
-        var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                  urlPath;
+        var url = crossOriginBaseURL() + urlPath;
         return requestViaImage(url, null, 'always')
           .then(function(message) {
             assert_equals(message.referrer, document.location.href);


### PR DESCRIPTION
Update python test infrastructure to not hardcode www1.
Instead make javascript code craft the necessary information in the request URLs.
Move from referrer-policy-test-case.js?pipe=sub to referrer-policy-test-case.sub.js.