### PR TITLE
Improve error message when virtualenv is missing

### DIFF
--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -4,7 +4,17 @@ import sys
 import logging
 from distutils.spawn import find_executable
 
-import pkg_resources
+# The `pkg_resources` module is provided by `setuptools`, which is itself a
+# dependency of `virtualenv`. Tolerate its absence so that this module may be
+# evaluated when that module is not available. Because users may not recognize
+# the `pkg_resources` module by name, raise a more descriptive error if it is
+# referenced during execution.
+try:
+    import pkg_resources as _pkg_resources
+    get_pkg_resources = lambda: _pkg_resources
+except ImportError:
+    def get_pkg_resources():
+        raise ValueError("The Python module `virtualenv` is not installed.")
 
 from tools.wpt.utils import call
 
@@ -69,7 +79,7 @@ class Virtualenv(object):
             raise ValueError("trying to read working_set when venv doesn't exist")
 
         if self._working_set is None:
-            self._working_set = pkg_resources.WorkingSet((self.lib_path,))
+            self._working_set = get_pkg_resources().WorkingSet((self.lib_path,))
 
         return self._working_set
 


### PR DESCRIPTION
It can be challenging to properly configure systems to run the WPT CLI.
In recognition of this, this project maintains code paths that improve
error messages, helping users troubleshoot misconfigured systems.

Users may not have the `virtualenv` module installed, or they may have
it installed in such a way that is inaccessible during command-line
execution. Prior to the application of this patch, the error message
reported by the WPT CLI is somewhat cryptic:

    $ ./wpt run firefox
    Traceback (most recent call last):
      File "./wpt", line 4, in <module>
        from tools.wpt import wpt
      File "/home/vagrant/wpt/tools/wpt/wpt.py", line 10, in <module>
        from . import virtualenv
      File "/home/vagrant/wpt/tools/wpt/virtualenv.py", line 7, in <module>
        import pkg_resources
    ImportError: No module named pkg_resources

With this patch applied, a more helpful error is produced by a branch
which was previously created for this purpose:

    $ ./wpt run firefox
    Traceback (most recent call last):
      File "./wpt", line 5, in <module>
        wpt.main()
      File "/home/vagrant/wpt/tools/wpt/wpt.py", line 143, in main
        venv = setup_virtualenv(main_args.venv, main_args.skip_venv_setup, props)
      File "/home/vagrant/wpt/tools/wpt/wpt.py", line 117, in setup_virtualenv
        venv = virtualenv.Virtualenv(path, should_skip_setup)
      File "/home/vagrant/wpt/tools/wpt/virtualenv.py", line 30, in __init__
        raise ValueError("virtualenv must be installed and on the PATH")
    ValueError: virtualenv must be installed and on the PATH

Some commands do not rely on `virtualenv`, e.g. `wpt lint`. This change
also makes it possible to execute those commands when `virtualenv` is
not available.