### PR TITLE
Corrected 'padding-left: auto' in c412-blockw-000.xht test

### DIFF
--- a/css/CSS2/css1/c412-blockw-000.xht
+++ b/css/CSS2/css1/c412-blockw-000.xht
@@ -23,7 +23,7 @@
    p.six {margin-left: auto; width: auto; margin-right: 0;}
    p.seven {margin-left: 0; width: auto; margin-right: auto;}
    p.eight {margin-left: auto; width: auto; margin-right: auto;}
-   p.nine {padding-left: auto; padding-right: auto; margin-left: 0; margin-right: 0; width: 50%;}
+   p.nine {padding-left: 0; padding-right: 0; margin-left: 0; margin-right: 0; width: 50%;}
    p.ten {margin-left: auto; width: 100%; margin-right: auto;}
   ]]></style>
   <link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#blockwidth" title="10.3.3 Block-level, non-replaced elements in normal flow"/>


### PR DESCRIPTION
Corrected 'padding-left: auto' and 'padding-right: auto' in c412-blockw-000.xht test
Credits should go to Tony Graham @tgraham-antenna for initially reporting these errors in [Issue 6960](https://github.com/web-platform-tests/wpt/issues/6960)