### PR TITLE
[css-writing-modes] Add text-combine-upright tests

### DIFF
--- a/css/css-writing-modes/text-combine-upright-all-001-manual.html
+++ b/css/css-writing-modes/text-combine-upright-all-001-manual.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>text-combine-upright:all (up to 2 chars)</title>
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org"/>
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#text-combine-upright"/>
+<meta name="assert" content="text-combine-upright:digits will display two-character numbers and text horizontally."/>
+<style type="text/css">
+@font-face {
+    font-family: "webfont";
+    src: url("../../fonts/CSSTest/mplus-1p-regular.woff") format("woff");
+    font-weight: normal;
+    font-style: normal;
+    }
+.test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
+</style>
+<!-- this is the test -->
+<style type="text/css"> 
+.test { writing-mode: vertical-rl; }
+.test span { text-combine-upright: all; }
+</style>
+</head>
+<body>
+<p class="instructions" dir="ltr">Test passes if all numbers and the text GI are upright and not more than one cell wide.</p>
+<div class="test">
+<p lang="ja"><span>今日</span>は<span>5</span>月<span>12</span>日です。<span>GI</span></p>
+</div>
+</body>
+</html>

--- a/css/css-writing-modes/text-combine-upright-all-001-manual.html
+++ b/css/css-writing-modes/text-combine-upright-all-001-manual.html
@@ -16,7 +16,7 @@
 .test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
 </style>
 <!-- this is the test -->
-<style type="text/css"> 
+<style type="text/css">
 .test { writing-mode: vertical-rl; }
 .test span { text-combine-upright: all; }
 </style>

--- a/css/css-writing-modes/text-combine-upright-all-002-manual.html
+++ b/css/css-writing-modes/text-combine-upright-all-002-manual.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>text-combine-upright:all (up to 4 chars)</title>
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org"/>
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#text-combine-upright"/>
+<meta name="assert" content="text-combine-upright:all will display up to four-character numbers horizontally."/>
+<style type="text/css">
+@font-face {
+    font-family: "webfont";
+    src: url("../../fonts/CSSTest/mplus-1p-regular.woff") format("woff");
+    font-weight: normal;
+    font-style: normal;
+    }
+.test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
+</style>
+<!-- this is the test -->
+<style type="text/css"> 
+.test { writing-mode: vertical-rl; }
+.test span { text-combine-upright: all; }
+</style>
+</head>
+<body>
+<p class="instructions" dir="ltr">Test passes if all four numbers are upright and not more than one cell wide.</p>
+<div class="test">
+<p lang="ja"><span>W3C</span>会議は<span>2016</span>年<span>5</span>月<span>12</span>日です。<span>242</span>日目です。</p>
+</div>
+</body>
+</html>

--- a/css/css-writing-modes/text-combine-upright-all-002-manual.html
+++ b/css/css-writing-modes/text-combine-upright-all-002-manual.html
@@ -16,7 +16,7 @@
 .test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
 </style>
 <!-- this is the test -->
-<style type="text/css"> 
+<style type="text/css">
 .test { writing-mode: vertical-rl; }
 .test span { text-combine-upright: all; }
 </style>

--- a/css/css-writing-modes/text-combine-upright-digits-001-manual.html
+++ b/css/css-writing-modes/text-combine-upright-digits-001-manual.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>text-combine-upright:digits</title>
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org"/>
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#text-combine-upright"/>
+<meta name="assert" content="text-combine-upright:digits will display two-digit numbers horizontally, but not others."/>
+<style type="text/css">
+@font-face {
+    font-family: "webfont";
+    src: url("../../fonts/CSSTest/mplus-1p-regular.woff") format("woff");
+    font-weight: normal;
+    font-style: normal;
+    }
+.test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
+</style>
+<!-- this is the test -->
+<style type="text/css"> 
+.test { writing-mode: vertical-rl; text-combine-upright: digits; }
+</style>
+</head>
+<body>
+<p class="instructions" dir="ltr">Test passes if 5 and 12 are upright, and 2016 and 242 are not.</p>
+<div class="test">
+<p lang="ja">今日は2016年5月12日です。242日目です。</p>
+</div>
+</body>
+</html>

--- a/css/css-writing-modes/text-combine-upright-digits-001-manual.html
+++ b/css/css-writing-modes/text-combine-upright-digits-001-manual.html
@@ -16,7 +16,7 @@
 .test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
 </style>
 <!-- this is the test -->
-<style type="text/css"> 
+<style type="text/css">
 .test { writing-mode: vertical-rl; text-combine-upright: digits; }
 </style>
 </head>

--- a/css/css-writing-modes/text-combine-upright-digits-002-manual.html
+++ b/css/css-writing-modes/text-combine-upright-digits-002-manual.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>text-combine-upright:digits 2</title>
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org"/>
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#text-combine-upright"/>
+<meta name="assert" content="text-combine-upright:digits 2 will display two-digit numbers horizontally, but not others."/>
+<style type="text/css">
+@font-face {
+    font-family: "webfont";
+    src: url("../../fonts/CSSTest/mplus-1p-regular.woff") format("woff");
+    font-weight: normal;
+    font-style: normal;
+    }
+.test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
+</style>
+<!-- this is the test -->
+<style type="text/css"> 
+.test { writing-mode: vertical-rl; text-combine-upright: digits 2; }
+</style>
+</head>
+<body>
+<p class="instructions" dir="ltr">Test passes if 5 and 12 are upright, and 2016 and 242 are not.</p>
+<div class="test">
+<p lang="ja">今日は2016年5月12日です。242日目です。</p>
+</div>
+</body>
+</html>

--- a/css/css-writing-modes/text-combine-upright-digits-002-manual.html
+++ b/css/css-writing-modes/text-combine-upright-digits-002-manual.html
@@ -16,7 +16,7 @@
 .test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
 </style>
 <!-- this is the test -->
-<style type="text/css"> 
+<style type="text/css">
 .test { writing-mode: vertical-rl; text-combine-upright: digits 2; }
 </style>
 </head>

--- a/css/css-writing-modes/text-combine-upright-digits-004-manual.html
+++ b/css/css-writing-modes/text-combine-upright-digits-004-manual.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>text-combine-upright:digits 4</title>
+<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org"/>
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#text-combine-upright"/>
+<meta name="assert" content="text-combine-upright:digits 4 will display all numbers up to four digits long horizontally."/>
+<style type="text/css">
+@font-face {
+    font-family: "webfont";
+    src: url("../../fonts/CSSTest/mplus-1p-regular.woff") format("woff");
+    font-weight: normal;
+    font-style: normal;
+    }
+.test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
+</style>
+<!-- this is the test -->
+<style type="text/css"> 
+.test { writing-mode: vertical-rl; text-combine-upright: digits 4; }
+</style>
+</head>
+<body>
+<p class="instructions" dir="ltr">Test passes if all numbers are upright.</p>
+<div class="test">
+<p lang="ja">今日は2016年5月12日です。242日目です。</p>
+</div>
+</body>
+</html>

--- a/css/css-writing-modes/text-combine-upright-digits-004-manual.html
+++ b/css/css-writing-modes/text-combine-upright-digits-004-manual.html
@@ -16,7 +16,7 @@
 .test, .ref { font-family: webfont, serif; font-size: 24px; height: 300px; width: 300px; }
 </style>
 <!-- this is the test -->
-<style type="text/css"> 
+<style type="text/css">
 .test { writing-mode: vertical-rl; text-combine-upright: digits 4; }
 </style>
 </head>


### PR DESCRIPTION
This PR ports https://w3c.github.io/i18n-tests/results/horizontal-in-vertical.html#text_combine_upright to WPT. Currently, the tests are manual tests, since we're unable to come up with a way to automate them.

These are simple tests designed to check basic functionality, rather than test all edge cases and implementation details.

/cc @r12a
