### PR TITLE
[tools] Remove use of deprecated API

### DIFF
--- a/tools/wptserve/tests/functional/test_response.py
+++ b/tools/wptserve/tests/functional/test_response.py
@@ -160,7 +160,7 @@ class TestResponse(TestUsingServer):
     def test_write_raw_none(self):
         @wptserve.handlers.handler
         def handler(request, response):
-            with pytest.raises(ValueError, message="data cannot be None"):
+            with pytest.raises(ValueError):
                 response.writer.write_raw_content(None)
 
         route = ("GET", "/test/test_write_raw_content", handler)


### PR DESCRIPTION
The "message" parameter of Pytests's `raises` method has been deprecated
[1]. This causes a test failure in the current configuration. Since the
parameter was not previously serving the intended purpose (that is, it
was *not* verifying the message of the raised exception), it may be
removed without degrading coverage.

[1] https://docs.pytest.org/en/4.6-maintenance/deprecations.html#message-parameter-of-pytest-raises