### PR TITLE
[ci] Collect results from prior release of Safari

### DIFF
--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -7,7 +7,10 @@ steps:
   - script: |
       # This is equivalent to `Homebrew/homebrew-cask-versions/safari-technology-preview`,
       # but the raw URL is used to bypass caching.
-      HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/safari-technology-preview.rb
+      # Safari Technology Preview version 83 includes a regression that
+      # interferes with results collection. The version of the installation
+      # script referenced here installs STP at version 82.
+      HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/dbde508bb83254c53be4eb6387dbd9fbf9797a35/Casks/safari-technology-preview.rb
       sudo "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable
       defaults write com.apple.SafariTechnologyPreview WebKitJavaScriptCanOpenWindowsAutomatically 1
       defaults write com.apple.SafariTechnologyPreview ExperimentalServerTimingEnabled 1


### PR DESCRIPTION
Safari Technology Preview version 83 includes a bug which interferes
with some of the web-platform-tests.

---

In Safari Technology Preview version 83, sending the "pointerDown" action on certain parts of the document causes the WebDriver server to withhold a response indefinitely. Verified on a Mac Mini runnning macOS 10.13 and a Macbook Pro running macOS 10.14.

This has interfered with [the results collection project](https://github.com/web-platform-tests/results-collection)'s attempts to collect results from that browser since [the release of version 83 last Wednesday](https://webkit.org/blog/8967/release-notes-for-safari-technology-preview-83/).

The problem hasn't effected results collection as managed from this project using Azure Pipelines because this project continues to use version 82 of STP. See gh-17186. Whatever the case, this patch ensures that we don't silently upgrade (and it documents the problem).

Here's a reduced test case:

<details>
  <summary><code>reduced.sh</code></summary>

```bash
#!/bin/bash

# This script demonstrates a bug in Safari Technology Preview version 83. The
# "actions" command is expected to complete immediately, but in that release
# the server holds the request open indefinitely. The mouse coordinates
# (12, 11) were selected through trial-and error.

set -e

port=2323
webdriver_bin=$1

if [ ! -x "${webdriver_bin}" ]; then
  echo Usage: $0 PATH_TO_WEBDRIVER_EXECUTABLE >&2
  exit 1
fi

"${webdriver_bin}" --port=${port} > /dev/null &

webdriver_pid=$!

function cleanup {
  if [ -n "${session_id}" ]; then
    curl \
      -X DELETE \
      --silent \
      http://localhost:${port}/session/${session_id} > /dev/null
  fi

  if [ -n "${webdriver_pid}" ]; then
    kill -9 ${webdriver_pid}
  fi
}

trap cleanup EXIT

sleep 1

session_id=$(
  curl \
    --data '{"capabilities": {"alwaysMatch": {"pageLoadStrategy": "eager"}}}' \
    --silent \
    http://localhost:${port}/session | \
  python -c 'import json, sys; print json.loads(sys.stdin.read())["value"]["sessionId"]'
)

curl \
  --verbose \
  --data '{"url": "data:text/html,Helloworld"}' \
  http://localhost:${port}/session/${session_id}/url

curl \
  --verbose \
  --data '{"actions": [{"actions": [{"y": 11, "x": 12, "type": "pointerMove", "origin": "viewport"}, {"button": 0, "type": "pointerDown"}], "type": "pointer", "id": "1", "parameters": {"pointerType": "mouse"}}]}' \
  http://localhost:${port}/session/${session_id}/actions
```

</details>

When the browser is being controlled by safaridriver, clicking anywhere within the browser window usually triggers a modal dialog about disabling automation. Strngely, clicking when safaridriver is paused like this does not trigger such a dialog, but it does cause the server to respond to the command.

Affected tests:

- [`pointerevents/pointerevent_mouse_pointercapture_in_frame.html`](https://github.com/web-platform-tests/wpt/blob/fe2961715f4663be36d5ff849e3f78374c1fc2f6/pointerevents/pointerevent_mouse_pointercapture_in_frame.html)
- [`webdriver/tests/perform_actions/pointer_contextmenu.py`](https://github.com/web-platform-tests/wpt/blob/fe2961715f4663be36d5ff849e3f78374c1fc2f6/webdriver/tests/perform_actions/pointer_contextmenu.py)

@burg is this a known bug?

