### PR TITLE
webmessaging/with[out]-ports/018.html should wait for frame load before…

### DIFF
--- a/webmessaging/with-ports/018.html
+++ b/webmessaging/with-ports/018.html
@@ -2,15 +2,19 @@
 <title>origin of the script that invoked the method, javascript:</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<iframe src="javascript:''"></iframe>
+<iframe src="javascript:'1'"></iframe>
 <div id=log></div>
 <script>
-async_test(function() {
-  window[0].postMessage('', '*', []);
-  window[0].onmessage = this.step_func(function(e) {
-    assert_equals(e.origin, location.protocol + '//' + location.host);
-    assert_array_equals(e.ports, []);
-    this.done();
+async_test(function(t) {
+  addEventListener("load", function() {
+    t.step(function() {
+      window[0].postMessage('', '*', []);
+      window[0].onmessage = this.step_func(function(e) {
+        assert_equals(e.origin, location.protocol + '//' + location.host);
+        assert_array_equals(e.ports, []);
+        t.done();
+      });
+    });
   });
 });
 </script>

--- a/webmessaging/without-ports/018.html
+++ b/webmessaging/without-ports/018.html
@@ -2,14 +2,18 @@
 <title>origin of the script that invoked the method, javascript:</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<iframe src="javascript:''"></iframe>
+<iframe src="javascript:'1'"></iframe>
 <div id=log></div>
 <script>
-async_test(function() {
-  window[0].postMessage('', '*');
-  window[0].onmessage = this.step_func(function(e) {
-    assert_equals(e.origin, location.protocol + '//' + location.host);
-    this.done();
+async_test(function(t) {
+  addEventListener("load", function() {
+    t.step(function() {
+      window[0].postMessage('', '*');
+      window[0].onmessage = this.step_func(function(e) {
+        assert_equals(e.origin, location.protocol + '//' + location.host);
+        t.done();
+      });
+    });
   });
 });
 </script>


### PR DESCRIPTION
… testing

These tests rely on an iframe with a javascript URL returning a string. The javascript
URL is executed asynchronously, after the test has called postMessage() on the iframe's
Window but likely before the message has been delivered to iframe's Window. As per
specification, since the Javascript URL returns a string, executing it will replace the
iframe's document / window. As a result, this can cause the message to not get delivered
because the window we've initialized called postMessage() on loses its browsing context
before the message is delivered. I found this issue using a development version of WebKit.

The test was passing in Blink because it loads "javascript:''" synchronously. However,
the test fails if you use the "javascript:'1'" URL, which Blink loads asynchronously.

The test was also passing in Gecko but it appears executing the javascript URL does not
replace the document. I am not sure why.