### PR TITLE
[docs] Increase strictness of build process

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# WPT documentation
+# Project documentation tooling
 
 The documentation for the web-platform-tests project is built using [the Sphinx
 documentation generator](http://www.sphinx-doc.org). [The GitHub Actions

--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -3,6 +3,15 @@
 This section documents all the information necessary to administer the
 infrastructure which makes the project possible.
 
+## Tooling
+
+```eval_rst
+.. toctree::
+   :titlesonly:
+
+   ../README
+```
+
 ## Secrets
 
 Some aspects of the infrastructure are only accessible to administrators.

--- a/docs/appendix/test-templates.md
+++ b/docs/appendix/test-templates.md
@@ -11,7 +11,12 @@ delimit text to be replaced and `#` represents a digit.
 
 ### Test
 
-``` html
+<!--
+  Syntax highlighting cannot be enabled for the following template because it
+  contains invalid CSS.
+-->
+
+```
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>${1:Test title}</title>
@@ -28,7 +33,12 @@ Filename: `{test-topic}-###.html`
 
 ### Reference:
 
-``` html
+<!--
+  Syntax highlighting cannot be enabled for the following template because it
+  contains invalid CSS.
+-->
+
+```
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>${1:Reference title}</title>

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -76,7 +76,7 @@ expectations:
   expected. They get their name from the JavaScript harness that's used to
   execute them.
 
-* [wdspec]() tests are written in Python and test [the WebDriver browser
+* [wdspec][] tests are written in Python and test [the WebDriver browser
   automation protocol](https://w3c.github.io/webdriver/)
 
 * [Manual tests][manual] rely on a human to run them and determine their

--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -115,6 +115,13 @@ customising the test run:
 [A complete listing of the command-line arguments is available
 here](command-line-arguments).
 
+```eval_rst
+.. toctree::
+   :hidden:
+
+   command-line-arguments
+```
+
 Additional browser-specific documentation:
 
 ```eval_rst

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -179,11 +179,13 @@ class Response(object):
         If any part of the content is a function, this will be called
         and the resulting value (if any) returned.
 
-        :param read_file: - boolean controlling the behaviour when content
-        is a file handle. When set to False the handle will be returned directly
-        allowing the file to be passed to the output in small chunks. When set to
-        True, the entire content of the file will be returned as a string facilitating
-        non-streaming operations like template substitution.
+        :param read_file: boolean controlling the behaviour when content is a
+                          file handle. When set to False the handle will be
+                          returned directly allowing the file to be passed to
+                          the output in small chunks. When set to True, the
+                          entire content of the file will be returned as a
+                          string facilitating non-streaming operations like
+                          template substitution.
         """
         if isinstance(self.content, binary_type):
             yield self.content


### PR DESCRIPTION
Use the `-W` flag to interpret Sphinx warnings as errors, causing the
build to fail in the presence of either. This makes various authoring
mistakes more visible. Perhaps most importantly: it highlights instances
of "orphaned" content.

Fix all details which were previously reported as warnings and thus
permitted.

@Hexcles @LukeZielinski This (along with gh-17365) will help guard against
regressions to gh-17362. It also establishes a place in the "Admin" section for
wptserve docs, as requested in gh-14648.