### PR TITLE
Allow trailing slash in test_get_current_url_file_protocol

### DIFF
--- a/webdriver/tests/get_current_url/get.py
+++ b/webdriver/tests/get_current_url/get.py
@@ -52,6 +52,8 @@ def test_get_current_url_file_protocol(session, server_config):
     session.url = url
 
     response = get_current_url(session)
+    if response.status == 200 and response.body['value'].endswith('/'):
+        url += '/'
     assert_success(response, url)
 
 


### PR DESCRIPTION
Chrome automatically adds a trailing slash if the suffix of the file protocol is a directory. Chromedriver currently fails this test due to this trailing slash (the rest of the URL is identical). This changelist considers  urls with and without a trailing slash correct.