### PR TITLE
HTML: WPT for tabIndex

### DIFF
--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
@@ -12,11 +12,14 @@
 <button hidden>button</button>
 <a>a</a>
 <a href="#">a</a>
+<link id="nohref">
 <textarea></textarea>
-<select></select>
+<select><optgroup><option>option</option></optgroup></select>
+<select multiple></select>
 <iframe width="10" height="10"></iframe>
 <span></span>
 <div></div>
+<details><summary>summary</summary><summary id="secondsummary">second summary</summary>details</details>
 <div id="hostDelegatesFocus"></div>
 <div id="hostNonDelegatesFocus"></div>
 <script>
@@ -32,9 +35,17 @@ const defaultList = [
   ["a[href]", 0],
   ["textarea", 0],
   ["select", 0],
+  ["select[multiple]", 0],
+  ["option", -1],
+  ["optgroup", -1],
   ["iframe", 0],
   ["span", -1],
   ["div", -1],
+  ["link#nohref", -1],
+  ["link[href]", -1],
+  ["details", -1],
+  ["summary", 0],
+  ["summary#secondsummary", -1],
   ["#hostDelegatesFocus", -1],
   ["#hostNonDelegatesFocus", -1],
 ];

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
@@ -12,11 +12,15 @@
 <button hidden>button</button>
 <a>a</a>
 <a href="#">a</a>
+<svg><a>svg a</a></svg>
+<svg><a>svg a</a></svg>
 <link id="nohref">
 <textarea></textarea>
 <select><optgroup><option>option</option></optgroup></select>
 <select multiple></select>
 <iframe width="10" height="10"></iframe>
+<embed width="10" height="10"></embed>
+<object width="10" height="10"></object>
 <span></span>
 <div></div>
 <details><summary>summary</summary><summary id="secondsummary">second summary</summary>details</details>
@@ -33,12 +37,15 @@ const defaultList = [
   ["button[hidden]", 0],
   ["a", 0],
   ["a[href]", 0],
+  ["svg a", 0],
   ["textarea", 0],
   ["select", 0],
   ["select[multiple]", 0],
   ["option", -1],
   ["optgroup", -1],
   ["iframe", 0],
+  ["embed", 0],
+  ["object", 0],
   ["span", -1],
   ["div", -1],
   ["link#nohref", -1],

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: tabIndex getter return value</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<input>
+<input type="hidden">
+<button>button</button>
+<button disabled>button</button>
+<button hidden>button</button>
+<a>a</a>
+<a href="#">a</a>
+<textarea></textarea>
+<select></select>
+<iframe width="10" height="10"></iframe>
+<span></span>
+<div></div>
+<div id="hostDelegatesFocus"></div>
+<div id="hostNonDelegatesFocus"></div>
+<script>
+hostDelegatesFocus.attachShadow({ mode: "open", delegatesFocus: true });
+hostNonDelegatesFocus.attachShadow({ mode: "open", delegatesFocus: false });
+
+const defaultList = [
+  ["input", 0],
+  ["input[type='hidden']", 0],
+  ["button", 0],
+  ["button[disabled]", 0],
+  ["button[hidden]", 0],
+  ["a", 0],
+  ["a[href]", 0],
+  ["textarea", 0],
+  ["select", 0],
+  ["iframe", 0],
+  ["span", -1],
+  ["div", -1],
+  ["#hostDelegatesFocus", -1],
+  ["#hostNonDelegatesFocus", -1],
+];
+
+const tabIndexValue = [-1, 0, 1];
+
+for (entry of defaultList) {
+  let element = document.querySelector(entry[0]);
+  test(() => {
+    assert_equals(element.tabIndex, entry[1]);
+  }, entry[0] + ".tabIndex should return " + entry[1] + " by default");
+
+  for (setValue of tabIndexValue ) {
+    test(() => {
+      element.setAttribute("tabindex", setValue);
+      assert_equals(element.tabIndex, setValue);
+    }, entry[0] + ".tabIndex should return " + setValue + " when set to " + setValue);
+  }
+}
+</script>
+</body>
+

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
@@ -20,8 +20,8 @@
 <div id="hostDelegatesFocus"></div>
 <div id="hostNonDelegatesFocus"></div>
 <script>
-hostDelegatesFocus.attachShadow({ mode: "open", delegatesFocus: true });
-hostNonDelegatesFocus.attachShadow({ mode: "open", delegatesFocus: false });
+document.getElementById("hostDelegatesFocus").attachShadow({ mode: "open", delegatesFocus: true });
+document.getElementById("hostNonDelegatesFocus").attachShadow({ mode: "open", delegatesFocus: false });
 const defaultList = [
   ["input", 0],
   ["input[type='hidden']", 0],

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
@@ -22,7 +22,6 @@
 <script>
 hostDelegatesFocus.attachShadow({ mode: "open", delegatesFocus: true });
 hostNonDelegatesFocus.attachShadow({ mode: "open", delegatesFocus: false });
-
 const defaultList = [
   ["input", 0],
   ["input[type='hidden']", 0],
@@ -39,16 +38,13 @@ const defaultList = [
   ["#hostDelegatesFocus", -1],
   ["#hostNonDelegatesFocus", -1],
 ];
-
 const tabIndexValue = [-1, 0, 1];
-
-for (entry of defaultList) {
-  let element = document.querySelector(entry[0]);
+for (const entry of defaultList) {
+  const element = document.querySelector(entry[0]);
   test(() => {
     assert_equals(element.tabIndex, entry[1]);
   }, entry[0] + ".tabIndex should return " + entry[1] + " by default");
-
-  for (setValue of tabIndexValue ) {
+  for (const setValue of tabIndexValue ) {
     test(() => {
       element.setAttribute("tabindex", setValue);
       assert_equals(element.tabIndex, setValue);

--- a/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
+++ b/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/tabindex-getter.html
@@ -44,7 +44,7 @@ const defaultList = [
   ["option", -1],
   ["optgroup", -1],
   ["iframe", 0],
-  ["embed", 0],
+  ["embed", -1],
   ["object", 0],
   ["span", -1],
   ["div", -1],


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/4754 for the spec change.

This is consistent with behaviors in Chrome, Safari, Firefox - see table in https://github.com/whatwg/html/issues/4464#issue-427037877(though Chrome is failing for the case with shadow host with delegatesFocus=true)