### PR TITLE
Update lint for `internals` to not assume `window.internals`

### DIFF
--- a/docs/_writing-tests/lint-tool.md
+++ b/docs/_writing-tests/lint-tool.md
@@ -52,7 +52,7 @@ below to fix all errors reported.
   the `<meta name="timeout"...>` element to precede the `script` element.
 
 * **LAYOUTTESTS APIS**: Test file uses `eventSender`, `testRunner`, or
-  `window.internals` which are LayoutTests-specific APIs used in WebKit/Blink.
+  `internals` which are LayoutTests-specific APIs used in WebKit/Blink.
 
 * **MALFORMED-VARIANT**: Test file with a `<meta name='variant'...>`
   element whose `content` attribute has a malformed value; **fix**: ensure

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -801,7 +801,10 @@ MISSING-LINK: css/filter-effects/*.any.js
 
 # Tests that use WebKit/Blink testing APIs
 LAYOUTTESTS APIS: css/css-regions/interactivity/*
+LAYOUTTESTS APIS: import-maps/resolving.tentative.html
+LAYOUTTESTS APIS: permissions/test-background-fetch-permission.html
 LAYOUTTESTS APIS: resources/chromium/generic_sensor_mocks.js
+LAYOUTTESTS APIS: resources/chromium/webxr-test.js
 
 # Gecko additons to remove
 CSS-COLLIDING-REF-NAME: css/css-contain/reference/contain-size-fieldset-001-ref.html

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -327,10 +327,10 @@ class PrintRegexp(Regexp):
     description = "Print function used"
 
 class LayoutTestsRegexp(Regexp):
-    pattern = br"eventSender|testRunner|window\.internals"
+    pattern = br"(eventSender|testRunner|internals)\."
     name = "LAYOUTTESTS APIS"
     file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
-    description = "eventSender/testRunner/window.internals used; these are LayoutTests-specific APIs (WebKit/Blink)"
+    description = "eventSender/testRunner/internals used; these are LayoutTests-specific APIs (WebKit/Blink)"
 
 class SpecialPowersRegexp(Regexp):
     pattern = b"SpecialPowers"

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -168,7 +168,7 @@ def test_eventSender():
             assert errors == [("PARSE-FAILED", "Unable to parse file", filename, 1)]
         else:
             assert errors == [('LAYOUTTESTS APIS',
-                               'eventSender/testRunner/window.internals used; these are LayoutTests-specific APIs (WebKit/Blink)',
+                               'eventSender/testRunner/internals used; these are LayoutTests-specific APIs (WebKit/Blink)',
                                filename,
                                1)]
 
@@ -183,12 +183,12 @@ def test_testRunner():
             assert errors == [("PARSE-FAILED", "Unable to parse file", filename, 1)]
         else:
             assert errors == [('LAYOUTTESTS APIS',
-                               'eventSender/testRunner/window.internals used; these are LayoutTests-specific APIs (WebKit/Blink)',
+                               'eventSender/testRunner/internals used; these are LayoutTests-specific APIs (WebKit/Blink)',
                                filename,
                                1)]
 
 
-def test_windowDotInternals():
+def test_internals():
     error_map = check_with_files(b"<script>if (window.internals) { internals.doAThing(); }</script>")
 
     for (filename, (errors, kind)) in error_map.items():
@@ -198,7 +198,7 @@ def test_windowDotInternals():
             assert errors == [("PARSE-FAILED", "Unable to parse file", filename, 1)]
         else:
             assert errors == [('LAYOUTTESTS APIS',
-                               'eventSender/testRunner/window.internals used; these are LayoutTests-specific APIs (WebKit/Blink)',
+                               'eventSender/testRunner/internals used; these are LayoutTests-specific APIs (WebKit/Blink)',
                                filename,
                                1)]
 


### PR DESCRIPTION
A few cases have slipped through that don't use `window.internals` but
just use `internals.something` directly. One of these is being fixed:
https://chromium-review.googlesource.com/c/chromium/src/+/1567748