### PR TITLE
Expand set of allowed types when updating manifest.

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -323,7 +323,7 @@ class Manifest(object):
 
         for source_file, update in tree:
             if not update:
-                assert isinstance(source_file, (bytes, str))
+                assert isinstance(source_file, (bytes, str, unicode))
                 rel_path = source_file  # type: Text
                 seen_files.add(rel_path)
                 assert rel_path in path_hash

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -2,7 +2,7 @@ import itertools
 import json
 import os
 from collections import MutableMapping, defaultdict
-from six import iteritems, iterkeys, itervalues, string_types
+from six import iteritems, iterkeys, itervalues, string_types, binary_type, text_type
 
 from . import vcs
 from .item import (ConformanceCheckerTest, ManifestItem, ManualTest, RefTest, RefTestNode, Stub,
@@ -323,7 +323,7 @@ class Manifest(object):
 
         for source_file, update in tree:
             if not update:
-                assert isinstance(source_file, (bytes, str, unicode))
+                assert isinstance(source_file, (binary_type, text_type))
                 rel_path = source_file  # type: Text
                 seen_files.add(rel_path)
                 assert rel_path in path_hash


### PR DESCRIPTION
Without this change, updating the Servo's WPT manifest yields the following:
```
  File "/Users/jdm/src/servo/python/servo/testing_commands.py", line 455, in update_manifest
    return run_update(self.context.topdir, **kwargs)
  File "/Users/jdm/src/servo/python/servo/testing_commands.py", line 90, in run_update
    return manifestupdate.update(logger, wpt_dir, check_clean, rebuild)
  File "/Users/jdm/src/servo/tests/wpt/manifestupdate.py", line 57, in update
    return _update(logger, test_paths, rebuild)
  File "/Users/jdm/src/servo/tests/wpt/manifestupdate.py", line 71, in _update
    cache_subdir))
  File "/Users/jdm/src/servo/tests/wpt/web-platform-tests/tools/manifest/manifest.py", line 571, in load_and_update
    changed = manifest.update(tree)
  File "/Users/jdm/src/servo/tests/wpt/web-platform-tests/tools/manifest/manifest.py", line 326, in update
    assert isinstance(source_file, (bytes, str))
```