### PR TITLE
Adapt to web-nfc latest spec

### DIFF
--- a/web-nfc/NFCReadingEvent_constructor.https.html
+++ b/web-nfc/NFCReadingEvent_constructor.https.html
@@ -3,9 +3,32 @@
 <link rel="help" href="https://w3c.github.io/web-nfc/#dom-nfcreadingevent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="resources/nfc_help.js"></script>
 <script>
+
+  const non_strings = [
+    123,
+    {},
+    true,
+    Symbol(),
+    () => {},
+    self
+  ]
+
   test(() => {
     assert_equals(NFCReadingEvent.length, 2);
     assert_throws(new TypeError, () => new NFCReadingEvent('message'));
   }, 'NFCReadingEvent constructor without init dict');
+
+  test(() => {
+    assert_equals(NFCReadingEvent.length, 2);
+    const message = createMessage([createJsonRecord(test_json_data)]);
+    non_strings.forEach(invalid_serialNumber => {
+      assert_throws(new TypeError, () => new NFCReadingEvent(
+        'message',
+        {invalid_serialNumber, message}
+      ));
+    });
+  }, 'NFCReadingEvent constructor without init dict');
+
 </script>

--- a/web-nfc/NFCReadingEvent_constructor.https.html
+++ b/web-nfc/NFCReadingEvent_constructor.https.html
@@ -29,6 +29,6 @@
         {invalid_serialNumber, message}
       ));
     });
-  }, 'NFCReadingEvent constructor without init dict');
+  }, 'NFCReadingEvent constructor with non-string serialNumber');
 
 </script>

--- a/web-nfc/NFCWriter_push.https.html
+++ b/web-nfc/NFCWriter_push.https.html
@@ -233,17 +233,4 @@ promise_test(t => {
   return Promise.all(promises);
 }, "Test that promise is rejected with TypeError if NDEFMessageSource contains non-string url.");
 
-promise_test(t => {
-  const writer = new NFCWriter();
-  const promises = [];
-  non_strings.forEach(invalid_serialNumber => {
-    promises.push(
-      promise_rejects(t, new TypeError(), writer.push({
-        serialNumber: invalid_serialNumber,
-        records: [{ recordType: "text", data: 'Hello World' }]
-      })));
-  });
-  return Promise.all(promises);
-}, "Test that promise is rejected with TypeError if NDEFMessageSource contains non-string serialNumber.");
-
 </script>


### PR DESCRIPTION
Spec change in #w3c/web-nfc/pull/227
- Move "serialNumber" from "NDEFMessage" to "NFCReadingEvent"/"NFCReadingEventInit"