### PR TITLE
Ensure that testfiles revish is a string.

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import sys
 
+import six
 from collections import OrderedDict
 from six import iteritems
 
@@ -375,11 +376,13 @@ def get_parser_affected():
 
 
 def get_revish(**kwargs):
-    # type: (**Any) -> str
-    revish = kwargs["revish"]
+    # type: (**Any) -> bytes
+    revish = kwargs.get("revish")
     if revish is None:
         revish = "%s..HEAD" % branch_point()
-    assert isinstance(revish, str)
+    if isinstance(revish, six.text_type):
+        revish = revish.encode("utf8")
+    assert isinstance(revish, six.binary_type)
     return revish
 
 

--- a/tools/wpt/tests/test_testfiles.py
+++ b/tools/wpt/tests/test_testfiles.py
@@ -1,0 +1,13 @@
+from mock import patch
+
+from tools.wpt import testfiles
+
+
+def test_getrevish_kwarg():
+    assert testfiles.get_revish(revish=u"abcdef") == b"abcdef"
+    assert testfiles.get_revish(revish=b"abcdef") == b"abcdef"
+
+
+def test_getrevish_implicit():
+    with patch("tools.wpt.testfiles.branch_point", return_value=u"base"):
+        assert testfiles.get_revish() == b"base..HEAD"


### PR DESCRIPTION
The mypy changes added an assert that will fail in the case where
no revish is supplied on the command line, since the branch_point
function returns unicode and so we cast the revish to unicode not str.