### PR TITLE
manifest.update.update's manifest_path argument should be optional

### DIFF
--- a/tools/manifest/update.py
+++ b/tools/manifest/update.py
@@ -23,7 +23,7 @@ if MYPY:
 
 def update(tests_root,  # type: str
            manifest,  # type: Manifest
-           manifest_path,  # type: Optional[str]
+           manifest_path=None,  # type: Optional[str]
            working_copy=True,  # type: bool
            cache_root=None,  # type: Optional[str]
            rebuild=False  # type: bool


### PR DESCRIPTION
It was prior to e98eee5aec6ba154f2f086e9d2f0a287617e8519 landing, and that inadvertently changed it to being required.

Closes #17128.

cc/ @jdm 