### PR TITLE
[docs] Automatically generate CLI documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,12 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-#import os
-#import sys
-#sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../tools/wptserve'))
+sys.path.insert(0, os.path.abspath('../tools'))
+import localpaths
 
 # -- Project information -----------------------------------------------------
 
@@ -38,7 +41,8 @@ release = u''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'recommonmark'
+    'recommonmark',
+    'sphinxarg.ext'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 recommonmark==0.5.0
 Sphinx==1.8.5
+sphinx-argparse==0.2.5

--- a/docs/running-tests/command-line-arguments.md
+++ b/docs/running-tests/command-line-arguments.md
@@ -1,0 +1,14 @@
+# Command-Line Arguments
+
+The `wpt` command-line application offers a number of features for interacting
+with WPT. The functionality is organized into "sub-commands", and each accepts
+a different set of command-line arguments.
+
+This page documents all of the available sub-commands and associated arguments.
+
+```eval_rst
+.. argparse::
+   :module: tools.wpt.wpt
+   :func: create_complete_parser
+   :prog: wpt
+```

--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -97,6 +97,9 @@ customising the test run:
 
     ./wpt run --help
 
+[A complete listing of the command-line arguments is available
+here](command-line-arguments).
+
 Additional browser-specific documentation:
 
 ```eval_rst

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -80,6 +80,34 @@ def import_command(prog, command, props):
     return script, parser
 
 
+def create_complete_parser():
+    """Eagerly load all subparsers. This involves more work than is required
+    for typical command-line usage. It is maintained for the purposes of
+    documentation generation as implemented in WPT's top-level `/docs`
+    directory."""
+
+    commands = load_commands()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    for command in commands:
+        props = commands[command]
+
+        if props["virtualenv"]:
+            setup_virtualenv(None, False, props)
+
+        subparser = import_command('wpt', command, props)[1]
+        if not subparser:
+            continue
+
+        subparsers.add_parser(command,
+                              help=props["help"],
+                              add_help=False,
+                              parents=[subparser])
+
+    return parser
+
+
 def setup_virtualenv(path, skip_venv_setup, props):
     if skip_venv_setup and path is None:
         raise ValueError("Must set --venv when --skip-venv-setup is used")


### PR DESCRIPTION
Command-line usage information was previously only available to users
who had successfully installed wptrunner. Consuming the information in
that form (e.g. navigating between sub-commands, scrolling through pages
of content and searching for keywords) also required some proficiency
with the command-line.

Extend the documentation build process to include this information in
the project website. This makes it easier to consume for those with
limited experience using the command-line, and in particular, it adds
the content to the data indexed by the website's "search" feature.

Because this content is generated from the state of the interface, it
avoids the need to maintain documentation separately.

This is implemented via a new code path that eagerly load wptrunner's
complete command-line interface. The new `create_complete_parser` is
consumed by the `sphinx-argparse` module to produce the rendered
documentation.

---

Previously discussed in https://github.com/bocoup/wpt-docs/pull/12

The wptrunner CLI is built lazily based on the subcommand being executed. Even then, the task of argument parsing is split across unrelated `argparse` instances. These two details resist documentation generation (at least in the terms expected by [the `sphinx-argparse` module](https://sphinx-argparse.readthedocs.io)).

Facilitating this work required an artificial code path. I'm sensitive to creating branches that aren't used by contributors, but given the small size of the new function, I think the documentation may be valuable enough to justify the maintenance burden.

Here's what the new page looks like:

![2019-03-27-docs-cli-top](https://user-images.githubusercontent.com/677252/55122618-ec0c5c80-50d5-11e9-8f87-6eb91057c096.png)

Like any other content on the Sphinx-powered site, it is indexed by the client-side "search" feature.

![2019-03-27-docs-cli-search-results](https://user-images.githubusercontent.com/677252/55122643-021a1d00-50d6-11e9-9e2b-3e3ca09bc3b5.png)

And the user's query is highlighted on the page itself

![2019-03-27-docs-cli-search-highlight-1](https://user-images.githubusercontent.com/677252/55122648-05ada400-50d6-11e9-8dbf-04fec129b321.png)

![2019-03-27-docs-cli-search-highlight-2](https://user-images.githubusercontent.com/677252/55122651-08a89480-50d6-11e9-9b26-1d8fae758e97.png)