### PR TITLE
[docs] Generate linting docs from source

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,11 +80,13 @@ exclude_patterns = [
     '.DS_Store'
 ]
 
+from docs.wpt_lint_rules import WPTLintRules
 # Enable inline reStructured Text within Markdown-formatted files
 # https://recommonmark.readthedocs.io/en/latest/auto_structify.html
 from recommonmark.transform import AutoStructify
 def setup(app):
     app.add_transform(AutoStructify)
+    app.add_directive('wpt-lint-rules', WPTLintRules)
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None

--- a/docs/wpt_lint_rules.py
+++ b/docs/wpt_lint_rules.py
@@ -1,0 +1,78 @@
+from docutils.parsers.rst import Directive, nodes
+from docutils.utils import new_document
+from recommonmark.parser import CommonMarkParser
+import importlib
+import textwrap
+
+class WPTLintRules(Directive):
+    """A docutils directive to generate documentation for the
+    web-platform-test-test's linting tool from its source code. Requires a
+    single argument: a Python module specifier for a file which declares
+    linting rules."""
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    _md_parser = CommonMarkParser()
+
+    @staticmethod
+    def _parse_markdown(markdown):
+        WPTLintRules._md_parser.parse(markdown, new_document("<string>"))
+        return WPTLintRules._md_parser.document.children[0]
+
+    @property
+    def module_specifier(self):
+        return self.arguments[0]
+
+    def _get_rules(self):
+        try:
+            module = importlib.import_module(self.module_specifier)
+        except ImportError:
+            raise ImportError(
+                """wpt-lint-rules: unable to resolve the module at "{}".""".format(self.module_specifier)
+            )
+
+        for binding_name, value in module.__dict__.iteritems():
+            if hasattr(value, "__abstractmethods__") and len(value.__abstractmethods__):
+                continue
+
+            description = getattr(value, "description", None)
+            name = getattr(value, "name", None)
+            to_fix = getattr(value, "to_fix", None)
+
+            if description is None:
+                continue
+
+            if to_fix is not None:
+                to_fix = textwrap.dedent(to_fix)
+
+            yield {
+                "name": name,
+                "description": textwrap.dedent(description),
+                "to_fix": to_fix
+            }
+
+
+    def run(self):
+        definition_list = nodes.definition_list()
+
+        for rule in sorted(self._get_rules(), key=lambda rule: rule['name']):
+            item = nodes.definition_list_item()
+            definition = nodes.definition()
+            term = nodes.term()
+            item += term
+            item += definition
+            definition_list += item
+
+            term += nodes.literal(text=rule["name"])
+            definition += WPTLintRules._parse_markdown(rule["description"])
+
+            if rule["to_fix"]:
+                definition += nodes.strong(text="To fix:")
+                definition += WPTLintRules._parse_markdown(rule["to_fix"])
+
+        if len(definition_list.children) == 0:
+            raise Exception(
+                """wpt-lint-rules: no linting rules found at "{}".""".format(self.module_specifier)
+            )
+
+        return [definition_list]

--- a/docs/writing-tests/lint-tool.md
+++ b/docs/writing-tests/lint-tool.md
@@ -22,81 +22,14 @@ those cases you can [whitelist test files](#updating-the-whitelist)
 to suppress the errors. In all other cases, follow the instructions
 below to fix all errors reported.
 
-* **CONSOLE**: Test-file line has a `console.*(...)` call; **fix**: remove
-  the `console.*(...)` call (and in some cases, consider adding an
-  `assert_*` of some kind in place of it).
+<!--
+  This listing is automatically generated from the linting tool's Python source
+  code.
+-->
 
-* **CR AT EOL**: Test-file line ends with CR (U+000D) character; **fix**:
-  reformat file so each line just has LF (U+000A) line ending (standard,
-  cross-platform "Unix" line endings instead of, e.g., DOS line endings).
-
-* **EARLY-TESTHARNESSREPORT**: Test file has an instance of
-  `<script src='/resources/testharnessreport.js'>` prior to
-  `<script src='/resources/testharness.js'>`; **fix**: flip the order.
-
-* **GENERATE_TESTS**: Test file line has a generate_tests call; **fix**: remove
-  the call and call `test()` a number of times instead.
-
-* **INDENT TABS**: Test-file line starts with one or more tab characters;
-  **fix**: use spaces to replace any tab characters at beginning of lines.
-
-* **INVALID-TIMEOUT**: Test file with `<meta name='timeout'...>` element
-  that has a `content` attribute whose value is not `long`; **fix**:
-  replace the value of the `content` attribute with `long`.
-
-* **LATE-TIMEOUT**: Test file with `<meta name="timeout"...>` element after
-  `<script src='/resources/testharnessreport.js'>` element ; **fix**: move
-  the `<meta name="timeout"...>` element to precede the `script` element.
-
-* **LAYOUTTESTS APIS**: Test file uses `eventSender`, `testRunner`, or
-  `internals` which are LayoutTests-specific APIs used in WebKit/Blink.
-
-* **MALFORMED-VARIANT**: Test file with a `<meta name='variant'...>`
-  element whose `content` attribute has a malformed value; **fix**: ensure
-  the value of the `content` attribute starts with `?` or `#` or is empty.
-
-* **MISSING-LINK**: CSS test file is missing a link to a spec. **fix**: Ensure that there is a `<link rel="help" href="[url]">` for the spec.
-  * Note: `MISSING-LINK` is designed to ensure that the CSS build tool can find the tests. Note that the CSS build system is primarily used by [test.csswg.org/](http://test.csswg.org/), which doesn't use `wptserve`, so `*.any.js` and similar tests won't work there; stick with the `.html` equivalent.
-
-* **MISSING-TESTHARNESSREPORT**: Test file is missing an instance of
-  `<script src='/resources/testharnessreport.js'>`; **fix**: ensure each
-  test file contains `<script src='/resources/testharnessreport.js'>`.
-
-* **MULTIPLE-TESTHARNESS**: Test file with multiple instances of
-  `<script src='/resources/testharness.js'>`; **fix**: ensure each test
-  has only one `<script src='/resources/testharness.js'>` instance.
-
-* **MULTIPLE-TESTHARNESSREPORT**: Test file with multiple instances of
-  `<script src='/resources/testharnessreport.js'>`; **fix**: ensure each test
-  has only one `<script src='/resources/testharnessreport.js'>` instance.
-
-* **MULTIPLE-TIMEOUT**: Test file with multiple `<meta name="timeout"...>`
-  elements; **fix**: ensure each test file has only one instance of a
-  `<meta name="timeout"...>` element.
-
-* **PARSE-FAILED**: Test file failed parsing by manifest builder; **fix**:
-  examine the file to find the causes of any parse errors, and fix them.
-
-* **PATH LENGTH**: Test file's pathname has a total length greater than 150
-  characters; **fix**: use shorter filename to rename the test file.
-
-* **PRINT STATEMENT**: A server-side python support file contains a `print`
-  statement; **fix**: remove the `print` statement or replace it with
-  something else that achieves the intended effect (e.g., a logging call).
-
-* **SET TIMEOUT**: Test-file line has `setTimeout(...)` call; **fix**:
-  replace all `setTimeout(...)` calls with `step_timeout(...)` calls.
-
-* **TRAILING WHITESPACE**: Test-file line has trailing whitespace; **fix**:
-  remove trailing whitespace from all lines in the file.
-
-* **VARIANT-MISSING**: Test file with a `<meta name='variant'...>` element
-  that's missing a `content` attribute; **fix**: add a `content` attribute
-  with an appropriate value to the `<meta name='variant'...>` element.
-
-* **W3C-TEST.ORG**: Test-file line has the string `w3c-test.org`; **fix**:
-  either replace the `w3c-test.org` string with the expression
-  `{{host}}:{{ports[http][0]}}` or a generic hostname like `example.org`.
+```eval_rst
+.. wpt-lint-rules:: tools.lint.rules
+```
 
 ## Updating the whitelist
 

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -54,7 +54,7 @@ def test_indent_tabs():
     for (filename, (errors, kind)) in error_map.items():
         check_errors(errors)
 
-        expected = [("INDENT TABS", "Tabs used for indentation", filename, 2)]
+        expected = [("INDENT TABS", "Test-file line starts with one or more tab characters", filename, 2)]
         if kind == "web-strict":
             expected.append(("PARSE-FAILED", "Unable to parse file", filename, None))
         assert errors == expected
@@ -66,7 +66,7 @@ def test_cr_not_at_eol():
     for (filename, (errors, kind)) in error_map.items():
         check_errors(errors)
 
-        expected = [("CR AT EOL", "CR character in line separator", filename, 1)]
+        expected = [("CR AT EOL", "Test-file line ends with CR (U+000D) character", filename, 1)]
         if kind == "web-strict":
             expected.append(("PARSE-FAILED", "Unable to parse file", filename, None))
         assert errors == expected
@@ -79,8 +79,8 @@ def test_cr_at_eol():
         check_errors(errors)
 
         expected = [
-            ("CR AT EOL", "CR character in line separator", filename, 1),
-            ("CR AT EOL", "CR character in line separator", filename, 2),
+            ("CR AT EOL", "Test-file line ends with CR (U+000D) character", filename, 1),
+            ("CR AT EOL", "Test-file line ends with CR (U+000D) character", filename, 2),
         ]
         if kind == "web-strict":
             expected.append(("PARSE-FAILED", "Unable to parse file", filename, None))
@@ -93,7 +93,7 @@ def test_w3c_test_org():
     for (filename, (errors, kind)) in error_map.items():
         check_errors(errors)
 
-        expected = [("W3C-TEST.ORG", "External w3c-test.org domain used", filename, 1)]
+        expected = [("W3C-TEST.ORG", "Test-file line has the string `w3c-test.org`", filename, 1)]
         if kind == "python":
             expected.append(("PARSE-FAILED", "Unable to parse file", filename, 1))
         elif kind == "web-strict":
@@ -136,8 +136,8 @@ def test_console():
 
         if kind in ["web-lax", "web-strict", "js"]:
             assert errors == [
-                ("CONSOLE", "Console logging API used", filename, 2),
-                ("CONSOLE", "Console logging API used", filename, 3),
+                ("CONSOLE", "Test-file line has a `console.*(...)` call", filename, 2),
+                ("CONSOLE", "Test-file line has a `console.*(...)` call", filename, 3),
             ]
         else:
             assert errors == [("PARSE-FAILED", "Unable to parse file", filename, 1)]
@@ -153,7 +153,7 @@ def test_setTimeout():
             assert errors == [("PARSE-FAILED", "Unable to parse file", filename, 1)]
         else:
             assert errors == [('SET TIMEOUT',
-                               'setTimeout used; step_timeout should typically be used instead',
+                               'setTimeout used',
                                filename,
                                1)]
 
@@ -249,8 +249,14 @@ def test_meta_timeout():
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
                 ("MULTIPLE-TIMEOUT", "More than one meta name='timeout'", filename, None),
-                ("INVALID-TIMEOUT", "Invalid timeout value ", filename, None),
-                ("INVALID-TIMEOUT", "Invalid timeout value short", filename, None),
+                ("INVALID-TIMEOUT",
+                    "Test file with `<meta name='timeout'...>` element that has a `content` attribute whose value is not `long`: ",
+                    filename,
+                    None),
+                ("INVALID-TIMEOUT",
+                    "Test file with `<meta name='timeout'...>` element that has a `content` attribute whose value is not `long`: short",
+                    filename,
+                    None),
             ]
         elif kind == "python":
             assert errors == [
@@ -272,7 +278,12 @@ def test_early_testharnessreport():
 
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
-                ("EARLY-TESTHARNESSREPORT", "testharnessreport.js script seen before testharness.js script", filename, None),
+                ("EARLY-TESTHARNESSREPORT",
+                    "Test file has an instance of "
+                    "`<script src='/resources/testharnessreport.js'>` "
+                    "prior to `<script src='/resources/testharness.js'>`",
+                    filename,
+                    None),
             ]
         elif kind == "python":
             assert errors == [
@@ -294,8 +305,8 @@ def test_multiple_testharness():
 
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
-                ("MULTIPLE-TESTHARNESS", "More than one <script src='/resources/testharness.js'>", filename, None),
-                ("MISSING-TESTHARNESSREPORT", "Missing <script src='/resources/testharnessreport.js'>", filename, None),
+                ("MULTIPLE-TESTHARNESS", "More than one `<script src='/resources/testharness.js'>`", filename, None),
+                ("MISSING-TESTHARNESSREPORT", "Missing `<script src='/resources/testharnessreport.js'>`", filename, None),
             ]
         elif kind == "python":
             assert errors == [
@@ -318,7 +329,7 @@ def test_multiple_testharnessreport():
 
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
-                ("MULTIPLE-TESTHARNESSREPORT", "More than one <script src='/resources/testharnessreport.js'>", filename, None),
+                ("MULTIPLE-TESTHARNESSREPORT", "More than one `<script src='/resources/testharnessreport.js'>`", filename, None),
             ]
         elif kind == "python":
             assert errors == [
@@ -343,7 +354,7 @@ def test_multiple_testdriver():
 
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
-                ("MULTIPLE-TESTDRIVER", "More than one <script src='/resources/testdriver.js'>", filename, None),
+                ("MULTIPLE-TESTDRIVER", "More than one `<script src='/resources/testdriver.js'>`", filename, None),
             ]
         elif kind == "python":
             assert errors == [
@@ -368,7 +379,7 @@ def test_multiple_testdriver_vendor():
 
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
-                ("MULTIPLE-TESTDRIVER-VENDOR", "More than one <script src='/resources/testdriver-vendor.js'>", filename, None),
+                ("MULTIPLE-TESTDRIVER-VENDOR", "More than one `<script src='/resources/testdriver-vendor.js'>`", filename, None),
             ]
         elif kind == "python":
             assert errors == [
@@ -391,7 +402,7 @@ def test_missing_testdriver_vendor():
 
         if kind in ["web-lax", "web-strict"]:
             assert errors == [
-                ("MISSING-TESTDRIVER-VENDOR", "Missing <script src='/resources/testdriver-vendor.js'>", filename, None),
+                ("MISSING-TESTDRIVER-VENDOR", "Missing `<script src='/resources/testdriver-vendor.js'>`", filename, None),
             ]
         elif kind == "python":
             assert errors == [
@@ -436,7 +447,7 @@ def test_testharness_path():
     for (filename, (errors, kind)) in error_map.items():
         check_errors(errors)
 
-        expected = [("W3C-TEST.ORG", "External w3c-test.org domain used", filename, 5)]
+        expected = [("W3C-TEST.ORG", "Test-file line has the string `w3c-test.org`", filename, 5)]
         if kind == "python":
             expected.append(("PARSE-FAILED", "Unable to parse file", filename, 1))
         elif kind in ["web-lax", "web-strict"]:
@@ -463,7 +474,7 @@ def test_testharnessreport_path():
     for (filename, (errors, kind)) in error_map.items():
         check_errors(errors)
 
-        expected = [("W3C-TEST.ORG", "External w3c-test.org domain used", filename, 5)]
+        expected = [("W3C-TEST.ORG", "Test-file line has the string `w3c-test.org`", filename, 5)]
         if kind == "python":
             expected.append(("PARSE-FAILED", "Unable to parse file", filename, 1))
         elif kind in ["web-lax", "web-strict"]:
@@ -530,7 +541,7 @@ def test_testdriver_vendor_path():
             expected = set([("PARSE-FAILED", "Unable to parse file", filename, 1)])
         elif kind in ["web-lax", "web-strict"]:
             expected = set([
-                ("MISSING-TESTDRIVER-VENDOR", "Missing <script src='/resources/testdriver-vendor.js'>", filename, None),
+                ("MISSING-TESTDRIVER-VENDOR", "Missing `<script src='/resources/testdriver-vendor.js'>`", filename, None),
                 ("TESTDRIVER-VENDOR-PATH", "testdriver-vendor.js script seen with incorrect path", filename, None),
                 ("TESTDRIVER-VENDOR-PATH", "testdriver-vendor.js script seen with incorrect path", filename, None),
                 ("TESTDRIVER-VENDOR-PATH", "testdriver-vendor.js script seen with incorrect path", filename, None),
@@ -585,7 +596,10 @@ def test_variant_missing():
             ]
         elif kind == "web-lax":
             assert errors == [
-                ("VARIANT-MISSING", "<meta name=variant> missing 'content' attribute", filename, None)
+                ("VARIANT-MISSING",
+                    "Test file with a `<meta name='variant'...>` element that's missing a `content` attribute",
+                    filename,
+                    None)
             ]
 
 
@@ -635,7 +649,10 @@ def test_late_timeout():
             ]
         elif kind == "web-lax":
             assert errors == [
-                ("LATE-TIMEOUT", "<meta name=timeout> seen after testharness.js script", filename, None)
+                ("LATE-TIMEOUT",
+                    "Test file with `<meta name='timeout'...>` element after `<script src='/resources/testharnessreport.js'>` element",
+                    filename,
+                    None)
             ]
 
 
@@ -648,8 +665,8 @@ def test_print_statement():
 
         if kind == "python":
             assert errors == [
-                ("PRINT STATEMENT", "Print function used", filename, 2),
-                ("PRINT STATEMENT", "Print function used", filename, 3),
+                ("PRINT STATEMENT", "A server-side python support file contains a `print` statement", filename, 2),
+                ("PRINT STATEMENT", "A server-side python support file contains a `print` statement", filename, 3),
             ]
         elif kind == "web-strict":
             assert errors == [
@@ -667,7 +684,7 @@ def test_print_function():
 
         if kind == "python":
             assert errors == [
-                ("PRINT STATEMENT", "Print function used", filename, 2),
+                ("PRINT STATEMENT", "A server-side python support file contains a `print` statement", filename, 2),
             ]
         elif kind == "web-strict":
             assert errors == [


### PR DESCRIPTION
When new rules have been added to WPT's "lint" tool, the corresponding
documentation has not always been updated [1] [2] [3]. The static list
of rules currently describes only 22 of the 53 available rules.
Automatically generating documentation from source code helps avoid this
state and the confusion it can cause contributors.

Rely on the previously-implemented source code structure [4] during
documentation generation to automatically create a listing of all
available linting rules.

Although the Sphinx documentation generator includes a built-in
extension for generating documentation from Python source code, the
output of that extension is designed to document Python primitives such
as functions and classes. Such a format is inappropriate for this case
because the users of the linting tool do not interact with the internals
in this way. Define a custom docutils directive to tailor the
documentation to the needs of its audience.

[1] https://github.com/web-platform-tests/wpt/issues/5299
[2] https://github.com/web-platform-tests/wpt/issues/10501
[3] https://github.com/web-platform-tests/wpt/issues/11479
[4] https://github.com/web-platform-tests/wpt/pull/16268

---

As noted in the commit message, this nearly doubles the number of documented
linting rules. Over time, we can further improve it by separating out explicit
"to fix" instructions (and maybe even require that new rules do the same).