### PR TITLE
Revert "[Gecko Bug 1546981] Remove duplicate test-case, and remove an error suppression it caused."

### DIFF
--- a/webrtc/RTCPeerConnection-setLocalDescription-answer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-answer.html
@@ -171,4 +171,19 @@
         pc.setLocalDescription(answer)));
   }, 'Calling setLocalDescription(answer) from have-local-offer state should reject with InvalidModificationError');
 
+  promise_test(async t => {
+    const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
+
+    const offer = await pc1.createOffer({offerToReceiveAudio: true});
+    await pc2.setRemoteDescription(offer);
+    const answer = await pc2.createAnswer(); // [[LastAnswer]] slot set
+    await pc2.setRemoteDescription({type: "rollback"});
+    await pc2.createOffer({offerToReceiveVideo: true}); // [[LastOffer]] slot set
+    await pc2.setRemoteDescription(offer);
+    await pc2.setLocalDescription(answer); // Should check against [[LastAnswer]], not [[LastOffer]]
+  }, "Setting previously generated answer after a call to createOffer should work");
+
 </script>


### PR DESCRIPTION
I'm pretty sure this was actually fixing a problem on thegecko side and ended up deleting a legitimate test here.