### PR TITLE
Fix the exception-handling for resize-observer.

### DIFF
--- a/resize-observer/resources/resizeTestHelper.js
+++ b/resize-observer/resources/resizeTestHelper.js
@@ -80,11 +80,20 @@ ResizeTestHelper.prototype = {
       delete this._timeoutId;
     }
     this._harnessTest.step(() => {
-      let rafDelay = this._currentStep.notify(entries, this._observer);
-      if (rafDelay)
-        window.requestAnimationFrame(this._nextStepBind);
-      else
-        this._nextStep();
+      try {
+        let rafDelay = this._currentStep.notify(entries, this._observer);
+        if (rafDelay)
+          window.requestAnimationFrame(this._nextStepBind);
+        else
+          this._nextStep();
+      }
+      catch(err) {
+        this._harnessTest.step(() => {
+          throw err;
+        });
+        // Force to _done() the current test.
+        this._done();
+      }
     });
   },
 


### PR DESCRIPTION
The current test framework of resize-observer will get timeout if any of the
`assert_equals` is failed. It's not good and pretty hard to debug.
A possible way to sub-optimize it is throw the error in the step function
(so we can catch the failure message) and keep running the next test cases
without triggering any timeout.