### PR TITLE
[wpt] Correctly set the browser channel for Edge

### DIFF
--- a/tools/wpt/install.py
+++ b/tools/wpt/install.py
@@ -6,6 +6,7 @@ import sys
 latest_channels = {
     'firefox': 'nightly',
     'chrome': 'dev',
+    'edgechromium': 'dev',
     'safari': 'preview',
     'servo': 'nightly'
 }
@@ -18,6 +19,7 @@ channel_by_name = {
     'dev': latest_channels,
     'preview': latest_channels,
     'experimental': latest_channels,
+    'canary': 'canary',
 }
 
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -576,7 +576,8 @@ def setup_wptrunner(venv, prompt=True, install_browser=False, **kwargs):
             kwargs["browser_channel"] = channel
         else:
             logger.info("Valid channels for %s not known; using argument unmodified" % kwargs["product"])
-    del kwargs["channel"]
+            kwargs["browser_channel"] = kwargs["channel"]
+        del kwargs["channel"]
 
     if install_browser:
         logger.info("Installing browser")


### PR DESCRIPTION
This PR fixes two issues:

1. Add the "dev" channel for Edge (edgechromium).
2. When a channel is unrecognized for a browser, the channel is now
   correctly passed as is to wptrunner (as the log message says).