### PR TITLE
[webnfc] Remove incorrect test

### DIFF
--- a/web-nfc/NFCReadingEvent_constructor.https.html
+++ b/web-nfc/NFCReadingEvent_constructor.https.html
@@ -6,30 +6,10 @@
 <script src="resources/nfc_help.js"></script>
 <script>
 
-  const non_strings = [
-    123,
-    {},
-    true,
-    Symbol(),
-    () => {},
-    self
-  ]
-
   test(() => {
     assert_equals(NFCReadingEvent.length, 2);
     assert_throws(new TypeError, () => new NFCReadingEvent('message'));
   }, 'NFCReadingEvent constructor without init dict');
-
-  test(() => {
-    assert_equals(NFCReadingEvent.length, 2);
-    const message = createMessage([createJsonRecord(test_json_data)]);
-    non_strings.forEach(invalid_serialNumber => {
-      assert_throws(new TypeError, () => new NFCReadingEvent(
-        'message',
-        {serialNumber: invalid_serialNumber, message: message}
-      ));
-    });
-  }, 'NFCReadingEvent constructor with invalid serialNumber');
 
   test(() => {
     const message = createMessage([createJsonRecord(test_json_data)]);

--- a/web-nfc/NFCWriter_push.https.html
+++ b/web-nfc/NFCWriter_push.https.html
@@ -82,16 +82,7 @@ const invalid_signals = [
   Symbol(),
   () => {},
   self
-]
-
-const non_strings = [
-  123,
-  {},
-  true,
-  Symbol(),
-  () => {},
-  self
-]
+];
 
 promise_test(t => {
   const writer = new NFCWriter();
@@ -219,18 +210,5 @@ promise_test(() => {
     }
   });
 }, 'Test that WebNFC API is not accessible from iframe context.');
-
-promise_test(t => {
-  const writer = new NFCWriter();
-  const promises = [];
-  non_strings.forEach(invalid_url => {
-    promises.push(
-      promise_rejects(t, new TypeError(), writer.push({
-        url: invalid_url,
-        records: [{ recordType: "text", data: 'Hello World' }]
-      })));
-  });
-  return Promise.all(promises);
-}, "Test that promise is rejected with TypeError if NDEFMessageSource contains non-string url.");
 
 </script>


### PR DESCRIPTION
Per spec https://heycam.github.io/webidl/#es-DOMString,
non string value will be converted to string via `toString()`
method, therefore there's no `TypeError` to be thrown.