### PR TITLE
[docs] Build (but do not deploy) for pull requests

### DIFF
--- a/tools/ci/website_build.sh
+++ b/tools/ci/website_build.sh
@@ -32,18 +32,6 @@ function modifies_relevant_files {
     grep -E --silent '^(docs|tools)/'
 }
 
-if is_pull_request ; then
-  echo Submission comes from a pull request. Exiting without building.
-
-  exit ${neutral_status}
-fi
-
-if ! targets_master ; then
-  echo Submission does not target the 'master' branch. Exiting without building.
-
-  exit ${neutral_status}
-fi
-
 if ! modifies_relevant_files ; then
   echo No files related to the website have been modified. Exiting without
   echo building.
@@ -77,6 +65,18 @@ touch .nojekyll
 
 # Publish the website by pushing the built contents to the `gh-pages` branch
 git add .
+
+if is_pull_request ; then
+  echo Submission comes from a pull request. Exiting without publishing.
+
+  exit ${neutral_status}
+fi
+
+if ! targets_master ; then
+  echo Submission does not target the 'master' branch. Exiting without publishing.
+
+  exit ${neutral_status}
+fi
 
 if git diff --exit-code --quiet --staged ; then
   echo No change to the website contents. Exiting without publishing.


### PR DESCRIPTION
Although the documentation website should not be rebuilt in response to
pull requests, refusing to simply build the site may potentially hide
errors during the review process.

Update the documentation generation script to build the site as part of
the pull request, provided a relevant file has been modified. With this
applied, if the patch under review regresses the script, the contributor
and reviewers are immediately notified.