### PR TITLE
Revert "Ignore lint failures until we import a rev with them fixed"

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -810,10 +810,6 @@ LAYOUTTESTS APIS: permissions/test-background-fetch-permission.html
 LAYOUTTESTS APIS: resources/chromium/generic_sensor_mocks.js
 LAYOUTTESTS APIS: resources/chromium/webxr-test.js
 
-# Gecko additons to remove
-CSS-COLLIDING-REF-NAME: css/css-contain/reference/contain-size-fieldset-001-ref.html
-CSS-COLLIDING-REF-NAME: css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-fieldset-001-ref.html
-
 # Signed Exchange files have hard-coded URLs in the certUrl field
 WEB-PLATFORM.TEST:signed-exchange/resources/*.sxg
 WEB-PLATFORM.TEST:signed-exchange/appcache/resources/*.sxg


### PR DESCRIPTION
This reverts https://github.com/web-platform-tests/wpt/pull/13396.

These exact lines are also in the "Duplicate filename where there's no
actual merging" section of the file.

The change came from https://hg.mozilla.org/mozilla-central/rev/f23487d9ab99d486fe3ab7f261e4d4e0bf1172ae
where those lines were present, although they were present in WPT when
that change was upstreamed.