### PR TITLE
Autofocus test port

### DIFF
--- a/html/semantics/forms/autofocus/focus-even-if-in-contenteditable.html
+++ b/html/semantics/forms/autofocus/focus-even-if-in-contenteditable.html
@@ -28,11 +28,12 @@ promise_test(async t => {
 
   document.querySelector("[contenteditable]").focus();
 
-  const button = document.createElement("button");
-  button.autofocus = true;
+  const input = document.createElement("input");
+  input.type = "text";
+  input.autofocus = true;
 
-  // This should queue a task on the user interaction task source to focus button.
-  document.body.appendChild(button);
+  // This should queue a task on the user interaction task source to focus input.
+  document.body.appendChild(input);
 
   // If waitForUserInteractionTaskSource doesn't work (which appears to be the case with Safari
   // 12.2/Safari Tech Preview 81), then do the test anyway after a bit. The prerequisite test
@@ -42,8 +43,8 @@ promise_test(async t => {
     new Promise(resolve => t.step_timeout(resolve, 100))
   ]);
 
-  assert_equals(document.activeElement, button);
-}, "The activeElement changes correctly after inserting an autofocused button");
+  assert_equals(document.activeElement, input);
+}, "The activeElement changes correctly after inserting an autofocused input");
 
 function waitForUserInteractionTaskSource() {
   return new Promise(resolve => {

--- a/html/semantics/forms/autofocus/focus-even-if-in-contenteditable.html
+++ b/html/semantics/forms/autofocus/focus-even-if-in-contenteditable.html
@@ -23,6 +23,9 @@ promise_test(
 );
 
 promise_test(async t => {
+  // https://github.com/whatwg/html/issues/3551
+  await waitForFirstFrame();
+
   document.querySelector("[contenteditable]").focus();
 
   const button = document.createElement("button");
@@ -52,5 +55,9 @@ function waitForUserInteractionTaskSource() {
     // This queues a task on the user interaction task source to fire a select event.
     input.setSelectionRange(0, 1);
   });
+}
+
+function waitForFirstFrame() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
 }
 </script>

--- a/html/semantics/forms/autofocus/focus-even-if-in-contenteditable.html
+++ b/html/semantics/forms/autofocus/focus-even-if-in-contenteditable.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>autofocus focuses the element, even if a contenteditable is currently focused</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div contenteditable></div>
+
+<script>
+"use strict";
+
+promise_test(async () => {
+  document.querySelector("[contenteditable]").focus();
+
+  const button = document.createElement("button");
+  button.autofocus = true;
+
+  // This should queue a task on the user interaction task source to focus button.
+  document.body.appendChild(button);
+
+  await waitForUserInteractionTaskSource();
+
+  assert_equals(document.activeElement, button);
+});
+
+function waitForUserInteractionTaskSource() {
+  return new Promise(resolve => {
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = "string";
+    input.onselect = () => resolve();
+
+    // This queues a task on the user interaction task source to fire a select event.
+    input.setSelectionRange(0, 1);
+  });
+}
+</script>

--- a/html/semantics/forms/autofocus/focus-even-if-in-contenteditable.html
+++ b/html/semantics/forms/autofocus/focus-even-if-in-contenteditable.html
@@ -10,7 +10,19 @@
 <script>
 "use strict";
 
-promise_test(async () => {
+promise_test(
+  t => {
+    return Promise.race([
+      waitForUserInteractionTaskSource(),
+      new Promise((resolve, reject) => {
+        t.step_timeout(() => reject(new Error("select event wasn't fired after 100 ms")), 100);
+      })
+    ]);
+  },
+  "prerequisite: setSelectionRange fires a select event, so we can test the user interaction task source accurately"
+);
+
+promise_test(async t => {
   document.querySelector("[contenteditable]").focus();
 
   const button = document.createElement("button");
@@ -19,10 +31,16 @@ promise_test(async () => {
   // This should queue a task on the user interaction task source to focus button.
   document.body.appendChild(button);
 
-  await waitForUserInteractionTaskSource();
+  // If waitForUserInteractionTaskSource doesn't work (which appears to be the case with Safari
+  // 12.2/Safari Tech Preview 81), then do the test anyway after a bit. The prerequisite test
+  // will fail, so folks will know something's up.
+  await Promise.race([
+    waitForUserInteractionTaskSource(),
+    new Promise(resolve => t.step_timeout(resolve, 100))
+  ]);
 
   assert_equals(document.activeElement, button);
-});
+}, "The activeElement changes correctly after inserting an autofocused button");
 
 function waitForUserInteractionTaskSource() {
   return new Promise(resolve => {


### PR DESCRIPTION
Supercedes https://github.com/web-platform-tests/wpt/pull/9440.

@annevk, I am hoping you and @tkent-google can be my review-buddies for these things.

This test fails in Firefox and Safari:

- Firefox does not move focus from the div. That seems bad.
- Safari puts focus on the body. I have no idea why it would do that.

I think of the three behaviors, the spec/Chrome behavior is the most reasonable, so I'd like to merge this and file bugs. Let me know if folks disagree. /cc @smaug---- @cdumez.