### PR TITLE
Allow browsers to block mixed content requests from cross-origin tests.

### DIFF
--- a/beacon/headers/header-referrer-strict-origin-when-cross-origin.https.html
+++ b/beacon/headers/header-referrer-strict-origin-when-cross-origin.https.html
@@ -12,10 +12,10 @@
     <script src="/common/get-host-info.sub.js"></script>
     <script src="/beacon/headers/header-referrer.js"></script>
     <script>
-      var testBase = get_host_info().HTTPS_ORIGIN +  RESOURCES_DIR;
+      var testBase = get_host_info().HTTPS_REMOTE_ORIGIN +  RESOURCES_DIR;
       testReferrerHeader(testBase, referrerOrigin);
-      testBase = get_host_info().HTTP_ORIGIN + RESOURCES_DIR;
-      testReferrerHeader(testBase, "");
+      testBase = get_host_info().HTTP_REMOTE_ORIGIN + RESOURCES_DIR;
+      testReferrerHeader(testBase, "", true);
     </script>
   </body>
 </html>

--- a/beacon/headers/header-referrer-strict-origin.https.html
+++ b/beacon/headers/header-referrer-strict-origin.https.html
@@ -15,7 +15,7 @@
       var testBase = get_host_info().HTTPS_ORIGIN +  RESOURCES_DIR;
       testReferrerHeader(testBase, referrerOrigin);
       testBase = get_host_info().HTTP_ORIGIN + RESOURCES_DIR;
-      testReferrerHeader(testBase, "");
+      testReferrerHeader(testBase, "", true);
     </script>
   </body>
 </html>

--- a/beacon/headers/header-referrer-unsafe-url.https.html
+++ b/beacon/headers/header-referrer-unsafe-url.https.html
@@ -12,8 +12,10 @@
     <script src="/common/get-host-info.sub.js"></script>
     <script src="/beacon/headers/header-referrer.js"></script>
     <script>
-      var testBase = get_host_info().HTTP_ORIGIN + RESOURCES_DIR;
+      var testBase = get_host_info().HTTPS_ORIGIN +  RESOURCES_DIR;
       testReferrerHeader(testBase, referrerUrl);
+      testBase = get_host_info().HTTP_ORIGIN + RESOURCES_DIR;
+      testReferrerHeader(testBase, referrerUrl, true);
     </script>
   </body>
 </html>

--- a/beacon/headers/header-referrer.js
+++ b/beacon/headers/header-referrer.js
@@ -3,12 +3,15 @@ var RESOURCES_DIR = "/beacon/resources/";
 var referrerOrigin = self.location.origin + '/';
 var referrerUrl = self.location.href;
 
-function testReferrerHeader(testBase, expectedReferrer) {
+function testReferrerHeader(testBase, expectedReferrer, mayBeBlockedAsMixedContent = false) {
   var id = self.token();
   var testUrl = testBase + "inspect-header.py?header=referer&cmd=put&id=" + id;
 
   promise_test(function(test) {
-    assert_true(navigator.sendBeacon(testUrl), "SendBeacon Succeeded");
+    const sentBeacon = navigator.sendBeacon(testUrl);
+    if (mayBeBlockedAsMixedContent && !sentBeacon)
+      return Promise.resolve();
+    assert_true(sentBeacon, "SendBeacon Succeeded");
     return pollResult(expectedReferrer, id) .then(result => {
       assert_equals(result, expectedReferrer, "Correct referrer header result");
     });


### PR DESCRIPTION
Gecko and Blink by default block mixed content requests.

As a result, header-referrer-strict-origin-when-cross-origin.https.html, header-referrer-strict-origin.https.html,
and beacon/headers/header-referrer-unsafe-url.https.html fail in those two browser engines.

Allow the mixed content beacon requests to be blocked in these tests as allowed by the specification:
https://www.w3.org/TR/mixed-content/#should-block-fetch
https://www.w3.org/TR/mixed-content/#requirements-user-controls

Also fixed a bug in header-referrer-strict-origin-when-cross-origin.https.html that it was not testing cross-origin.