### PR TITLE
Pass required argument when updating manifest

### DIFF
--- a/tools/manifest/update.py
+++ b/tools/manifest/update.py
@@ -23,7 +23,7 @@ if MYPY:
 
 def update(tests_root,  # type: str
            manifest,  # type: Manifest
-           manifest_path,  # type: Optional[str]
+           manifest_path=None,  # type: Optional[str]
            working_copy=True,  # type: bool
            cache_root=None,  # type: Optional[str]
            rebuild=False  # type: bool


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/commit/e98eee5aec6ba154f2f086e9d2f0a287617e8519#diff-c67a86f05dbb8ec4a05b7380fa26262dR26 made an argument that was previously optional required. This broke Servo's nightly Sync process.