### PR TITLE
Use consistent test naming in encoding/encodeInto.any.js

### DIFF
--- a/encoding/encodeInto.any.js
+++ b/encoding/encodeInto.any.js
@@ -126,7 +126,7 @@
  Float64Array].forEach(view => {
   test(() => {
     assert_throws(new TypeError(), () => new TextEncoder().encodeInto("", new view(new ArrayBuffer(0))));
-  }, "Invalid encodeInto() destination: " + view);
+  }, "Invalid encodeInto() destination: " + view.name);
  });
 
 test(() => {


### PR DESCRIPTION
Chrome was emitting 

    function Foo {
      [native code]
    }

where other browsers had

    function Foo { [native code] }

Causing a mismatch of the subtests, e.g.
https://wpt.fyi/results/encoding/encodeInto.any.html?run_id=266890006&run_id=262730005&run_id=241080002