### PR TITLE
Support .mjs as a javascript suffix

### DIFF
--- a/tools/wptserve/wptserve/constants.py
+++ b/tools/wptserve/wptserve/constants.py
@@ -20,7 +20,7 @@ content_types = utils.invert_dict({
     "text/css": ["css"],
     "text/event-stream": ["event_stream"],
     "text/html": ["htm", "html"],
-    "text/javascript": ["js"],
+    "text/javascript": ["js", "mjs"],
     "text/plain": ["txt", "md"],
     "text/vtt": ["vtt"],
     "video/mp4": ["mp4", "m4v"],


### PR DESCRIPTION
Current situation forces test authors to name their module-JS files `.js` which is confusing for human and tooling.