### PR TITLE
Link to testdriver docs from the main docs site

### DIFF
--- a/docs/writing-tests/index.md
+++ b/docs/writing-tests/index.md
@@ -22,11 +22,11 @@ There's also a load of [general guidelines](general-guidelines) that apply to al
    rendering
    server-features
    submission-process
+   testdriver
+   testdriver-tutorial
    testharness
    visual
    wdspec
-   testdriver
-   testdriver-tutorial
 ```
 
 ## Test Type

--- a/docs/writing-tests/index.md
+++ b/docs/writing-tests/index.md
@@ -25,6 +25,8 @@ There's also a load of [general guidelines](general-guidelines) that apply to al
    testharness
    visual
    wdspec
+   testdriver
+   testdriver-tutorial
 ```
 
 ## Test Type


### PR DESCRIPTION
`testdriver.md` and `testdriver-tutorial.md` aren't correctly indexed anywhere
because of https://github.com/bocoup/wpt-docs/issues/1 .

This PR manually adds them to the ToC in "Writing Tests" as per user requests.