### PR TITLE
[css-ui] Correct property name

### DIFF
--- a/css/css-ui/appearance-menulist-button-002.html
+++ b/css/css-ui/appearance-menulist-button-002.html
@@ -6,7 +6,7 @@
 <link rel="mismatch" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }
- #container > #drop-down-select { -webkit-appearance: none; -webkit-appearance: menulist-button; }
+ #container > #drop-down-select { appearance: none; appearance: menulist-button; }
 </style>
 <div id="container">
 	<a>a</a>

--- a/css/css-ui/webkit-appearance-menulist-button-002.html
+++ b/css/css-ui/webkit-appearance-menulist-button-002.html
@@ -10,7 +10,7 @@ Edit the appearance-* file instead and then run:
 <link rel="mismatch" href="appearance-auto-ref.html">
 <style>
  #container { width: 500px; }
- #container > #drop-down-select { -webkit--webkit-appearance: none; -webkit--webkit-appearance: menulist-button; }
+ #container > #drop-down-select { -webkit-appearance: none; -webkit-appearance: menulist-button; }
 </style>
 <div id="container">
 	<a>a</a>


### PR DESCRIPTION
The test for the `appearance` property mistakenly referred to the vendor
prefixed version, `-webkit-appearance`. In addition to contradicting the
test name and metadata, this caused the test intended for
`-webkit-appearance` to reference the non-existent property
`-webkit--webkit-appearance`.

Correct both tests, using the suite's build process to generate the
`-webkit-appearance` test from the corrected version of the `appearance`
test.

---

[Recent research has demonstrated that the `menulist-button` value is necessary for web compatibility.](https://github.com/w3c/csswg-drafts/issues/3024#issuecomment-431339106)

This seems to be the only instance of this particular mistake:

    $ git rev-parse HEAD
    48af14aaebdbcaf90bc21d07965f7c16661f8d90
    $ git grep -E 'moz-+moz'
    $ git grep -E 'webkit-+webkit'
    css/css-ui/webkit-appearance-menulist-button-002.html: #container > #drop-down-select { -webkit--webkit-appearance: none; -webkit--webkit-appearance: menulist-button; }
    $