### PR TITLE
Restore webidl2.js.headers.

### DIFF
--- a/resources/webidl2/lib/webidl2.js.headers
+++ b/resources/webidl2/lib/webidl2.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8


### PR DESCRIPTION
It was added in #6685 and removed accidentally in #16864.