### PR TITLE
Use Chromium based Edge for Edge test runs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -220,10 +220,11 @@ jobs:
     parameters:
       packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
+  - template: tools/ci/azure/install_edge.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
-  - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --webdriver-arg=--verbose --log-tbpl $(Build.ArtifactStagingDirectory)/edge.tbpl.log --log-tbpl-level info edge_webdriver infrastructure/
-    displayName: 'Run tests (Edge)'
+  - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --webdriver-arg=--verbose --log-tbpl $(Build.ArtifactStagingDirectory)/edgechromium.tbpl.log --log-tbpl-level info edgechromium infrastructure/
+    displayName: 'Run tests (Edge Canary)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
     inputs:
@@ -252,10 +253,11 @@ jobs:
     parameters:
       packages: virtualenv
   - template: tools/ci/azure/install_certs.yml
+  - template: tools/ci/azure/install_edge.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
-  - script: python ./wpt run --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --webdriver-arg=--verbose --test-types reftest testharness --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-tbpl - --log-tbpl-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt edge_webdriver
-    displayName: 'Run tests'
+  - script: python ./wpt run --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --webdriver-arg=--verbose --test-types reftest testharness --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-tbpl - --log-tbpl-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt edgechromium
+    displayName: 'Run tests (Edge Canary)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
     inputs:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -223,7 +223,7 @@ jobs:
   - template: tools/ci/azure/install_edge.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
-  - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --webdriver-arg=--verbose --log-tbpl $(Build.ArtifactStagingDirectory)/edge.tbpl.log --log-tbpl-level info --channel canary edgechromium infrastructure/
+  - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-tbpl $(Build.ArtifactStagingDirectory)/edge.tbpl.log --log-tbpl-level info --channel canary edgechromium infrastructure/
     displayName: 'Run tests (Edge Canary)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
@@ -256,7 +256,7 @@ jobs:
   - template: tools/ci/azure/install_edge.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
-  - script: python ./wpt run --yes --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --webdriver-arg=--verbose --test-types reftest testharness --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-tbpl - --log-tbpl-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt edgechromium
+  - script: python ./wpt run --yes --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --test-types reftest testharness --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-tbpl - --log-tbpl-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt edgechromium
     displayName: 'Run tests (Edge Canary)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -223,7 +223,7 @@ jobs:
   - template: tools/ci/azure/install_edge.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
-  - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --webdriver-arg=--verbose --log-tbpl $(Build.ArtifactStagingDirectory)/edgechromium.tbpl.log --log-tbpl-level info edgechromium infrastructure/
+  - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --webdriver-arg=--verbose --log-tbpl $(Build.ArtifactStagingDirectory)/edge.tbpl.log --log-tbpl-level info --channel canary edgechromium infrastructure/
     displayName: 'Run tests (Edge Canary)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
@@ -256,7 +256,7 @@ jobs:
   - template: tools/ci/azure/install_edge.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
-  - script: python ./wpt run --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --webdriver-arg=--verbose --test-types reftest testharness --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-tbpl - --log-tbpl-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt edgechromium
+  - script: python ./wpt run --yes --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --webdriver-arg=--verbose --test-types reftest testharness --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-tbpl - --log-tbpl-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt edgechromium
     displayName: 'Run tests (Edge Canary)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -223,8 +223,8 @@ jobs:
   - template: tools/ci/azure/install_edge.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
-  - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-tbpl $(Build.ArtifactStagingDirectory)/edge.tbpl.log --log-tbpl-level info --channel canary edgechromium infrastructure/
-    displayName: 'Run tests (Edge Canary)'
+  - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-tbpl $(Build.ArtifactStagingDirectory)/edge.tbpl.log --log-tbpl-level info --channel dev edgechromium infrastructure/
+    displayName: 'Run tests (Edge Dev)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
     inputs:
@@ -256,8 +256,8 @@ jobs:
   - template: tools/ci/azure/install_edge.yml
   - template: tools/ci/azure/update_hosts.yml
   - template: tools/ci/azure/update_manifest.yml
-  - script: python ./wpt run --yes --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --test-types reftest testharness --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-tbpl - --log-tbpl-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt edgechromium
-    displayName: 'Run tests (Edge Canary)'
+  - script: python ./wpt run --yes --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-tbpl - --log-tbpl-level info --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt edgechromium
+    displayName: 'Run tests (Edge Dev)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
     inputs:

--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -24,7 +24,7 @@ steps:
     $hostFile = "$env:systemroot\System32\drivers\etc\hosts"
     Copy-Item -Path "$hostFile.back" -Destination $hostFile -Force
 
-    # uinstall Edge
+    # uninstall Edge
     UninstallEdge "$env:localappdata\Microsoft\Edge\Application" "--uninstall --force-uninstall"
     # uninstall Edge Canary channel
     UninstallEdge "$env:localappdata\Microsoft\Edge SxS\Application" "--uninstall --msedge-sxs --system-level --force-uninstall"

--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -3,10 +3,35 @@
 # necessary because the Windows 10 agents aren't reset between each job.
 steps:
 - powershell: |
+    function UninstallEdge($edgePath, $uninstallArgs) {
+      try {
+        cmd /c taskkill /f /im msedge* `> nul 2`> nul
+        cmd /c taskkill /f /im setup.exe `> nul 2`> nul
+        if (Test-Path $edgePath) {
+          $installerPath = Get-ChildItem -PATH $edgePath -Filter "setup.exe" -Recurse | Select -First 1 FullName
+          if (Test-Path $installerPath.FullName) {
+            Write-Host "Uninstall: $($installerPath.FullName) $uninstallArgs"
+            Start-Process "$($installerPath.FullName)" -ArgumentList $uninstallArgs -Wait
+            Remove-Item -Path $edgePath -Recurse -Force -ErrorAction SilentlyContinue
+          }
+        }
+      } catch [Exception] {
+        Write-Host "Failed to unstall Edge from $edgePath. ERROR= $($_.Exception.Message)" -ForegroundColor Red
+      }
+    }
+
+    # restore hosts file
     $hostFile = "$env:systemroot\System32\drivers\etc\hosts"
     Copy-Item -Path "$hostFile.back" -Destination $hostFile -Force
-    taskkill /f /im MicrosoftEdge*
-    taskkill /f /im MicrosoftWebDriver.exe
+
+    # uinstall Edge
+    UninstallEdge "$env:localappdata\Microsoft\Edge\Application" "--uninstall --force-uninstall"
+    # uninstall Edge Canary channel
+    UninstallEdge "$env:localappdata\Microsoft\Edge SxS\Application" "--uninstall --msedge-sxs --system-level --force-uninstall"
+    # uninstall Edge Dev channel
+    UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev\Application" "--uninstall --msedge-dev --system-level --force-uninstall"
+    # uninstall Edge Beta channel
+    UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Beta\Application" "--uninstall --msedge-beta --system-level --force-uninstall"
   displayName: 'Restore hosts file and cleanup test machine'
   condition: always()
   errorActionPreference: silentlyContinue

--- a/tools/ci/azure/install_edge.yml
+++ b/tools/ci/azure/install_edge.yml
@@ -1,7 +1,8 @@
 parameters:
   channel: canary
 
-# Should match https://web-platform-tests.org/running-tests/safari.html
+# Should match https://web-platform-tests.org/running-tests/chrome.html
+# Just replace chrome with edgechromium
 steps:
 - ${{ if eq(parameters.channel, 'canary') }}:
   - powershell: |
@@ -19,7 +20,7 @@ steps:
 - ${{ if eq(parameters.channel, 'dev') }}:
   - powershell: |
       $edgeInstallerName = 'MicrosoftEdgeSetup.exe'
-      # Link to DEV channel installer
+      # Link to Dev channel installer
       Start-BitsTransfer -Source 'https://go.microsoft.com/fwlink/?linkid=2069324&Channel=Dev&language=en-us' -Destination MicrosoftEdgeSetup.exe
       cmd /c START /WAIT $edgeInstallerName /silent /install
       $edgePath = "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev\Application"

--- a/tools/ci/azure/install_edge.yml
+++ b/tools/ci/azure/install_edge.yml
@@ -1,0 +1,31 @@
+parameters:
+  channel: canary
+
+# Should match https://web-platform-tests.org/running-tests/safari.html
+steps:
+- ${{ if eq(parameters.channel, 'canary') }}:
+  - powershell: |
+      $edgeInstallerName = 'MicrosoftEdgeSetup.exe'
+      # Link to Canary channel installer
+      Start-BitsTransfer -Source 'https://go.microsoft.com/fwlink/?linkid=2084649&Channel=Canary&language=en-us' -Destination MicrosoftEdgeSetup.exe
+      cmd /c START /WAIT $edgeInstallerName /silent /install
+      $edgePath = "$env:localappdata\Microsoft\Edge SxS\Application"
+      if (Test-Path $edgePath) {
+        Write-Host "##vso[task.prependpath]$edgePath"
+      } else {
+        Throw "Failed to install Edge at $edgePath"
+      }
+    displayName: 'Install Edge Canary'
+- ${{ if eq(parameters.channel, 'dev') }}:
+  - powershell: |
+      $edgeInstallerName = 'MicrosoftEdgeSetup.exe'
+      # Link to DEV channel installer
+      Start-BitsTransfer -Source 'https://go.microsoft.com/fwlink/?linkid=2069324&Channel=Dev&language=en-us&Consent=1&IID=bdcefba8-2cdc-5df1-8a17-4b6ecbe69241' -Destination MicrosoftEdgeSetup.exe
+      cmd /c START /WAIT $edgeInstallerName /silent /install
+      $edgePath = "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev\Application"
+      if (Test-Path $edgePath) {
+        Write-Host "##vso[task.prependpath]$edgePath"
+      } else {
+        Throw "Failed to install Edge at $edgePath"
+      }
+    displayName: 'Install Edge Dev'

--- a/tools/ci/azure/install_edge.yml
+++ b/tools/ci/azure/install_edge.yml
@@ -20,7 +20,7 @@ steps:
   - powershell: |
       $edgeInstallerName = 'MicrosoftEdgeSetup.exe'
       # Link to DEV channel installer
-      Start-BitsTransfer -Source 'https://go.microsoft.com/fwlink/?linkid=2069324&Channel=Dev&language=en-us&Consent=1&IID=bdcefba8-2cdc-5df1-8a17-4b6ecbe69241' -Destination MicrosoftEdgeSetup.exe
+      Start-BitsTransfer -Source 'https://go.microsoft.com/fwlink/?linkid=2069324&Channel=Dev&language=en-us' -Destination MicrosoftEdgeSetup.exe
       cmd /c START /WAIT $edgeInstallerName /silent /install
       $edgePath = "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev\Application"
       if (Test-Path $edgePath) {

--- a/tools/ci/azure/install_edge.yml
+++ b/tools/ci/azure/install_edge.yml
@@ -1,5 +1,5 @@
 parameters:
-  channel: canary
+  channel: dev
 
 # Should match https://web-platform-tests.org/running-tests/chrome.html
 # Just replace chrome with edgechromium

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -697,7 +697,7 @@ class EdgeChromium(Browser):
         return find_executable("msedgedriver")
 
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):
-        if self.platform == "win":
+        if self.platform != "win":
             raise ValueError("Only Windows platform is currently supported")
 
         if dest is None:

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -354,6 +354,11 @@ class EdgeChromium(BrowserSetup):
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
                 raise WptrunError("Unable to locate or install msedgedriver binary")
+        if kwargs["browser_channel"] == "dev":
+            logger.info("Automatically turning on experimental features for Edge Dev")
+            kwargs["binary_args"].append("--enable-experimental-web-platform-features")
+            # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
+            kwargs["webdriver_args"].append("--disable-build-check")
 
 
 class Edge(BrowserSetup):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -357,8 +357,6 @@ class EdgeChromium(BrowserSetup):
         if kwargs["browser_channel"] == "dev":
             logger.info("Automatically turning on experimental features for Edge Dev")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
-            # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
-            kwargs["webdriver_args"].append("--disable-build-check")
 
 
 class Edge(BrowserSetup):


### PR DESCRIPTION
This change replaces Win10 built-in Edge browser with Chromium based Edge for test runs. It uses the recently added edgechromium WPT browser. 

Results diff from latest run; https://staging.wpt.fyi/results/?product=edge@dd73c48261&product=chrome@fe2961715f&diff&filter=ADC 