### PR TITLE
Deal with the virtualenv .Python link being broken

### DIFF
--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -34,6 +34,11 @@ class Virtualenv(object):
     def exists(self):
         return os.path.isdir(self.path)
 
+    @property
+    def broken_link(self):
+        python_link = os.path.join(self.path, ".Python")
+        return os.path.lexists(python_link) and not os.path.exists(python_link)
+
     def create(self):
         if os.path.exists(self.path):
             shutil.rmtree(self.path)
@@ -88,7 +93,7 @@ class Virtualenv(object):
         execfile(path, {"__file__": path})  # noqa: F821
 
     def start(self):
-        if not self.exists:
+        if not self.exists or self.broken_link:
             self.create()
         self.activate()
 


### PR DESCRIPTION
This happens relatively frequently on macOS when using Homebrew, as
Homebrew installs into versioned paths, so following an upgrade and
a cleanup of the old install, the old path no longer exists.