### PR TITLE
Load Ahem as a web font everywhere (part 1a)

### DIFF
--- a/css/css-grid/grid-layout-properties.html
+++ b/css/css-grid/grid-layout-properties.html
@@ -11,6 +11,7 @@
   <meta name="assert" content="Test checks that css properties of grid layout exist.">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     #container {
         width: 800px;
@@ -34,6 +35,8 @@
   </div>
 
   <script>
+  setup({explicit_done: true});
+  document.fonts.ready.then(()=> {
     var myDiv = document.getElementById('myDiv')
 
     test(function(){
@@ -228,6 +231,8 @@
         'reset': ['auto', 'auto'],
       },
     })
+    done();
+  });
   </script>
 </body>
 </html>

--- a/css/css-ui/text-overflow-023.html
+++ b/css/css-ui/text-overflow-023.html
@@ -15,6 +15,7 @@
 -->
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 #parent {
   position: absolute;
@@ -27,9 +28,13 @@
 </style>
 <div id=parent>&nbsp;&nbsp;<span id=target>&nbsp;&nbsp;</span></div>
 <script>
-test(
-  function() {
-    var e = document.elementFromPoint(125,25);
-    assert_equals(e.id,"target", "the element targeted by a hit on the ellipsis is the elided inline.");
-  }, "Checks hit testing on the ellipsis");
+setup({explicit_done: true});
+document.fonts.ready.then(()=> {
+  test(
+    function() {
+      var e = document.elementFromPoint(125,25);
+      assert_equals(e.id,"target", "the element targeted by a hit on the ellipsis is the elided inline.");
+    }, "Checks hit testing on the ellipsis");
+  done();
+});
 </script>


### PR DESCRIPTION
Small fixup for two tests that are not reftests but use Ahem. They need
to use explicit_done and also wait for font load event before running.