### PR TITLE
Sync Mozilla CSS tests as of 2019-06-26

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/reftest.list
@@ -75,6 +75,7 @@
 == object-fit-fill-svg-006i.html object-fit-fill-svg-006-ref.html
 == object-fit-fill-svg-006o.html object-fit-fill-svg-006-ref.html
 == object-fit-fill-svg-006p.html object-fit-fill-svg-006-ref.html
+# All the random-if(geckoview) failures in this file are tracked by bug 1558515
 == object-fit-contain-svg-001e.html object-fit-contain-svg-001-ref.html
 == object-fit-contain-svg-001i.html object-fit-contain-svg-001-ref.html
 == object-fit-contain-svg-001o.html object-fit-contain-svg-001-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-inlinize-blocks-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-inlinize-blocks-002-ref.html
@@ -5,6 +5,11 @@
   <title>CSS Reference: Inlinize block-level boxes inside ruby</title>
   <link rel="author" title="Xidorn Quan" href="mailto:quanxunzhen@gmail.com">
   <style>
+    body {
+      /* Use a sans-serif font to avoid fuzzy pixels where e.g. the
+         letter "a" bottom-right serif might overlap the table border: */
+      font: 16px sans-serif;
+    }
     .block, table, .flex {
       background-color: yellow;
       width: 100px; height: 30px;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-inlinize-blocks-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-inlinize-blocks-002.html
@@ -7,6 +7,11 @@
   <link rel="help" href="http://www.w3.org/TR/css-ruby-1/#anon-gen-inlinize">
   <link rel="match" href="ruby-inlinize-blocks-002-ref.html">
   <style>
+    body {
+      /* Use a sans-serif font to avoid fuzzy pixels where e.g. the
+         letter "a" bottom-right serif might overlap the table border: */
+      font: 16px sans-serif;
+    }
     .block, table, .flex {
       background-color: yellow;
       width: 100px; height: 30px;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-056-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-056-ref.html
@@ -3,7 +3,6 @@
     <head>
         <title>CSS Reference File</title>
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
-    </head>
     <style>
        body {
            margin: 0;
@@ -28,6 +27,7 @@
            background-color: green;
        }
     </style>
+    </head>
     <body>
         <p>The test passes if there is a green square to the right of the blue line. There should be no red.</p>
         <div id="container">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-056.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-056.html
@@ -15,7 +15,6 @@
                                      top left with a shape-margin. Additionally, the
                                      shape-outside: circle element is offset from
                                      its containing block.">
-    </head>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
     @font-face {
@@ -66,6 +65,7 @@
         z-index: -1;
     }
     </style>
+    </head>
     <body>
     <p>The test passes if there is a green square to the right of the blue line. There should be no red.</p>
     <div id="container">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-052-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-052-ref.html
@@ -3,7 +3,6 @@
     <head>
         <title>CSS Reference File</title>
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
-    </head>
     <style>
        body {
            margin: 0;
@@ -28,6 +27,7 @@
            background-color: green;
        }
     </style>
+    </head>
     <body>
         <p>The test passes if there is a green square to the right of the blue line. There should be no red.</p>
         <div id="container">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-052.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-052.html
@@ -13,7 +13,6 @@
                                      a ellipse with a shape-margin in pixel units.
                                      Additionally, the shape-outside: ellipse element
                                      is offset from its containing block.">
-    </head>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
     @font-face {
@@ -64,6 +63,7 @@
         z-index: -1;
     }
     </style>
+    </head>
     <body>
     <p>The test passes if there is a green square to the right of the blue line. There should be no red.</p>
     <div id="container">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-032-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-032-ref.html
@@ -3,7 +3,6 @@
     <head>
         <title>CSS Reference File</title>
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
-    </head>
     <style>
        body {
             margin: 0;
@@ -17,6 +16,7 @@
           background-color: green;
       }
     </style>
+    </head>
     <body>
         <p>The test passes if there is green square and no red.</p>
         <div id="green-square"></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-032.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-032.html
@@ -14,7 +14,6 @@
                                      an polygon from the margin box with a shape margin.
                                      Additionally, the shape-outside: polygon element is
                                      offset from its containing block.">
-    </head>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         @font-face {
@@ -77,6 +76,7 @@
             height: 60px;
         }
     </style>
+    </head>
     <body>
     <p>The test passes if there is green square and no red.</p>
     <div id="red"></div>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/91c42888cf7fa67f2b9d08d0e62cb203ad1e6619 .

This contains changes from two bugs:
* [bug 1558849](https://bugzilla.mozilla.org/show_bug.cgi?id=1558849) by @dholbert, reviewed by @jfkthame (the ruby/ changes)
* [bug 1561351](https://bugzilla.mozilla.org/show_bug.cgi?id=1561351) by me, reviewed by @dholbert (the shapes1/ changes)