### PR TITLE
Add a precondition to all the element timing tests

### DIFF
--- a/element-timing/background-image-data-uri.html
+++ b/element-timing/background-image-data-uri.html
@@ -18,6 +18,9 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/background-image-multiple-elements.html
+++ b/element-timing/background-image-multiple-elements.html
@@ -23,6 +23,9 @@ body {
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     let beforeRender = performance.now();
     let numObservedElements = 0;
     let observedDiv1 = false;

--- a/element-timing/background-image-stretched.html
+++ b/element-timing/background-image-stretched.html
@@ -18,6 +18,9 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/buffer-before-onload.html
+++ b/element-timing/buffer-before-onload.html
@@ -14,6 +14,9 @@
   the performance timeline.
   */
   async_test(function(t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     beforeRender = performance.now();
     const img = document.createElement('img');
     img.src = 'resources/square20.jpg';

--- a/element-timing/cross-origin-element.sub.html
+++ b/element-timing/cross-origin-element.sub.html
@@ -12,6 +12,9 @@ body {
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test((t) => {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     let img;
     const pathname = 'http://{{domains[www]}}:{{ports[http][1]}}'
           + '/element-timing/resources/square100.png';

--- a/element-timing/cross-origin-iframe-element.sub.html
+++ b/element-timing/cross-origin-iframe-element.sub.html
@@ -7,6 +7,9 @@
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test((t) => {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done((entryList) => {
         assert_unreached("We should not observe a cross origin element.");

--- a/element-timing/disconnect-image.html
+++ b/element-timing/disconnect-image.html
@@ -9,6 +9,9 @@
   let beforeRender;
   let img;
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-TAO-wildcard.sub.html
+++ b/element-timing/image-TAO-wildcard.sub.html
@@ -12,6 +12,9 @@ body {
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test((t) => {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     let beforeRender;
     let img;
     const img_src = 'http://{{domains[www]}}:{{ports[http][1]}}/element-timing/'

--- a/element-timing/image-carousel.html
+++ b/element-timing/image-carousel.html
@@ -26,6 +26,9 @@ body {
 
 <script>
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const beforeRenderTimes = [];
     let entry_count = 0;
     const entry_count_per_element = [0, 0];

--- a/element-timing/image-clipped-svg.html
+++ b/element-timing/image-clipped-svg.html
@@ -7,6 +7,9 @@
 <script>
 let beforeRender;
 async_test(function (t) {
+  if (!window.PerformanceElementTiming) {
+    assert_unreached("PerformanceElementTiming is not implemented");
+  }
   const observer = new PerformanceObserver(
     t.step_func_done(function(entryList) {
       assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-data-uri.html
+++ b/element-timing/image-data-uri.html
@@ -16,6 +16,9 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-not-added.html
+++ b/element-timing/image-not-added.html
@@ -5,6 +5,9 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(() => {
         // The image should not have caused an entry, so fail test.

--- a/element-timing/image-not-fully-visible.html
+++ b/element-timing/image-not-fully-visible.html
@@ -14,6 +14,9 @@ body {
   let beforeRender;
   let img;
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-rect-iframe.html
+++ b/element-timing/image-rect-iframe.html
@@ -11,6 +11,9 @@ body {
 <script src="/resources/testharnessreport.js"></script>
 <script>
   async_test((t) => {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     on_event(window, 'message', e => {
       assert_equals(e.data.length, 1);
       assert_equals(e.data.entryType, 'element');

--- a/element-timing/image-with-css-scale.html
+++ b/element-timing/image-with-css-scale.html
@@ -21,6 +21,9 @@ body {
 <script>
   const beforeRender = performance.now();
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-with-rotation.html
+++ b/element-timing/image-with-rotation.html
@@ -21,6 +21,9 @@ body {
 <script>
   const beforeRender = performance.now();
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/images-repeated-resource.html
+++ b/element-timing/images-repeated-resource.html
@@ -21,6 +21,9 @@ body {
   const pathname = window.location.href.substring(0, index) +
       '/resources/square100.png';
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func(function(entryList) {
         entryList.getEntries().forEach(entry => {

--- a/element-timing/invisible-images.html
+++ b/element-timing/invisible-images.html
@@ -16,6 +16,9 @@
 </style>
 <script>
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(() => {
         // The image should not have caused an entry, so fail test.

--- a/element-timing/multiple-background-images.html
+++ b/element-timing/multiple-background-images.html
@@ -18,6 +18,9 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     let numObservedElements = 0;
     let observedCircle = false;
     let observedSquare = false;

--- a/element-timing/observe-background-image.html
+++ b/element-timing/observe-background-image.html
@@ -18,6 +18,9 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/observe-child-element.html
+++ b/element-timing/observe-child-element.html
@@ -12,6 +12,9 @@ body {
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test((t) => {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done((entryList) => {
         assert_unreached("Should not have received an entry!");

--- a/element-timing/observe-elementtiming.html
+++ b/element-timing/observe-elementtiming.html
@@ -14,6 +14,9 @@ body {
   let beforeRender;
   let img;
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/observe-large-image.html
+++ b/element-timing/observe-large-image.html
@@ -14,6 +14,9 @@ body {
   let beforeRender;
   let img;
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/observe-multiple-images.html
+++ b/element-timing/observe-multiple-images.html
@@ -22,6 +22,9 @@ body {
 <script>
   let beforeRender, image1Observed=0, image2Observed=0, image3Observed=0;
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const index = window.location.href.lastIndexOf('/');
     const observer = new PerformanceObserver(
       t.step_func(function(entryList) {

--- a/element-timing/observe-shadow-image.html
+++ b/element-timing/observe-shadow-image.html
@@ -14,6 +14,9 @@ body {
   let beforeRender;
   let img;
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/observe-svg-image.html
+++ b/element-timing/observe-svg-image.html
@@ -7,6 +7,9 @@
 <script>
 let beforeRender;
 async_test(function (t) {
+  if (!window.PerformanceElementTiming) {
+    assert_unreached("PerformanceElementTiming is not implemented");
+  }
   const observer = new PerformanceObserver(
     t.step_func_done(function(entryList) {
       assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/observe-video-poster.html
+++ b/element-timing/observe-video-poster.html
@@ -7,6 +7,9 @@
 <script>
 let beforeRender;
 async_test(function (t) {
+  if (!window.PerformanceElementTiming) {
+    assert_unreached("PerformanceElementTiming is not implemented");
+  }
   const observer = new PerformanceObserver(
     t.step_func_done(function(entryList) {
       assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/progressively-loaded-image.html
+++ b/element-timing/progressively-loaded-image.html
@@ -14,6 +14,9 @@
   let numInitial = 75;
   let sleep = 500;
   async_test(function(t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const img_src = 'resources/progressive-image.py?name=square20.jpg&numInitial='
       + numInitial + '&sleep=' + sleep;
     const observer = new PerformanceObserver(

--- a/element-timing/rectangular-image.html
+++ b/element-timing/rectangular-image.html
@@ -14,6 +14,9 @@ body {
   let beforeRender;
   let img;
   async_test(function (t) {
+    if (!window.PerformanceElementTiming) {
+      assert_unreached("PerformanceElementTiming is not implemented");
+    }
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);


### PR DESCRIPTION
Since PerformanceObserver.observe doesn't have any way to signal an
unsupported type we end up just timing out all the tests in
implementations that doesn't support element timing. For efficiency
add a precondition to all the tests to check for the relevant API instead.