### PR TITLE
Get more of tools/wpt/tests passing on Windows

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -149,7 +149,7 @@ class Firefox(Browser):
 
         installer_path = os.path.join(dest, filename)
 
-        with open(installer_path, "w") as f:
+        with open(installer_path, "wb") as f:
             f.write(resp.content)
 
         try:

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -108,7 +108,7 @@ class Firefox(Browser):
             ("linux", "x86"): "linux",
             ("linux", "x86_64"): "linux64",
             ("win", "x86"): "win",
-            ("win", "x86_64"): "win64",
+            ("win", "AMD64"): "win64",
             ("macos", "x86_64"): "osx",
         }
         os_key = (self.platform, uname[4])

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -215,7 +215,7 @@ class Firefox(Browser):
         path = find_executable("certutil")
         if path is None:
             return None
-        if os.path.splitdrive(path)[1].split(os.path.sep) == ["", "Windows", "system32", "certutil.exe"]:
+        if os.path.splitdrive(os.path.normcase(path))[1].split(os.path.sep) == ["", "windows", "system32", "certutil.exe"]:
             return None
         return path
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -207,6 +207,14 @@ class Firefox(Browser):
         path = os.path.join(venv_path, "browsers", channel)
         binary = self.find_binary_path(path, channel)
 
+        if not binary and self.platform == "win":
+            winpaths = [os.path.expandvars("$SYSTEMDRIVE\\Program Files\\Mozilla Firefox"),
+                        os.path.expandvars("$SYSTEMDRIVE\\Program Files (x86)\\Mozilla Firefox")]
+            for winpath in winpaths:
+                binary = self.find_binary_path(winpath, channel)
+                if binary is not None:
+                    break
+
         if not binary and self.platform == "macos":
             macpaths = ["/Applications/Firefox Nightly.app/Contents/MacOS",
                         os.path.expanduser("~/Applications/Firefox Nightly.app/Contents/MacOS"),

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -17,6 +17,16 @@ from utils import call, get, untar, unzip
 uname = platform.uname()
 
 
+def _get_fileversion(binary, logger=None):
+    command = "(Get-Item '%s').VersionInfo.FileVersion" % binary.replace("'", "''")
+    try:
+        return call("powershell.exe", command).strip()
+    except (subprocess.CalledProcessError, OSError):
+        if logger is not None:
+            logger.warning("Failed to call %s in PowerShell" % command)
+        return None
+
+
 class Browser(object):
     __metaclass__ = ABCMeta
 
@@ -418,7 +428,8 @@ class Chrome(Browser):
             return "/usr/bin/google-chrome"
         if uname[0] == "Darwin":
             return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-        # TODO Windows?
+        if uname[0] == "Windows":
+            return os.path.expandvars("$SYSTEMDRIVE\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         self.logger.warning("Unable to find the browser binary.")
         return None
 
@@ -521,19 +532,19 @@ class Chrome(Browser):
 
     def version(self, binary=None, webdriver_binary=None):
         binary = binary or self.binary
-        if uname[0] != "Windows":
-            try:
-                version_string = call(binary, "--version").strip()
-            except subprocess.CalledProcessError:
-                self.logger.warning("Failed to call %s" % binary)
-                return None
-            m = re.match(r"(?:Google Chrome|Chromium) (.*)", version_string)
-            if not m:
-                self.logger.warning("Failed to extract version from: %s" % version_string)
-                return None
-            return m.group(1)
-        self.logger.warning("Unable to extract version from binary on Windows.")
-        return None
+        if uname[0] == "Windows":
+            return _get_fileversion(binary, self.logger)
+
+        try:
+            version_string = call(binary, "--version").strip()
+        except subprocess.CalledProcessError:
+            self.logger.warning("Failed to call %s" % binary)
+            return None
+        m = re.match(r"(?:Google Chrome|Chromium) (.*)", version_string)
+        if not m:
+            self.logger.warning("Failed to extract version from: %s" % version_string)
+            return None
+        return m.group(1)
 
 
 class ChromeAndroid(Browser):
@@ -711,12 +722,7 @@ class EdgeChromium(Browser):
             return m.group(1)
         else:
             if binary is not None:
-                command = "(Get-Item '%s').VersionInfo.FileVersion" % binary
-                try:
-                    return call("powershell.exe", command).strip()
-                except (subprocess.CalledProcessError, OSError):
-                    self.logger.warning("Failed to call %s in PowerShell" % command)
-                    return None
+                return _get_fileversion(binary, self.logger)
             self.logger.warning("Failed to find Edge binary.")
             return None
 

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -378,8 +378,8 @@ def test_tests_affected_null(capsys, manifest_dir):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="Tests currently don't work on Windows for path reasons")
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="no os.setsid/killpg to easily cleanup the process tree")
 def test_serve():
     if is_port_8000_in_use():
         pytest.skip("port 8000 already in use")

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -108,8 +108,6 @@ def test_list_tests(manifest_dir):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12935")
 def test_list_tests_missing_manifest(manifest_dir):
     """The `--list-tests` option should not produce an error in the absence of
     a test manifest file."""
@@ -133,8 +131,6 @@ def test_list_tests_missing_manifest(manifest_dir):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12935")
 def test_list_tests_invalid_manifest(manifest_dir):
     """The `--list-tests` option should not produce an error in the presence of
     a malformed test manifest file."""

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -255,7 +255,7 @@ def test_install_chromedriver():
 @pytest.mark.slow
 @pytest.mark.remote_network
 @pytest.mark.xfail(sys.platform == "win32",
-                   reason="Tests currently don't work on Windows for path reasons")
+                   reason="https://github.com/web-platform-tests/wpt/issues/17074")
 def test_install_firefox():
     if sys.platform == "darwin":
         fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "nightly", "Firefox Nightly.app")

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -270,41 +270,39 @@ def test_install_firefox():
     shutil.rmtree(fx_path)
 
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="Tests currently don't work on Windows for path reasons")
 def test_files_changed(capsys):
     commit = "9047ac1d9f51b1e9faa4f9fad9c47d109609ab09"
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["files-changed", "%s~..%s" % (commit, commit)])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
-    assert out == """html/browsers/offline/appcache/workers/appcache-worker.html
+    expected = """html/browsers/offline/appcache/workers/appcache-worker.html
 html/browsers/offline/appcache/workers/resources/appcache-dedicated-worker-not-in-cache.js
 html/browsers/offline/appcache/workers/resources/appcache-shared-worker-not-in-cache.js
 html/browsers/offline/appcache/workers/resources/appcache-worker-data.py
 html/browsers/offline/appcache/workers/resources/appcache-worker-import.py
 html/browsers/offline/appcache/workers/resources/appcache-worker.manifest
 html/browsers/offline/appcache/workers/resources/appcache-worker.py
-"""
+""".replace("/", os.path.sep)
+    assert out == expected
     assert err == ""
 
 
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="Tests currently don't work on Windows for path reasons")
 def test_files_changed_null(capsys):
     commit = "9047ac1d9f51b1e9faa4f9fad9c47d109609ab09"
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["files-changed", "--null", "%s~..%s" % (commit, commit)])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
-    assert out == "\0".join(["html/browsers/offline/appcache/workers/appcache-worker.html",
+    expected = "\0".join(["html/browsers/offline/appcache/workers/appcache-worker.html",
         "html/browsers/offline/appcache/workers/resources/appcache-dedicated-worker-not-in-cache.js",
         "html/browsers/offline/appcache/workers/resources/appcache-shared-worker-not-in-cache.js",
         "html/browsers/offline/appcache/workers/resources/appcache-worker-data.py",
         "html/browsers/offline/appcache/workers/resources/appcache-worker-import.py",
         "html/browsers/offline/appcache/workers/resources/appcache-worker.manifest",
         "html/browsers/offline/appcache/workers/resources/appcache-worker.py",
-        ""])
+        ""]).replace("/", os.path.sep)
+    assert out == expected
     assert err == ""
 
 

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -94,8 +94,6 @@ def test_help():
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="https://github.com/web-platform-tests/wpt/issues/12935")
 def test_list_tests(manifest_dir):
     """The `--list-tests` option should not produce an error under normal
     conditions."""
@@ -160,8 +158,6 @@ def test_list_tests_invalid_manifest(manifest_dir):
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="Tests currently don't work on Windows for path reasons")
 def test_run_zero_tests():
     """A test execution describing zero tests should be reported as an error
     even in the presence of the `--no-fail-on-unexpected` option."""
@@ -182,8 +178,6 @@ def test_run_zero_tests():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="Tests currently don't work on Windows for path reasons")
 def test_run_failing_test():
     """Failing tests should be reported with a non-zero exit status unless the
     `--no-fail-on-unexpected` option has been specified."""
@@ -207,8 +201,6 @@ def test_run_failing_test():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="Tests currently don't work on Windows for path reasons")
 def test_run_verify_unstable(temp_test):
     """Unstable tests should be reported with a non-zero exit status. Stable
     tests should be reported with a zero exit status."""
@@ -239,10 +231,11 @@ def test_run_verify_unstable(temp_test):
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-@pytest.mark.xfail(sys.platform == "win32",
-                   reason="Tests currently don't work on Windows for path reasons")
 def test_install_chromedriver():
-    chromedriver_path = os.path.join(wpt.localpaths.repo_root, "_venv", "bin", "chromedriver")
+    if sys.platform == "win32":
+        chromedriver_path = os.path.join(wpt.localpaths.repo_root, "_venv", "Scripts", "chromedriver.exe")
+    else:
+        chromedriver_path = os.path.join(wpt.localpaths.repo_root, "_venv", "bin", "chromedriver")
     if os.path.exists(chromedriver_path):
         os.unlink(chromedriver_path)
     with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
This makes some progress on #12935.

This leaves the tests mentioned in #12934 (which take forever on Windows) and `test_serve`, which I should probably file an actual bug for.