### PR TITLE
wake-lock: Fix invalid types test in wakelock-type.https.any.js

### DIFF
--- a/wake-lock/wakelock-type.https.any.js
+++ b/wake-lock/wakelock-type.https.any.js
@@ -13,7 +13,7 @@ promise_test(t => {
     "",
     true
   ];
-  invalidTypes.map(async invalidType => {
-    await promise_rejects(t, new TypeError(), WakeLock.request(invalidType));
-  });
+  return Promise.all(invalidTypes.map(invalidType => {
+    return promise_rejects(t, new TypeError(), WakeLock.request(invalidType));
+  }));
 }, "'TypeError' is thrown when set an invalid wake lock type");


### PR DESCRIPTION
During #17019's review process, `async` was dropped from a promise_test(),
and we ended up not returning a Promise there at all.

Fix the test by wrapping the `invalidTypes.map()` call in `Promise.all()`.