### PR TITLE
Update error type test for attachInternals()

### DIFF
--- a/custom-elements/HTMLElement-attachInternals.html
+++ b/custom-elements/HTMLElement-attachInternals.html
@@ -14,19 +14,19 @@ test(() => {
   let element = new MyElement1();
   assert_true(element.attachInternals() instanceof ElementInternals,
               'New - 1st call');
-  assert_throws('InvalidStateError', () => { element.attachInternals(); },
+  assert_throws('NotSupportedError', () => { element.attachInternals(); },
                 'New - 2nd call');
 
   element = document.createElement('my-element1');
   assert_true(element.attachInternals() instanceof ElementInternals,
               'createElement - 1st call');
-  assert_throws('InvalidStateError', () => { element.attachInternals(); },
+  assert_throws('NotSupportedError', () => { element.attachInternals(); },
                 'createElement - 2nd call');
 
   container.innerHTML = '<my-element1></my-element1>';
   assert_true(container.firstChild.attachInternals() instanceof ElementInternals,
               'Parser - 1st call');
-  assert_throws('InvalidStateError', () => {
+  assert_throws('NotSupportedError', () => {
     container.firstChild.attachInternals();
   }, 'Parser - 2nd call');
 }, 'Successful attachInternals() and the second call.');
@@ -41,17 +41,17 @@ test(() => {
 
 test(() => {
   const builtin = document.createElement('div');
-  assert_throws('InvalidStateError', () => { builtin.attachInternals() });
+  assert_throws('NotSupportedError', () => { builtin.attachInternals() });
 
   const doc = document.implementation.createDocument('foo', null);
   const span = doc.appendChild(doc.createElementNS('http://www.w3.org/1999/xhtml', 'html:span'));
   assert_true(span instanceof HTMLElement);
-  assert_throws('InvalidStateError', () => { span.attachInternals(); });
+  assert_throws('NotSupportedError', () => { span.attachInternals(); });
 
   const undefinedCustom = document.createElement('undefined-element');
-  assert_throws('InvalidStateError', () => { undefinedCustom.attachInternals() });
+  assert_throws('NotSupportedError', () => { undefinedCustom.attachInternals() });
 }, 'If a custom element definition for the local name of the element doesn\'t' +
-     ' exist, throw an InvalidStateError');
+     ' exist, throw an NotSupportedError');
 
 test(() => {
   class MyElement2 extends HTMLElement {


### PR DESCRIPTION
Follows latest developments in https://github.com/whatwg/html/pull/4324.