### PR TITLE
Ignore the stacktrace when checking errors

### DIFF
--- a/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
+++ b/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
@@ -48,7 +48,9 @@ async_test((t) => {
       // 8. This is the second message we receive, from the second load.
       // Since the allowpaymentrequest flag was not set, we expect an exception.
       assert_equals(e.data.message, 'Exception', 'after navigation');
-      assert_array_equals(e.data.details, [true /* ex instanceof DOMException*/, 18 /* ex.code */, 'SecurityError' /* ex.name */], 'after navigation');
+      assert_equals(4, e.data.details.length);
+      // The last entry is the error stacktrace. Ignore it in comparison.
+      assert_array_equals(e.data.details.slice(0, 3), [true /* ex instanceof DOMException*/, 18 /* ex.code */, 'SecurityError' /* ex.name */], 'after navigation');
       t.done();
     }
   });

--- a/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
+++ b/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
@@ -24,7 +24,9 @@ async_test((t) => {
 
   window.onmessage = t.step_func_done((e) => {
     assert_equals(e.data.message, 'Exception');
-    assert_array_equals(e.data.details, [true /* ex instanceof DOMException */, DOMException.SECURITY_ERR, 'SecurityError']);
+    assert_equals(4, e.data.details.length);
+    // The last entry is the error stacktrace. Ignore it in comparison.
+    assert_array_equals(e.data.details.slice(0, 3), [true /* ex instanceof DOMException */, DOMException.SECURITY_ERR, 'SecurityError']);
   });
 
   document.body.appendChild(iframe);

--- a/payment-request/allowpaymentrequest/setting-allowpaymentrequest.https.sub.html
+++ b/payment-request/allowpaymentrequest/setting-allowpaymentrequest.https.sub.html
@@ -23,7 +23,9 @@ async_test((t) => {
     i++;
     if (i === 1) {
       assert_equals(e.data.message, 'Exception', 'before navigation');
-      assert_array_equals(e.data.details, [true /* ex instanceof DOMException*/, 18 /* ex.code */, 'SecurityError' /* ex.name */], 'before navigation');
+      assert_equals(4, e.data.details.length);
+      // The last entry is the error stacktrace. Ignore it in comparison.
+      assert_array_equals(e.data.details.slice(0, 3), [true /* ex instanceof DOMException*/, 18 /* ex.code */, 'SecurityError' /* ex.name */], 'before navigation');
 
       // Navigate the iframe. This will fire a second 'load' event on the iframe.
       iframe.contentWindow.location.href = iframe.src + '?2';


### PR DESCRIPTION
Fix a test regression introduced by https://github.com/web-platform-tests/wpt/pull/12713.

These tests use `assert_array_equals` on `e.data.details`. Pull/12713 changed the expected length of `e.data.details` by also including the error stacktrace as a 4th element. This pull request changes the tests to only check for the first 3 elements.