### PR TITLE
[idlharness] Accumulate skipped (ignored) deps over IdlArray lifetime

### DIFF
--- a/interfaces/longtasks.idl
+++ b/interfaces/longtasks.idl
@@ -5,6 +5,7 @@
 
 interface PerformanceLongTaskTiming : PerformanceEntry {
     readonly attribute FrozenArray<TaskAttributionTiming> attribution;
+    [Default] object toJSON();
 };
 
 interface TaskAttributionTiming : PerformanceEntry {
@@ -12,4 +13,5 @@ interface TaskAttributionTiming : PerformanceEntry {
     readonly attribute DOMString containerSrc;
     readonly attribute DOMString containerId;
     readonly attribute DOMString containerName;
+    [Default] object toJSON();
 };

--- a/longtask-timing/idlharness.window.js
+++ b/longtask-timing/idlharness.window.js
@@ -8,7 +8,7 @@
 idl_test(
   ['longtasks'],
   ['performance-timeline', 'hr-time'],
-  (idl_array, t) => new Promise(async (resolve, reject) => {
+  (idl_array, t) => new Promise((resolve, reject) => {
 
 
     const longTask = () => {

--- a/longtask-timing/idlharness.window.js
+++ b/longtask-timing/idlharness.window.js
@@ -7,8 +7,10 @@
 
 idl_test(
   ['longtasks'],
-  ['performance-timeline'],
-  (idl_array, t) => new Promise((resolve, reject) => {
+  ['performance-timeline', 'hr-time'],
+  (idl_array, t) => new Promise(async (resolve, reject) => {
+
+
     const longTask = () => {
       const begin = self.performance.now();
       while (self.performance.now() < begin + 100);

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -193,6 +193,12 @@ self.IdlArray = function()
     this["implements"] = {};
     this["includes"] = {};
     this["inheritance"] = {};
+
+    /**
+     * Record of skipped IDL items, in case we later realize that they are a
+     * dependency (to retroactively process them).
+     */
+    this.skipped = new Map();
 };
 
 IdlArray.prototype.add_idls = function(raw_idls, options)
@@ -244,16 +250,34 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
         all_deps.add(k);
         this.includes[k].forEach(v => all_deps.add(v));
     });
-    this.partials.map(p => p.name).forEach(v => all_deps.add(v));
-    // Add the attribute idlTypes of all the nested members of all tested idls.
-    for (const obj of [this.members, this.partials]) {
-        const tested = Object.values(obj).filter(m => !m.untested && m.members);
-        for (const parsed of tested) {
-            for (const attr of Object.values(parsed.members).filter(m => !m.untested && m.type === 'attribute')) {
-                all_deps.add(attr.idlType.idlType);
+    this.partials.map(p => p.name).forEach(v => all_deps.add(v.idlType));
+
+    // Add the attribute idlTypes of all the nested members of idls.
+    const attrDeps = parsedIdls => {
+        return parsedIdls.reduce((deps, parsed) => {
+            if (parsed.members) {
+                for (const attr of Object.values(parsed.members).filter(m => m.type === 'attribute')) {
+                    let attrType = attr.idlType;
+                    if (attrType.generic) {
+                        deps.add(attrType.generic);
+                        attrType = attrType.idlType;
+                    }
+                    deps.add(attrType.idlType);
+                }
             }
-        }
-    }
+            if (parsed.base in this.members) {
+                attrDeps([this.members[parsed.base]]).forEach(dep => deps.add(dep));
+            }
+            return deps;
+        }, new Set());
+    };
+
+    const testedMembers = Object.values(this.members).filter(m => !m.untested && m.members);
+    Array.from(attrDeps(testedMembers)).forEach(dep => all_deps.add(dep));
+
+    const testedPartials = this.partials.filter(m => !m.untested && m.members);
+    Array.from(attrDeps(testedPartials)).forEach(dep => all_deps.add(dep));
+
 
     if (options && options.except && options.only) {
         throw new IdlHarnessError("The only and except options can't be used together.");
@@ -268,9 +292,7 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
         return name in this.members
             || this.is_excluded_by_options(name, options);
     }
-    // Record of skipped items, in case we later determine they are a dependency.
     // Maps name -> [parsed_idl, ...]
-    const skipped = new Map();
     const process = function(parsed) {
         var deps = [];
         if (parsed.name) {
@@ -288,9 +310,9 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
                 // Flag as skipped, if it's not already processed, so we can
                 // come back to it later if we retrospectively call it a dep.
                 if (name && !(name in this.members)) {
-                    skipped.has(name)
-                        ? skipped.get(name).push(parsed)
-                        : skipped.set(name, [parsed]);
+                    this.skipped.has(name)
+                        ? this.skipped.get(name).push(parsed)
+                        : this.skipped.set(name, [parsed]);
                 }
                 return false;
             }
@@ -326,11 +348,18 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
                     }
                 }
             }
+            for (const attrDep of attrDeps([parsed])) {
+                if (!new_options.only.includes(attrDep)) {
+                    new_options.only.push(attrDep);
+                }
+                all_deps.add(attrDep);
+                follow_up.add(attrDep);
+            }
 
             for (const deferred of follow_up) {
-                if (skipped.has(deferred)) {
-                    const next = skipped.get(deferred);
-                    skipped.delete(deferred);
+                if (this.skipped.has(deferred)) {
+                    const next = this.skipped.get(deferred);
+                    this.skipped.delete(deferred);
                     next.forEach(process);
                 }
             }

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -277,7 +277,7 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
     attrDeps(testedMembers).forEach(dep => all_deps.add(dep));
 
     const testedPartials = this.partials.filter(m => !m.untested && m.members);
-    Array.from(attrDeps(testedPartials)).forEach(dep => all_deps.add(dep));
+    attrDeps(testedPartials).forEach(dep => all_deps.add(dep));
 
 
     if (options && options.except && options.only) {

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -250,7 +250,7 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
         all_deps.add(k);
         this.includes[k].forEach(v => all_deps.add(v));
     });
-    this.partials.map(p => p.name).forEach(v => all_deps.add(v.idlType));
+    this.partials.forEach(p => all_deps.add(p.name));
 
     // Add the attribute idlTypes of all the nested members of idls.
     const attrDeps = parsedIdls => {

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -258,6 +258,7 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
             if (parsed.members) {
                 for (const attr of Object.values(parsed.members).filter(m => m.type === 'attribute')) {
                     let attrType = attr.idlType;
+                    // Check for generic members (e.g. FrozenArray<MyType>)
                     if (attrType.generic) {
                         deps.add(attrType.generic);
                         attrType = attrType.idlType;

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -284,15 +284,14 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
         throw new IdlHarnessError("The only and except options can't be used together.");
     }
 
-    const defined_or_untested = parsed => {
+    const defined_or_untested = name => {
         // NOTE: Deps are untested, so we're lenient, and skip re-encountered definitions.
         // e.g. for 'idl' containing A:B, B:C, C:D
         //      array.add_idls(idl, {only: ['A','B']}).
         //      array.add_dependency_idls(idl);
         // B would be encountered as tested, and encountered as a dep, so we ignore.
-        return parsed.name
-            && (parsed.name in this.members
-                || this.is_excluded_by_options(parsed.name, options));
+        return name in this.members
+            || this.is_excluded_by_options(name, options);
     }
     // Maps name -> [parsed_idl, ...]
     const process = function(parsed) {
@@ -308,7 +307,9 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
         }
 
         deps = deps.filter(function(name) {
-            if (!name || defined_or_untested(parsed) || !all_deps.has(name)) {
+            if (!name
+                || name === parsed.name && defined_or_untested(name)
+                || !all_deps.has(name)) {
                 // Flag as skipped, if it's not already processed, so we can
                 // come back to it later if we retrospectively call it a dep.
                 if (name && !(name in this.members)) {
@@ -349,13 +350,6 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
                         follow_up.add(dep);
                     }
                 }
-            }
-            for (const attrDep of attrDeps([parsed])) {
-                if (!new_options.only.includes(attrDep)) {
-                    new_options.only.push(attrDep);
-                }
-                all_deps.add(attrDep);
-                follow_up.add(attrDep);
             }
 
             for (const deferred of follow_up) {

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -284,14 +284,15 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
         throw new IdlHarnessError("The only and except options can't be used together.");
     }
 
-    const should_skip = name => {
+    const defined_or_untested = parsed => {
         // NOTE: Deps are untested, so we're lenient, and skip re-encountered definitions.
         // e.g. for 'idl' containing A:B, B:C, C:D
         //      array.add_idls(idl, {only: ['A','B']}).
         //      array.add_dependency_idls(idl);
         // B would be encountered as tested, and encountered as a dep, so we ignore.
-        return name in this.members
-            || this.is_excluded_by_options(name, options);
+        return parsed.name
+            && (parsed.name in this.members
+                || this.is_excluded_by_options(parsed.name, options));
     }
     // Maps name -> [parsed_idl, ...]
     const process = function(parsed) {
@@ -307,7 +308,7 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
         }
 
         deps = deps.filter(function(name) {
-            if (!name || should_skip(name) || !all_deps.has(name)) {
+            if (!name || defined_or_untested(parsed) || !all_deps.has(name)) {
                 // Flag as skipped, if it's not already processed, so we can
                 // come back to it later if we retrospectively call it a dep.
                 if (name && !(name in this.members)) {

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -273,7 +273,7 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
     };
 
     const testedMembers = Object.values(this.members).filter(m => !m.untested && m.members);
-    Array.from(attrDeps(testedMembers)).forEach(dep => all_deps.add(dep));
+    attrDeps(testedMembers).forEach(dep => all_deps.add(dep));
 
     const testedPartials = this.partials.filter(m => !m.untested && m.members);
     Array.from(attrDeps(testedPartials)).forEach(dep => all_deps.add(dep));

--- a/service-workers/service-worker/interfaces-window.https.html
+++ b/service-workers/service-worker/interfaces-window.https.html
@@ -10,8 +10,8 @@
 'use strict';
 
 promise_test(async (t) => {
-  const srcs = ['dom', 'html', 'service-workers', 'dedicated-workers'];
-  const [dom, html, serviceWorkerIdl, dedicated] = await Promise.all(
+  const srcs = ['dom', 'html', 'service-workers'];
+  const [dom, html, serviceWorkerIdl] = await Promise.all(
     srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
 
   var idlArray = new IdlArray();
@@ -29,7 +29,6 @@ promise_test(async (t) => {
     'Cache',
     'CacheStorage',
   ]});
-  idlArray.add_dependency_idls(dedicated);
   idlArray.add_dependency_idls(dom);
   idlArray.add_dependency_idls(html);
   idlArray.add_objects({


### PR DESCRIPTION
Issue was found via https://github.com/web-platform-tests/wpt/pull/17305

Changes the `skipped` map to be an IdlArray member (over the course of the IDL accumulation), such that retroactive imports can be done across multiple files.

