### PR TITLE
Web Audio: SharedArrayBuffer and COOP/COEP

### DIFF
--- a/webaudio/the-audio-api/the-audiobuffer-interface/audiobuffer-copy-channel.html
+++ b/webaudio/the-audio-api/the-audiobuffer-interface/audiobuffer-copy-channel.html
@@ -149,22 +149,20 @@
           buffer.copyFromChannel(x, 3);
         }, '7: buffer.copyFromChannel(x, 3)').throw(DOMException, 'IndexSizeError');
 
-        if (window.SharedArrayBuffer) {
-          let shared_buffer = new Float32Array(new SharedArrayBuffer(32));
-          should(
-              () => {
-                buffer.copyFromChannel(shared_buffer, 0);
-              },
-              '8: buffer.copyFromChannel(SharedArrayBuffer view, 0)')
-              .throw(TypeError);
+        let shared_buffer = new Float32Array(new SharedArrayBuffer(32));
+        should(
+            () => {
+              buffer.copyFromChannel(shared_buffer, 0);
+            },
+            '8: buffer.copyFromChannel(SharedArrayBuffer view, 0)')
+            .throw(TypeError);
 
-          should(
-              () => {
-                buffer.copyFromChannel(shared_buffer, 0, 0);
-              },
-              '9: buffer.copyFromChannel(SharedArrayBuffer view, 0, 0)')
-              .throw(TypeError);
-        }
+        should(
+            () => {
+              buffer.copyFromChannel(shared_buffer, 0, 0);
+            },
+            '9: buffer.copyFromChannel(SharedArrayBuffer view, 0, 0)')
+            .throw(TypeError);
 
         task.done();
       });
@@ -204,22 +202,20 @@
           buffer.copyToChannel(x, 3);
         }, '6: buffer.copyToChannel(x, 3)').throw(DOMException, 'IndexSizeError');
 
-        if (window.SharedArrayBuffer) {
-          let shared_buffer = new Float32Array(new SharedArrayBuffer(32));
-          should(
-              () => {
-                buffer.copyToChannel(shared_buffer, 0);
-              },
-              '7: buffer.copyToChannel(SharedArrayBuffer view, 0)')
-              .throw(TypeError);
+        let shared_buffer = new Float32Array(new SharedArrayBuffer(32));
+        should(
+            () => {
+              buffer.copyToChannel(shared_buffer, 0);
+            },
+            '7: buffer.copyToChannel(SharedArrayBuffer view, 0)')
+            .throw(TypeError);
 
-          should(
-              () => {
-                buffer.copyToChannel(shared_buffer, 0, 0);
-              },
-              '8: buffer.copyToChannel(SharedArrayBuffer view, 0, 0)')
-              .throw(TypeError);
-        }
+        should(
+            () => {
+              buffer.copyToChannel(shared_buffer, 0, 0);
+            },
+            '8: buffer.copyToChannel(SharedArrayBuffer view, 0, 0)')
+            .throw(TypeError);
 
         task.done();
       });

--- a/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-sharedarraybuffer.https.html
+++ b/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-sharedarraybuffer.https.html
@@ -16,65 +16,56 @@
 
       let filePath = 'processors/sharedarraybuffer-processor.js';
 
-      if (window.SharedArrayBuffer) {
-        audit.define(
-            'Test postMessage from AudioWorkletProcessor to AudioWorkletNode',
-            (task, should) => {
-              let workletNode =
-                  new AudioWorkletNode(context, 'sharedarraybuffer-processor');
-
-              // After it is created, the worklet will send a new
-              // SharedArrayBuffer to the main thread.
-              //
-              // The worklet will then wait to receive a message from the main
-              // thread.
-              //
-              // When it receives the message, it will check whether it is a
-              // SharedArrayBuffer, and send this information back to the main
-              // thread.
-
-              workletNode.port.onmessage = (event) => {
-                let data = event.data;
-                switch (data.state) {
-                  case 'created':
-                    should(
-                        data.sab instanceof SharedArrayBuffer,
-                        'event.data.sab from worklet is an instance of SharedArrayBuffer')
-                        .beTrue();
-
-                    // Send a SharedArrayBuffer back to the worklet.
-                    let sab = new SharedArrayBuffer(8);
-                    workletNode.port.postMessage(sab);
-                    break;
-
-                  case 'received message':
-                    should(data.isSab, 'event.data from main thread is an instance of SharedArrayBuffer')
-                        .beTrue();
-                    task.done();
-                    break;
-
-                  default:
-                    should(false,
-                           `Got unexpected message from worklet: ${data.state}`)
-                        .beTrue();
-                    task.done();
-                    break;
-                }
-              };
-
-              workletNode.port.onmessageerror = (event) => {
-                should(false, 'Got messageerror from worklet').beTrue();
-                task.done();
-              };
-            });
-      } else {
-        // NOTE(binji): SharedArrayBuffer is only enabled where we have site
-        // isolation.
-        audit.define('Skipping test because SharedArrayBuffer is not defined',
+      audit.define(
+          'Test postMessage from AudioWorkletProcessor to AudioWorkletNode',
           (task, should) => {
-            task.done();
+            let workletNode =
+                new AudioWorkletNode(context, 'sharedarraybuffer-processor');
+
+            // After it is created, the worklet will send a new
+            // SharedArrayBuffer to the main thread.
+            //
+            // The worklet will then wait to receive a message from the main
+            // thread.
+            //
+            // When it receives the message, it will check whether it is a
+            // SharedArrayBuffer, and send this information back to the main
+            // thread.
+
+            workletNode.port.onmessage = (event) => {
+              let data = event.data;
+              switch (data.state) {
+                case 'created':
+                  should(
+                      data.sab instanceof SharedArrayBuffer,
+                      'event.data.sab from worklet is an instance of SharedArrayBuffer')
+                      .beTrue();
+
+                  // Send a SharedArrayBuffer back to the worklet.
+                  let sab = new SharedArrayBuffer(8);
+                  workletNode.port.postMessage(sab);
+                  break;
+
+                case 'received message':
+                  should(data.isSab, 'event.data from main thread is an instance of SharedArrayBuffer')
+                      .beTrue();
+                  task.done();
+                  break;
+
+                default:
+                  should(false,
+                         `Got unexpected message from worklet: ${data.state}`)
+                      .beTrue();
+                  task.done();
+                  break;
+              }
+            };
+
+            workletNode.port.onmessageerror = (event) => {
+              should(false, 'Got messageerror from worklet').beTrue();
+              task.done();
+            };
           });
-      }
 
       context.audioWorklet.addModule(filePath).then(() => {
         audit.run();

--- a/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-sharedarraybuffer.https.html.headers
+++ b/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-sharedarraybuffer.https.html.headers
@@ -1,0 +1,2 @@
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp


### PR DESCRIPTION
Stop making SharedArrayBuffer usage conditional as it should always be enabled. postMessage() can fail however and only works if the appropriate headers are set, so add those to the worklet test. (I'm assuming here that worklets will inherit COEP without having to declare it.)