### PR TITLE
Test that font-family does not match against postscript names.

### DIFF
--- a/css/css-fonts/font-family-name-025-ref.html
+++ b/css/css-fonts/font-family-name-025-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Test: PASS rendering</title>
+<link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
+<link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
+<meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font." />
+<style type="text/css">
+body { font-size: 36px; }
+span#verify { font-family: CSSTest Verify; }
+p {
+  font-family: ahem, monospace;
+}
+</style>
+<div><a href="http://www.w3.org/Style/CSS/Test/Fonts/">Test fonts</a> must be installed for this test: <span id="verify">FAIL</span></div>
+<p>These two lines should use the same font.</p>
+<p>These two lines should use the same font.</p>

--- a/css/css-fonts/font-family-name-025.html
+++ b/css/css-fonts/font-family-name-025.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Test: font family name should not match postscript font name</title>
+<link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
+<link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
+<link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop" />
+<link rel="match" href="font-family-name-025-ref.html" />
+<meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Postscript name should not match." />
+<style>
+body { font-size: 36px; }
+span#verify { font-family: CSSTest Verify; }
+p.test {
+  /* Verdana-Bold is a standard supplied font on Windows, Mac, and Linux
+     allowing this test to actually work on most systems without the CSS
+     test fonts. */
+  font-family: CSSTestBasic-Bold, Verdana-Bold, ahem, monospace;
+}
+p {
+  font-family: ahem, monospace;
+}
+</style>
+<div><a href="http://www.w3.org/Style/CSS/Test/Fonts/">Test fonts</a> must be installed for this test: <span id="verify">FAIL</span></div>
+<p class="test">These two lines should use the same font.</p>
+<p>These two lines should use the same font.</p>


### PR DESCRIPTION
The spec states "A font family name only specifies a name given to a set
of font faces, it does not specify an individual face." [1] however a
postscript name uniquely identifies a specific face rather than a family
and so should not be matched by font-family. See
https://crbug.com/641861 for more details.

[1] https://drafts.csswg.org/css-fonts-3/#font-family-prop