### PR TITLE
Address review comments that were mistakenly abandoned in #16452.

### DIFF
--- a/sms/constructor.tentative.https.any.js
+++ b/sms/constructor.tentative.https.any.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-promise_test(async t => {
+test(function() {
   let used = false;
 
   new SMSReceiver({
@@ -15,46 +15,38 @@ promise_test(async t => {
   assert_true(used, 'constructor options "timeout" member was used');
 }, 'constructor uses timeout property');
 
-promise_test(async t => {
-  try {
+test(function() {
+  assert_throws(new TypeError(), function () {
     new SMSReceiver({timeout: 0});
     assert_unreached('Timeout 0 should reject');
-  } catch (error) {
-    assert_equals(error.name, 'TypeError');
-  }
+  });
 }, 'constructor throws with invalid timeout (0)');
 
-promise_test(async t => {
-  try {
+test(function() {
+  assert_throws(new TypeError(), function () {
     new SMSReceiver({timeout: null});
     assert_unreached('Timeout of null should reject');
-  } catch (error) {
-    assert_equals(error.name, 'TypeError');
-  }
+  });
 }, 'constructor throws with invalid timeout (null)');
 
-promise_test(async t => {
-  try {
+test(function() {
+  assert_throws(new TypeError(), function () {
     new SMSReceiver({timeout: -1});
     assert_unreached('Timeout negative numbers should reject');
-  } catch (error) {
-    assert_equals(error.name, 'TypeError');
-  }
+  });
 }, 'constructor throws with invalid timeout (-1)');
 
-promise_test(async t => {
-  try {
+test(function() {
+  assert_throws(new TypeError(), function () {
     new SMSReceiver({timeout: NaN});
     assert_unreached('Timeout of NaN should reject');
-  } catch (error) {
-    assert_equals(error.name, 'TypeError');
-  }
+  });
 }, 'constructor throws with invalid timeout (NaN)');
 
-promise_test(async t => {
+test(function() {
   new SMSReceiver();
 }, 'constructor uses a default value for the timeout when none is passed');
 
-promise_test(async t => {
+test(function() {
   new SMSReceiver({timeout: undefined});
 }, 'constructor uses a default value for the timeout');


### PR DESCRIPTION
- switch to synchronous test syntax
- use assert_throws util function