### PR TITLE
Remove deadlock from payment-is-showing test

### DIFF
--- a/payment-request/payment-is-showing.https.html
+++ b/payment-request/payment-is-showing.https.html
@@ -10,24 +10,24 @@
 <script src="/resources/testdriver.js"></script>
 <body>
   <script>
-    "use strict";
+    'use strict';
     const applePayMethod = {
-      supportedMethods: "https://apple.com/apple-pay",
+      supportedMethods: 'https://apple.com/apple-pay',
       data: {
         version: 3,
-        merchantIdentifier: "merchant.com.example",
-        countryCode: "US",
-        merchantCapabilities: ["supports3DS"],
-        supportedNetworks: ["visa"],
+        merchantIdentifier: 'merchant.com.example',
+        countryCode: 'US',
+        merchantCapabilities: ['supports3DS'],
+        supportedNetworks: ['visa'],
       },
     };
-    const methods = [{ supportedMethods: "basic-card" }, applePayMethod];
+    const methods = [{supportedMethods: 'basic-card'}, applePayMethod];
     const details = {
       total: {
-        label: "Total",
+        label: 'Total',
         amount: {
-          currency: "USD",
-          value: "1.00",
+          currency: 'USD',
+          value: '1.00',
         },
       },
     };
@@ -38,13 +38,13 @@
      * @param {String} src Optional resource URL to load.
      * @returns {Promise} Resolves when the src loads.
      */
-    async function attachIframe(src = "blank.html") {
-      const iframe = document.createElement("iframe");
+    async function attachIframe(src = 'blank.html') {
+      const iframe = document.createElement('iframe');
       iframe.allowPaymentRequest = true;
       iframe.src = src;
       document.body.appendChild(iframe);
       await new Promise(resolve => {
-        iframe.addEventListener("load", resolve, { once: true });
+        iframe.addEventListener('load', resolve, {once: true});
       });
       return iframe;
     }
@@ -55,12 +55,12 @@
      * @param {String} src Optional resource URL to load.
      * @returns {Promise} Resolves when the src loads.
      */
-    async function loadPopup(src = "blank.html") {
-      const popupWindow = await test_driver.bless("a popup window", () =>
-        window.open(src, "", "width=400,height=400")
+    async function loadPopup(src = 'blank.html') {
+      const popupWindow = await test_driver.bless('a popup window', () =>
+        window.open(src, '', 'width=400,height=400'),
       );
       await new Promise(resolve => {
-        popupWindow.addEventListener("load", resolve, { once: true });
+        popupWindow.addEventListener('load', resolve, {once: true});
       });
       popupWindow.focus();
       return popupWindow;
@@ -71,30 +71,30 @@
       const request2 = new PaymentRequest(methods, details);
 
       // Sets the "payment-relevant browsing context's payment request is showing boolean" to true.
-      const showPromise1 = test_driver.bless("show payment request", () =>
-        request1.show()
+      const showPromise1 = test_driver.bless('show payment request', () =>
+        request1.show(),
       );
 
       // Try to show a second payment sheet in the same window, which should reject.
-      const showPromise2 = test_driver.bless("show payment request", () =>
+      const showPromise2 = test_driver.bless('show payment request', () =>
         // Sets the request's state to "closed", and rejects with AbortError.
         // See: https://github.com/w3c/payment-request/pull/821
-        request2.show()
+        request2.show(),
       );
 
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         showPromise2,
-        "Attempting to show a second payment request must reject."
+        'Attempting to show a second payment request must reject.',
       );
       await request1.abort();
 
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         showPromise1,
-        "request1 was aborted via .abort()"
+        'request1 was aborted via .abort()',
       );
       // Finally, request2 should have been "closed", so trying to show
       // it will again result in promise rejected with an InvalidStateError.
@@ -102,17 +102,17 @@
       const rejectedPromise = request2.show();
       await promise_rejects(
         t,
-        "InvalidStateError",
+        'InvalidStateError',
         rejectedPromise,
-        "Attempting to show a second payment request must reject."
+        'Attempting to show a second payment request must reject.',
       );
       // Finally, we confirm that request2's returned promises are unique.
       assert_not_equals(
         showPromise2,
         rejectedPromise,
-        "Returned Promises be unique"
+        'Returned Promises be unique',
       );
-    }, "The top browsing context can only show one payment sheet at a time.");
+    }, 'The top browsing context can only show one payment sheet at a time.');
 
     promise_test(async t => {
       const iframe = await attachIframe();
@@ -123,7 +123,7 @@
       const windowRequest = new window.PaymentRequest(methods, details);
 
       // Let's get some blessed showPromises
-      const showPromise = test_driver.bless("show payment request", () => {
+      const showPromise = test_driver.bless('show payment request', () => {
         // iframe sets "is showing boolean", ignore the returned promise.
         iframeRequest.show();
         // The top level window now tries to show() the payment request.
@@ -132,9 +132,9 @@
 
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         showPromise,
-        "iframe is already showing a payment request."
+        'iframe is already showing a payment request.',
       );
 
       // Cleanup
@@ -153,24 +153,24 @@
       // We show a payment request via the the top level browsing context,
       // windowRequest.show() sets "is showing boolean" to true.
       // We don't care about the returned promise.
-      test_driver.bless("show payment request", () => windowRequest.show());
+      test_driver.bless('show payment request', () => windowRequest.show());
 
       // calling iframeRequest.show() must return a rejected promise.
-      const iframeShowPromise = test_driver.bless("show payment request", () =>
-        iframeRequest.show()
+      const iframeShowPromise = test_driver.bless('show payment request', () =>
+        iframeRequest.show(),
       );
 
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         iframeShowPromise,
-        "The top window is already showing a payment request."
+        'The top window is already showing a payment request.',
       );
 
       // Cleanup
       await windowRequest.abort();
       iframe.remove();
-    }, "An iframe cannot show a payment request if the top-level window is already showing one.");
+    }, 'An iframe cannot show a payment request if the top-level window is already showing one.');
 
     promise_test(async t => {
       const popupWindow = await loadPopup();
@@ -184,19 +184,19 @@
         "show popup's payment request",
         () =>
           // popupRequest.show(), but via the window.PaymentRequest.prototype
-          window.PaymentRequest.prototype.show.call(popupRequest)
+          window.PaymentRequest.prototype.show.call(popupRequest),
       );
-      const showPromise = test_driver.bless("show window payment request", () =>
-        windowRequest.show()
+      const showPromise = test_driver.bless('show window payment request', () =>
+        windowRequest.show(),
       );
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         showPromise,
-        "Expected window's showPromise to reject, request is already showing"
+        "Expected window's showPromise to reject, request is already showing",
       );
       popupWindow.close();
-    }, "Using a popup window prevents the top-browsing context from showing a payment request");
+    }, 'Using a popup window prevents the top-browsing context from showing a payment request');
 
     promise_test(async t => {
       const iframe = await attachIframe();
@@ -212,7 +212,7 @@
         windowShowPromise,
         popupShowPromise,
         iframeShowPromise,
-      ] = await test_driver.bless("show payment request", () => {
+      ] = await test_driver.bless('show payment request', () => {
         return [
           windowRequest.show(),
           popupRequest.show(),
@@ -223,16 +223,16 @@
       // popupRequest and iframeRequest will both reject
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         popupShowPromise,
-        "Expected popupShowPromise to reject, request is already showing."
+        'Expected popupShowPromise to reject, request is already showing.',
       );
 
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         iframeShowPromise,
-        "Expected iframeShowPromise to reject, request is already showing."
+        'Expected iframeShowPromise to reject, request is already showing.',
       );
 
       await windowRequest.abort();
@@ -255,7 +255,7 @@
         popupShowPromise,
         windowShowPromise,
         iframeShowPromise,
-      ] = await test_driver.bless("show payment request", () => {
+      ] = await test_driver.bless('show payment request', () => {
         return [
           popupRequest.show(),
           windowRequest.show(),
@@ -266,16 +266,16 @@
       // windowShowPromise and iframeRequest will both reject
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         windowShowPromise,
-        "Expected windowShowPromise to reject, the popup is showing a payment request."
+        'Expected windowShowPromise to reject, the popup is showing a payment request.',
       );
 
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         iframeShowPromise,
-        "Expected iframeShowPromise to reject, the popup is showing a payment request."
+        'Expected iframeShowPromise to reject, the popup is showing a payment request.',
       );
 
       await popupRequest.abort();
@@ -298,7 +298,7 @@
         iframeShowPromise,
         popupShowPromise,
         windowShowPromise,
-      ] = await test_driver.bless("show payment request", () => {
+      ] = await test_driver.bless('show payment request', () => {
         return [
           iframeRequest.show(),
           popupRequest.show(),
@@ -309,16 +309,16 @@
       // windowShowPromise and iframeRequest will both reject
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         windowShowPromise,
-        "Expected windowShowPromise to reject, the popup is showing a payment request."
+        'Expected windowShowPromise to reject, the popup is showing a payment request.',
       );
 
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         popupShowPromise,
-        "Expected popupShowPromise to reject, the popup is showing a payment request."
+        'Expected popupShowPromise to reject, the popup is showing a payment request.',
       );
 
       await iframeRequest.abort();
@@ -330,19 +330,19 @@
       const iframe = await attachIframe();
       const iframeWindow = iframe.contentWindow;
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
-      const iframeShowPromise = test_driver.bless("show payment request", () =>
-        iframeRequest.show()
+      const iframeShowPromise = test_driver.bless('show payment request', () =>
+        iframeRequest.show(),
       );
 
       // We navigate away, causing the payment sheet to close
       // and the request is showing boolean to become false.
-      iframe.src = "blank.html?abc=123";
+      iframe.src = 'blank.html?abc=123';
       await new Promise(resolve => (iframe.onload = resolve));
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         iframeShowPromise,
-        "Navigating iframe away must cause the iframeShowPromise to reject."
+        'Navigating iframe away must cause the iframeShowPromise to reject.',
       );
       iframe.remove();
 
@@ -355,19 +355,19 @@
     promise_test(async t => {
       const popupWindow = await loadPopup();
       const popupRequest = new popupWindow.PaymentRequest(methods, details);
-      const showPromise = test_driver.bless("show payment request", () =>
-        popupRequest.show()
+      const showPromise = test_driver.bless('show payment request', () =>
+        popupRequest.show(),
       );
 
       // We navigate away, causing the payment sheet to close
       // and the request is showing boolean to become false.
-      popupWindow.location = "blank.html?abc=123";
+      popupWindow.location = 'blank.html?abc=123';
       await new Promise(resolve => (popupWindow.onload = resolve));
       await promise_rejects(
         t,
-        "AbortError",
+        'AbortError',
         showPromise,
-        "Navigating away must cause the showPromise to reject with an AbortError"
+        'Navigating away must cause the showPromise to reject with an AbortError',
       );
       popupWindow.close();
 

--- a/payment-request/payment-is-showing.https.html
+++ b/payment-request/payment-is-showing.https.html
@@ -219,16 +219,19 @@
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
 
       // Open a popup window
-      const [popupWindow, popupRequest] = await test_driver.bless(
-        'open popup',
+      const [popupWindow, popupRequest] =
+      await test_driver.bless(
+        'open popup to test multiple context and window calls show() first',
         async () => {
-          const w = await loadPopupInsideUserGesture();
-          const r = new w.PaymentRequest(methods, details);
-          return [w, r];
+          const popupWindow = await loadPopupInsideUserGesture();
+          const popupRequest = new popupWindow.PaymentRequest(methods, details);
+          return [popupWindow, popupRequest];
         },
       );
 
-      // Get the showPromise for each browsing context
+      // Get the showPromise for each browsing context. Doing this in a separate
+      // test_driver.bless() is important because the user gesture brings
+      // |window| to the foreground, so that the payment sheet can show.
       const [
         windowShowPromise,
         popupShowPromise,
@@ -276,19 +279,22 @@
         popupWindow,
         popupRequest,
         popupShowPromise,
-      ] = await test_driver.bless('open popup', async () => {
-        const w = await loadPopupInsideUserGesture();
-        const r = new w.PaymentRequest(methods, details);
-        return [w, r, r.show()];
+        windowShowPromise,
+        iframeShowPromise
+      ] = await test_driver.bless(
+        'test multiple browsing context and iframe calls show() first',
+        async () => {
+          const popupWindow = await loadPopupInsideUserGesture();
+          const popupRequest = new popupWindow.PaymentRequest(methods, details);
+          const popupShowPromise = popupRequest.show();
+          const windowShowPromise = windowRequest.show();
+          const iframeShowPromise = iframeRequest.show();
+          return [popupWindow,
+                  popupRequest,
+                  popupShowPromise,
+                  windowShowPromise,
+                  iframeShowPromise];
       });
-
-      // Get the showPromise for each browsing context.
-      const [windowShowPromise, iframeShowPromise] = await test_driver.bless(
-        'test multiple nested context and popup calls show() first',
-        () => {
-          return [windowRequest.show(), iframeRequest.show()];
-        },
-      );
 
       // windowShowPromise and iframeRequest will both reject
       await promise_rejects(
@@ -319,7 +325,7 @@
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
 
       const [popupWindow, popupRequest] = await test_driver.bless(
-        'open popup',
+        'open popup to test multiple context and iframe calls show() first',
         async () => {
           const w = await loadPopupInsideUserGesture();
           const r = new w.PaymentRequest(methods, details);
@@ -327,7 +333,9 @@
         },
       );
 
-      // Get the showPromise for each browsing context
+      // Get the showPromise for each browsing context. Doing this in a separate
+      // test_driver.bless() is important because the user gesture brings
+      // |window| to the foreground, so that the payment sheet can show.
       const [
         iframeShowPromise,
         popupShowPromise,
@@ -390,34 +398,32 @@
       await request.abort();
     }, "Navigating an iframe as a nested browsing context sets 'payment request is showing boolean' to false.");
 
-    // Broken
-    //promise_test(async t => {
-    //  const [popupWindow, popupRequest, showPromise] = await test_driver.bless(
-    //    'test navigating popup after show()',
-    //    async () => {
-    //      const popupWindow = await loadPopupInsideUserGesture();
-    //      const popupRequest = new popupWindow.PaymentRequest(methods, details);
+    promise_test(async t => {
+      const [popupWindow, popupRequest, showPromise] = await test_driver.bless(
+        'test navigating popup after show()',
+        async () => {
+          const popupWindow = await loadPopupInsideUserGesture();
+          const popupRequest = new popupWindow.PaymentRequest(methods, details);
+          return [popupWindow, popupRequest, popupRequest.show()];
+        },
+      );
 
-    //      return [popupWindow, popupRequest, popupRequest.show()];
-    //    },
-    //  );
+      // We navigate away, causing the payment sheet to close
+      // and the request is showing boolean to become false.
+      popupWindow.location = 'blank.html?abc=123';
+      await new Promise(resolve => (popupWindow.onload = resolve));
+      await promise_rejects(
+        t,
+        'AbortError',
+        showPromise,
+        'Navigating away must cause the showPromise to reject with an AbortError',
+      );
+      popupWindow.close();
 
-    //  // We navigate away, causing the payment sheet to close
-    //  // and the request is showing boolean to become false.
-    //  popupWindow.location = 'blank.html?abc=123';
-    //  await new Promise(resolve => (popupWindow.onload = resolve));
-    //  await promise_rejects(
-    //    t,
-    //    'AbortError',
-    //    showPromise,
-    //    'Navigating away must cause the showPromise to reject with an AbortError',
-    //  );
-    //  popupWindow.close();
-
-    //  // Now we should be ok to spin up a new payment request.
-    //  const request = new window.PaymentRequest(methods, details);
-    //  request.show();
-    //  await request.abort();
-    //}, "Navigating a popup as a nested browsing context sets 'payment request is showing boolean' to false.");
+      // Now we should be ok to spin up a new payment request.
+      const request = new window.PaymentRequest(methods, details);
+      request.show();
+      await request.abort();
+    }, "Navigating a popup as a nested browsing context sets 'payment request is showing boolean' to false.");
   </script>
 </body>

--- a/payment-request/payment-is-showing.https.html
+++ b/payment-request/payment-is-showing.https.html
@@ -70,32 +70,30 @@
       const request1 = new PaymentRequest(methods, details);
       const request2 = new PaymentRequest(methods, details);
 
-      // Sets the "payment-relevant browsing context's payment request is showing boolean" to true.
-      const showPromise1 = test_driver.bless('show payment request', () =>
-        request1.show(),
+      // Sets the "payment-relevant browsing context's payment request is
+      // showing boolean" to true and then try to show a second payment sheet in
+      // the same window. The second show() should reject.
+      const [showPromise1, showPromise2] = await test_driver.bless(
+        'testing one payment sheet per window',
+        () => {
+          return [request1.show(), request2.show()];
+        },
       );
-
-      // Try to show a second payment sheet in the same window, which should reject.
-      const showPromise2 = test_driver.bless('show payment request', () =>
-        // Sets the request's state to "closed", and rejects with AbortError.
-        // See: https://github.com/w3c/payment-request/pull/821
-        request2.show(),
-      );
-
       await promise_rejects(
         t,
         'AbortError',
         showPromise2,
         'Attempting to show a second payment request must reject.',
       );
-      await request1.abort();
 
+      await request1.abort();
       await promise_rejects(
         t,
         'AbortError',
         showPromise1,
         'request1 was aborted via .abort()',
       );
+
       // Finally, request2 should have been "closed", so trying to show
       // it will again result in promise rejected with an InvalidStateError.
       // See: https://github.com/w3c/payment-request/pull/821
@@ -123,12 +121,15 @@
       const windowRequest = new window.PaymentRequest(methods, details);
 
       // Let's get some blessed showPromises
-      const showPromise = test_driver.bless('show payment request', () => {
-        // iframe sets "is showing boolean", ignore the returned promise.
-        iframeRequest.show();
-        // The top level window now tries to show() the payment request.
-        return windowRequest.show();
-      });
+      const [showPromise] = await test_driver.bless(
+        'testing top window show() blocked by payment sheet in iframe',
+        () => {
+          // iframe sets "is showing boolean", ignore the returned promise.
+          iframeRequest.show();
+          // The top level window now tries to show() the payment request.
+          return [windowRequest.show()];
+        },
+      );
 
       await promise_rejects(
         t,
@@ -150,14 +151,15 @@
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
       const windowRequest = new window.PaymentRequest(methods, details);
 
-      // We show a payment request via the the top level browsing context,
-      // windowRequest.show() sets "is showing boolean" to true.
-      // We don't care about the returned promise.
-      test_driver.bless('show payment request', () => windowRequest.show());
-
-      // calling iframeRequest.show() must return a rejected promise.
-      const iframeShowPromise = test_driver.bless('show payment request', () =>
-        iframeRequest.show(),
+      // We first show a payment request via the the top level browsing context,
+      // windowRequest.show() sets "is showing boolean" to true. Then we try to
+      // show a payment request in the iframe, which should reject.
+      const [iframeShowPromise] = await test_driver.bless(
+        'testing iframe show() blocked by payment sheet in top window',
+        () => {
+          windowRequest.show();
+          return [iframeRequest.show()];
+        },
       );
 
       await promise_rejects(
@@ -212,13 +214,16 @@
         windowShowPromise,
         popupShowPromise,
         iframeShowPromise,
-      ] = await test_driver.bless('show payment request', () => {
-        return [
-          windowRequest.show(),
-          popupRequest.show(),
-          iframeRequest.show(),
-        ];
-      });
+      ] = await test_driver.bless(
+        'test multiple nested browsing context',
+        () => {
+          return [
+            windowRequest.show(),
+            popupRequest.show(),
+            iframeRequest.show(),
+          ];
+        },
+      );
 
       // popupRequest and iframeRequest will both reject
       await promise_rejects(
@@ -298,13 +303,16 @@
         iframeShowPromise,
         popupShowPromise,
         windowShowPromise,
-      ] = await test_driver.bless('show payment request', () => {
-        return [
-          iframeRequest.show(),
-          popupRequest.show(),
-          windowRequest.show(),
-        ];
-      });
+      ] = await test_driver.bless(
+        'test multiple browsing context and iframe show first',
+        () => {
+          return [
+            iframeRequest.show(),
+            popupRequest.show(),
+            windowRequest.show(),
+          ];
+        },
+      );
 
       // windowShowPromise and iframeRequest will both reject
       await promise_rejects(
@@ -330,8 +338,9 @@
       const iframe = await attachIframe();
       const iframeWindow = iframe.contentWindow;
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
-      const iframeShowPromise = test_driver.bless('show payment request', () =>
-        iframeRequest.show(),
+      const iframeShowPromise = test_driver.bless(
+        'test iframe navigation resets is showing boolean',
+        () => iframeRequest.show(),
       );
 
       // We navigate away, causing the payment sheet to close

--- a/payment-request/payment-is-showing.https.html
+++ b/payment-request/payment-is-showing.https.html
@@ -50,15 +50,13 @@
     }
 
     /**
-     * Creates a popup window
+     * Creates a popup window. The caller must be triggered with a user gesture.
      *
      * @param {String} src Optional resource URL to load.
      * @returns {Promise} Resolves when the src loads.
      */
-    async function loadPopup(src = 'blank.html') {
-      const popupWindow = await test_driver.bless('a popup window', () =>
-        window.open(src, '', 'width=400,height=400'),
-      );
+    async function loadPopupInsideUserGesture(src = 'blank.html') {
+      const popupWindow = window.open(src, '', 'width=400,height=400');
       await new Promise(resolve => {
         popupWindow.addEventListener('load', resolve, {once: true});
       });
@@ -175,40 +173,61 @@
     }, 'An iframe cannot show a payment request if the top-level window is already showing one.');
 
     promise_test(async t => {
-      const popupWindow = await loadPopup();
-
-      // Create requests
-      const popupRequest = new popupWindow.PaymentRequest(methods, details);
+      // Create a PaymentReuqest in top-level window.
       const windowRequest = new window.PaymentRequest(methods, details);
 
-      // show the Popup's payment request.
-      const popupShowPromise = test_driver.bless(
-        "show popup's payment request",
-        () =>
-          // popupRequest.show(), but via the window.PaymentRequest.prototype
-          window.PaymentRequest.prototype.show.call(popupRequest),
+      // Use a single user gesture to open a popup window with a PaymentRequest.
+      // Then trigger show() first on |popupRequest| then on |windowRequest|.
+      // The latter should reject.
+      const [
+        popupWindow,
+        popupRequest,
+        popupShowPromise,
+        windowShowPromise,
+      ] = await test_driver.bless(
+        'testing top-level show() blocked by payment sheet in popup',
+        async () => {
+          const popupWindow = await loadPopupInsideUserGesture();
+          const popupRequest = new popupWindow.PaymentRequest(methods, details);
+          const popupShowPromise = popupRequest.show();
+          const windowShowPromise = windowRequest.show();
+          return [
+            popupWindow,
+            popupRequest,
+            popupShowPromise,
+            windowShowPromise,
+          ];
+        },
       );
-      const showPromise = test_driver.bless('show window payment request', () =>
-        windowRequest.show(),
-      );
+      await popupRequest.abort();
+      popupWindow.close();
+
       await promise_rejects(
         t,
         'AbortError',
-        showPromise,
+        windowShowPromise,
         "Expected window's showPromise to reject, request is already showing",
       );
-      popupWindow.close();
     }, 'Using a popup window prevents the top-browsing context from showing a payment request');
 
     promise_test(async t => {
       const iframe = await attachIframe();
       const iframeWindow = iframe.contentWindow;
-      const popupWindow = await loadPopup();
 
       // Create requests
       const windowRequest = new window.PaymentRequest(methods, details);
-      const popupRequest = new popupWindow.PaymentRequest(methods, details);
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
+
+      // Open a popup window
+      const [popupWindow, popupRequest] = await test_driver.bless(
+        'open popup',
+        async () => {
+          const w = await loadPopupInsideUserGesture();
+          const r = new w.PaymentRequest(methods, details);
+          return [w, r];
+        },
+      );
+
       // Get the showPromise for each browsing context
       const [
         windowShowPromise,
@@ -224,7 +243,6 @@
           ];
         },
       );
-
       // popupRequest and iframeRequest will both reject
       await promise_rejects(
         t,
@@ -248,25 +266,29 @@
     promise_test(async t => {
       const iframe = await attachIframe();
       const iframeWindow = iframe.contentWindow;
-      const popupWindow = await loadPopup();
 
       // Create requests
       const windowRequest = new window.PaymentRequest(methods, details);
-      const popupRequest = new popupWindow.PaymentRequest(methods, details);
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
 
-      // Get the showPromise for each browsing context
+      // Open a popup window
       const [
+        popupWindow,
+        popupRequest,
         popupShowPromise,
-        windowShowPromise,
-        iframeShowPromise,
-      ] = await test_driver.bless('show payment request', () => {
-        return [
-          popupRequest.show(),
-          windowRequest.show(),
-          iframeRequest.show(),
-        ];
+      ] = await test_driver.bless('open popup', async () => {
+        const w = await loadPopupInsideUserGesture();
+        const r = new w.PaymentRequest(methods, details);
+        return [w, r, r.show()];
       });
+
+      // Get the showPromise for each browsing context.
+      const [windowShowPromise, iframeShowPromise] = await test_driver.bless(
+        'test multiple nested context and popup calls show() first',
+        () => {
+          return [windowRequest.show(), iframeRequest.show()];
+        },
+      );
 
       // windowShowPromise and iframeRequest will both reject
       await promise_rejects(
@@ -291,12 +313,19 @@
     promise_test(async t => {
       const iframe = await attachIframe();
       const iframeWindow = iframe.contentWindow;
-      const popupWindow = await loadPopup();
 
       // Create requests
       const windowRequest = new window.PaymentRequest(methods, details);
-      const popupRequest = new popupWindow.PaymentRequest(methods, details);
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
+
+      const [popupWindow, popupRequest] = await test_driver.bless(
+        'open popup',
+        async () => {
+          const w = await loadPopupInsideUserGesture();
+          const r = new w.PaymentRequest(methods, details);
+          return [w, r];
+        },
+      );
 
       // Get the showPromise for each browsing context
       const [
@@ -304,8 +333,8 @@
         popupShowPromise,
         windowShowPromise,
       ] = await test_driver.bless(
-        'test multiple browsing context and iframe show first',
-        () => {
+        'test multiple browsing context and iframe calls show() first',
+        async () => {
           return [
             iframeRequest.show(),
             popupRequest.show(),
@@ -339,7 +368,7 @@
       const iframeWindow = iframe.contentWindow;
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
       const iframeShowPromise = test_driver.bless(
-        'test iframe navigation resets is showing boolean',
+        'test navigating iframe after show()',
         () => iframeRequest.show(),
       );
 
@@ -356,34 +385,39 @@
       iframe.remove();
 
       // Now we should be ok to spin up a new payment request
-      const request = new window.PaymentRequest(method, details);
+      const request = new window.PaymentRequest(methods, details);
       const showPromise = request.show();
       await request.abort();
     }, "Navigating an iframe as a nested browsing context sets 'payment request is showing boolean' to false.");
 
-    promise_test(async t => {
-      const popupWindow = await loadPopup();
-      const popupRequest = new popupWindow.PaymentRequest(methods, details);
-      const showPromise = test_driver.bless('show payment request', () =>
-        popupRequest.show(),
-      );
+    // Broken
+    //promise_test(async t => {
+    //  const [popupWindow, popupRequest, showPromise] = await test_driver.bless(
+    //    'test navigating popup after show()',
+    //    async () => {
+    //      const popupWindow = await loadPopupInsideUserGesture();
+    //      const popupRequest = new popupWindow.PaymentRequest(methods, details);
 
-      // We navigate away, causing the payment sheet to close
-      // and the request is showing boolean to become false.
-      popupWindow.location = 'blank.html?abc=123';
-      await new Promise(resolve => (popupWindow.onload = resolve));
-      await promise_rejects(
-        t,
-        'AbortError',
-        showPromise,
-        'Navigating away must cause the showPromise to reject with an AbortError',
-      );
-      popupWindow.close();
+    //      return [popupWindow, popupRequest, popupRequest.show()];
+    //    },
+    //  );
 
-      // Now we should be ok to spin up a new payment request.
-      const request = new window.PaymentRequest(method, details);
-      request.show();
-      await request.abort();
-    }, "Navigating a popup as a nested browsing context sets 'payment request is showing boolean' to false.");
+    //  // We navigate away, causing the payment sheet to close
+    //  // and the request is showing boolean to become false.
+    //  popupWindow.location = 'blank.html?abc=123';
+    //  await new Promise(resolve => (popupWindow.onload = resolve));
+    //  await promise_rejects(
+    //    t,
+    //    'AbortError',
+    //    showPromise,
+    //    'Navigating away must cause the showPromise to reject with an AbortError',
+    //  );
+    //  popupWindow.close();
+
+    //  // Now we should be ok to spin up a new payment request.
+    //  const request = new window.PaymentRequest(methods, details);
+    //  request.show();
+    //  await request.abort();
+    //}, "Navigating a popup as a nested browsing context sets 'payment request is showing boolean' to false.");
   </script>
 </body>


### PR DESCRIPTION
payment-is-show.https.html tests that if multiple contexts try to call `PaymentRequest.show()`, all but the first one rejects.

Before this patch, each `PaymentRequest.show()` is wrapped inside its own `test_driver.bless()`. This creates a deadlock when running the tests directly in the browser: the first payment sheet prevents the user from interacting with the test page to click on the button generated by `test_driver.bless()`, which in turn blocks the test from proceeding, which will eventually abort the payment sheet. This deadlock breaks the web test runner.

This patch combines all `PaymentRequset.show()` calls of a single test case inside a single `test_driver.bless()` call. This way, each test only requires user to click on a single block.

The only exceptions are the two tests that trigger popups and call `.show()` from the main test page. The test requires a user gesture to bring the main page back into foreground. User has to click on two buttons to make these tests proceed.