### PR TITLE
Remove the test that checks that pointer events and compatibility mouse events have the same timestamp

### DIFF
--- a/pointerevents/pointerevent_suppress_compat_events_on_drag_mouse.html
+++ b/pointerevents/pointerevent_suppress_compat_events_on_drag_mouse.html
@@ -46,7 +46,6 @@
           var target_list = ["target0", "target1"];
           var pointer_event_list = ["pointerdown" , "pointermove", "pointerup"];
           var mouse_event_list = ["mousedown", "mouseup", "mousemove"];
-          var last_pointer_event = null;
 
           target_list.forEach(function(targetId) {
               var target = document.getElementById(targetId);
@@ -64,8 +63,6 @@
 
                       if (label === "pointerdown@target0")
                           event.preventDefault();
-
-                      last_pointer_event = event;
                   });
               });
 
@@ -77,11 +74,6 @@
                       event_log.push(event.type + "@" + targetId);
 
                       include_next_mousemove = (event.type == "mousedown");
-                      test(function() {
-                          test(function () {
-                              assert_equals(event.timeStamp, last_pointer_event.timeStamp, "The time stamp of the compat mouse event should be the same as its pointerevent");
-                          });
-                      }, event.type + "'s time stamp should be the same as " + last_pointer_event.type + "'s time stamp.");
                   });
               });
           });


### PR DESCRIPTION
There is no requirement by the specification to do this as per the discussion in https://github.com/w3c/pointerevents/issues/284. This addresses https://github.com/web-platform-tests/wpt/issues/17016.