### PR TITLE
Expect actionsWithKeyPressed.html to fail on Mac

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/actionsWithKeyPressed.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/actionsWithKeyPressed.html.ini
@@ -2,8 +2,7 @@
   expected:
     if product == "safari": ERROR
 
-
   [TestDriver actions: actions with key pressed]
     expected:
       if product == "firefox": FAIL
-
+      if os == "mac" and product == "chrome": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/elementPosition.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/elementPosition.html.ini
@@ -1,4 +1,7 @@
 [elementPosition.html]
+  expected:
+    if os == "mac" and product == "chrome": TIMEOUT
+
   [TestDriver actions: element position]
     expected:
       if product == "safari": FAIL


### PR DESCRIPTION
Related to issue #17296. This PR does not fix the underlying issue, but
only unblocks the infrastructure tests on macOS.