### PR TITLE
[ci] Disable terminal colors in Taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -222,6 +222,7 @@ tasks:
           script: >-
             export TOXENV=py27;
             export HYPOTHESIS_PROFILE=ci;
+            export PY_COLORS=0;
             ./tools/ci/run_tc.py \
               tools_unittest \
               tools/ci/ci_tools_unittest.sh
@@ -234,6 +235,7 @@ tasks:
           script: >-
             export TOXENV=py36;
             export HYPOTHESIS_PROFILE=ci;
+            export PY_COLORS=0;
             sudo apt update -qqy;
             sudo apt install -qqy python3-pip;
             ./tools/ci/run_tc.py \

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -13,6 +13,7 @@ commands = pytest {posargs}
 
 passenv =
   HYPOTHESIS_PROFILE
+  PY_COLORS
 
 [testenv:py27-flake8]
 deps = -rrequirements_flake8.txt


### PR DESCRIPTION
The logs are a bit difficult to interpret when they contain control codes for terminal colors. Pytest generally detects the absence of a TTY and disables colors accordingly, but it looks like Taskcluster is allocating on.