### PR TITLE
Service worker: Altering ready test due to resurrection

### DIFF
--- a/service-workers/service-worker/ready.https.html
+++ b/service-workers/service-worker/ready.https.html
@@ -296,6 +296,8 @@ promise_test(async function(t) {
   // This registration will resolve all ready promises in clients that match the scope.
   // That includes frame's client.
 
+  const reg1Active = reg1.active;
+
   await reg1.unregister();
 
   // Access the ready promise while the registration is unregistering.
@@ -309,7 +311,7 @@ promise_test(async function(t) {
 
   const readyReg = await readyPromise;
 
-  assert_equals(readyReg.active.scriptURL, reg1.active.scriptURL, 'Resolves with the second registration');
+  assert_equals(readyReg.active.scriptURL, reg1Active.scriptURL, 'Resolves with the first registration');
   assert_not_equals(reg1, reg2, 'Registrations should be different');
 }, 'resolve ready before unregistering and reregistering');
 </script>

--- a/service-workers/service-worker/ready.https.html
+++ b/service-workers/service-worker/ready.https.html
@@ -250,51 +250,64 @@ promise_test(function(t) {
   }, 'access ready after it has been resolved');
 
 promise_test(async function(t) {
-    var url = 'resources/empty-worker.js';
-    var matched_scope = 'resources/blank.html?ready-after-resurrect';
+  const url = 'resources/empty-worker.js';
+  const matched_scope = 'resources/blank.html?ready-after-unregister';
 
-    let reg1 = await service_worker_unregister_and_register(t, url, matched_scope);
-    add_completion_callback(function() {
-        reg1.unregister();
-      });
-    await wait_for_state(t, reg1.installing, 'activated');
+  const reg1 = await service_worker_unregister_and_register(t, url, matched_scope);
+  t.add_cleanup(() => reg1.unregister());
 
-    // Hold the worker alive with a controlled worker
-    let frame = await with_iframe(matched_scope);
-    add_completion_callback(function() {
-        frame.remove();
-      });
+  await wait_for_state(t, reg1.installing, 'activated');
+  // This registration will resolve all ready promises in clients that match the scope.
+  // But there are no clients.
 
-    // Doom the registration as uninstalling.
-    await reg1.unregister();
+  const frame = await with_iframe(matched_scope);
+  t.add_cleanup(() => frame.remove());
 
-    // Access the ready promise while the registration is doomed.
-    let readyPromise = frame.contentWindow.navigator.serviceWorker.ready;
+  await reg1.unregister();
 
-    // Resurrect the doomed registration;
-    let reg2 = await service_worker_unregister_and_register(t, url, matched_scope);
-    assert_equals(reg1, reg2, 'existing registration should be resurrected');
+  // Access the ready promise while the registration is unregistering.
+  const readyPromise = frame.contentWindow.navigator.serviceWorker.ready;
 
-    // We are trying to test if the ready promise ever resolves here.  Use
-    // an explicit timeout check here rather than forcing a full infrastructure
-    // level timeout.
-    let timeoutId;
-    let timeoutPromise = new Promise(resolve => {
-      timeoutId = setTimeout(_ => {
-        timeoutId = null;
-        resolve();
-      }, 500);
-    });
+  // Create a new registration.
+  const reg2 = await navigator.serviceWorker.register(url, { scope: matched_scope });
+  t.add_cleanup(() => reg2.unregister());
+  // This registration will resolve all ready promises in clients that match the scope.
+  // That includes frame's client.
 
-    // This should resolve immediately since there is an alive registration
-    // with an active promise for the matching scope.
-    await Promise.race([readyPromise, timeoutPromise]);
+  const readyReg = await readyPromise;
 
-    assert_not_equals(timeoutId, null,
-                      'ready promise should resolve before timeout');
-    clearTimeout(timeoutId);
+  assert_equals(readyReg, reg2, 'Resolves with the second registration');
+  assert_not_equals(reg1, reg2, 'Registrations should be different');
+}, 'resolve ready after unregistrating and reregistering');
 
-    // We should get here and not time out.
+promise_test(async function(t) {
+  const url = 'resources/empty-worker.js';
+  const matched_scope = 'resources/blank.html?ready-after-unregister';
 
-  }, 'access ready on uninstalling registration that is resurrected');
+  const frame = await with_iframe(matched_scope);
+  t.add_cleanup(() => frame.remove());
+
+  const reg1 = await service_worker_unregister_and_register(t, url, matched_scope);
+  t.add_cleanup(() => reg1.unregister());
+
+  await wait_for_state(t, reg1.installing, 'activated');
+  // This registration will resolve all ready promises in clients that match the scope.
+  // That includes frame's client.
+
+  await reg1.unregister();
+
+  // Access the ready promise while the registration is unregistering.
+  const readyPromise = frame.contentWindow.navigator.serviceWorker.ready;
+
+  // Create a new registration.
+  const reg2 = await navigator.serviceWorker.register(url, { scope: matched_scope });
+  t.add_cleanup(() => reg2.unregister());
+  // This registration will resolve all ready promises in clients that match the scope.
+  // That includes frame's client, but its ready promise has already resolved.
+
+  const readyReg = await readyPromise;
+
+  assert_equals(readyReg, reg1, 'Resolves with the first registration');
+  assert_not_equals(reg1, reg2, 'Registrations should be different');
+}, 'resolve ready before unregistrating and reregistering');
 </script>

--- a/service-workers/service-worker/ready.https.html
+++ b/service-workers/service-worker/ready.https.html
@@ -250,13 +250,14 @@ promise_test(function(t) {
   }, 'access ready after it has been resolved');
 
 promise_test(async function(t) {
-  const url = 'resources/empty-worker.js';
+  const url1 = 'resources/empty-worker.js';
+  const url2 = url1 + '?2';
   const matched_scope = 'resources/blank.html?ready-after-unregister';
 
-  const reg1 = await service_worker_unregister_and_register(t, url, matched_scope);
+  const reg1 = await service_worker_unregister_and_register(t, url1, matched_scope);
   t.add_cleanup(() => reg1.unregister());
 
-  await wait_for_state(t, reg1.installing, 'activated');
+  await wait_for_state(t, reg1.installing, 'activating');
   // This registration will resolve all ready promises in clients that match the scope.
   // But there are no clients.
 
@@ -269,25 +270,26 @@ promise_test(async function(t) {
   const readyPromise = frame.contentWindow.navigator.serviceWorker.ready;
 
   // Create a new registration.
-  const reg2 = await navigator.serviceWorker.register(url, { scope: matched_scope });
+  const reg2 = await navigator.serviceWorker.register(url2, { scope: matched_scope });
   t.add_cleanup(() => reg2.unregister());
   // This registration will resolve all ready promises in clients that match the scope.
   // That includes frame's client.
 
   const readyReg = await readyPromise;
 
-  assert_equals(readyReg, reg2, 'Resolves with the second registration');
+  assert_equals(readyReg.active.scriptURL, reg2.active.scriptURL, 'Resolves with the second registration');
   assert_not_equals(reg1, reg2, 'Registrations should be different');
 }, 'resolve ready after unregistering and reregistering');
 
 promise_test(async function(t) {
-  const url = 'resources/empty-worker.js';
+  const url1 = 'resources/empty-worker.js';
+  const url2 = url1 + '?2';
   const matched_scope = 'resources/blank.html?ready-after-unregister';
 
   const frame = await with_iframe(matched_scope);
   t.add_cleanup(() => frame.remove());
 
-  const reg1 = await service_worker_unregister_and_register(t, url, matched_scope);
+  const reg1 = await service_worker_unregister_and_register(t, url1, matched_scope);
   t.add_cleanup(() => reg1.unregister());
 
   await wait_for_state(t, reg1.installing, 'activated');
@@ -300,14 +302,14 @@ promise_test(async function(t) {
   const readyPromise = frame.contentWindow.navigator.serviceWorker.ready;
 
   // Create a new registration.
-  const reg2 = await navigator.serviceWorker.register(url, { scope: matched_scope });
+  const reg2 = await navigator.serviceWorker.register(url2, { scope: matched_scope });
   t.add_cleanup(() => reg2.unregister());
   // This registration will resolve all ready promises in clients that match the scope.
   // That includes frame's client, but its ready promise has already resolved.
 
   const readyReg = await readyPromise;
 
-  assert_equals(readyReg, reg1, 'Resolves with the first registration');
+  assert_equals(readyReg.active.scriptURL, reg1.active.scriptURL, 'Resolves with the second registration');
   assert_not_equals(reg1, reg2, 'Registrations should be different');
 }, 'resolve ready before unregistering and reregistering');
 </script>

--- a/service-workers/service-worker/ready.https.html
+++ b/service-workers/service-worker/ready.https.html
@@ -278,7 +278,7 @@ promise_test(async function(t) {
 
   assert_equals(readyReg, reg2, 'Resolves with the second registration');
   assert_not_equals(reg1, reg2, 'Registrations should be different');
-}, 'resolve ready after unregistrating and reregistering');
+}, 'resolve ready after unregistering and reregistering');
 
 promise_test(async function(t) {
   const url = 'resources/empty-worker.js';
@@ -309,5 +309,5 @@ promise_test(async function(t) {
 
   assert_equals(readyReg, reg1, 'Resolves with the first registration');
   assert_not_equals(reg1, reg2, 'Registrations should be different');
-}, 'resolve ready before unregistrating and reregistering');
+}, 'resolve ready before unregistering and reregistering');
 </script>


### PR DESCRIPTION
Found another resurrection test.

If I'm reading the spec correctly:

* When the `ready` property is accessed, and there's a matching registration with an active service worker. This takes care of clients that were created after the registration was already 'ready'.
* When a new service worker becomes active, it goes through all clients that would be controlled by this worker if they loaded now, and resolves their `ready` promise.

Chrome times outs on the first test, which I didn't expect. Firefox & Safari behave as I'd expect (given they implement resurrection).