### PR TITLE
Expand the chromium logger with a few more fields.

### DIFF
--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -24,12 +24,32 @@ class ChromiumFormatter(base.BaseFormatter):
         # the trie and the leaf contains the dict of per-test data.
         self.tests = {}
 
-    def _store_test_result(self, name, actual, expected):
+        # Message dictionary, keyed by test name. Value is a concatenation of
+        # the subtest messages for this test.
+        self.messages = defaultdict(str)
+
+    def _append_test_message(self, test, subtest, status, message):
+        """
+        Appends the message data for a test.
+        :param str test: the name of the test
+        :param str subtest: the name of the subtest with the message
+        :param str message: the string to append to the message for this test
+        """
+        if not message:
+            return
+        # Add the prefix, with the test status and subtest name (if available)
+        prefix = "[%s] " % status
+        if subtest:
+            prefix += "%s: " % subtest
+        self.messages[test] += prefix + message + "\n"
+
+    def _store_test_result(self, name, actual, expected, message):
         """
         Stores the result of a single test in |self.tests|
         :param str name: name of the test.
         :param str actual: actual status of the test.
         :param str expected: expected status of the test.
+        :param str message: test output, such as status, subtest, errors etc.
         """
         # The test name can contain a leading / which will produce an empty
         # string in the first position of the list returned by split. We use
@@ -40,6 +60,16 @@ class ChromiumFormatter(base.BaseFormatter):
             cur_dict = cur_dict.setdefault(name_part, {})
         cur_dict["actual"] = actual
         cur_dict["expected"] = expected
+        if message != "":
+            cur_dict["artifacts"] = { "log": message }
+
+        # Figure out if there was a regression or unexpected status. This only
+        # happens for tests that were run
+        if actual != "SKIP":
+            if actual != expected:
+                cur_dict["is_unexpected"] = True
+                if actual != "PASS":
+                    cur_dict["is_regression"] = True
 
     def _map_status_name(self, status):
         """
@@ -75,10 +105,20 @@ class ChromiumFormatter(base.BaseFormatter):
     def suite_start(self, data):
         self.start_timestamp_seconds = data["time"] if "time" in data else time.time()
 
+    def test_status(self, data):
+        if "message" in data:
+            self._append_test_message(data["test"], data["subtest"], data["status"], data["message"])
+
     def test_end(self, data):
         actual_status = self._map_status_name(data["status"])
         expected_status = self._map_status_name(data["expected"]) if "expected" in data else "PASS"
-        self._store_test_result(data["test"], actual_status, expected_status)
+        test_name = data["test"]
+        if "message" in data:
+            self._append_test_message(test_name, None, actual_status, data["message"])
+        self._store_test_result(test_name, actual_status, expected_status, self.messages[test_name])
+
+        # Remove the test from messages dict to avoid accumulating lots of tests
+        self.messages.keys().remove(test_name)
 
         # Update the count of how many tests ran with each status.
         self.num_failures_by_status[actual_status] += 1

--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -107,7 +107,8 @@ class ChromiumFormatter(base.BaseFormatter):
 
     def test_status(self, data):
         if "message" in data:
-            self._append_test_message(data["test"], data["subtest"], data["status"], data["message"])
+            self._append_test_message(data["test"], data["subtest"],
+                                      data["status"], data["message"])
 
     def test_end(self, data):
         actual_status = self._map_status_name(data["status"])
@@ -115,7 +116,8 @@ class ChromiumFormatter(base.BaseFormatter):
         test_name = data["test"]
         if "message" in data:
             self._append_test_message(test_name, None, actual_status, data["message"])
-        self._store_test_result(test_name, actual_status, expected_status, self.messages[test_name])
+        self._store_test_result(test_name, actual_status, expected_status,
+                                self.messages[test_name])
 
         # Remove the test from messages dict to avoid accumulating lots of tests
         self.messages.keys().remove(test_name)

--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -61,7 +61,7 @@ class ChromiumFormatter(base.BaseFormatter):
         cur_dict["actual"] = actual
         cur_dict["expected"] = expected
         if message != "":
-            cur_dict["artifacts"] = { "log": message }
+            cur_dict["artifacts"] = {"log": message}
 
         # Figure out if there was a regression or unexpected status. This only
         # happens for tests that were run
@@ -103,7 +103,8 @@ class ChromiumFormatter(base.BaseFormatter):
         return status
 
     def suite_start(self, data):
-        self.start_timestamp_seconds = data["time"] if "time" in data else time.time()
+        self.start_timestamp_seconds = (data["time"] if "time" in data
+                                        else time.time())
 
     def test_status(self, data):
         if "message" in data:
@@ -112,15 +113,17 @@ class ChromiumFormatter(base.BaseFormatter):
 
     def test_end(self, data):
         actual_status = self._map_status_name(data["status"])
-        expected_status = self._map_status_name(data["expected"]) if "expected" in data else "PASS"
+        expected_status = (self._map_status_name(data["expected"])
+                           if "expected" in data else "PASS")
         test_name = data["test"]
         if "message" in data:
-            self._append_test_message(test_name, None, actual_status, data["message"])
+            self._append_test_message(test_name, None, actual_status,
+                                      data["message"])
         self._store_test_result(test_name, actual_status, expected_status,
                                 self.messages[test_name])
 
-        # Remove the test from messages dict to avoid accumulating lots of tests
-        self.messages.keys().remove(test_name)
+        # Remove the test from messages dict to avoid accumulating too many.
+        self.messages.pop(test_name)
 
         # Update the count of how many tests ran with each status.
         self.num_failures_by_status[actual_status] += 1

--- a/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
@@ -6,7 +6,7 @@ from six.moves import cStringIO as StringIO
 from mozlog import handlers, structuredlog
 
 sys.path.insert(0, join(dirname(__file__), "..", ".."))
-from formatters import chromium
+from formatters.chromium import ChromiumFormatter
 
 
 def test_chromium_required_fields(capfd):
@@ -15,7 +15,7 @@ def test_chromium_required_fields(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
-    logger.add_handler(handlers.StreamHandler(output, chromium.ChromiumFormatter()))
+    logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # output a bunch of stuff
     logger.suite_start(["test-id-1"], run_info={}, time=123)
@@ -44,6 +44,7 @@ def test_chromium_required_fields(capfd):
     assert "actual" in test_obj
     assert "expected" in test_obj
 
+
 def test_chromium_test_name_trie(capfd):
     # Ensure test names are broken into directories and stored in a trie with
     # test results at the leaves.
@@ -51,10 +52,11 @@ def test_chromium_test_name_trie(capfd):
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
-    logger.add_handler(handlers.StreamHandler(output, chromium.ChromiumFormatter()))
+    logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # output a bunch of stuff
-    logger.suite_start(["/foo/bar/test-id-1", "/foo/test-id-2"], run_info={}, time=123)
+    logger.suite_start(["/foo/bar/test-id-1", "/foo/test-id-2"], run_info={},
+                       time=123)
     logger.test_start("/foo/bar/test-id-1")
     logger.test_end("/foo/bar/test-id-1", status="TIMEOUT", expected="FAIL")
     logger.test_start("/foo/test-id-2")
@@ -82,13 +84,14 @@ def test_chromium_test_name_trie(capfd):
     assert test_obj["actual"] == "FAIL"
     assert test_obj["expected"] == "TIMEOUT"
 
+
 def test_num_failures_by_type(capfd):
     # Test that the number of failures by status type is correctly calculated.
 
     # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
-    logger.add_handler(handlers.StreamHandler(output, chromium.ChromiumFormatter()))
+    logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run some tests with different statuses: 3 passes, 1 timeout
     logger.suite_start(["t1", "t2", "t3", "t4"], run_info={}, time=123)
@@ -117,26 +120,30 @@ def test_num_failures_by_type(capfd):
     assert num_failures_by_type["PASS"] == 3
     assert num_failures_by_type["TIMEOUT"] == 1
 
+
 def test_subtest_messages(capfd):
     # Tests accumulation of test output
 
-    #Set up the handler.
+    # Set up the handler.
     output = StringIO()
     logger = structuredlog.StructuredLogger("test_a")
-    logger.add_handler(handlers.StreamHandler(output, chromium.ChromiumFormatter()))
+    logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
 
     # Run two tests with subtest messages. The subtest name should be included
     # in the output. We should also tolerate missing messages.
     logger.suite_start(["t1", "t2"], run_info={}, time=123)
     logger.test_start("t1")
-    logger.test_status("t1", status="FAIL", subtest="t1_a", message="t1_a_message")
-    logger.test_status("t1", status = "PASS", subtest="t1_b", message="t1_b_message")
+    logger.test_status("t1", status="FAIL", subtest="t1_a",
+                       message="t1_a_message")
+    logger.test_status("t1", status="PASS", subtest="t1_b",
+                       message="t1_b_message")
     logger.test_end("t1", status="PASS", expected="PASS")
     logger.test_start("t2")
     # Currently, subtests with empty messages will be ignored
     logger.test_status("t2", status="PASS", subtest="t2_a")
     # A test-level message will also be appended
-    logger.test_end("t2", status="TIMEOUT", expected="PASS", message="t2_message")
+    logger.test_end("t2", status="TIMEOUT", expected="PASS",
+                    message="t2_message")
     logger.suite_end()
 
     # check nothing got output to stdout/stderr


### PR DESCRIPTION
- is_unexpected indicates that a test did not run as expected
- is_regression indicates that a test used to pass and now doesn't
- artifacts includes log entries from tests, to capture failure output