### PR TITLE
[docs] Remove instructions for submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,55 +156,6 @@ commands are:
 * `wpt install` - For installing the latest release of a browser or
   webdriver server on the local machine.
 
-<span id="submodules">Submodules</span>
-=======================================
-
-Some optional components of web-platform-tests (test components from
-third party software and pieces of the CSS build system) are included
-as submodules. To obtain these components run the following in the
-root of your checkout:
-
-```
-git submodule update --init --recursive
-```
-
-Prior to commit `39d07eb01fab607ab1ffd092051cded1bdd64d78` submodules
-were required for basic functionality. If you are working with an
-older checkout, the above command is required in all cases.
-
-When moving between a commit prior to `39d07eb` and one after it git
-may complain
-
-```
-$ git checkout master
-error: The following untracked working tree files would be overwritten by checkout:
-[…]
-```
-
-...followed by a long list of files. To avoid this error, remove
-the `resources` and `tools` directories before switching branches:
-
-```
-$ rm -r resources/ tools/
-$ git checkout master
-Switched to branch 'master'
-Your branch is up-to-date with 'origin/master'
-```
-
-When moving in the opposite direction, i.e. to a commit that does have
-submodules, you will need to `git submodule update`, as above. If git
-throws an error like:
-
-```
-fatal: No url found for submodule path 'resources/webidl2/test/widlproc' in .gitmodules
-Failed to recurse into submodule path 'resources/webidl2'
-fatal: No url found for submodule path 'tools/html5lib' in .gitmodules
-Failed to recurse into submodule path 'resources'
-Failed to recurse into submodule path 'tools'
-```
-
-...then remove the `tools` and `resources` directories, as above.
-
 <span id="windows-notes">Windows Notes</span>
 =============================================
 


### PR DESCRIPTION
Running `git submodule update` from the root of this repository no
longer has any effect because the project no longer defines any valid
git submodules at the top level.

The commit referenced in these instructions was created over two years
ago. Such an extended duration reduces the relevance of these
instructions for a general audience. Those who are interested in working
with such a dated revision will recognize that project installation
instructions change with time, and they will find the relevant
instructions in the corresponding revision of this document.