### PR TITLE
Remove git submodule configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "resources/webidl2/test/widlproc"]
-	path = resources/webidl2/test/widlproc
-	url = https://github.com/dontcallmedom/widlproc.git


### PR DESCRIPTION
The directory referenced by this submodule was incorporated into the
repository using a git subtree over one year ago [1]. Remove the
submodule configuration as it no longer accurately describes the state
of the repository.

[1] see commit b73adc31e4437fc5d3e33441a3631727da0f7f25