### PR TITLE
[docs] Provide more realistic guidance on review

### DIFF
--- a/docs/appendix/github-intro.md
+++ b/docs/appendix/github-intro.md
@@ -249,7 +249,11 @@ GitHub UI.  Below is one method and others can be found on
 4. Wait for feedback on your pull request and once your pull request is
 accepted, delete your branch (see '[When Pull Request is Accepted](#cleanup)').
 
-That's it! Your pull request will go into a queue and will be reviewed soon.
+That's it! A number of project maintainers will be informed of your submission,
+and one of them should give you feedback within three Western business days
+(i.e. Monday through Friday). If you don't receive any response, you may find
+support by asking in [the "#testing" chat room on the W3C IRC
+server](http://irc.w3.org/).
 
 ## Modify
 


### PR DESCRIPTION
There is no formal queue for submissions to WPT, and there is no
guarantee that any submission will be reviewed. Update the documentation
to set contributors' expectations more realistically, and recommend a
possible recourse in the event that no reviewer is available.

I made up the duration of "three business days." We can change it, but I think
it's very important to give contributors some concrete expectation about
support.

This is in service of gh-5301