### PR TITLE
[testharness.js] Tolerate late tests

### DIFF
--- a/resources/test/tests/unit/late-test.html
+++ b/resources/test/tests/unit/late-test.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Test declared after harness completion</title>
+</head>
+<body>
+<div id="log"></div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<p>This test simulates an automated test running scenario, where the test
+results emitted by testharness.js may be interpreted after some delay. It is
+intended to demonstrate that in such cases, any additional tests which are
+executed during that delay are <em>not</em> included in the dataset.</p>
+
+<p>Although these "late" tests are likely an indication of a mistake in test
+design, they cannot be detected deterministically, so in the interest of
+stability, they should be silently tolerated.</p>
+<script>
+async_test(function(t) {
+    var source = [
+        "<div id='log'></div>",
+        "<script src='/resources/testharness.js'></" + "script>",
+        "<script src='/resources/testharnessreport.js'></" + "script>",
+        "<script>",
+        "parent.childReady(window);",
+        "setup({ explicit_done: true });",
+        "test(function() {}, 'acceptable test');",
+        "onload = function() {",
+        "  done();",
+        "  test(function() {}, 'this test is late and should be ignored');",
+        "};",
+        "</" + "script>"
+    ].join("\n");
+    var iframe = document.createElement("iframe");
+
+    document.body.appendChild(iframe);
+    window.childReady = t.step_func(function(childWindow) {
+        childWindow.add_completion_callback(t.step_func(function(tests, status) {
+            t.step_timeout(t.step_func(function() {
+                assert_equals(tests.length, 1);
+                assert_equals(tests[0].name, "acceptable test");
+                assert_equals(status.status, status.OK);
+                t.done();
+            }), 0);
+        }));
+    });
+
+    iframe.contentDocument.open();
+    iframe.contentDocument.write(source);
+    iframe.contentDocument.close();
+});
+</script>
+</body>
+</html>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1499,7 +1499,7 @@ policies and contribution forms [3].
         }
         this.name = name;
 
-        this.phase = tests.is_aborted ?
+        this.phase = (tests.is_aborted || tests.phase === tests.phases.COMPLETE) ?
             this.phases.COMPLETE : this.phases.INITIAL;
 
         this.status = this.NOTRUN;
@@ -1521,6 +1521,13 @@ policies and contribution forms [3].
         this.cleanup_callbacks = [];
         this._user_defined_cleanup_count = 0;
         this._done_callbacks = [];
+
+        // Tests declared following harness completion are likely an indication
+        // of a programming error, but they cannot be reported
+        // deterministically.
+        if (tests.phase === tests.phases.COMPLETE) {
+            return;
+        }
 
         tests.push(this);
     }
@@ -2672,7 +2679,7 @@ policies and contribution forms [3].
         if (this.phase < this.STARTED) {
             this.init();
         }
-        if (!this.enabled) {
+        if (!this.enabled || this.phase === this.COMPLETE) {
             return;
         }
         this.resolve_log();


### PR DESCRIPTION
This reinstates the change originally merged as [1] and subsequently
reverted via [2]. This version of the patch updates the code to pass the
project's linting scripts (by changing the automated test to rely on
`step_timeout` instead of `setTimeout`).

[1] 7a02521f636f1c686a73487c3ee9af88ea470a0c
[2] eba8d664eb05a6ca4f7e50fc0e0fa83458ee86cb

---

@foolip CI failed to catch the linting error in [the original submission](https://github.com/web-platform-tests/wpt/pull/15634) because neither TravisCI nor Taskcluster ran the lint script. The task was being migrated from TravisCI to Taskcluster at the time. We're not sure if the omission was due to [a bug in the Taskcluster configuration](https://github.com/web-platform-tests/wpt/pull/15594) or a result of differing merge strategies between the two systems, but neither explanation calls for a fix to the infrastructure.

@jgraham wrote in IRC,

> jgraham: I wonder how well tested that patch was
>
> jgraham: Not related to the lint breakage, but related to whether it breaks tests

In acknowledgement of that concern, we should also carefully review the results published to wpt.fyi for this pull request.