### PR TITLE
[css-values] Added 3 complex gCS tests with calc()

### DIFF
--- a/css/css-values/getComputedStyle-calc-background-position-percent-012.html
+++ b/css/css-values/getComputedStyle-calc-background-position-percent-012.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Values Test: serialization of computed value of background-position: calc(100% - 100% + 1em)</title>
+
+  <!--
+  "
+  Where percentages are not resolved at computed-value time,
+  they are not resolved in math functions, e.g.
+  calc(100% - 100% + 1em) resolves to calc(1em + 0%), not to
+  1em. If there are special rules for computing percentages
+  in a value (e.g. the height property), they apply whenever
+  a math function contains percentages.
+  "
+  https://www.w3.org/TR/css-values-4/#calc-serialize
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-values-3/#calc-computed-value">
+
+  <meta name="flags" content="">
+  <meta content="This test verifies that a term with a percentage unit that can not be resolved at computed-value time will require a calc() wrapper. And, in such case, even if it has the 0 value, it must be preserved. A term with an em value, on the other hand, can be resolved at computed-value time and therefore must be absolutized to 'px'." name="assert">
+
+  <script src="/resources/testharness.js"></script>
+
+  <script src="/resources/testharnessreport.js"></script>
+
+  <style>
+  div#target
+    {
+      background-color: yellow;
+      background-image: url("support/cat.png");
+      background-repeat: no-repeat;
+      background-size: 14% 50%; /* entirely arbitrary and random background-size values */
+      font-size: 16px;
+      height: 200px;
+    }
+  </style>
+
+  <div id="target"></div>
+
+  <script>
+  function startTesting()
+  {
+
+  var targetElement = document.getElementById("target");
+
+    function verifyComputedStyle(property_name, specified_value, expected_value, description)
+    {
+
+    test(function()
+      {
+
+      targetElement.style.setProperty(property_name, specified_value);
+
+      assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
+
+      }, description);
+    }
+
+ /* verifyComputedStyle(property_name, specified_value, expected_value, description) */
+
+    verifyComputedStyle("background-position", "calc(100% - 100% + 1em)", "calc(0% + 16px) 50%", "testing background-position: calc(100% - 100% + 1em)");
+
+    /*
+    "Where percentages are not resolved at computed-value time,
+    they are not resolved in math functions (...)"
+    https://www.w3.org/TR/css-values-4/#calc-serialize
+
+    Therefore here, the percentage is preserved and
+    a calc() wrapper must be used. The 1em term
+    should be resolved though.
+    */
+
+  }
+
+  startTesting();
+
+  </script>

--- a/css/css-values/getComputedStyle-calc-background-size-percent-016.html
+++ b/css/css-values/getComputedStyle-calc-background-size-percent-016.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Values Test: serialization of computed value of background-size: calc(67% - 50% + 4em)</title>
+
+  <!--
+  "
+  Where percentages are not resolved at computed-value time,
+  they are not resolved in math functions, e.g.
+  calc(100% - 100% + 1em) resolves to calc(1em + 0%), not to
+  1em. If there are special rules for computing percentages
+  in a value (e.g. the height property), they apply whenever
+  a math function contains percentages.
+  "
+  https://www.w3.org/TR/css-values-4/#calc-serialize
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-values-3/#calc-computed-value">
+
+  <meta name="flags" content="">
+  <meta content="This test verifies that a term with a percentage unit that can not be resolved at computed-value time will require a calc() wrapper. A term with an em value, on the other hand, can be resolved at computed-value time and therefore must be absolutized to 'px'." name="assert">
+
+  <script src="/resources/testharness.js"></script>
+
+  <script src="/resources/testharnessreport.js"></script>
+
+  <style>
+  html, body
+    {
+      height: 100%;
+      font-size: 16px;
+      margin: 0px 8px;
+    }
+
+  div#target
+    {
+      background-color: yellow;
+      background-image: url("support/cat.png");
+      background-position: top center;
+      background-repeat: no-repeat;
+      height: 140px;
+    }
+  </style>
+
+  <div id="target"></div>
+
+  <script>
+  function startTesting()
+  {
+
+  var targetElement = document.getElementById("target");
+
+    function verifyComputedStyle(property_name, specified_value, expected_value, description)
+    {
+
+    test(function()
+      {
+
+      targetElement.style.setProperty(property_name, specified_value);
+
+      assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
+
+      }, description);
+    }
+
+ /* verifyComputedStyle(property_name, specified_value, expected_value, description) */
+
+    verifyComputedStyle("background-size", "calc(67% - 50% + 4em)", "calc(17% + 64px) auto", "testing background-size: calc(67% - 50% + 4em)");
+
+    /*
+    "Where percentages are not resolved at computed-value time,
+    they are not resolved in math functions (...)"
+    https://www.w3.org/TR/css-values-4/#calc-serialize
+
+    Therefore here, the percentage is preserved and
+    a calc() wrapper must be used. The 4em term
+    should be resolved though.
+    */
+
+  }
+
+  startTesting();
+
+  </script>

--- a/css/css-values/getComputedStyle-calc-height-percent-014.html
+++ b/css/css-values/getComputedStyle-calc-height-percent-014.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Values Test: serialization of computed value of height: calc(60% - 50% + 3em)</title>
+
+  <!--
+  "
+  Where percentages are not resolved at computed-value time,
+  they are not resolved in math functions, e.g.
+  calc(100% - 100% + 1em) resolves to calc(1em + 0%), not to
+  1em. If there are special rules for computing percentages
+  in a value (e.g. the height property), they apply whenever
+  a math function contains percentages.
+  "
+  https://www.w3.org/TR/css-values-4/#calc-serialize
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-values-3/#calc-computed-value">
+
+  <meta name="flags" content="">
+  <meta content="This test verifies that a term with a percentage unit that can be resolved at computed-value time must be absolutized to 'px'. In this test, the term with the percentage unit can be computed and resolved and so is the term with the em unit." name="assert">
+
+  <script src="/resources/testharness.js"></script>
+
+  <script src="/resources/testharnessreport.js"></script>
+
+  <style>
+  html, body
+    {
+      font-size: 16px;
+      height: 600px;
+      margin: 0px 8px;
+    }
+
+  div#target
+    {
+      background-color: yellow;
+    }
+  </style>
+
+  <div id="target"></div>
+
+  <script>
+  function startTesting()
+  {
+
+  var targetElement = document.getElementById("target");
+
+    function verifyComputedStyle(property_name, specified_value, expected_value, description)
+    {
+
+    test(function()
+      {
+
+      targetElement.style.setProperty(property_name, specified_value);
+
+      assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
+
+      }, description);
+    }
+
+ /* verifyComputedStyle(property_name, specified_value, expected_value, description) */
+
+    verifyComputedStyle("height", "calc(60% - 50% + 3em)", "108px", "testing height: calc(60% - 50% + 3em)");
+
+    /*
+
+     600px mult 10% == 60px
+
+                 +     48px
+                 ============
+                      108px
+
+    */
+
+  }
+
+  startTesting();
+
+  </script>


### PR DESCRIPTION
Added 3 complex getComputedStyle with calc() with percentages, with 2 involving background-position and background-size which can not be resolved at computed-value time, therefore the calc() wrapper with percentage must remain.