### PR TITLE
Sync Mozilla CSS tests as of 2019-06-27

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-select-elem-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-select-elem-001-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
+  <style>
+  select {
+    color: transparent;
+  }
+  .minWidth {
+    min-width: 100px;
+  }
+  .width {
+    width: 100px;
+  }
+  .floatLWidth {
+    float: left;
+    width: 100px;
+  }
+  </style>
+</head>
+<body>
+  <select class="floatLWidth">
+  </select>
+  <br style="clear:both;">
+
+  <select class="minWidth">
+  </select>
+  <br>
+
+  <select class="width">
+  </select>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-select-elem-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-select-elem-001.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: 'contain: size' on select objects should cause them to be sized as if they have no contents.</title>
+  <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-size">
+  <link rel="match" href="contain-size-select-elem-001-ref.html">
+  <style>
+  select {
+    contain: size;
+    color: transparent;
+  }
+  .minWidth {
+    min-width: 100px;
+  }
+  .width {
+    width: 100px;
+  }
+  .floatLWidth {
+    float: left;
+    width: 100px;
+  }
+  </style>
+</head>
+<body>
+  <select class="floatLWidth">
+    <option>CSS Test: A size-contained floated select with specified width and no specified height should size itself as if it had no contents.</option>
+    <option>a</option>
+    <option>b</option>
+    <option>c</option>
+  </select>
+  <br style="clear:both;">
+
+  <select class="minWidth">
+    <option>CSS Test: A size-contained select with specified min-width should size itself as if it had no contents.</option>
+    <option>a</option>
+    <option>b</option>
+    <option>c</option>
+  </select>
+  <br>
+
+  <select class="width">
+    <option>CSS Test: A size-contained select with specified width should size itself as if it had no contents.</option>
+    <option>a</option>
+    <option>b</option>
+    <option>c</option>
+  </select>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-select-elem-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-select-elem-002-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
+  <style>
+  select {
+    color: transparent;
+  }
+  .floatLBasic {
+    float: left;
+  }
+  </style>
+</head>
+<body>
+  <select>
+  </select>
+  <br>
+
+  <select class="floatLBasic">
+  </select>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-select-elem-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-select-elem-002.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: 'contain: size' on select objects should cause them to be sized as if they have no contents.</title>
+  <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-size">
+  <link rel="match" href="contain-size-select-elem-002-ref.html">
+  <style>
+  select {
+    contain: size;
+    color: transparent;
+  }
+  .floatLBasic {
+    float: left;
+  }
+  </style>
+</head>
+<body>
+  <select>
+    <option>CSS Test: A size-contained select with no specified size should size itself as if it had no contents.</option>
+    <option>aaaaaa</option>
+    <option>b</option>
+    <option>c</option>
+  </select>
+  <br>
+
+  <select class="floatLBasic">
+    <option>CSS Test: A size-contained floated select with no specified size should size itself as if it had no contents.</option>
+    <option>a</option>
+    <option>b</option>
+    <option>c</option>
+  </select>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
@@ -34,6 +34,8 @@
 == contain-size-fieldset-002.html contain-size-fieldset-002-ref.html
 == contain-size-multicol-002.html contain-size-multicol-002-ref.html
 == contain-size-multicol-003.html contain-size-multicol-003-ref.html
+== contain-size-select-elem-001.html contain-size-select-elem-001-ref.html
+== contain-size-select-elem-002.html contain-size-select-elem-002-ref.html
 == contain-layout-overflow-001.html contain-layout-overflow-001-ref.html
 == contain-layout-overflow-002.html contain-layout-overflow-002-ref.html
 == contain-size-table-caption-001.html contain-size-table-caption-001-ref.html


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/9ee669c657c79b26a6ec0df246cc5bfe2b1d9a9a .

This contains changes from [bug 1561717](https://bugzilla.mozilla.org/show_bug.cgi?id=1561717) by @MReschenberg, reviewed by @dholbert.