### PR TITLE
[css-contain] Mark body as overflow:hidden in contain-size-grid-002.html

### DIFF
--- a/css/css-contain/contain-size-grid-002.html
+++ b/css/css-contain/contain-size-grid-002.html
@@ -7,6 +7,9 @@
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 
 <style>
+body {
+  overflow: hidden;
+}
 div {
   position: absolute;
 }


### PR DESCRIPTION
This way we avoid any kind of scrollbar when running on small viewports
like 800x600.