### PR TITLE
Add contact address to web-based runner page

### DIFF
--- a/tools/runner/index.html
+++ b/tools/runner/index.html
@@ -23,9 +23,16 @@
   <div class="alert alert-warning">
         This runner does not fully support all test types and has a number of
         <a href="https://github.com/web-platform-tests/wpt/labels/runner">known issues</a>.
-        If this runner isn’t working, contact <a href="mailto:mike@w3.org">mike@w3.org</a>.
+        <span id="runner-contact-info"></span>
         <code>./wpt run</code> is a more well-supported runner, see the documentation on
         <a href="https://web-platform-tests.org/running-tests/">running tests</a>.
+        <script>
+        if (location.host == "w3c-test.org") {
+            document.getElementById("runner-contact-info")
+                .innerHTML = ' If this runner isn’t working, contact'
+                    + ' <a href="mailto:mike@w3.org">mike@w3.org</a>. '
+        }
+        </script>
   </div>
 
   <div id="testControl" class="panel panel-default">

--- a/tools/runner/index.html
+++ b/tools/runner/index.html
@@ -23,6 +23,7 @@
   <div class="alert alert-warning">
         This runner does not fully support all test types and has a number of
         <a href="https://github.com/web-platform-tests/wpt/labels/runner">known issues</a>.
+        If this runner isn’t working, contact <a href="mailto:mike@w3.org">mike@w3.org</a>.
         <code>./wpt run</code> is a more well-supported runner, see the documentation on
         <a href="https://web-platform-tests.org/running-tests/">running tests</a>.
   </div>


### PR DESCRIPTION
This change mostly is intended for people using the instance of the web-based runner at https://w3c-test.org/tools/runner/index.html.  Not finding any other contact info there, people otherwise contact the W3C Systems team to report problems with the tool. But the W3C Systems team doesn’t maintain the tool; hence this change.