### PR TITLE
math-script-level-004: Fix expectation for the font-size values.

### DIFF
--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-004.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-004.tentative.html
@@ -94,11 +94,12 @@
           }, "scriptPercentScaleDown=80, scriptScriptPercentScaleDown=40");
 
           test(function() {
+              var scriptPercentScaleDown = .71;
               CheckFontSizes("scale0-40-scaledown", {
                   "-3": big,
                   "-1": big * .71 * .71,
                   "0": big * .71 * .71 * .71,
-                  "1": big * .71 * .71 * .71 * .71,
+                  "1": big * .71 * .71 * .71 * scriptPercentScaleDown,
                   "2": big * .71 * .71 * .71 * .4,
                   "3": big * .71 * .71 * .71 * .4 * .71,
                   "5": big * .71 * .71 * .71 * .4 * .71 * .71 * .71
@@ -107,7 +108,7 @@
                   "5": small,
                   "3": small / (.71 * .71),
                   "2": small / (.71 * .71 * .71),
-                  "1": small / (.71 * .71 * .71 * (.4 / .71)),
+                  "1": small / (.71 * .71 * .71 * (.4 / scriptPercentScaleDown)),
                   "0": small  / (.71 * .71 * .71 * .4),
                   "-1": small / (.71 * .71 * .71 * .4 * .71),
                   "-3": small / (.71 * .71 * .71 * .4 * .71 * .71 * .71)
@@ -115,23 +116,24 @@
           }, "scriptPercentScaleDown=0, scriptScriptPercentScaleDown=40");
 
           test(function() {
+              var scriptScriptPercentScaleDown = 0.5041;
               CheckFontSizes("scale80-0-scaledown", {
                   "-3": big,
                   "-1": big * .71 * .71,
                   "0": big * .71 * .71 * .71,
                   "1": big * .71 * .71 * .71 * .8,
-                  "2": big * .71 * .71 * .71 * .71 * .71,
-                  "3": big * .71 * .71 * .71 * .71 * .71 * .71,
-                  "5": big * .71 * .71 * .71 * .71 * .71 * .71 * .71 * .71
+                  "2": big * .71 * .71 * .71 * scriptScriptPercentScaleDown,
+                  "3": big * .71 * .71 * .71 * scriptScriptPercentScaleDown * .71,
+                  "5": big * .71 * .71 * .71 * scriptScriptPercentScaleDown * .71 * .71 * .71
               });
               CheckFontSizes("scale80-0-scaleup", {
                   "5": small,
                   "3": small / (.71 * .71),
                   "2": small / (.71 * .71 * .71),
-                  "1": small / (.71 * .71 * .71 * (.71 / .8)),
-                  "0": small  / (.71 * .71 * .71 * .71),
-                  "-1": small / (.71 * .71 * .71 * .71 * .71),
-                  "-3": small / (.71 * .71 * .71 * .71 * .71 * .71 * .71)
+                  "1": small / (.71 * .71 * .71 * (scriptScriptPercentScaleDown / .8)),
+                  "0": small  / (.71 * .71 * .71 * scriptScriptPercentScaleDown),
+                  "-1": small / (.71 * .71 * .71 * scriptScriptPercentScaleDown * .71),
+                  "-3": small / (.71 * .71 * .71 * scriptScriptPercentScaleDown * .71 * .71 * .71)
               });
           }, "scriptPercentScaleDown=80, scriptScriptPercentScaleDown=0");
 


### PR DESCRIPTION
When the MATH table has scriptScriptPercentScaleDown the spec says 0.5041 = 0.71^2 should be used as the default value.
The scale80-0-scaleup test incorrectly uses a hardcoded value of 0.71 instead.
This patch fixes this issue and introduces new variables for the fallback values of scriptPercentScaleDown and scriptScriptPercentScaleDown
to clarify the expectation.