### PR TITLE
Don't use assert_own_property in CSS tests.

### DIFF
--- a/css/support/computed-testcommon.js
+++ b/css/support/computed-testcommon.js
@@ -14,7 +14,7 @@ function test_computed_value(property, specified, computed) {
     computed = specified;
   test(() => {
     const target = document.getElementById('target');
-    assert_own_property(getComputedStyle(target), property);
+    assert_true(property in getComputedStyle(target), property + " doesn't seem to be supported in the computed style");
     target.style[property] = '';
     target.style[property] = specified;
     assert_equals(getComputedStyle(target)[property], computed);

--- a/css/support/inheritance-testcommon.js
+++ b/css/support/inheritance-testcommon.js
@@ -5,7 +5,7 @@
 function assert_initial(property, initial) {
   test(() => {
     const target = document.getElementById('target');
-    assert_own_property(getComputedStyle(target), property);
+    assert_true(property in getComputedStyle(target), property + " doesn't seem to be supported in the computed style");
     target.style[property] = 'initial';
     assert_equals(getComputedStyle(target)[property], initial);
     target.style[property] = '';
@@ -28,7 +28,7 @@ function assert_inherited(property, initial, other) {
   test(() => {
     const container = document.getElementById('container');
     const target = document.getElementById('target');
-    assert_own_property(getComputedStyle(target), property);
+    assert_true(property in getComputedStyle(target), property + " doesn't seem to be supported in the computed style");
     container.style[property] = 'initial';
     target.style[property] = 'unset';
     assert_not_equals(getComputedStyle(container)[property], other);
@@ -63,7 +63,7 @@ function assert_not_inherited(property, initial, other) {
   test(() => {
     const container = document.getElementById('container');
     const target = document.getElementById('target');
-    assert_own_property(getComputedStyle(target), property);
+    assert_true(property in getComputedStyle(target));
     container.style[property] = 'initial';
     target.style[property] = 'unset';
     assert_not_equals(getComputedStyle(container)[property], other);


### PR DESCRIPTION
They are in fact not supposed to be own properties.

This caused all CSS tests to fail on Firefox for no good reason.

See https://bugs.chromium.org/p/chromium/issues/detail?id=700338 for the bug
that this tests are relying on.

This fixes e8b0b32310a. CC @lilles  @ewilligers 