### PR TITLE
Fix timeout in rejects_if_not_active.https.html

### DIFF
--- a/payment-request/rejects_if_not_active.https.html
+++ b/payment-request/rejects_if_not_active.https.html
@@ -58,8 +58,8 @@ promise_test(async t => {
     iframe,
     "/payment-request/resources/page1.html"
   );
-  const showPromise = await test_driver.bless("show payment request", () => {
-    return request.show();
+  const [showPromise] = await test_driver.bless("show payment request", () => {
+    return [request.show()];
   });
   // Navigate the iframe to a new location. Wait for the load event to fire.
   await new Promise(resolve => {


### PR DESCRIPTION
The test should only wait for show promise to be created, not when show promise is resolved.

Without this patch, the test times out because the payment sheet is waiting for user action.