### PR TITLE
Rename referrer-policy-test-case.js to referrer-policy-test-case.sub.js

### DIFF
--- a/referrer-policy/README.md
+++ b/referrer-policy/README.md
@@ -96,7 +96,7 @@ The ```./generic/tools/clean.py``` utility will only work if there is a valid ``
 
 ## Updating the tests
 
-The main test logic lives in ```./generic/referrer-policy-test-case.js``` with helper functions defined in ```./common/security-features/resources/common.js``` so you should probably start there.
+The main test logic lives in ```./generic/referrer-policy-test-case.sub.js``` with helper functions defined in ```./common/security-features/resources/common.js``` so you should probably start there.
 
 For updating the test suite you will most likely do **a subset** of the following:
 
@@ -105,7 +105,7 @@ For updating the test suite you will most likely do **a subset** of the followin
 
 * Add a sanity check test for a sub-resource to ```./generic/subresource-test/```.
 
-* Implement new or update existing assertions in ```./generic/referrer-policy-test-case.js```.
+* Implement new or update existing assertions in ```./generic/referrer-policy-test-case.sub.js```.
 
 * Exclude or add some tests by updating ```spec.src.json``` test expansions.
 

--- a/referrer-policy/css-integration/child-css/external-import-stylesheet.html
+++ b/referrer-policy/css-integration/child-css/external-import-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="origin">
   </head>
   <body>

--- a/referrer-policy/css-integration/child-css/internal-import-stylesheet.html
+++ b/referrer-policy/css-integration/child-css/internal-import-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="never">
   </head>
   <body>

--- a/referrer-policy/css-integration/child-css/processing-instruction.html
+++ b/referrer-policy/css-integration/child-css/processing-instruction.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="origin">
   </head>
   <body>

--- a/referrer-policy/css-integration/font-face/external-import-stylesheet.html
+++ b/referrer-policy/css-integration/font-face/external-import-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="never">
   </head>
   <body>

--- a/referrer-policy/css-integration/font-face/external-stylesheet.html
+++ b/referrer-policy/css-integration/font-face/external-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="never">
   </head>
   <body>

--- a/referrer-policy/css-integration/font-face/internal-import-stylesheet.html
+++ b/referrer-policy/css-integration/font-face/internal-import-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="origin">
   </head>
   <body>

--- a/referrer-policy/css-integration/font-face/internal-stylesheet.html
+++ b/referrer-policy/css-integration/font-face/internal-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="origin">
   </head>
   <body>

--- a/referrer-policy/css-integration/font-face/processing-instruction.html
+++ b/referrer-policy/css-integration/font-face/processing-instruction.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="never">
   </head>
   <body>

--- a/referrer-policy/css-integration/image/external-import-stylesheet.html
+++ b/referrer-policy/css-integration/image/external-import-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="never">
   </head>
   <body>

--- a/referrer-policy/css-integration/image/external-stylesheet.html
+++ b/referrer-policy/css-integration/image/external-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="never">
   </head>
   <body>

--- a/referrer-policy/css-integration/image/inline-style.html
+++ b/referrer-policy/css-integration/image/inline-style.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="origin">
   </head>
   <body>

--- a/referrer-policy/css-integration/image/internal-import-stylesheet.html
+++ b/referrer-policy/css-integration/image/internal-import-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="origin">
   </head>
   <body>

--- a/referrer-policy/css-integration/image/internal-stylesheet.html
+++ b/referrer-policy/css-integration/image/internal-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="origin">
   </head>
   <body>

--- a/referrer-policy/css-integration/image/presentation-attribute.html
+++ b/referrer-policy/css-integration/image/presentation-attribute.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="origin">
   </head>
   <body>

--- a/referrer-policy/css-integration/image/processing-instruction.html
+++ b/referrer-policy/css-integration/image/processing-instruction.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="never">
   </head>
   <body>

--- a/referrer-policy/css-integration/svg/external-stylesheet.html
+++ b/referrer-policy/css-integration/svg/external-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <!-- Helper functions for referrer-policy css tests. -->
     <script src="/referrer-policy/css-integration/css-test-helper.js"></script>
     <meta name="referrer" content="never">

--- a/referrer-policy/css-integration/svg/inline-style.html
+++ b/referrer-policy/css-integration/svg/inline-style.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <!-- Helper functions for referrer-policy css tests. -->
     <script src="/referrer-policy/css-integration/css-test-helper.js"></script>
     <meta name="referrer" content="origin">

--- a/referrer-policy/css-integration/svg/internal-stylesheet.html
+++ b/referrer-policy/css-integration/svg/internal-stylesheet.html
@@ -7,7 +7,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <!-- Helper functions for referrer-policy css tests. -->
     <script src="/referrer-policy/css-integration/css-test-helper.js"></script>
     <meta name="referrer" content="origin">

--- a/referrer-policy/css-integration/svg/presentation-attribute.html
+++ b/referrer-policy/css-integration/svg/presentation-attribute.html
@@ -8,7 +8,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <!-- Helper functions for referrer-policy css tests. -->
     <script src="/referrer-policy/css-integration/css-test-helper.js"></script>
     <meta name="referrer" content="origin">

--- a/referrer-policy/css-integration/svg/processing-instruction.html
+++ b/referrer-policy/css-integration/svg/processing-instruction.html
@@ -8,7 +8,7 @@
     <script src="/common/utils.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <!-- Helper functions for referrer-policy css tests. -->
     <script src="/referrer-policy/css-integration/css-test-helper.js"></script>
     <meta name="referrer" content="origin">

--- a/referrer-policy/generic/iframe-inheritance.html
+++ b/referrer-policy/generic/iframe-inheritance.html
@@ -8,7 +8,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
     <meta name="referrer" content="origin">
   </head>
   <body onload="runTest()">
@@ -26,7 +26,7 @@
         document.body.appendChild(iframe);
         iframe.contentDocument.write(`
             <script src = "/common/security-features/resources/common.js"></` + `script>
-            <script src = "/referrer-policy/generic/referrer-policy-test-case.js"></` + `script>
+            <script src = "/referrer-policy/generic/referrer-policy-test-case.sub.js"></` + `script>
             <script>
               var urlPath = "/common/security-features/subresource/xhr.py";
               var url = "${location.protocol}//www1.${location.hostname}:${location.port}" + urlPath;

--- a/referrer-policy/generic/multiple-headers-and-values.html
+++ b/referrer-policy/generic/multiple-headers-and-values.html
@@ -6,7 +6,7 @@
     <script src="/resources/testharnessreport.js"></script>
 
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Referrer Policy: multiple Referrer-Policy header and header values are allowed</h1>

--- a/referrer-policy/generic/multiple-headers-combined.html
+++ b/referrer-policy/generic/multiple-headers-combined.html
@@ -6,7 +6,7 @@
     <script src="/resources/testharnessreport.js"></script>
 
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Referrer Policy: multiple Referrer-Policy header values are allowed</h1>

--- a/referrer-policy/generic/multiple-headers-one-invalid.html
+++ b/referrer-policy/generic/multiple-headers-one-invalid.html
@@ -6,7 +6,7 @@
     <script src="/resources/testharnessreport.js"></script>
 
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Referrer Policy: multiple Referrer-Policy headers with one invalid</h1>

--- a/referrer-policy/generic/multiple-headers-one-unknown-token.html
+++ b/referrer-policy/generic/multiple-headers-one-unknown-token.html
@@ -6,7 +6,7 @@
     <script src="/resources/testharnessreport.js"></script>
 
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Referrer Policy: multiple Referrer-Policy headers with one invalid</h1>

--- a/referrer-policy/generic/multiple-headers.html
+++ b/referrer-policy/generic/multiple-headers.html
@@ -6,7 +6,7 @@
     <script src="/resources/testharnessreport.js"></script>
 
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Referrer Policy: multiple Referrer-Policy headers are allowed</h1>

--- a/referrer-policy/generic/referrer-policy-test-case.sub.js
+++ b/referrer-policy/generic/referrer-policy-test-case.sub.js
@@ -1,6 +1,6 @@
 // TODO: This function is currently placed and duplicated at:
 // - mixed-content/generic/mixed-content-test-case.js
-// - referrer-policy/generic/referrer-policy-test-case.js
+// - referrer-policy/generic/referrer-policy-test-case.sub.js
 // but should be moved to /common/security-features/resources/common.js.
 function getSubresourceOrigin(originType) {
   const httpProtocol = "http";

--- a/referrer-policy/generic/sandboxed-iframe-with-opaque-origin.html
+++ b/referrer-policy/generic/sandboxed-iframe-with-opaque-origin.html
@@ -8,7 +8,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Referrer Policy: A document with an opaque origin doesn't send referrers</h1>
@@ -27,7 +27,7 @@
           iframe.srcdoc = `
               <meta name = "referrer" content = "always">
               <script src = "/common/security-features/resources/common.js"></` + `script>
-              <script src = "/referrer-policy/generic/referrer-policy-test-case.js"></` + `script>
+              <script src = "/referrer-policy/generic/referrer-policy-test-case.sub.js"></` + `script>
               <script>
                 var urlPath = "/common/security-features/subresource/xhr.py";
                 var url = "${location.protocol}//www1.${location.hostname}:${location.port}" + urlPath;

--- a/referrer-policy/generic/subresource-test/area-navigate.html
+++ b/referrer-policy/generic/subresource-test/area-navigate.html
@@ -7,7 +7,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Area Link messaging - cross-origin Area Link navigation</h1>

--- a/referrer-policy/generic/subresource-test/fetch-messaging.html
+++ b/referrer-policy/generic/subresource-test/fetch-messaging.html
@@ -7,7 +7,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Fetch messaging - same-origin Fetch request</h1>

--- a/referrer-policy/generic/subresource-test/iframe-messaging.html
+++ b/referrer-policy/generic/subresource-test/iframe-messaging.html
@@ -7,7 +7,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Iframe messaging - cross-origin iframe request</h1>

--- a/referrer-policy/generic/subresource-test/image-decoding.html
+++ b/referrer-policy/generic/subresource-test/image-decoding.html
@@ -7,7 +7,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Image decoding - cross-origin image request</h1>

--- a/referrer-policy/generic/subresource-test/link-navigate.html
+++ b/referrer-policy/generic/subresource-test/link-navigate.html
@@ -7,7 +7,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Link messaging - cross-origin Link navigation</h1>

--- a/referrer-policy/generic/subresource-test/script-messaging.html
+++ b/referrer-policy/generic/subresource-test/script-messaging.html
@@ -7,7 +7,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Script messaging - cross-origin Script request</h1>

--- a/referrer-policy/generic/subresource-test/worker-messaging.html
+++ b/referrer-policy/generic/subresource-test/worker-messaging.html
@@ -7,7 +7,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Worker messaging - same-origin Worker request</h1>

--- a/referrer-policy/generic/subresource-test/xhr-messaging.html
+++ b/referrer-policy/generic/subresource-test/xhr-messaging.html
@@ -7,7 +7,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>XHR messaging - cross-origin XHR request</h1>

--- a/referrer-policy/generic/tools/generate.py
+++ b/referrer-policy/generic/tools/generate.py
@@ -25,7 +25,7 @@ the target request is %(origin)s.'''
 
     self.test_page_title_template = 'Referrer-Policy: %s'
 
-    self.helper_js = '/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub'
+    self.helper_js = '/referrer-policy/generic/referrer-policy-test-case.sub.js'
 
     # For debug target only.
     self.sanity_checker_js = '/referrer-policy/generic/sanity-checker.js'

--- a/referrer-policy/generic/unsupported-csp-referrer-directive.html
+++ b/referrer-policy/generic/unsupported-csp-referrer-directive.html
@@ -7,7 +7,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <h1>Referrer Policy: CSP 'referrer' directive should not be supported</h1>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/no-referrer-when-downgrade/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/module-worker/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/module-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/shared-worker/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/shared-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/worker-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/worker-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/module-worker/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/module-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/shared-worker/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/shared-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/worker-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/worker-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/no-referrer/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/a-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/a-tag/no-redirect/same-origin-upgrade.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/same-origin-upgrade.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/same-origin-upgrade.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/same-origin-upgrade.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/no-redirect/same-origin-upgrade.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/same-origin-upgrade.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/no-redirect/same-origin-upgrade.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/module-worker/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/module-worker/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/shared-worker/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/shared-worker/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/worker-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/worker-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/a-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/a-tag/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/a-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/a-tag/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/no-redirect/same-origin-upgrade.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/no-redirect/same-origin-upgrade.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/module-worker/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/module-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/shared-worker/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/shared-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/worker-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/worker-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/fetch-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/fetch-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/module-worker/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/module-worker/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/shared-worker/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/shared-worker/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/worker-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/worker-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/cross-origin.http.html
+++ b/referrer-policy/same-origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/cross-origin.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/same-origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
+++ b/referrer-policy/same-origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/same-origin-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-insecure.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/a-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/a-tag/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/a-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/a-tag/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/module-worker/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/module-worker/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/shared-worker/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/shared-worker/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/worker-request/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/worker-request/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/cross-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/same-insecure.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/same-insecure.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin-when-cross-origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/strict-origin/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/module-worker/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/module-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/shared-worker/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/shared-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/worker-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/worker-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/module-worker/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/module-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/shared-worker/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/shared-worker/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/worker-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/worker-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/a-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/fetch-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/fetch-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/img-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/script-tag/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/xhr-request/no-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/xhr-request/no-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
+++ b/referrer-policy/unsafe-url/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/generic.http.html
@@ -15,7 +15,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/attr-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/http-rp/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/cross-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/a-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/fetch-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/fetch-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/fetch-request/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/iframe-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/iframe-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/iframe-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/img-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/img-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/img-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/module-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/module-worker/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/script-tag/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/script-tag/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/script-tag/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/shared-worker/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/shared-worker/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/worker-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/worker-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/xhr-request/keep-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/xhr-request/no-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-http/xhr-request/swap-origin-redirect/insecure-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/a-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/fetch-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/fetch-request/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/fetch-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/iframe-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/iframe-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/iframe-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/img-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/img-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/img-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/script-tag/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/script-tag/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/script-tag/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/xhr-request/keep-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/xhr-request/no-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>

--- a/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
+++ b/referrer-policy/unset-referrer-policy/meta-referrer/same-origin/http-https/xhr-request/swap-origin-redirect/upgrade-protocol.http.html
@@ -14,7 +14,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/security-features/resources/common.js"></script>
-    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.sub.js"></script>
   </head>
   <body>
     <script>


### PR DESCRIPTION
referrer-policy-test-case.js is using wpt server pipe sub.
Some of the tests do not add ?pipe=sub when fetching the script.
Instead of fixing those tests, rename referrer-policy-test-case.js to referrer-policy-test-case.sub.js to ensure the file is updated by WPT server appropriately.