### PR TITLE
[docs] Add information on virtualenv

### DIFF
--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -11,6 +11,21 @@ On Windows, be sure to add the Python directory (`c:\python2x`, by default) to
 your `%Path%` [Environment Variable](http://www.computerhope.com/issues/ch000549.htm),
 and read the [Windows Notes](#windows-notes) section below.
 
+<!--
+  There does not appear to be a cross-platform means of installing `pip`.
+  https://github.com/web-platform-tests/wpt/pull/16670
+-->
+
+Install `pip`. On many systems, this can be achieved with the command `python
+-m ensurepip`. If this is not possible, use your system's package manager to
+install the `python-pip` package.
+
+Next, install `virtualenv` using the following command:
+
+```bash
+pip install virtualenv
+```
+
 To get the tests running, you need to set up the test domains in your
 [`hosts` file](http://en.wikipedia.org/wiki/Hosts_%28file%29%23Location_in_the_file_system).
 


### PR DESCRIPTION
Many of the subcommands of the WPT CLI require the `virtualenv` utility,
but the installation instructions did not instruct contributors to
install it. Add an installation step describing how to install the
dependency.

---

This is intended to resolve gh-6565.

[I initially wrote this patch to assume Python 2.7.9](https://github.com/web-platform-tests/wpt/compare/master...bocoup:docs-virtualenv-279) since that would allow us to take the presence of Pip for granted. However, it seems like older (but still common) releases of macOS may bundle prior versions of Python. If that's the case, it seems better to add a potentially-unnecessary invocation of `easy_install` than to try to guide users on updating their system Python.