### PR TITLE
[docs] Correct typo in example of user styles

### DIFF
--- a/docs/writing-tests/css-user-styles.md
+++ b/docs/writing-tests/css-user-styles.md
@@ -25,12 +25,12 @@ should not be applied.
 Harness style sheet rules:
 
 ``` css
-#userstyle
+.userstyle
 {
     color: green;
     display: none;
 }
-#nouserstyle
+.nouserstyle
 {
     color: red;
     display: none;


### PR DESCRIPTION
`userstyle` and `nouserstyle` are referenced as CSS class names in this
document, so they should be declared as such.