### PR TITLE
Update MsEdgeDriver download to get driver binary based on channel info

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -225,6 +225,8 @@ jobs:
   - template: tools/ci/azure/update_manifest.yml
   - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-tbpl - --log-tbpl-level info --channel dev edgechromium infrastructure/
     displayName: 'Run tests (Edge Dev)'
+  - script: python ./wpt run --yes --no-manifest-update --install-fonts --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-tbpl - --log-tbpl-level info --channel canary edgechromium infrastructure/
+    displayName: 'Run tests (Edge Canary)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
     inputs:
@@ -258,6 +260,8 @@ jobs:
   - template: tools/ci/azure/update_manifest.yml
   - script: python ./wpt run --yes --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt --log-tbpl - --log-tbpl-level info --channel dev edgechromium
     displayName: 'Run tests (Edge Dev)'
+  - script: python ./wpt run --yes --no-manifest-update --no-restart-on-unexpected --no-fail-on-unexpected --install-fonts --this-chunk $(System.JobPositionInPhase) --total-chunks $(System.TotalJobsInPhase) --chunk-type hash --log-wptreport $(Build.ArtifactStagingDirectory)/wpt_report_$(System.JobPositionInPhase).json --log-wptscreenshot $(Build.ArtifactStagingDirectory)/wpt_screenshot_$(System.JobPositionInPhase).txt --log-tbpl - --log-tbpl-level info --channel canary edgechromium
+    displayName: 'Run tests (Edge Canary)'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
     inputs:

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -28,7 +28,7 @@ def _get_fileversion(binary, logger=None):
         return None
 
 
-def handleRemoveReadonly(func, path, exc):
+def handle_remove_readonly(func, path, exc):
     excvalue = exc[1]
     if func in (os.rmdir, os.remove) and excvalue.errno == errno.EACCES:
         os.chmod(path, stat.S_IRWXU| stat.S_IRWXG| stat.S_IRWXO) # 0777
@@ -734,7 +734,7 @@ class EdgeChromium(Browser):
             os.remove(edgedriver_path)
             driver_notes_path = os.path.join(dest, "Driver_notes")
             if os.path.isdir(driver_notes_path):
-                shutil.rmtree(driver_notes_path, ignore_errors=False, onerror=handleRemoveReadonly)
+                shutil.rmtree(driver_notes_path, ignore_errors=False, onerror=handle_remove_readonly)
 
         self.logger.info("Downloading MSEdgeDriver from %s" % url)
         unzip(get(url).raw, dest)

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -738,7 +738,6 @@ class EdgeChromium(Browser):
 
         self.logger.info("Downloading MSEdgeDriver from %s" % url)
         unzip(get(url).raw, dest)
-        
         if os.path.isfile(edgedriver_path):
             self.logger.info("Successfully downloaded MSEdgeDriver to %s" % edgedriver_path)
         return find_executable(self.edgedriver_name, dest)

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -31,7 +31,7 @@ def _get_fileversion(binary, logger=None):
 def handle_remove_readonly(func, path, exc):
     excvalue = exc[1]
     if func in (os.rmdir, os.remove) and excvalue.errno == errno.EACCES:
-        os.chmod(path, stat.S_IRWXU| stat.S_IRWXG| stat.S_IRWXO) # 0777
+        os.chmod(path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
         func(path)
     else:
         raise
@@ -730,7 +730,7 @@ class EdgeChromium(Browser):
         # cleanup existing Edge driver files to avoid access_denied errors when unzipping
         if os.path.isfile(edgedriver_path):
             # remove read-only attribute
-            os.chmod(edgedriver_path, stat.S_IRWXU| stat.S_IRWXG| stat.S_IRWXO) # 0777
+            os.chmod(edgedriver_path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
             os.remove(edgedriver_path)
             driver_notes_path = os.path.join(dest, "Driver_notes")
             if os.path.isdir(driver_notes_path):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -338,6 +338,13 @@ class EdgeChromium(BrowserSetup):
     browser_cls = browser.EdgeChromium
 
     def setup_kwargs(self, kwargs):
+        browser_channel = kwargs["browser_channel"]
+        if kwargs["binary"] is None:
+            binary = self.browser.find_binary(channel=browser_channel)
+            if binary:
+                kwargs["binary"] = self.browser.find_binary()
+            else:
+                raise WptrunError("Unable to locate Edge binary")
         if kwargs["webdriver_binary"] is None:
             webdriver_binary = self.browser.find_webdriver()
 
@@ -346,7 +353,7 @@ class EdgeChromium(BrowserSetup):
 
                 if install:
                     logger.info("Downloading msedgedriver")
-                    webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path)
+                    webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path, channel=browser_channel)
             else:
                 logger.info("Using webdriver binary %s" % webdriver_binary)
 
@@ -354,11 +361,9 @@ class EdgeChromium(BrowserSetup):
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
                 raise WptrunError("Unable to locate or install msedgedriver binary")
-        if kwargs["browser_channel"] == "dev":
+        if browser_channel == "dev":
             logger.info("Automatically turning on experimental features for Edge Dev")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
-        # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/17403
-        kwargs["webdriver_args"].append("--disable-build-check")
 
 
 class Edge(BrowserSetup):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -348,7 +348,8 @@ class EdgeChromium(BrowserSetup):
         if kwargs["webdriver_binary"] is None:
             webdriver_binary = self.browser.find_webdriver()
 
-            if webdriver_binary is None:
+            # Install browser if none are found or if it's found in venv path
+            if webdriver_binary is None or self.venv.bin_path in webdriver_binary:
                 install = self.prompt_install("msedgedriver")
 
                 if install:

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -349,7 +349,7 @@ class EdgeChromium(BrowserSetup):
             webdriver_binary = self.browser.find_webdriver()
 
             # Install browser if none are found or if it's found in venv path
-            if webdriver_binary is None or self.venv.bin_path in webdriver_binary:
+            if webdriver_binary is None or webdriver_binary in self.venv.bin_path:
                 install = self.prompt_install("msedgedriver")
 
                 if install:


### PR DESCRIPTION
We've updated our driver download page to know include LATEST_{channel} files to allow us to download driver binaries that match the channel. This change updates our download code to use these files to get driver binary that matches the channel being tested. 

Additional changes:

- Updated the edgechromium code to set binary path, if it's not specified and to error if we fail to find it.

- Added Edge canary channel runs as we use WPT.fyi results to track regressions and would like to get regular runs from this channel.

- Removed workaround for #17403 