### PR TITLE
Make url/historical.any.js run in shell environment

### DIFF
--- a/url/historical.any.js
+++ b/url/historical.any.js
@@ -1,7 +1,9 @@
-test(function() {
-  assert_false("searchParams" in self.location,
-               "location object should not have a searchParams attribute");
-}, "searchParams on location object");
+if (self.location) {
+  test(function() {
+    assert_false("searchParams" in self.location,
+                "location object should not have a searchParams attribute");
+  }, "searchParams on location object");
+}
 
 if(self.GLOBAL.isWindow()) {
   test(() => {


### PR DESCRIPTION
The shell test environment does not have `self.location`, so skip
testing the absence of `searchParams` there if `self.location`
does not exists at all.