### PR TITLE
Ignore all exceptions when checking if requirements are met

### DIFF
--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -85,7 +85,7 @@ class Virtualenv(object):
     def install(self, *requirements):
         try:
             self.working_set.require(*requirements)
-        except pkg_resources.ResolutionError:
+        except Exception:
             pass
         else:
             return
@@ -98,7 +98,7 @@ class Virtualenv(object):
         with open(requirements_path) as f:
             try:
                 self.working_set.require(f.read())
-            except pkg_resources.ResolutionError:
+            except Exception:
                 pass
             else:
                 return


### PR DESCRIPTION
Worse case, we fall back to needlessly calling pip here. I've occasionally seen surprising failures due to (possibly broken) packages, so let's just let pip deal with this.