### PR TITLE
Sync Mozilla CSS tests as of 2019-05-25

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-suppress-baseline-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-suppress-baseline-002-ref.html
@@ -8,19 +8,18 @@
   .flexBaselineCheck {
     display: flex;
     border: 1px solid black;
-    height: 70px;
   }
   .flexBaselineCheck > * {
     border: 2px solid teal;
-
     /* In the testcase, the (baseline-aligned) items should all have their
        bottom borders aligned with the 50px-tall canvas.  In other words, their
-       bottom borders should all be 20px away from the bottom of their flex
-       container.  Here in the reference case, we just use "flex-end" alignment
-       plus a hardcoded 20px margin-bottom to produce a precise reference
-       for what that should look like. */
+       bottom borders should all be aligned at the bottom of their flex
+       container, separated from the bottom by only by their margin-end
+       distance.  Here in the reference case, we just use "flex-end" alignment
+       (plus the same amount of margin) to produce a precise reference for what
+       that should look like. */
     align-self: flex-end;
-    margin-bottom: 20px;
+    margin: 2px;
   }
   canvas {
     background: purple;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-suppress-baseline-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-layout-suppress-baseline-002.html
@@ -11,12 +11,12 @@
   .flexBaselineCheck {
     display: flex;
     border: 1px solid black;
-    height: 70px;
   }
   .flexBaselineCheck > * {
     contain: layout;
     border: 2px solid teal;
     align-self: baseline;
+    margin: 2px;
   }
   canvas {
     background: purple;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
@@ -48,3 +48,10 @@
 == contain-layout-ignored-cases-no-principal-box-003.html contain-layout-ignored-cases-no-principal-box-003-ref.html
 == contain-layout-suppress-baseline-001.html contain-layout-suppress-baseline-001-ref.html
 == contain-layout-suppress-baseline-002.html contain-layout-suppress-baseline-002-ref.html
+
+# The following lines are duplicates of other lines from further up in this
+# manifest. They're listed again here so we can re-run these tests with
+# column-span enabled. These lines can be removed once the pref becomes
+# default-enabled (Bug 1426010).
+== contain-size-multicol-002.html contain-size-multicol-002-ref.html
+== contain-size-multicol-003.html contain-size-multicol-003-ref.html


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/af54b2de7028db03f42207598f7a0b4ba81e262f .

This contains changes from a single bug:
* [bug 1552287](https://bugzilla.mozilla.org/show_bug.cgi?id=1552287) by @dholbert, reviewed by @aethanyc