### PR TITLE
[css-ui] Test serialization: `-webkit-appearance`

### DIFF
--- a/css/css-ui/appearance-parsing.html
+++ b/css/css-ui/appearance-parsing.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Parsing of `appearance`</title>
+  <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/css/css-ui/appearance-parsing.html
+++ b/css/css-ui/appearance-parsing.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Parsing of `appearance`</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+test(function() {
+  var input = document.createElement('input');
+  input.setAttribute('style', 'appearance: none;');
+
+  assert_equals(input.style.getPropertyValue('appearance'), 'none');
+}, 'parsing via attribute change steps of CSS declaration block\'s owner node');
+
+test(function() {
+  var input = document.createElement('input');
+  input.style.cssText = 'appearance: none;';
+
+  assert_equals(input.style.getPropertyValue('appearance'), 'none');
+}, 'parsing via modification of cssText');
+
+test(function(t) {
+  var style = document.createElement('style');
+  style.appendChild(
+    document.createTextNode('#foo { appearance: none; }')
+  );
+  document.body.appendChild(style);
+  t.add_cleanup(function() {
+    document.body.removeChild(style);
+  });
+
+  assert_equals(style.sheet.cssRules.length, 1);
+  assert_equals(
+    style.sheet.cssRules[0].style.getPropertyValue('appearance'),
+    'none'
+  );
+}, 'parsing via creation of CSS declaration block');
+</script>
+</body>

--- a/css/css-ui/appearance-property.html
+++ b/css/css-ui/appearance-property.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Property references to `appearance`</title>
+  <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/css/css-ui/appearance-property.html
+++ b/css/css-ui/appearance-property.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Property references to `appearance`</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function create(initialValue) {
+  var style = document.createElement('input').style;
+
+  style.setProperty('appearance', initialValue);
+
+  return style;
+}
+
+test(function() {
+  var style = create('');
+
+  style.setProperty('appearance', 'none');
+
+  assert_equals(style.appearance, 'none');
+}, 'setProperty');
+
+test(function() {
+  var style = create('none');
+
+  style.removeProperty('appearance');
+
+  assert_equals(style.appearance, '');
+}, 'removeProperty');
+
+test(function() {
+  var style = create('');
+
+  style['appearance'] = 'none';
+
+  assert_equals(style.appearance, 'none');
+}, 'property assignment');
+
+test(function() {
+  var style = create('none');
+
+  assert_equals(style.getPropertyValue('appearance'), 'none');
+}, 'getPropertyValue');
+
+test(function() {
+  var style = create('none');
+
+  assert_equals(style['appearance'], 'none');
+}, 'property access');
+</script>
+</body>

--- a/css/css-ui/appearance-serialization.html
+++ b/css/css-ui/appearance-serialization.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Serialization of `appearance`</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+test(function() {
+  var input = document.createElement('input');
+  input.style.setProperty('appearance', 'none');
+
+  assert_equals(input.style.cssText, 'appearance: none;');
+}, 'serialization via CSSStyleDeclaration');
+
+test(function(t) {
+  var style = document.createElement('style');
+  document.body.appendChild(style);
+  t.add_cleanup(function() {
+    document.body.removeChild(style);
+  });
+  style.sheet.insertRule('#foo {}', 0);
+  style.sheet.cssRules[0].style.setProperty('appearance', 'none');
+
+  assert_equals(
+    style.sheet.cssRules[0].cssText, '#foo { appearance: none; }'
+  );
+}, 'serialization via CSSStyleRule');
+
+test(function(t) {
+  var style = document.createElement('style');
+  document.body.appendChild(style);
+  t.add_cleanup(function() {
+    document.body.removeChild(style);
+  });
+  style.sheet.insertRule('@media print { #foo {} }', 0);
+  style.sheet.cssRules[0].cssRules[0].style.setProperty('appearance', 'none');
+
+  assert_equals(
+    style.sheet.cssRules[0].cssText,
+    '@media print {\n  #foo { appearance: none; }\n}'
+  );
+}, 'serialization via CSSMediaRule');
+</script>
+</body>

--- a/css/css-ui/appearance-serialization.html
+++ b/css/css-ui/appearance-serialization.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Serialization of `appearance`</title>
+  <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/css/css-ui/webkit-appearance-parsing.html
+++ b/css/css-ui/webkit-appearance-parsing.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Parsing of `-webkit-appearance`</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+test(function() {
+  var input = document.createElement('input');
+  input.style = '-webkit-appearance: none;';
+
+  assert_equals(
+    input.style.getPropertyValue('-webkit-appearance'),
+    'none',
+    'accessed using legacy name'
+  );
+  assert_equals(
+    input.style.getPropertyValue('appearance'),
+    'none',
+    'accessed using modern name'
+  );
+}, 'parsing via attribute change steps of CSS declaration block\'s owner node');
+
+test(function() {
+  var input = document.createElement('input');
+  input.style.cssText = '-webkit-appearance: none;';
+
+  assert_equals(
+    input.style.getPropertyValue('-webkit-appearance'),
+    'none',
+    'accessed using legacy name'
+  );
+  assert_equals(
+    input.style.getPropertyValue('appearance'),
+    'none',
+    'accessed using modern name'
+  );
+}, 'parsing via modification of cssText');
+
+test(function(t) {
+  var style = document.createElement('style');
+  style.appendChild(
+    document.createTextNode('#foo { -webkit-appearance: none; }')
+  );
+  document.body.appendChild(style);
+  t.add_cleanup(function() {
+    document.body.removeChild(style);
+  });
+
+  assert_equals(style.sheet.cssRules.length, 1);
+  assert_equals(
+    style.sheet.cssRules[0].style.getPropertyValue('appearance'),
+    'none',
+    'accessed using legacay name'
+  );
+  assert_equals(
+    style.sheet.cssRules[0].style.getPropertyValue('-webkit-appearance'),
+    'none',
+    'accessed using modern name'
+  );
+}, 'parsing via creation of CSS declaration block');
+</script>
+</body>

--- a/css/css-ui/webkit-appearance-parsing.html
+++ b/css/css-ui/webkit-appearance-parsing.html
@@ -12,32 +12,14 @@ test(function() {
   var input = document.createElement('input');
   input.setAttribute('style', '-webkit-appearance: none;');
 
-  assert_equals(
-    input.style.getPropertyValue('-webkit-appearance'),
-    'none',
-    'accessed using legacy name'
-  );
-  assert_equals(
-    input.style.getPropertyValue('appearance'),
-    'none',
-    'accessed using modern name'
-  );
+  assert_equals(input.style.getPropertyValue('appearance'), 'none');
 }, 'parsing via attribute change steps of CSS declaration block\'s owner node');
 
 test(function() {
   var input = document.createElement('input');
   input.style.cssText = '-webkit-appearance: none;';
 
-  assert_equals(
-    input.style.getPropertyValue('-webkit-appearance'),
-    'none',
-    'accessed using legacy name'
-  );
-  assert_equals(
-    input.style.getPropertyValue('appearance'),
-    'none',
-    'accessed using modern name'
-  );
+  assert_equals(input.style.getPropertyValue('appearance'), 'none');
 }, 'parsing via modification of cssText');
 
 test(function(t) {
@@ -53,13 +35,7 @@ test(function(t) {
   assert_equals(style.sheet.cssRules.length, 1);
   assert_equals(
     style.sheet.cssRules[0].style.getPropertyValue('appearance'),
-    'none',
-    'accessed using legacay name'
-  );
-  assert_equals(
-    style.sheet.cssRules[0].style.getPropertyValue('-webkit-appearance'),
-    'none',
-    'accessed using modern name'
+    'none'
   );
 }, 'parsing via creation of CSS declaration block');
 </script>

--- a/css/css-ui/webkit-appearance-parsing.html
+++ b/css/css-ui/webkit-appearance-parsing.html
@@ -10,7 +10,7 @@
 <script>
 test(function() {
   var input = document.createElement('input');
-  input.style = '-webkit-appearance: none;';
+  input.setAttribute('style', '-webkit-appearance: none;');
 
   assert_equals(
     input.style.getPropertyValue('-webkit-appearance'),

--- a/css/css-ui/webkit-appearance-parsing.html
+++ b/css/css-ui/webkit-appearance-parsing.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Parsing of `-webkit-appearance`</title>
+  <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/css/css-ui/webkit-appearance-property.html
+++ b/css/css-ui/webkit-appearance-property.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Property references to `-webkit-appearance`</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function create(initialValue) {
+  var style = document.createElement('input').style;
+
+  style.setProperty('appearance', initialValue);
+
+  return style;
+}
+
+test(function() {
+  var style = create('');
+
+  style.setProperty('-webkit-appearance', 'none');
+
+  assert_equals(style.appearance, 'none');
+}, 'setProperty - CSS property name');
+
+test(function() {
+  var style = create('');
+
+  style.setProperty('WebkitAppearance', 'none');
+
+  assert_equals(style.appearance, '');
+}, 'setProperty - camel-cased property name (ignored)');
+
+test(function() {
+  var style = create('');
+
+  style.setProperty('webkitAppearance', 'none');
+
+  assert_equals(style.appearance, '');
+}, 'setProperty - webkit-cased property name (ignored)');
+
+test(function() {
+  var style = create('none');
+
+  style.removeProperty('-webkit-appearance');
+
+  assert_equals(style.appearance, '');
+}, 'removeProperty - CSS property name');
+
+test(function() {
+  var style = create('none');
+
+  style.removeProperty('WebkitAppearance');
+
+  assert_equals(style.appearance, 'none');
+}, 'removeProperty - camel-cased property name (ignored)');
+
+test(function() {
+  var style = create('none');
+
+  style.removeProperty('webkitAppearance');
+
+  assert_equals(style.appearance, 'none');
+}, 'removeProperty - webkit-cased property name (ignored)');
+
+test(function() {
+  var style = create('');
+
+  style['-webkit-appearance'] = 'none';
+
+  assert_equals(style.appearance, 'none');
+}, 'property assignment - CSS property name');
+
+test(function() {
+  var style = create('');
+
+  style['WebkitAppearance'] = 'none';
+
+  assert_equals(style.appearance, 'none');
+}, 'property assignment - camel-cased property name');
+
+test(function() {
+  var style = create('');
+
+  style['webkitAppearance'] = 'none';
+
+  assert_equals(style.appearance, 'none');
+}, 'property assignment - webkit-cased property name');
+
+test(function() {
+  var style = create('none');
+
+  assert_equals(style.getPropertyValue('-webkit-appearance'), 'none');
+}, 'getPropertyValue - CSS property name');
+
+test(function() {
+  var style = create('none');
+
+  assert_equals(style.getPropertyValue('WebkitAppearance'), '');
+}, 'getPropertyValue - camel-cased property name (ignored)');
+
+test(function() {
+  var style = create('none');
+
+  assert_equals(style.getPropertyValue('webkitAppearance'), '');
+}, 'getPropertyValue - webkit-cased property name (ignored)');
+
+test(function() {
+  var style = create('none');
+
+  assert_equals(style['-webkit-appearance'], 'none');
+}, 'property access - CSS property name');
+
+test(function() {
+  var style = create('none');
+
+  assert_equals(style['WebkitAppearance'], 'none');
+}, 'property access - camel-cased property name');
+
+test(function() {
+  var style = create('none');
+
+  assert_equals(style['webkitAppearance'], 'none');
+}, 'property access - webkit-cased property name');
+</script>
+</body>

--- a/css/css-ui/webkit-appearance-property.html
+++ b/css/css-ui/webkit-appearance-property.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Property references to `-webkit-appearance`</title>
+  <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/css/css-ui/webkit-appearance-serialization.html
+++ b/css/css-ui/webkit-appearance-serialization.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Serialization of `-webkit-appearance`</title>
+  <link rel="help" href="https://drafts.csswg.org/css-ui-4/#appearance-switching">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/css/css-ui/webkit-appearance-serialization.html
+++ b/css/css-ui/webkit-appearance-serialization.html
@@ -27,9 +27,6 @@ test(function(t) {
   assert_equals(
     style.sheet.cssRules[0].cssText, '#foo { appearance: none; }'
   );
-  assert_equals(
-    style.sheet.cssRules[0].cssText, '#foo { appearance: none; }'
-  );
 }, 'serialization via CSSStyleRule');
 
 test(function(t) {

--- a/css/css-ui/webkit-appearance-serialization.html
+++ b/css/css-ui/webkit-appearance-serialization.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Serialization of `-webkit-appearance`</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+test(function() {
+  var input = document.createElement('input');
+  input.style.setProperty('-webkit-appearance', 'none');
+
+  assert_equals(input.style.cssText, 'appearance: none;');
+}, 'serialization via CSSStyleDeclaration');
+
+test(function(t) {
+  var style = document.createElement('style');
+  document.body.appendChild(style);
+  t.add_cleanup(function() {
+    document.body.removeChild(style);
+  });
+  style.sheet.insertRule('#foo {}', 0);
+  style.sheet.cssRules[0].style.setProperty('-webkit-appearance', 'none');
+
+  assert_equals(
+    style.sheet.cssRules[0].cssText, '#foo { appearance: none; }'
+  );
+  assert_equals(
+    style.sheet.cssRules[0].cssText, '#foo { appearance: none; }'
+  );
+}, 'serialization via CSSStyleRule');
+
+test(function(t) {
+  var style = document.createElement('style');
+  document.body.appendChild(style);
+  t.add_cleanup(function() {
+    document.body.removeChild(style);
+  });
+  style.sheet.insertRule('@media print { #foo {} }', 0);
+  style.sheet.cssRules[0].cssRules[0].style.setProperty('-webkit-appearance', 'none');
+
+  assert_equals(
+    style.sheet.cssRules[0].cssText,
+    '@media print {\n  #foo { appearance: none; }\n}'
+  );
+}, 'serialization via CSSMediaRule');
+</script>
+</body>


### PR DESCRIPTION
This is in service of [csswg-drafts #3024 - Unprefix 'appearance' and/or make the spec web-compatible](https://github.com/w3c/csswg-drafts/issues/3024)

I've tried to avoid the parsing code paths from the serialization tests and vice versa. Was I successful?