### PR TITLE
Handle numeric code values in assert_throws

### DIFF
--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -170,14 +170,14 @@
     test(function()
     {
         var e = {code:0, name:"TEST_ERR", TEST_ERR:0}
-        assert_throws("TEST_ERR", function() {throw e});
-    }, "Test assert_throws with non-DOM-exception expected to Fail");
+        assert_throws(0, function() {throw e});
+    }, "Test assert_throws with ambiguous DOM-exception expected to Fail");
 
     test(function()
     {
         var e = {code:0, name:"TEST_ERR", TEST_ERR:0}
-        assert_throws(0, function() {throw e});
-    }, "Test assert_throws with ambiguous DOM-exception expected to Fail");
+        assert_throws("TEST_ERR", function() {throw e});
+    }, "Test assert_throws with non-DOM-exception expected to Fail");
 
     test(function()
     {
@@ -231,14 +231,14 @@
     },
     {
       "status_string": "FAIL",
-      "name": "Test assert_throws with non-DOM-exception expected to Fail",
-      "message": "Test bug: unrecognized DOMException code \"TEST_ERR\" passed to assert_throws()",
+      "name": "Test assert_throws with ambiguous DOM-exception expected to Fail",
+      "message": "Test bug: ambiguous DOMException code 0 passed to assert_throws()",
       "properties": {}
     },
     {
       "status_string": "FAIL",
-      "name": "Test assert_throws with ambiguous DOM-exception expected to Fail",
-      "message": "Test bug: ambiguous DOMException code 0 passed to assert_throws()",
+      "name": "Test assert_throws with non-DOM-exception expected to Fail",
+      "message": "Test bug: unrecognized DOMException code \"TEST_ERR\" passed to assert_throws()",
       "properties": {}
     },
     {

--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -173,6 +173,18 @@
         assert_throws("TEST_ERR", function() {throw e});
     }, "Test assert_throws with non-DOM-exception expected to Fail");
 
+    test(function()
+    {
+        var e = {code:0, name:"TEST_ERR", TEST_ERR:0}
+        assert_throws(0, function() {throw e});
+    }, "Test assert_throws with ambiguous DOM-exception expected to Fail");
+
+    test(function()
+    {
+        var e = {code: DOMException.SYNTAX_ERR, name:"SyntaxError"}
+        assert_throws(DOMException.SYNTAX_ERR, function() {throw e});
+    }, "Test assert_throws with number code value expected to Pass");
+
     var t = async_test("Test step_func")
     setTimeout(
       t.step_func(
@@ -221,6 +233,18 @@
       "status_string": "FAIL",
       "name": "Test assert_throws with non-DOM-exception expected to Fail",
       "message": "Test bug: unrecognized DOMException code \"TEST_ERR\" passed to assert_throws()",
+      "properties": {}
+    },
+    {
+      "status_string": "FAIL",
+      "name": "Test assert_throws with ambiguous DOM-exception expected to Fail",
+      "message": "Test bug: ambiguous DOMException code 0 passed to assert_throws()",
+      "properties": {}
+    },
+    {
+      "status_string": "PASS",
+      "name": "Test assert_throws with number code value expected to Pass",
+      "message": null,
       "properties": {}
     },
     {

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -14,4 +14,4 @@ deps =
   six
   requests
 
-commands = pytest -vv {posargs} tests/functional/api-tests-1.html
+commands = pytest -vv {posargs}

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -14,4 +14,4 @@ deps =
   six
   requests
 
-commands = pytest -vv {posargs}
+commands = pytest -vv {posargs} tests/functional/api-tests-1.html

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1448,7 +1448,7 @@ policies and contribution forms [3].
             if (typeof code === "number") {
                 if (code === 0) {
                     throw new AssertionError('Test bug: ambiguous DOMException code 0 passed to assert_throws()');
-                } else if (!Array.from(Object.values(name_code_map)).includes(code)) {
+                } else if (!(code in code_name_map)) {
                     throw new AssertionError('Test bug: unrecognized DOMException code "' + code + '" passed to assert_throws()');
                 }
                 name = code_name_map[code];

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1436,11 +1436,20 @@ policies and contribution forms [3].
                 NotAllowedError: 0
             };
 
-            if (!(name in name_code_map)) {
-                throw new AssertionError('Test bug: unrecognized DOMException code "' + code + '" passed to assert_throws()');
-            }
+            var required_props = { code };
 
-            var required_props = { code: name_code_map[name] };
+            if (typeof code === "number") {
+                if (code === 0) {
+                    throw new AssertionError('Test bug: ambiguous DOMException code 0 passed to assert_throws()');
+                } else if (!Array.from(Object.values(name_code_map)).includes(code)) {
+                    throw new AssertionError('Test bug: unrecognized DOMException code "' + code + '" passed to assert_throws()');
+                }
+            } else if (typeof code === "string") {
+                if (!(name in name_code_map)) {
+                    throw new AssertionError('Test bug: unrecognized DOMException code "' + code + '" passed to assert_throws()');
+                }
+                required_props.code = name_code_map[name];
+            }
 
             if (required_props.code === 0 ||
                ("name" in e &&

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1437,11 +1437,11 @@ policies and contribution forms [3].
             };
 
             var code_name_map = {};
-            for (let [k, v] of Object.entries(name_code_map)) {
-                if (v > 0) {
-                    code_name_map[v] = k;
+            Object.entries(name_code_map).forEach(function(keyValue) {
+                if (keyValue[1] > 0) {
+                    code_name_map[keyValue[1]] = keyValue[0];
                 }
-            }
+            });
 
             var required_props = { code };
 

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1436,6 +1436,13 @@ policies and contribution forms [3].
                 NotAllowedError: 0
             };
 
+            var code_name_map = {};
+            for (let [k, v] of Object.entries(name_code_map)) {
+                if (v > 0) {
+                    code_name_map[v] = k;
+                }
+            }
+
             var required_props = { code };
 
             if (typeof code === "number") {
@@ -1444,6 +1451,7 @@ policies and contribution forms [3].
                 } else if (!Array.from(Object.values(name_code_map)).includes(code)) {
                     throw new AssertionError('Test bug: unrecognized DOMException code "' + code + '" passed to assert_throws()');
                 }
+                name = code_name_map[code];
             } else if (typeof code === "string") {
                 if (!(name in name_code_map)) {
                     throw new AssertionError('Test bug: unrecognized DOMException code "' + code + '" passed to assert_throws()');

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1437,13 +1437,13 @@ policies and contribution forms [3].
             };
 
             var code_name_map = {};
-            Object.entries(name_code_map).forEach(function(keyValue) {
-                if (keyValue[1] > 0) {
-                    code_name_map[keyValue[1]] = keyValue[0];
+            for (var key in name_code_map) {
+                if (name_code_map[key] > 0) {
+                    code_name_map[name_code_map[key]] = key;
                 }
-            });
+            }
 
-            var required_props = { code };
+            var required_props = { code: code };
 
             if (typeof code === "number") {
                 if (code === 0) {


### PR DESCRIPTION
Allows a `number` type to be passed in, as specified in the method's documentation.