### PR TITLE
Revise match link in floating-first-letter reftests

### DIFF
--- a/css/selectors/floating-first-letter-05d0.html
+++ b/css/selectors/floating-first-letter-05d0.html
@@ -3,7 +3,7 @@
 <title>Drop cap with U+05D0 in the document</title>
 <meta name="assert" content="The text placement within :first-line should not be affected by later presence of a right-to-left character.">
 <link rel=help href=https://drafts.csswg.org/css-pseudo-4/#first-line-styling>
-<link rel=match href=/css/selectors/floating-first-letter-ref.html>
+<link rel=match href=floating-first-letter-ref.html>
 <style>
   p:first-line {
     background: lightblue;

--- a/css/selectors/floating-first-letter-feff.html
+++ b/css/selectors/floating-first-letter-feff.html
@@ -3,7 +3,7 @@
 <title>Drop cap with U+FEFF in the document</title>
 <meta name="assert" content="The text placement within :first-line should not be affected by later presence of U+FEFF.">
 <link rel=help href=https://drafts.csswg.org/css-pseudo-4/#first-line-styling>
-<link rel=match href=/css/selectors/floating-first-letter-ref.html>
+<link rel=match href=floating-first-letter-ref.html>
 <style>
   p:first-line {
     background: lightblue;


### PR DESCRIPTION
The reference file is in the same directory, so no need to specify
/css/selectors/.