### PR TITLE
[css-text] tweak test

### DIFF
--- a/css/css-text/hyphens/shy-styling-001.html
+++ b/css/css-text/hyphens/shy-styling-001.html
@@ -9,7 +9,7 @@
 <meta name="assert" content="hypens inserted where there was a soft-hyphen take on the styles that would have applied to the soft hyphen">
 <style>
 div {
-  width: 4ch;
+  width: 0ch;
   hyphens: manual;
 }
 span {


### PR DESCRIPTION
Both tests are equally valid, but prior to this change, chrome and
safari failed it for reasons unrelated to the main point of this test.

(the bug they were hitting is still tested by hyphens-span-001.html)