### PR TITLE
Switch to random OS port retrieval for webdriver server

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -36,24 +36,16 @@ def cmd_arg(name, value=None):
     return rv
 
 
-def get_free_port(start_port, exclude=None):
-    """Get the first port number after start_port (inclusive) that is
-    not currently bound.
-
-    :param start_port: Integer port number at which to start testing.
-    :param exclude: Set of port numbers to skip"""
-    port = start_port
+def get_free_port():
+    """Get a random unbound port"""
     while True:
-        if exclude and port in exclude:
-            port += 1
-            continue
         s = socket.socket()
         try:
-            s.bind(("127.0.0.1", port))
+            s.bind(("127.0.0.1", 0))
         except socket.error:
-            port += 1
+            continue
         else:
-            return port
+            return s.getsockname()[1]
         finally:
             s.close()
 

--- a/tools/wptrunner/wptrunner/browsers/fennec.py
+++ b/tools/wptrunner/wptrunner/browsers/fennec.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import os
 import tempfile
 
@@ -101,8 +100,6 @@ def write_hosts_file(config, device):
 
 
 class FennecBrowser(FirefoxBrowser):
-    used_ports = set()
-    used_ports_lock = multiprocessing.Lock()
     init_timeout = 300
     shutdown_timeout = 60
 
@@ -129,9 +126,7 @@ class FennecBrowser(FirefoxBrowser):
 
     def start(self, **kwargs):
         if self.marionette_port is None:
-            with FennecBrowser.used_ports_lock:
-                self.marionette_port = get_free_port(2828, exclude=self.used_ports)
-                self.used_ports.add(self.marionette_port)
+            self.marionette_port = get_free_port()
 
         env = {}
         env["MOZ_CRASHREPORTER"] = "1"

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -1,5 +1,4 @@
 import json
-import multiprocessing
 import os
 import platform
 import signal
@@ -184,8 +183,6 @@ def update_properties():
 
 
 class FirefoxBrowser(Browser):
-    used_ports = set()
-    used_ports_lock = multiprocessing.Lock()
     init_timeout = 70
     shutdown_timeout = 70
 
@@ -251,9 +248,7 @@ class FirefoxBrowser(Browser):
         self.mozleak_thresholds = kwargs.get("mozleak_thresholds")
 
         if self.marionette_port is None:
-            with FirefoxBrowser.used_ports_lock:
-                self.marionette_port = get_free_port(2828, exclude=self.used_ports)
-                self.used_ports.add(self.marionette_port)
+            self.marionette_port = get_free_port()
 
         if self.asan:
             self.lsan_handler = mozleak.LSANLeaks(self.logger,

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import os
 import subprocess
 import tempfile
@@ -74,8 +73,6 @@ def write_hosts_file(config):
     return hosts_path
 
 class ServoWebDriverBrowser(Browser):
-    used_ports = set()
-    used_ports_lock = multiprocessing.Lock()
     init_timeout = 300  # Large timeout for cases where we're booting an Android emulator
 
     def __init__(self, logger, binary, debug_info=None, webdriver_host="127.0.0.1",
@@ -95,9 +92,7 @@ class ServoWebDriverBrowser(Browser):
         self.ca_certificate_path = server_config.ssl_config["ca_cert_path"]
 
     def start(self, **kwargs):
-        with ServoWebDriverBrowser.used_ports_lock:
-            self.webdriver_port = get_free_port(4444, exclude=self.used_ports)
-            self.used_ports.add(self.webdriver_port)
+        self.webdriver_port = get_free_port()
 
         env = os.environ.copy()
         env["HOST_FILE"] = self.hosts_path

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -1,6 +1,5 @@
 import abc
 import errno
-import multiprocessing
 import os
 import platform
 import socket
@@ -19,8 +18,6 @@ class WebDriverServer(object):
     __metaclass__ = abc.ABCMeta
 
     default_base_path = "/"
-    _used_ports = set()
-    _used_ports_lock = multiprocessing.Lock()
 
     def __init__(self, logger, binary, host="127.0.0.1", port=None,
                  base_path="", env=None, args=None):
@@ -108,15 +105,8 @@ class WebDriverServer(object):
     @property
     def port(self):
         if self._port is None:
-            self._port = self._find_next_free_port()
+            self._port = get_free_port()
         return self._port
-
-    @staticmethod
-    def _find_next_free_port():
-        with WebDriverServer._used_ports_lock:
-            port = get_free_port(4444, exclude=WebDriverServer._used_ports)
-            WebDriverServer._used_ports.add(port)
-        return port
 
 
 class SeleniumServer(WebDriverServer):
@@ -235,24 +225,16 @@ def cmd_arg(name, value=None):
     return rv
 
 
-def get_free_port(start_port, exclude=None):
-    """Get the first port number after start_port (inclusive) that is
-    not currently bound.
-
-    :param start_port: Integer port number at which to start testing.
-    :param exclude: Set of port numbers to skip"""
-    port = start_port
+def get_free_port():
+    """Get a random unbound port"""
     while True:
-        if exclude and port in exclude:
-            port += 1
-            continue
         s = socket.socket()
         try:
-            s.bind(("127.0.0.1", port))
+            s.bind(("127.0.0.1", 0))
         except socket.error:
-            port += 1
+            continue
         else:
-            return port
+            return s.getsockname()[1]
         finally:
             s.close()
 


### PR DESCRIPTION
While working on [enabling wdspec tests in Servo](https://github.com/servo/servo/pull/23443), I noticed that although [`_used_ports`](https://github.com/web-platform-tests/wpt/blob/9954b61de31f317c7a0a3e286aca0731b81e7e5f/tools/wptrunner/wptrunner/webdriver_server.py#L22) is protected by a lock, when running the tests in parallel, each process had the same connection port. [Here](https://github.com/servo/servo/issues/22619#issuecomment-496270969) I provided a full description. Basically, `_used_ports` is not shared between the processes (each process has a different copy of it) so the changes one process makes to it are not reflected in the other processes. Thus, we get multiple processes running WebDriver on the same port. The easiest way to solve this is to switch to random OS port retrieval by binding to port 0.