### PR TITLE
Revert "[Gecko Bug 1552671] [wpt PR 16911] - Revert "Portals: Add test that portals can't load data, javascript or about URLs.", a=testonly"

### DIFF
--- a/portals/portal-non-http-navigation.html
+++ b/portals/portal-non-http-navigation.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Tests that portal don't navigate to non-http schemes.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+async_test(t => {
+  var portal = document.createElement("portal");
+  portal.src = "data:text/html,empty portal";
+  portal.onload = t.unreached_func("Portal loaded data URL.");
+  document.body.appendChild(portal);
+  t.step_timeout(() => { portal.remove(); t.done(); }, 3000);
+}, "Tests that a portal can't navigate to a data URL.");
+
+async_test(t => {
+  var portal = document.createElement("portal");
+  portal.src = "about:blank";
+  portal.onload = t.unreached_func("Portal loaded about:blank.");
+  document.body.appendChild(portal);
+  t.step_timeout(() => { portal.remove(); t.done(); }, 3000);
+}, "Tests that a portal can't navigate to about:blank.");
+
+async_test(t => {
+  var portal = document.createElement("portal");
+  portal.src = "resources/simple-portal.html";
+  portal.onload = t.step_func(() => {
+    portal.onmessage = t.unreached_func("Portal execute javascript.");
+    portal.src = "javascript:window.portalHost.postMessage('executed', '*')";
+    t.step_timeout(() => { portal.remove(); t.done(); }, 3000);
+  });
+  document.body.appendChild(portal);
+}, "Tests that a portal can't navigate to javascript URLs.");
+</script>
+</body>


### PR DESCRIPTION
Reverts web-platform-tests/wpt#17457.

It appears that @moz-wptsync-bot mistakenly re-exported the original revert after it was merged into mozilla-central for a second time (weeks after the reland by @chromium-wpt-export-bot). This reverts that revert to make the test exist once again.

Left a [comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1552671#c9) the Bugzilla bug.