### PR TITLE
Add tests for cases where a <base target> shouldn't apply

### DIFF
--- a/html/semantics/document-metadata/the-base-element/base_target_does_not_affect_iframe_src_navigation.html
+++ b/html/semantics/document-metadata/the-base-element/base_target_does_not_affect_iframe_src_navigation.html
@@ -4,7 +4,7 @@
 <iframe id="i" src="about:blank"></iframe>
 <script>
 async_test(function(t) {
-  i.src = "data:text/html,This should navigate the iframe";
-  i.onload = () => t.done();
+  window.onmessage = () => t.done();
+  i.src = "data:text/html,This should navigate the iframe<script>top.postMessage('done', '*');</sc" + "ript>";
 });
 </script>

--- a/html/semantics/document-metadata/the-base-element/base_target_does_not_affect_iframe_src_navigation.html
+++ b/html/semantics/document-metadata/the-base-element/base_target_does_not_affect_iframe_src_navigation.html
@@ -1,0 +1,10 @@
+<base id="base" target="_blank">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="i" src="about:blank"></iframe>
+<script>
+async_test(function(t) {
+  i.src = "data:text/html,This should navigate the iframe";
+  i.onload = () => t.done();
+});
+</script>

--- a/html/semantics/document-metadata/the-base-element/base_target_does_not_affect_location_assignment.html
+++ b/html/semantics/document-metadata/the-base-element/base_target_does_not_affect_location_assignment.html
@@ -1,0 +1,10 @@
+<base id="base" target="_blank">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="i" src="about:blank"></iframe>
+<script>
+async_test(function(t) {
+  i.contentWindow.location = "data:text/html,This should navigate the iframe";
+  i.onload = () => t.done();
+});
+</script>

--- a/html/semantics/document-metadata/the-base-element/base_target_does_not_affect_location_assignment.html
+++ b/html/semantics/document-metadata/the-base-element/base_target_does_not_affect_location_assignment.html
@@ -4,7 +4,7 @@
 <iframe id="i" src="about:blank"></iframe>
 <script>
 async_test(function(t) {
-  i.contentWindow.location = "data:text/html,This should navigate the iframe";
-  i.onload = () => t.done();
+  window.onmessage = () => t.done();
+  i.contentWindow.location = "data:text/html,This should navigate the iframe<script>top.postMessage('done', '*');</sc" + "ript>";
 });
 </script>


### PR DESCRIPTION
A base target attribute should only be considered when navigating via a, area, or form elements: https://html.spec.whatwg.org/multipage/semantics.html#get-an-element's-target

Chrome recently hit a couple of bugs where a base target attribute was incorrectly being applied to other navigations. There don't appear to be any tests for cases where the base target attribute should be ignored. This adds tests for navigation via iframe src and location assignment.