### PR TITLE
[cssom-view] Correct the expectedX and create direction:rtl case for ScrollIntoViewOptions

### DIFF
--- a/css/cssom-view/scrollIntoView-direction-rtl.html
+++ b/css/cssom-view/scrollIntoView-direction-rtl.html
@@ -2,7 +2,7 @@
 <title>CSSOM View - scrollIntoView considers direction:rtl</title>
 <meta charset="utf-8">
 <link rel="author" title="Cathie Chen" href="mailto:cathiechen@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#beginning-edges">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 

--- a/css/cssom-view/scrollIntoView-direction-rtl.html
+++ b/css/cssom-view/scrollIntoView-direction-rtl.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<title>CSSOM View - scrollIntoView considers vertical-rl writing mode</title>
+<title>CSSOM View - scrollIntoView considers direction:rtl</title>
 <meta charset="utf-8">
-<link rel="author" title="Suneel Kota" href="mailto:suneel.kota@samsung.com">
+<link rel="author" title="Cathie Chen" href="mailto:cathiechen@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -29,14 +29,11 @@
 <body>
 <div id="scroller">
   <div id="container">
-
-    <!-- ROW-2 -->
     <div class="row">
       <div class="box"></div>
       <div class="box" id="target"></div>
       <div class="box"></div>
     </div>
-
   </div>
 </div>
 
@@ -45,11 +42,12 @@ var target = document.getElementById("target");
 var scroller = document.getElementById("scroller");
 var box_width = target.offsetWidth;
 
+// Get the left edge of scrolling area.
 scroller.scrollLeft = -10000;
 var leftEdge = scroller.scrollLeft + box_width;
+// Get the right edge of scrolling area.
 scroller.scrollLeft = 10000;
 var rightEdge = scroller.scrollLeft - box_width;
-
 
 test(() => {
   scroller.scrollTo(0, 0);
@@ -62,7 +60,6 @@ test(() => {
   target.scrollIntoView({inline: "end"});
   assert_approx_equals(scroller.scrollLeft, leftEdge, 0.5, "end should be the left edge");
 }, `scrollIntoView({inline: "end"}), direction: rtl`);
-
 </script>
 
 </body>

--- a/css/cssom-view/scrollIntoView-direction-rtl.html
+++ b/css/cssom-view/scrollIntoView-direction-rtl.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<title>CSSOM View - scrollIntoView considers vertical-rl writing mode</title>
+<meta charset="utf-8">
+<link rel="author" title="Suneel Kota" href="mailto:suneel.kota@samsung.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+.box {
+  float: left;
+  width: 200px;
+  height: 200px;
+}
+#scroller {
+  direction: rtl;
+  overflow-x: scroll;
+  width: 300px;
+  height: 215px;
+}
+#container{
+  width: 600px;
+  height: 200px;
+}
+#target {
+  background-color: #ff0;
+}
+</style>
+<body>
+<div id="scroller">
+  <div id="container">
+
+    <!-- ROW-2 -->
+    <div class="row">
+      <div class="box"></div>
+      <div class="box" id="target"></div>
+      <div class="box"></div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+var target = document.getElementById("target");
+var scroller = document.getElementById("scroller");
+var box_width = target.offsetWidth;
+
+scroller.scrollLeft = -10000;
+var leftEdge = scroller.scrollLeft + box_width;
+scroller.scrollLeft = 10000;
+var rightEdge = scroller.scrollLeft - box_width;
+
+
+test(() => {
+  scroller.scrollTo(0, 0);
+  target.scrollIntoView({inline: "start"});
+  assert_approx_equals(scroller.scrollLeft, rightEdge, 0.5, "start should be the right edge");
+}, `scrollIntoView({inline: "start"}), direction: rtl`);
+
+test(() => {
+  scroller.scrollTo(0, 0);
+  target.scrollIntoView({inline: "end"});
+  assert_approx_equals(scroller.scrollLeft, leftEdge, 0.5, "end should be the left edge");
+}, `scrollIntoView({inline: "end"}), direction: rtl`);
+
+</script>
+
+</body>
+</html>

--- a/css/cssom-view/scrollIntoView-vertical-rl-writing-mode.html
+++ b/css/cssom-view/scrollIntoView-vertical-rl-writing-mode.html
@@ -69,7 +69,7 @@ var expectedY = [ box_height, ((3*box_height - scroller_height)/2) + (scrollbar_
 // in a right-to-left mode, we adjust the expectation
 // to match the semantics of scrollLeft.
 if(scroller.scrollLeft === 0)
-  expectedX = [ -box_width, -(((3*box_width - scroller_width)/2)+ (scrollbar_width/2)), -(((2*box_width)-scroller_width)+scrollbar_width)];
+  expectedX = [ -(box_width - scrollbar_width), -(((3*box_width - scroller_width)/2) + (scrollbar_width/2) - scrollbar_width), -((2*box_width) - scroller_width) ];
 
 // This formats dict as a string suitable as test name.
 // format_value() is provided by testharness.js,


### PR DESCRIPTION
In scrollIntoView-vertical-rl-writing-mode.html, the origin is at the left top padding edge of the Element, scroll bar is inside padding edges.
So the visible width is scroller_width - scrollbar_width, and expectedX should be moved left.

There's no direction:rtl case for ScrollIntoViewOptions. According to the spec, leftward and downward element, the beginning edges are the top and right edges. The end edges are the bottom and left edges.
scrollIntoView-direction-rtl.html tests the horizontal edges.