### PR TITLE
Split out the manual parts of webauthn idlharness test

### DIFF
--- a/webauthn/idlharness-manual.https.window.js
+++ b/webauthn/idlharness-manual.https.window.js
@@ -17,6 +17,9 @@ idl_test(
       AuthenticatorAssertionResponse: ['assertion.response']
     });
 
+    const challengeBytes = new Uint8Array(16);
+    window.crypto.getRandomValues(challengeBytes);
+
     self.cred = await Promise.race([
       new Promise((_, reject) => window.setTimeout(() => {
         reject('Timed out waiting for user to touch security key')

--- a/webauthn/idlharness-manual.https.window.js
+++ b/webauthn/idlharness-manual.https.window.js
@@ -11,17 +11,11 @@ idl_test(
   ['webauthn'],
   ['credential-management'],
   async idlArray => {
-    idlArray.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
     idlArray.add_objects({
-      // Tested in (non-manual) idlharness.https.window.js:
-      // WebAuthentication: ['navigator.authentication'],
       PublicKeyCredential: ['cred', 'assertion'],
       AuthenticatorAttestationResponse: ['cred.response'],
       AuthenticatorAssertionResponse: ['assertion.response']
     });
-
-    const challengeBytes = new Uint8Array(16);
-    window.crypto.getRandomValues(challengeBytes);
 
     self.cred = await Promise.race([
       new Promise((_, reject) => window.setTimeout(() => {

--- a/webauthn/idlharness-manual.https.window.js
+++ b/webauthn/idlharness-manual.https.window.js
@@ -11,6 +11,8 @@ idl_test(
   ['webauthn'],
   ['credential-management'],
   async idlArray => {
+    idlArray.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
+
     idlArray.add_objects({
       PublicKeyCredential: ['cred', 'assertion'],
       AuthenticatorAttestationResponse: ['cred.response'],
@@ -36,23 +38,16 @@ idl_test(
       }),
     ]);
 
-    if (self.cred) {
-      self.assertion = await Promise.race([
-        new Promise((_, reject) => window.setTimeout(() => {
-          reject('Timed out waiting for user to touch security key')
-        }, 3000)),
-        navigator.credentials.get({
-          publicKey: {
-            timeout: 3000,
-            allowCredentials: [{
-              id: cred.rawId,
-              transports: ["usb", "nfc", "ble"],
-              type: "public-key"
-            }],
-            challenge: challengeBytes,
-          }
-        })
-      ]);
-    }
+    self.assertion = await navigator.credentials.get({
+      publicKey: {
+        timeout: 3000,
+        allowCredentials: [{
+          id: cred.rawId,
+          transports: ["usb", "nfc", "ble"],
+          type: "public-key"
+        }],
+        challenge: challengeBytes,
+      }
+    });
   }
 );

--- a/webauthn/idlharness-manual.https.window.js
+++ b/webauthn/idlharness-manual.https.window.js
@@ -13,7 +13,8 @@ idl_test(
   async idlArray => {
     idlArray.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
     idlArray.add_objects({
-      WebAuthentication: ['navigator.authentication'],
+      // Tested in (non-manual) idlharness.https.window.js:
+      // WebAuthentication: ['navigator.authentication'],
       PublicKeyCredential: ['cred', 'assertion'],
       AuthenticatorAttestationResponse: ['cred.response'],
       AuthenticatorAssertionResponse: ['assertion.response']

--- a/webauthn/idlharness-manual.https.window.js
+++ b/webauthn/idlharness-manual.https.window.js
@@ -1,0 +1,60 @@
+// META: timeout=long
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+// META: script=helpers.js
+
+// https://w3c.github.io/webauthn/
+
+'use strict';
+
+idl_test(
+  ['webauthn'],
+  ['credential-management'],
+  async idlArray => {
+    idlArray.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
+    idlArray.add_objects({
+      WebAuthentication: ['navigator.authentication'],
+      PublicKeyCredential: ['cred', 'assertion'],
+      AuthenticatorAttestationResponse: ['cred.response'],
+      AuthenticatorAssertionResponse: ['assertion.response']
+    });
+
+    const challengeBytes = new Uint8Array(16);
+    window.crypto.getRandomValues(challengeBytes);
+
+    self.cred = await Promise.race([
+      new Promise((_, reject) => window.setTimeout(() => {
+        reject('Timed out waiting for user to touch security key')
+      }, 3000)),
+      createCredential({
+        options: {
+          publicKey: {
+            timeout: 3000,
+            user: {
+              id: new Uint8Array(16),
+            },
+          }
+        }
+      }),
+    ]);
+
+    if (self.cred) {
+      self.assertion = await Promise.race([
+        new Promise((_, reject) => window.setTimeout(() => {
+          reject('Timed out waiting for user to touch security key')
+        }, 3000)),
+        navigator.credentials.get({
+          publicKey: {
+            timeout: 3000,
+            allowCredentials: [{
+              id: cred.rawId,
+              transports: ["usb", "nfc", "ble"],
+              type: "public-key"
+            }],
+            challenge: challengeBytes,
+          }
+        })
+      ]);
+    }
+  }
+);

--- a/webauthn/idlharness.https.window.js
+++ b/webauthn/idlharness.https.window.js
@@ -11,16 +11,11 @@ idl_test(
   ['webauthn'],
   ['credential-management'],
   async idlArray => {
-    idlArray.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
-    idlArray.add_objects({
-      WebAuthentication: ['navigator.authentication'],
-      // The following are tested in idlharness-manual.https.window.js:
-      // PublicKeyCredential: ['cred', 'assertion'],
-      // AuthenticatorAttestationResponse: ['cred.response'],
-      // AuthenticatorAssertionResponse: ['assertion.response']
-    });
-
-    const challengeBytes = new Uint8Array(16);
-    window.crypto.getRandomValues(challengeBytes);
+    // NOTE: The following are tested in idlharness-manual.https.window.js:
+    // idlArray.add_objects({
+    //   PublicKeyCredential: ['cred', 'assertion'],
+    //   AuthenticatorAttestationResponse: ['cred.response'],
+    //   AuthenticatorAssertionResponse: ['assertion.response']
+    // });
   }
 );

--- a/webauthn/idlharness.https.window.js
+++ b/webauthn/idlharness.https.window.js
@@ -14,7 +14,7 @@ idl_test(
     idlArray.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
     idlArray.add_objects({
       WebAuthentication: ['navigator.authentication'],
-      // The following are tested in idlharness-manual:
+      // The following are tested in idlharness-manual.https.window.js:
       // PublicKeyCredential: ['cred', 'assertion'],
       // AuthenticatorAttestationResponse: ['cred.response'],
       // AuthenticatorAssertionResponse: ['assertion.response']

--- a/webauthn/idlharness.https.window.js
+++ b/webauthn/idlharness.https.window.js
@@ -14,35 +14,13 @@ idl_test(
     idlArray.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
     idlArray.add_objects({
       WebAuthentication: ['navigator.authentication'],
-      PublicKeyCredential: ['cred', 'assertion'],
-      AuthenticatorAttestationResponse: ['cred.response'],
-      AuthenticatorAssertionResponse: ['assertion.response']
+      // The following are tested in idlharness-manual:
+      // PublicKeyCredential: ['cred', 'assertion'],
+      // AuthenticatorAttestationResponse: ['cred.response'],
+      // AuthenticatorAssertionResponse: ['assertion.response']
     });
 
     const challengeBytes = new Uint8Array(16);
     window.crypto.getRandomValues(challengeBytes);
-
-    self.cred = await createCredential({
-      options: {
-        publicKey: {
-          timeout: 3000,
-          user: {
-            id: new Uint8Array(16),
-          },
-        }
-      }
-    });
-
-    self.assertion = await navigator.credentials.get({
-      publicKey: {
-        timeout: 3000,
-        allowCredentials: [{
-          id: cred.rawId,
-          transports: ["usb", "nfc", "ble"],
-          type: "public-key"
-        }],
-        challenge: challengeBytes,
-      }
-    });
   }
 );


### PR DESCRIPTION
The test partially requires a user interaction (touching their security key). This PR duplicates the test into a manual version (see https://web-platform-tests.org/writing-tests/manual.html?highlight=manual#requirements-for-a-manual-test), and removes the manual interactions from the existing test.