### PR TITLE
[testharness.js] Refactor integration tests

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -319,6 +319,7 @@ SET TIMEOUT: resources/test/tests/functional/api-tests-1.html
 SET TIMEOUT: resources/test/tests/functional/worker.js
 SET TIMEOUT: resources/test/tests/functional/worker-uncaught-allow.js
 SET TIMEOUT: resources/test/tests/unit/exceptional-cases.html
+SET TIMEOUT: resources/test/tests/unit/exceptional-cases-timeouts.html
 SET TIMEOUT: resources/testharness.js
 
 # setTimeout use in reftests

--- a/resources/test/tests/unit/exceptional-cases-timeouts.html
+++ b/resources/test/tests/unit/exceptional-cases-timeouts.html
@@ -1,0 +1,120 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="timeout" content="long">
+  <script src="/resources/testharness.js"></script>
+  <title>Exceptional cases - timeouts</title>
+</head>
+<body>
+<p>
+  The tests in this file are executed in parallel to avoid exceeding the "long"
+  timeout duration.
+</p>
+<script>
+function makeTest(...bodies) {
+  const closeScript = '<' + '/script>';
+  let src = `
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Document title</title>
+<script src="/resources/testharness.js?${Math.random()}">${closeScript}
+</head>
+
+<body>
+<div id="log"></div>`;
+  bodies.forEach((body) => {
+    src += '<script>(' + body + ')();' + closeScript;
+  });
+
+  const iframe = document.createElement('iframe');
+
+  document.body.appendChild(iframe);
+  iframe.contentDocument.write(src);
+
+  return new Promise((resolve) => {
+    window.addEventListener('message', function onMessage(e) {
+      if (e.source !== iframe.contentWindow) {
+        return;
+      }
+      if (!e.data || e.data.type !=='complete') {
+        return;
+      }
+      window.removeEventListener('message', onMessage);
+      resolve(e.data);
+    });
+
+    iframe.contentDocument.close();
+  }).then(({ tests, status }) => {
+    const summary = {
+      harness: getEnumProp(status, status.status),
+      tests: {}
+    };
+
+    tests.forEach((test) => {
+      summary.tests[test.name] = getEnumProp(test, test.status);
+    });
+
+    return summary;
+  });
+}
+
+function getEnumProp(object, value) {
+  for (let property in object) {
+    if (!/^[A-Z]+$/.test(property)) {
+      continue;
+    }
+
+    if (object[property] === value) {
+      return property;
+    }
+  }
+}
+
+(() => {
+  window.asyncTestCleanupCount1 = 0;
+  const nestedTest = makeTest(
+    () => {
+      async_test((t) => {
+        t.add_cleanup(() => window.parent.asyncTestCleanupCount1 += 1);
+        setTimeout(() => {
+          throw new Error('this error is expected');
+        });
+      }, 'test');
+    }
+  );
+  promise_test(() => {
+    return nestedTest.then(({harness, tests}) => {
+        assert_equals(harness, 'ERROR');
+        assert_equals(tests.test, 'TIMEOUT');
+        assert_equals(window.asyncTestCleanupCount1, 1);
+      });
+  }, 'uncaught exception during async_test which times out');
+})();
+
+(() => {
+  window.promiseTestCleanupCount2 = 0;
+  const nestedTest = makeTest(
+    () => {
+      promise_test((t) => {
+        t.add_cleanup(() => window.parent.promiseTestCleanupCount2 += 1);
+        setTimeout(() => {
+          throw new Error('this error is expected');
+        });
+
+        return new Promise(() => {});
+      }, 'test');
+    }
+  );
+  promise_test(() => {
+    return nestedTest.then(({harness, tests}) => {
+        assert_equals(harness, 'ERROR');
+        assert_equals(tests.test, 'TIMEOUT');
+        assert_equals(window.promiseTestCleanupCount2, 1);
+      });
+  }, 'uncaught exception during promise_test which times out');
+})();
+</script>
+</body>
+</html>

--- a/resources/test/tests/unit/exceptional-cases.html
+++ b/resources/test/tests/unit/exceptional-cases.html
@@ -116,44 +116,6 @@ promise_test(() => {
 }, 'uncaught exception during promise_test');
 
 promise_test(() => {
-  window.asyncTestCleanupCount = 0;
-  return makeTest(
-      () => {
-        async_test((t) => {
-          t.add_cleanup(() => window.parent.asyncTestCleanupCount += 1);
-          setTimeout(() => {
-            throw new Error('this error is expected');
-          });
-        }, 'test');
-      }
-    ).then(({harness, tests}) => {
-      assert_equals(harness, 'ERROR');
-      assert_equals(tests.test, 'TIMEOUT');
-      assert_equals(window.asyncTestCleanupCount, 1);
-    });
-}, 'uncaught exception during async_test which times out');
-
-promise_test(() => {
-  window.promiseTestCleanupCount = 0;
-  return makeTest(
-      () => {
-        promise_test((t) => {
-          t.add_cleanup(() => window.parent.promiseTestCleanupCount += 1);
-          setTimeout(() => {
-            throw new Error('this error is expected');
-          });
-
-          return new Promise(() => {});
-        }, 'test');
-      }
-    ).then(({harness, tests}) => {
-      assert_equals(harness, 'ERROR');
-      assert_equals(tests.test, 'TIMEOUT');
-      assert_equals(window.promiseTestCleanupCount, 1);
-    });
-}, 'uncaught exception during promise_test which times out');
-
-promise_test(() => {
   return makeTest(
       () => { test(() => {}, 'before'); },
       () => { throw new Error('this error is expected'); },

--- a/resources/test/tests/unit/exceptional-cases.html
+++ b/resources/test/tests/unit/exceptional-cases.html
@@ -156,7 +156,6 @@ if ('onunhandledrejection' in window) {
   promise_test(() => {
     return makeTest(
         () => {
-          async_test('pending');
           async_test((t) => {
             Promise.reject(new Error('this error is expected'));
 
@@ -169,7 +168,6 @@ if ('onunhandledrejection' in window) {
         }
       ).then(({harness, tests}) => {
         assert_equals(harness, 'ERROR');
-        assert_equals(tests.pending, 'NOTRUN');
         assert_equals(tests.during, 'PASS');
         assert_equals(tests.after, 'PASS');
       });
@@ -211,8 +209,7 @@ if ('onunhandledrejection' in window) {
       ).then(({harness, tests}) => {
         assert_equals(harness, 'ERROR');
         assert_equals(tests.before, 'PASS');
-        // TODO: investigate why this is not present
-        assert_false('after' in tests);
+        assert_true('after' in tests);
       });
   }, 'unhandled rejection between tests');
 
@@ -248,8 +245,7 @@ if ('onunhandledrejection' in window) {
       ).then(({harness, tests}) => {
         assert_equals(harness, 'ERROR');
         assert_equals(tests.before, 'PASS');
-        // TODO: investigate why this is not present
-        assert_false('after' in tests);
+        assert_true('after' in tests);
       });
   }, 'unhandled rejection between promise_tests');
 


### PR DESCRIPTION
Some of the tests for testharness.js are intended to verify the
framework's behavior following test timeouts. Because these tests are
expressed in terms of the framework, the task of executing them is also
susceptible to timeouts. This is partially mitigated by using the "long"
timeout metadata, but experience has demonstrated that the tests may
exceed even this extended duration in some contexts.

Relocate the tests for timeout behavior to a dedicated file, and
refactor them to occur in parallel. This halves the execution time for
the current tests and also provides a more reliable pattern for the
future introduction of additional tests.