### PR TITLE
Use `assert_approx_equals` in MediaSource tests

### DIFF
--- a/media-source/mediasource-endofstream.html
+++ b/media-source/mediasource-endofstream.html
@@ -33,11 +33,6 @@
         });
     }, 'MediaSource.endOfStream(): media element notified that it now has all of the media data');
 
-    function threeDecimalPlaces(number)
-    {
-        return Number(number.toFixed(3));
-    }
-
     mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
     {
         sourceBuffer.appendBuffer(mediaData);
@@ -52,7 +47,7 @@
             // Note that segmentInfo.duration is expected to also be the
             // highest track buffer range end time. Therefore, endOfStream() should
             // not change duration with this media.
-            assert_equals(threeDecimalPlaces(segmentInfo.duration), threeDecimalPlaces(mediaSource.duration),
+            assert_approx_equals(segmentInfo.duration, mediaSource.duration, 0.001,
                 'SegmentInfo duration should initially roughly match mediaSource duration');
             assert_less_than_equal(highestEndTime, mediaSource.duration,
                 'Media duration may be slightly longer than intersected track buffered ranges');
@@ -65,7 +60,7 @@
             assert_equals(sourceBuffer.buffered.length, 1,
               'Media data properly buffered after endOfStream');
 
-            assert_equals(threeDecimalPlaces(segmentInfo.duration), threeDecimalPlaces(mediaSource.duration),
+            assert_approx_equals(segmentInfo.duration, mediaSource.duration, 0.001,
                 'SegmentInfo duration should still roughly match mediaSource duration');
             assert_less_than_equal(highestEndTime, mediaSource.duration,
                 'Media duration may be slightly longer than intersected track buffered ranges');

--- a/media-source/mediasource-sequencemode-append-buffer.html
+++ b/media-source/mediasource-sequencemode-append-buffer.html
@@ -42,11 +42,6 @@
               test.waitForExpectedEvents(callback);
           }
 
-          function threeDecimalPlaces(number)
-          {
-              return Number(number.toFixed(3));
-          }
-
           // Verifies expected times to 3 decimal places before and after mediaSource.endOfStream(),
           // and calls |callback| on success.
           function verify_offset_and_buffered(test, mediaSource, sourceBuffer,
@@ -54,19 +49,21 @@
                                               expectedBufferedRangeMaxEndTimeBeforeEOS,
                                               expectedBufferedRangeEndTimeAfterEOS,
                                               callback) {
-              assert_equals(threeDecimalPlaces(sourceBuffer.timestampOffset),
-                            threeDecimalPlaces(expectedTimestampOffset),
-                            "expectedTimestampOffset");
+              assert_approx_equals(sourceBuffer.timestampOffset,
+                                   expectedTimestampOffset,
+                                   0.001,
+                                   "expectedTimestampOffset");
 
               // Prior to EOS, the buffered range end time may not have fully reached the next media
               // segment's timecode (adjusted by any timestampOffset). It should not exceed it though.
               // Therefore, an exact assertBufferedEquals() will not work here.
               assert_greater_than(sourceBuffer.buffered.length, 0, "sourceBuffer.buffered has at least 1 range before EOS");
-              assert_equals(threeDecimalPlaces(sourceBuffer.buffered.start(0)),
-                            threeDecimalPlaces(expectedBufferedRangeStartTime),
-                            "sourceBuffer.buffered range begins where expected before EOS");
-              assert_less_than_equal(threeDecimalPlaces(sourceBuffer.buffered.end(0)),
-                                     threeDecimalPlaces(expectedBufferedRangeMaxEndTimeBeforeEOS),
+              assert_approx_equals(sourceBuffer.buffered.start(0),
+                                   expectedBufferedRangeStartTime,
+                                   0.001,
+                                   "sourceBuffer.buffered range begins where expected before EOS");
+              assert_less_than_equal(sourceBuffer.buffered.end(0),
+                                     expectedBufferedRangeMaxEndTimeBeforeEOS + 0.001,
                                      "sourceBuffer.buffered range ends at or before expected upper bound before EOS");
 
               test.expectEvent(mediaSource, "sourceended", "mediaSource endOfStream");


### PR DESCRIPTION
The `threeDecimalPlaces` helper using `number.toFixed(3)` allowed for
a maximum difference of 0.001 for a pair like 0.0005 / 0.00149999, but
had no lower limit on the difference, a pair like 0.0004999 / 0.0005
would fail.

This may be the cause of a Safari failure `!EQ(6.548, 6.549)`:
https://wpt.fyi/results/media-source/mediasource-endofstream.html?run_id=255090001