### PR TITLE
Load Ahem as a webfont everywhere (part 1)

### DIFF
--- a/css/CSS2/text/letter-spacing-004-ref.xht
+++ b/css/CSS2/text/letter-spacing-004-ref.xht
@@ -3,6 +3,7 @@
 <title>CSS Reftest Reference</title>
 <link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com"/>
 <meta name="flags" content="ahem"/>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style type="text/css"><![CDATA[
 div {
   font: 24px/1em Ahem;

--- a/css/CSS2/text/letter-spacing-065.xht
+++ b/css/CSS2/text/letter-spacing-065.xht
@@ -8,6 +8,7 @@
         <link rel="match" href="letter-spacing-004-ref.xht" />
         <meta name="flags" content="ahem" />
         <meta name="assert" content="The 'letter-spacing' property sets a zero length value in inches." />
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
         <style type="text/css">
             div
             {

--- a/css/css-grid/grid-definition/grid-inline-support-flexible-lengths-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-flexible-lengths-001.html
@@ -27,6 +27,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "1fr", "1fr", "800px", "600px");
@@ -99,5 +100,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "(1fr) auto", "(1fr) auto", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "90px", "10px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-inline-support-flexible-lengths-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-flexible-lengths-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .inline-grid {
     display: inline-grid;
@@ -26,6 +27,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "1fr", "1fr", "800px", "600px");
   TestingUtils.testGridTemplateColumnsRows("grid", "1fr", "1fr", "800px", "600px");
@@ -97,4 +99,5 @@
   TestingUtils.testGridTemplateColumnsRows("grid", "(1fr) auto", "(1fr) auto", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "90px", "10px");
+});
 </script>

--- a/css/css-grid/grid-definition/grid-inline-support-grid-template-columns-rows-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-grid-template-columns-rows-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .inline-grid {
     display: inline-grid;
@@ -26,6 +27,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Single values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "none", "none", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "none", "none", "90px", "10px");
@@ -81,4 +83,5 @@
   TestingUtils.testGridTemplateColumnsRows("grid", "100px, 200px", "300px, 400px", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 200px, 300px)", "minmax(100px, 200px, 300px)", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(100px, 200px, 300px)", "minmax(100px, 200px, 300px)", "90px", "10px");
+});
 </script>

--- a/css/css-grid/grid-definition/grid-inline-support-grid-template-columns-rows-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-grid-template-columns-rows-001.html
@@ -27,6 +27,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Single values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "none", "none", "none", "none");
@@ -83,5 +84,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "100px, 200px", "300px, 400px", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 200px, 300px)", "minmax(100px, 200px, 300px)", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(100px, 200px, 300px)", "minmax(100px, 200px, 300px)", "90px", "10px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-inline-support-named-grid-lines-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-named-grid-lines-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .inline-grid {
     display: inline-grid;
@@ -26,6 +27,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "[first] auto [last]", "[first] auto [last]", "[first] 0px [last]", "[first] 0px [last]");
   TestingUtils.testGridTemplateColumnsRows("grid", "[first] auto [last]", "[first] auto [last]", "[first] 90px [last]", "[first] 10px [last]");
@@ -115,4 +117,5 @@
   TestingUtils.testGridTemplateColumnsRows("grid", "[inherit] auto", "[inherit] auto", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "[default] auto", "[default] auto", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "[default] auto", "[default] auto", "90px", "10px");
+});
 </script>

--- a/css/css-grid/grid-definition/grid-inline-support-named-grid-lines-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-named-grid-lines-001.html
@@ -27,6 +27,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "[first] auto [last]", "[first] auto [last]", "[first] 0px [last]", "[first] 0px [last]");
@@ -117,5 +118,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "[inherit] auto", "[inherit] auto", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "[default] auto", "[default] auto", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "[default] auto", "[default] auto", "90px", "10px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-inline-support-repeat-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-repeat-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .inline-grid {
     display: inline-grid;
@@ -26,6 +27,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "repeat(1, auto)", "repeat(1, auto)", "0px", "0px");
   TestingUtils.testGridTemplateColumnsRows("grid", "repeat(1, auto)", "repeat(1, auto)", "90px", "10px");
@@ -75,4 +77,5 @@
   TestingUtils.testGridTemplateColumnsRows("grid", "repeat(2, 50px repeat(2, 100px))", "repeat(2, 50px repeat(2, 100px))", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "100px repeat(2, [a])", "100px repeat(2, [a])", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "100px repeat(2, [a])", "100px repeat(2, [a])", "90px", "10px");
+});
 </script>

--- a/css/css-grid/grid-definition/grid-inline-support-repeat-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-repeat-001.html
@@ -27,6 +27,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "repeat(1, auto)", "repeat(1, auto)", "0px", "0px");
@@ -77,5 +78,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "repeat(2, 50px repeat(2, 100px))", "repeat(2, 50px repeat(2, 100px))", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "100px repeat(2, [a])", "100px repeat(2, [a])", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "100px repeat(2, [a])", "100px repeat(2, [a])", "90px", "10px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-inline-template-columns-rows-resolved-values-001.html
+++ b/css/css-grid/grid-definition/grid-inline-template-columns-rows-resolved-values-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .inline-grid {
     display: inline-grid;
@@ -57,6 +58,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("grid", "", "", "110px", ["10px 10px 20px", "repeat(2, 10px) 20px"]);
   TestingUtils.testGridTemplateColumnsRows("grid", "auto auto", "", "100px 110px", "10px 20px");
@@ -99,4 +101,5 @@
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px", "60px 70px", ["60px 50px 0px 0px 100px", "60px 50px repeat(2, 0px) 100px"], "60px 70px 0px 20px");
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px 70px", "60px", ["60px 70px 0px 0px 100px", "60px 70px repeat(2, 0px) 100px"], ["60px 0px 0px 20px", "60px repeat(2, 0px) 20px"]);
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px 70px", "60px 70px", ["60px 70px 0px 0px 100px", "60px 70px repeat(2, 0px) 100px"], "60px 70px 0px 20px");
+});
 </script>

--- a/css/css-grid/grid-definition/grid-inline-template-columns-rows-resolved-values-001.html
+++ b/css/css-grid/grid-definition/grid-inline-template-columns-rows-resolved-values-001.html
@@ -58,6 +58,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("grid", "", "", "110px", ["10px 10px 20px", "repeat(2, 10px) 20px"]);
@@ -101,5 +102,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px", "60px 70px", ["60px 50px 0px 0px 100px", "60px 50px repeat(2, 0px) 100px"], "60px 70px 0px 20px");
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px 70px", "60px", ["60px 70px 0px 0px 100px", "60px 70px repeat(2, 0px) 100px"], ["60px 0px 0px 20px", "60px repeat(2, 0px) 20px"]);
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px 70px", "60px 70px", ["60px 70px 0px 0px 100px", "60px 70px repeat(2, 0px) 100px"], "60px 70px 0px 20px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html
+++ b/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html
@@ -27,6 +27,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "1fr", "1fr", "800px", "600px");
@@ -99,5 +100,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "(1fr) auto", "(1fr) auto", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "90px", "10px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html
+++ b/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .grid {
     display: grid;
@@ -26,6 +27,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "1fr", "1fr", "800px", "600px");
   TestingUtils.testGridTemplateColumnsRows("grid", "1fr", "1fr", "800px", "600px");
@@ -97,4 +99,5 @@
   TestingUtils.testGridTemplateColumnsRows("grid", "(1fr) auto", "(1fr) auto", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(1fr, 1000px)", "minmax(1fr, 700px)", "90px", "10px");
+});
 </script>

--- a/css/css-grid/grid-definition/grid-support-grid-template-columns-rows-001.html
+++ b/css/css-grid/grid-definition/grid-support-grid-template-columns-rows-001.html
@@ -27,6 +27,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Single values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "none", "none", "none", "none");
@@ -83,5 +84,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "100px, 200px", "300px, 400px", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 200px, 300px)", "minmax(100px, 200px, 300px)", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(100px, 200px, 300px)", "minmax(100px, 200px, 300px)", "90px", "10px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-support-grid-template-columns-rows-001.html
+++ b/css/css-grid/grid-definition/grid-support-grid-template-columns-rows-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .grid {
     display: grid;
@@ -26,6 +27,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Single values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "none", "none", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "none", "none", "90px", "10px");
@@ -81,4 +83,5 @@
   TestingUtils.testGridTemplateColumnsRows("grid", "100px, 200px", "300px, 400px", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "minmax(100px, 200px, 300px)", "minmax(100px, 200px, 300px)", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "minmax(100px, 200px, 300px)", "minmax(100px, 200px, 300px)", "90px", "10px");
+});
 </script>

--- a/css/css-grid/grid-definition/grid-support-named-grid-lines-001.html
+++ b/css/css-grid/grid-definition/grid-support-named-grid-lines-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .grid {
     display: grid;
@@ -26,6 +27,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "[first] auto [last]", "[first] auto [last]", "[first] 0px [last]", "[first] 0px [last]");
   TestingUtils.testGridTemplateColumnsRows("grid", "[first] auto [last]", "[first] auto [last]", "[first] 90px [last]", "[first] 10px [last]");
@@ -115,4 +117,5 @@
   TestingUtils.testGridTemplateColumnsRows("grid", "[inherit] auto", "[inherit] auto", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "[default] auto", "[default] auto", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "[default] auto", "[default] auto", "90px", "10px");
+});
 </script>

--- a/css/css-grid/grid-definition/grid-support-named-grid-lines-001.html
+++ b/css/css-grid/grid-definition/grid-support-named-grid-lines-001.html
@@ -27,6 +27,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "[first] auto [last]", "[first] auto [last]", "[first] 0px [last]", "[first] 0px [last]");
@@ -117,5 +118,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "[inherit] auto", "[inherit] auto", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "[default] auto", "[default] auto", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "[default] auto", "[default] auto", "90px", "10px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-support-repeat-001.html
+++ b/css/css-grid/grid-definition/grid-support-repeat-001.html
@@ -27,6 +27,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "repeat(1, auto)", "repeat(1, auto)", "0px", "0px");
@@ -77,5 +78,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("grid", "repeat(2, 50px repeat(2, 100px))", "repeat(2, 50px repeat(2, 100px))", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "100px repeat(2, [a])", "100px repeat(2, [a])", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "100px repeat(2, [a])", "100px repeat(2, [a])", "90px", "10px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-support-repeat-001.html
+++ b/css/css-grid/grid-definition/grid-support-repeat-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .grid {
     display: grid;
@@ -26,6 +27,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "repeat(1, auto)", "repeat(1, auto)", "0px", "0px");
   TestingUtils.testGridTemplateColumnsRows("grid", "repeat(1, auto)", "repeat(1, auto)", "90px", "10px");
@@ -75,4 +77,5 @@
   TestingUtils.testGridTemplateColumnsRows("grid", "repeat(2, 50px repeat(2, 100px))", "repeat(2, 50px repeat(2, 100px))", "90px", "10px");
   TestingUtils.testGridTemplateColumnsRows("emptyGrid", "100px repeat(2, [a])", "100px repeat(2, [a])", "none", "none");
   TestingUtils.testGridTemplateColumnsRows("grid", "100px repeat(2, [a])", "100px repeat(2, [a])", "90px", "10px");
+});
 </script>

--- a/css/css-grid/grid-definition/grid-template-columns-rows-resolved-values-001.html
+++ b/css/css-grid/grid-definition/grid-template-columns-rows-resolved-values-001.html
@@ -58,6 +58,7 @@
 </div>
 
 <script>
+setup({explicit_done: true});
 document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("grid", "", "", "110px", ["10px 10px 20px", "repeat(2, 10px) 20px"]);
@@ -101,5 +102,6 @@ document.fonts.ready.then(()=> {
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px", "60px 70px", ["60px 50px 0px 0px 100px", "60px 50px repeat(2, 0px) 100px"], "60px 70px 0px 20px");
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px 70px", "60px", ["60px 70px 0px 0px 100px", "60px 70px repeat(2, 0px) 100px"], ["60px 0px 0px 20px", "60px repeat(2, 0px) 20px"]);
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px 70px", "60px 70px", ["60px 70px 0px 0px 100px", "60px 70px repeat(2, 0px) 100px"], "60px 70px 0px 20px");
+  done();
 });
 </script>

--- a/css/css-grid/grid-definition/grid-template-columns-rows-resolved-values-001.html
+++ b/css/css-grid/grid-definition/grid-template-columns-rows-resolved-values-001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   .grid {
     display: grid;
@@ -57,6 +58,7 @@
 </div>
 
 <script>
+document.fonts.ready.then(()=> {
   // Valid values.
   TestingUtils.testGridTemplateColumnsRows("grid", "", "", "110px", ["10px 10px 20px", "repeat(2, 10px) 20px"]);
   TestingUtils.testGridTemplateColumnsRows("grid", "auto auto", "", "100px 110px", "10px 20px");
@@ -99,4 +101,5 @@
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px", "60px 70px", ["60px 50px 0px 0px 100px", "60px 50px repeat(2, 0px) 100px"], "60px 70px 0px 20px");
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px 70px", "60px", ["60px 70px 0px 0px 100px", "60px 70px repeat(2, 0px) 100px"], ["60px 0px 0px 20px", "60px repeat(2, 0px) 20px"]);
   TestingUtils.testGridTemplateColumnsRows("gridAutoFlowColumnItemsPositions", "60px 70px", "60px 70px", ["60px 70px 0px 0px 100px", "60px 70px repeat(2, 0px) 100px"], "60px 70px 0px 20px");
+});
 </script>

--- a/css/css-shapes/spec-examples/shape-outside-018.html
+++ b/css/css-shapes/spec-examples/shape-outside-018.html
@@ -39,8 +39,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({explicit_done: true});
     document.fonts.ready.then(()=> {
       approxShapeTest('test', 'line-', 2, [48, 88, 128, 168, 180, 0]);
+      done();
     });
     </script>
 </head>

--- a/css/css-shapes/spec-examples/shape-outside-018.html
+++ b/css/css-shapes/spec-examples/shape-outside-018.html
@@ -11,6 +11,7 @@
                                  defined on a polygonal shape-outside."/>
     <!-- This test is derived from Example 10 in this version of the spec:
          http://www.w3.org/TR/2014/WD-css-shapes-1-20140211/ -->
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         #test {
             position: relative;
@@ -38,12 +39,12 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
-    function checkFloats() {
+    document.fonts.ready.then(()=> {
       approxShapeTest('test', 'line-', 2, [48, 88, 128, 168, 180, 0]);
-    }
+    });
     </script>
 </head>
-<body onload="checkFloats();">
+<body>
     <p>
         The test passes if the longest green horizontal bar is beneath the triangle and the
         rest of them are to its right and none intersect it. There should be no red.

--- a/docs/writing-tests/ahem.md
+++ b/docs/writing-tests/ahem.md
@@ -23,6 +23,13 @@ that its bottom is flush with the baseline.
 Most other US-ASCII characters in the font have the same glyph as X.
 
 ## Usage
+Ahem should be loaded in tests as a WebFont. To simplify this, a test can
+link to the `/fonts/ahem.css` stylesheet:
+
+```
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+```
+
 If the test uses the Ahem font, make sure its computed font-size is a
 multiple of 5px, otherwise baseline alignment may be rendered
 inconsistently. A minimum computed font-size of 20px is suggested.

--- a/docs/writing-tests/ahem.md
+++ b/docs/writing-tests/ahem.md
@@ -23,7 +23,7 @@ that its bottom is flush with the baseline.
 Most other US-ASCII characters in the font have the same glyph as X.
 
 ## Usage
-Ahem should be loaded in tests as a WebFont. To simplify this, a test can
+Ahem should be loaded in tests as a web font. To simplify this, a test can
 link to the `/fonts/ahem.css` stylesheet:
 
 ```

--- a/docs/writing-tests/assumptions.md
+++ b/docs/writing-tests/assumptions.md
@@ -11,7 +11,6 @@ tests can freely rely on these assumptions being true:
  * The initial value of `color` is `black`.
  * The user stylesheet is empty (except where indicated by the tests).
  * The device is interactive and uses scroll bars.
- * The device has the Ahem font installed.
  * The HTML `div` element is assigned `display: block;`, the
    `unicode-bidi` property may be declared, and no other property
    declarations.

--- a/docs/writing-tests/assumptions.md
+++ b/docs/writing-tests/assumptions.md
@@ -11,6 +11,7 @@ tests can freely rely on these assumptions being true:
  * The initial value of `color` is `black`.
  * The user stylesheet is empty (except where indicated by the tests).
  * The device is interactive and uses scroll bars.
+ * The device has the Ahem font installed.
  * The HTML `div` element is assigned `display: block;`, the
    `unicode-bidi` property may be declared, and no other property
    declarations.

--- a/fonts/ahem.css
+++ b/fonts/ahem.css
@@ -1,0 +1,5 @@
+@font-face {
+    font-family: 'Ahem';
+    src: url('/fonts/Ahem.ttf');
+}
+


### PR DESCRIPTION
This adds the fonts/ahem.css stylesheet and updates some representative
tests. Also updating docs to not assume Ahem is installed as a system font.

css/CSS2/text/letter-spacing-065.xht (and its ref) simply load the
ahem.css stylesheet. The vast majority of reftests will need such a change (to be done in part 2).

The 10 tests in css/css-grid/grid-definition use Ahem but are not
reftests. These tests load the ahem.css stylesheet but also explicitly
preload the Ahem.ttf font file.
css/css-shapes/spec-examples/shape-outside-018.html is like the grid
tests above.