### PR TITLE
HTML: applet no longer exists

### DIFF
--- a/html/dom/elements-obsolete.js
+++ b/html/dom/elements-obsolete.js
@@ -1,17 +1,4 @@
 var obsoleteElements = {
-  applet: {
-    align: "string",
-    alt: "string",
-    archive: "string",
-    code: "string",
-    codeBase: "url",
-    height: "string",
-    hspace: "unsigned long",
-    name: "string",
-    object: "url",
-    vspace: "unsigned long",
-    width: "string",
-  },
   marquee: {
     behavior: {
       type: {


### PR DESCRIPTION
For HTML purposes that's "worse" than obsolete.

In the same directory there's historical.html to ensure it won't be added again.

Fixes #17559.