### PR TITLE
Define __slots__ on all manifest item classes

### DIFF
--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -105,6 +105,8 @@ class URLManifestItem(ManifestItem):
 
 
 class TestharnessTest(URLManifestItem):
+    __slots__ = ()
+
     item_type = "testharness"
 
     @property
@@ -207,30 +209,44 @@ class RefTestBase(URLManifestItem):
 
 
 class RefTestNode(RefTestBase):
+    __slots__ = ()
+
     item_type = "reftest_node"
 
 
 class RefTest(RefTestBase):
+    __slots__ = ()
+
     item_type = "reftest"
 
 
 class ManualTest(URLManifestItem):
+    __slots__ = ()
+
     item_type = "manual"
 
 
 class ConformanceCheckerTest(URLManifestItem):
+    __slots__ = ()
+
     item_type = "conformancechecker"
 
 
 class VisualTest(URLManifestItem):
+    __slots__ = ()
+
     item_type = "visual"
 
 
 class Stub(URLManifestItem):
+    __slots__ = ()
+
     item_type = "stub"
 
 
 class WebDriverSpecTest(URLManifestItem):
+    __slots__ = ()
+
     item_type = "wdspec"
 
     @property
@@ -245,6 +261,8 @@ class WebDriverSpecTest(URLManifestItem):
 
 
 class SupportFile(ManifestItem):
+    __slots__ = ()
+
     item_type = "support"
 
     @property


### PR DESCRIPTION
We previously only defined it on classes which created instance attributes. We still don't need an instance dict on those that don't.