### PR TITLE
Screen Orientation: Fix lock-unlock-check.html

### DIFF
--- a/screen-orientation/lock-unlock-check.html
+++ b/screen-orientation/lock-unlock-check.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script>
+<script type="module">
   import { getOppositeOrientation } from "/screen-orientation/resources/orientation-utils.js";
   promise_test(async t => {
     await test_driver.bless("request full screen", () => {
@@ -15,10 +15,10 @@
     // This one resolves, because we are re-locking.
     const pMustResolve = new Promise(r => {
       screen.orientation.onchange = () => {
-        r(orientation.lock("any"));
+        r(screen.orientation.lock("any"));
       };
     });
-    await promise_rejects(t, new TypeError(), pMustReject);
+    await promise_rejects(t, "AbortError", pMustReject);
     await pMustResolve;
     screen.orientation.unlock();
     return document.exitFullscreen();

--- a/screen-orientation/resources/orientation-utils.js
+++ b/screen-orientation/resources/orientation-utils.js
@@ -13,5 +13,5 @@ export async function loadIframe(src = "/screen-orientation/resources/blank.html
 export function getOppositeOrientation() {
   const { type: currentOrientation } = screen.orientation;
   const isPortrait = currentOrientation.includes("portrait");
-  return (newOrientation = `${isPortrait ? "landscape" : "portrait"}`);
+  return isPortrait ? "landscape" : "portrait";
 }


### PR DESCRIPTION
Resolves #17547 where the `screen-orientation/lock-unlock-check` test failed due to an import outside of a module.

Changes:

- The script is now a module to allow the import.
- On the `onchange` event, we use the full reference to the lock function, as orientation is not defined.
- The type which the lock promise rejects with has been updated, to match https://www.w3.org/TR/screen-orientation/#apply-an-orientation-lock.
- We no longer create an unused variable in `getOppositeOrientation`, as undeclared variables cannot be set in the module's strict mode, and the variable wasn't being used anyway.