### PR TITLE
Test that changing <iframe srcdoc> processes attributes

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/srcdoc_process_attributes.html
+++ b/html/semantics/embedded-content/the-iframe-element/srcdoc_process_attributes.html
@@ -14,19 +14,19 @@ function createIFrameWithBlobSrc() {
 
 async_test(function(t) {
   var iframe = createIFrameWithBlobSrc();
+  var isAdded = false;
   iframe.onload = t.step_func(function() {
     assert_equals(iframe.contentDocument.location.protocol, "blob:");
     assert_equals(iframe.contentDocument.body.textContent, "src");
 
-      assert_false(isSetting);
     iframe.onload = t.step_func_done(function() {
+      assert_false(isAdded);
       assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
       assert_equals(iframe.contentDocument.body.textContent, "srcdoc");
     });
 
-    var isSetting = true;
     iframe.setAttribute("srcdoc", "srcdoc");
-    isSetting = false;
+    isAdded = true;
   });
 
   document.body.appendChild(iframe);
@@ -34,20 +34,20 @@ async_test(function(t) {
 
 async_test(function(t) {
   var iframe = createIFrameWithBlobSrc();
+  var isChanged = false;
   iframe.srcdoc = "old";
   iframe.onload = t.step_func(function() {
     assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
     assert_equals(iframe.contentDocument.body.textContent, "old");
 
-      assert_false(isChanging);
     iframe.onload = t.step_func_done(function() {
+      assert_false(isChanged);
       assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
       assert_equals(iframe.contentDocument.body.textContent, "new");
     });
 
-    var isChanging = true;
     iframe.srcdoc = "new";
-    isChanging = false;
+    isChanged = true;
   });
 
   document.body.appendChild(iframe);
@@ -55,20 +55,20 @@ async_test(function(t) {
 
 async_test(function(t) {
   var iframe = createIFrameWithBlobSrc();
+  var isRemoved = false;
   iframe.srcdoc = "srcdoc";
   iframe.onload = t.step_func(function() {
     assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
     assert_equals(iframe.contentDocument.body.textContent, "srcdoc");
 
-      assert_false(isRemoving);
     iframe.onload = t.step_func_done(function() {
+      assert_false(isRemoved);
       assert_equals(iframe.contentDocument.location.protocol, "blob:");
       assert_equals(iframe.contentDocument.body.textContent, "src");
     });
 
-    var isRemoving = true;
     iframe.removeAttribute("srcdoc");
-    isRemoving = false;
+    isRemoved = true;
   });
 
   document.body.appendChild(iframe);

--- a/html/semantics/embedded-content/the-iframe-element/srcdoc_process_attributes.html
+++ b/html/semantics/embedded-content/the-iframe-element/srcdoc_process_attributes.html
@@ -30,7 +30,7 @@ async_test(function(t) {
   });
 
   document.body.appendChild(iframe);
-}, "Setting `srcdoc` triggers attributes processing");
+}, "Adding `srcdoc` attribute triggers attributes processing");
 
 async_test(function(t) {
   var iframe = createIFrameWithBlobSrc();
@@ -51,7 +51,7 @@ async_test(function(t) {
   });
 
   document.body.appendChild(iframe);
-}, "Changing `srcdoc` triggers attributes processing");
+}, "Changing `srcdoc` (via property) triggers attributes processing");
 
 async_test(function(t) {
   var iframe = createIFrameWithBlobSrc();
@@ -72,5 +72,5 @@ async_test(function(t) {
   });
 
   document.body.appendChild(iframe);
-}, "Removing `srcdoc` triggers attributes processing");
+}, "Removing `srcdoc` attribute triggers attributes processing");
 </script>

--- a/html/semantics/embedded-content/the-iframe-element/srcdoc_process_attributes.html
+++ b/html/semantics/embedded-content/the-iframe-element/srcdoc_process_attributes.html
@@ -18,11 +18,10 @@ async_test(function(t) {
     assert_equals(iframe.contentDocument.location.protocol, "blob:");
     assert_equals(iframe.contentDocument.body.textContent, "src");
 
-    iframe.onload = t.step_func(function() {
       assert_false(isSetting);
+    iframe.onload = t.step_func_done(function() {
       assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
       assert_equals(iframe.contentDocument.body.textContent, "srcdoc");
-      t.done();
     });
 
     var isSetting = true;
@@ -40,11 +39,10 @@ async_test(function(t) {
     assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
     assert_equals(iframe.contentDocument.body.textContent, "old");
 
-    iframe.onload = t.step_func(function() {
       assert_false(isChanging);
+    iframe.onload = t.step_func_done(function() {
       assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
       assert_equals(iframe.contentDocument.body.textContent, "new");
-      t.done();
     });
 
     var isChanging = true;
@@ -62,11 +60,10 @@ async_test(function(t) {
     assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
     assert_equals(iframe.contentDocument.body.textContent, "srcdoc");
 
-    iframe.onload = t.step_func(function() {
       assert_false(isRemoving);
+    iframe.onload = t.step_func_done(function() {
       assert_equals(iframe.contentDocument.location.protocol, "blob:");
       assert_equals(iframe.contentDocument.body.textContent, "src");
-      t.done();
     });
 
     var isRemoving = true;

--- a/html/semantics/embedded-content/the-iframe-element/srcdoc_process_attributes.html
+++ b/html/semantics/embedded-content/the-iframe-element/srcdoc_process_attributes.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Whenever `srcdoc` attribute is set, changed, or removed, the UA must process the &lt;iframe> attributes</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:process-the-iframe-attributes-2">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+function createIFrameWithBlobSrc() {
+  var iframe = document.createElement("iframe");
+  iframe.src = URL.createObjectURL(new Blob(["src"], {type: "text/html"}));
+  return iframe;
+}
+
+async_test(function(t) {
+  var iframe = createIFrameWithBlobSrc();
+  iframe.onload = t.step_func(function() {
+    assert_equals(iframe.contentDocument.location.protocol, "blob:");
+    assert_equals(iframe.contentDocument.body.textContent, "src");
+
+    iframe.onload = t.step_func(function() {
+      assert_false(isSetting);
+      assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
+      assert_equals(iframe.contentDocument.body.textContent, "srcdoc");
+      t.done();
+    });
+
+    var isSetting = true;
+    iframe.setAttribute("srcdoc", "srcdoc");
+    isSetting = false;
+  });
+
+  document.body.appendChild(iframe);
+}, "Setting `srcdoc` triggers attributes processing");
+
+async_test(function(t) {
+  var iframe = createIFrameWithBlobSrc();
+  iframe.srcdoc = "old";
+  iframe.onload = t.step_func(function() {
+    assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
+    assert_equals(iframe.contentDocument.body.textContent, "old");
+
+    iframe.onload = t.step_func(function() {
+      assert_false(isChanging);
+      assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
+      assert_equals(iframe.contentDocument.body.textContent, "new");
+      t.done();
+    });
+
+    var isChanging = true;
+    iframe.srcdoc = "new";
+    isChanging = false;
+  });
+
+  document.body.appendChild(iframe);
+}, "Changing `srcdoc` triggers attributes processing");
+
+async_test(function(t) {
+  var iframe = createIFrameWithBlobSrc();
+  iframe.srcdoc = "srcdoc";
+  iframe.onload = t.step_func(function() {
+    assert_equals(iframe.contentDocument.location.href, "about:srcdoc");
+    assert_equals(iframe.contentDocument.body.textContent, "srcdoc");
+
+    iframe.onload = t.step_func(function() {
+      assert_false(isRemoving);
+      assert_equals(iframe.contentDocument.location.protocol, "blob:");
+      assert_equals(iframe.contentDocument.body.textContent, "src");
+      t.done();
+    });
+
+    var isRemoving = true;
+    iframe.removeAttribute("srcdoc");
+    isRemoving = false;
+  });
+
+  document.body.appendChild(iframe);
+}, "Removing `srcdoc` triggers attributes processing");
+</script>


### PR DESCRIPTION
Blink bug: [srcdoc removal does not process iframe attributes](https://bugs.chromium.org/p/chromium/issues/detail?id=513689).
WebKit bug: [`<iframe>` attributes should be processed on "srcdoc" attribute removal](https://bugs.webkit.org/show_bug.cgi?id=205995).