### PR TITLE
[cssom-view] Replace bounds with getBounds()

### DIFF
--- a/css/cssom-view/cssom-getBoxQuads-001.html
+++ b/css/cssom-view/cssom-getBoxQuads-001.html
@@ -35,16 +35,16 @@
   <script>
     test(function() {
       let bb = document.getElementById("block-block");
-      assert_equals(bb.getBoxQuads({box: "border"})[0].bounds.width,  20, "Block layout border box is expected width.");
-      assert_equals(bb.getBoxQuads({box: "margin"})[0].bounds.width, 100, "Block layout margin box is expected width.");
+      assert_equals(bb.getBoxQuads({box: "border"})[0].getBounds().width,  20, "Block layout border box is expected width.");
+      assert_equals(bb.getBoxQuads({box: "margin"})[0].getBounds().width, 100, "Block layout margin box is expected width.");
 
       // For containers that expand items to fill block-axis space, measure the box heights also.
       let fb = document.getElementById("flex-block");
-      assert_equals(fb.getBoxQuads({box: "border"})[0].bounds.width,  20, "Flex layout border box is expected width.");
-      assert_equals(fb.getBoxQuads({box: "margin"})[0].bounds.width, 100, "Flex layout margin box is expected width.");
+      assert_equals(fb.getBoxQuads({box: "border"})[0].getBounds().width,  20, "Flex layout border box is expected width.");
+      assert_equals(fb.getBoxQuads({box: "margin"})[0].getBounds().width, 100, "Flex layout margin box is expected width.");
 
-      assert_equals(fb.getBoxQuads({box: "border"})[0].bounds.height, 10, "Flex layout border box is expected height.");
-      assert_equals(fb.getBoxQuads({box: "margin"})[0].bounds.height, 50, "Flex layout margin box is expected height.");
+      assert_equals(fb.getBoxQuads({box: "border"})[0].getBounds().height, 10, "Flex layout border box is expected height.");
+      assert_equals(fb.getBoxQuads({box: "margin"})[0].getBounds().height, 50, "Flex layout margin box is expected height.");
     });
   </script>
  </body>


### PR DESCRIPTION
`bounds` has been removed from [the geometry spec](https://drafts.fxtf.org/geometry/#DOMQuad), so this fixes it.