### PR TITLE
Fix a typo in app-change-payment-method.js

### DIFF
--- a/payment-handler/app-change-payment-method.js
+++ b/payment-handler/app-change-payment-method.js
@@ -20,7 +20,7 @@ async function responder(event) {
     });
     changePaymentMethodReturned = response;
   } catch (err) {
-    changePaymentMethodReturned = error.message;
+    changePaymentMethodReturned = err.message;
   }
   return {methodName, details: {changePaymentMethodReturned}};
 }


### PR DESCRIPTION
I still don't know why `payment-handler/change-payment-method.https.html` fails on master. I tried triggering just the test itself on Taskcluster through this PR and [it passed](https://tools.taskcluster.net/groups/foH6jJTTTXSv4xOk6SOKmw/tasks/Urx-tDgxSV2QsQFzGl4dAg/runs/0/logs/public%2Flogs%2Flive.log#L808).

However, in the process, I noticed a typo in a resource file. Though perhaps unrelated, let's fix it anyway.