### PR TITLE
Wrap event handlers in Client Hints tests in `t.step_func`

### DIFF
--- a/client-hints/accept_ch.tentative.https.html
+++ b/client-hints/accept_ch.tentative.https.html
@@ -38,7 +38,7 @@ promise_test(t => {
 }, "Precondition: Test that the browser does not have client hints preferences cached");
 
 async_test(t => {
-  window.addEventListener('message', function(e) {
+  window.addEventListener('message', t.step_func(function(e) {
     if(!e.source.location.pathname.includes("do_not_expect_client_hints_headers.html")) {
       return;
     }
@@ -46,7 +46,7 @@ async_test(t => {
       return;
     assert_equals(e.data, "PASS");
     t.done();
-  })
+  }));
 }, "Loading of resources/do_not_expect_client_hints_headers.html did not finish.");
 
 function acceptChLoaded() {

--- a/client-hints/accept_ch_lifetime.tentative.https.html
+++ b/client-hints/accept_ch_lifetime.tentative.https.html
@@ -38,7 +38,7 @@ promise_test(t => {
 }, "Precondition: Test that the browser does not have client hints preferences cached");
 
 async_test(t => {
-  window.addEventListener('message', function(e) {
+  window.addEventListener('message', t.step_func(function(e) {
     if(!e.source.location.pathname.includes("expect_client_hints_headers.html")) {
       return;
     }
@@ -46,7 +46,7 @@ async_test(t => {
       return;
     assert_equals(e.data, "PASS");
     t.done();
-})
+  }));
 }, "Loading of resources/expect_client_hints_headers.html did not finish.");
 
 

--- a/client-hints/accept_ch_lifetime_cross_origin_iframe.tentative.sub.https.html
+++ b/client-hints/accept_ch_lifetime_cross_origin_iframe.tentative.sub.https.html
@@ -40,7 +40,7 @@ promise_test(t => {
 }, "Precondition: Test that the browser does not have client hints preferences cached");
 
 async_test(t => {
-  window.addEventListener('message', function(e) {
+  window.addEventListener('message', t.step_func(function(e) {
     if(!e.source.location.pathname.includes("do_not_expect_client_hints_headers.html")) {
       return;
     }
@@ -48,7 +48,7 @@ async_test(t => {
       return;
     assert_equals(e.data, "PASS");
     t.done();
-  })
+  }));
 }, "Loading of resources/do_not_expect_client_hints_headers.html did not finish.");
 
 function acceptChLifetimeLoaded() {

--- a/client-hints/accept_ch_lifetime_subresource.tentative.https.html
+++ b/client-hints/accept_ch_lifetime_subresource.tentative.https.html
@@ -56,7 +56,7 @@ promise_test(t => {
 }, "Test receiving Accept-CH-Lifetime header");
 
 async_test(t => {
-  window.addEventListener('message', function(e) {
+  window.addEventListener('message', t.step_func(function(e) {
     if(!e.source.location.pathname.includes("do_not_expect_client_hints_headers.html")) {
       return;
     }
@@ -64,7 +64,7 @@ async_test(t => {
       return;
     assert_equals(e.data, "PASS");
     t.done();
-  })
+  }));
 }, "Loading of resources/do_not_expect_client_hints_headers.html did not finish.");
 
 </script>

--- a/client-hints/http_equiv_accept_ch_lifetime.tentative.https.html
+++ b/client-hints/http_equiv_accept_ch_lifetime.tentative.https.html
@@ -38,7 +38,7 @@ promise_test(t => {
 }, "Precondition: Test that the browser does not have client hints preferences cached");
 
 async_test(t => {
-  window.addEventListener('message', function(e) {
+  window.addEventListener('message', t.step_func(function(e) {
     if(!e.source.location.pathname.includes("expect_client_hints_headers.html")) {
       return;
     }
@@ -46,7 +46,7 @@ async_test(t => {
       return;
     assert_equals(e.data, "PASS");
     t.done();
-})
+  }));
 }, "Loading of resources/expect_client_hints_headers.html did not finish.");
 
 function acceptChLifetimeLoaded() {

--- a/client-hints/http_equiv_accept_ch_lifetime_cross_origin_iframe.tentative.sub.https.html
+++ b/client-hints/http_equiv_accept_ch_lifetime_cross_origin_iframe.tentative.sub.https.html
@@ -40,7 +40,7 @@ promise_test(t => {
 }, "Precondition: Test that the browser does not have client hints preferences cached");
 
 async_test(t => {
-  window.addEventListener('message', function(e) {
+  window.addEventListener('message', t.step_func(function(e) {
     if(!e.source.location.pathname.includes("do_not_expect_client_hints_headers.html")) {
       return;
     }
@@ -48,7 +48,7 @@ async_test(t => {
       return;
     assert_equals(e.data, "PASS");
     t.done();
-  })
+  }));
 }, "Loading of resources/do_not_expect_client_hints_headers.html did not finish.");
 
 function acceptChLifetimeLoaded() {

--- a/client-hints/http_equiv_accept_ch_lifetime_subresource.tentative.https.html
+++ b/client-hints/http_equiv_accept_ch_lifetime_subresource.tentative.https.html
@@ -58,7 +58,7 @@ promise_test(t => {
 }, "Test receiving Accept-CH-Lifetime header");
 
 async_test(t => {
-  window.addEventListener('message', function(e) {
+  window.addEventListener('message', t.step_func(function(e) {
     if(!e.source.location.pathname.includes("do_not_expect_client_hints_headers.html")) {
       return;
     }
@@ -66,7 +66,7 @@ async_test(t => {
       return;
     assert_equals(e.data, "PASS");
     t.done();
-  })
+  }));
 }, "Loading of resources/do_not_expect_client_hints_headers.html did not finish.");
 
 


### PR DESCRIPTION
Without this, any failed assert will cause a harness error instead of
failing the test.

Note that some problematic use like
`win.addEventListener('load', acceptChLifetimeLoaded, false)` remains,
but fixing these would require introducing new tests.