### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=197338

### DIFF
--- a/fetch/api/request/request-keepalive.html
+++ b/fetch/api/request/request-keepalive.html
@@ -21,7 +21,7 @@ test(() => {
 
 test(() => {
   const init = {method: 'POST', keepalive: true, body: new ReadableStream()};
-  assert_throws('TypeError', () => {new Request('/', init)});
+  assert_throws(new TypeError(), () => {new Request('/', init)});
 }, 'keepalive flag with stream body');
 </script>
 </body>


### PR DESCRIPTION
WebKit export from bug: [Fix imported/w3c/web-platform-tests/fetch/api/request/request-keepalive.html assert_throws call](https://bugs.webkit.org/show_bug.cgi?id=197338)