### PR TITLE
HTML: top-level data: URLs

### DIFF
--- a/html/browsers/browsing-the-web/navigating-across-documents/resources/redirect.py
+++ b/html/browsers/browsing-the-web/navigating-across-documents/resources/redirect.py
@@ -1,0 +1,4 @@
+def main(request, response):
+    location = request.GET.first("location")
+    response.status = 302
+    response.headers.set("Location", location)

--- a/html/browsers/browsing-the-web/navigating-across-documents/top-level-data-url.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/top-level-data-url.window.js
@@ -1,0 +1,10 @@
+async_test(t => {
+  const popup = window.open(`data:text/html,<script>alert(1)</script>`);
+  // TODO
+}, "Navigating a popup to a data: URL");
+
+async_test(t => {
+  const dataURL = encodeURIComponent(`data:text/html,<script>alert(1)</script>`);
+  const popup = window.open(`resources/redirect.py?location=${dataURL}`);
+  // TODO
+}, "Navigating a popup to a data: URL via a redirect");

--- a/html/browsers/browsing-the-web/navigating-across-documents/top-level-data-url.window.js
+++ b/html/browsers/browsing-the-web/navigating-across-documents/top-level-data-url.window.js
@@ -1,10 +1,20 @@
-async_test(t => {
-  const popup = window.open(`data:text/html,<script>alert(1)</script>`);
-  // TODO
-}, "Navigating a popup to a data: URL");
+// META: timeout=long
 
-async_test(t => {
-  const dataURL = encodeURIComponent(`data:text/html,<script>alert(1)</script>`);
-  const popup = window.open(`resources/redirect.py?location=${dataURL}`);
-  // TODO
-}, "Navigating a popup to a data: URL via a redirect");
+const dataURL = `data:text/html,...`;
+const encodedDataURL = encodeURIComponent(dataURL);
+
+[dataURL, `resources/redirect.py?location=${encodedDataURL}`].forEach(url => {
+  [undefined, "opener", "noopener", "noreferrer"].forEach(opener => {
+    async_test(t => {
+      const popup = window.open(url, "", opener);
+      t.step_timeout(() => {
+        if (opener === "noopener" || opener == "noreferrer") {
+          assert_equals(popup, null);
+        } else {
+          assert_true(popup.closed);
+        }
+        t.done();
+      }, 1500);
+    }, `Navigating a popup using window.open("${url}", "", "${opener}")`);
+  });
+});


### PR DESCRIPTION
What is the exact behavior that we want here?

Firefox behavior of closing the popups makes some sense to me and could be explained through COOP. In that the `data:` URL acts as if it creates a new browsing context group (which we then error and leave up to the user agent to figure out UX for).

cc @cdumez @mystor @natechapin @domenic @mikewest @JuniorHsu