### PR TITLE
Amend test_document_element_is_interactable

### DIFF
--- a/webdriver/tests/element_send_keys/interactability.py
+++ b/webdriver/tests/element_send_keys/interactability.py
@@ -45,7 +45,7 @@ def test_document_element_is_interactable(session):
 
     response = element_send_keys(session, element, "foo")
     assert_success(response)
-    assert session.active_element == element or session.active_element == body
+    assert session.active_element in [element, body]
     assert result.property("value") == "foo"
 
 

--- a/webdriver/tests/element_send_keys/interactability.py
+++ b/webdriver/tests/element_send_keys/interactability.py
@@ -28,6 +28,27 @@ def test_body_is_interactable(session):
     assert session.active_element == element
     assert result.property("value") == "foo"
 
+
+def test_document_element_is_interactable(session):
+    session.url = inline("""
+        <html onkeypress="document.querySelector('input').value += event.key">
+          <input>
+        </html>
+    """)
+
+    body = session.find.css("body", all=False)
+    element = session.find.css(":root", all=False)
+    result = session.find.css("input", all=False)
+
+    # By default body is the active element
+    assert session.active_element == body
+
+    response = element_send_keys(session, element, "foo")
+    assert_success(response)
+    assert session.active_element == element or session.active_element == body
+    assert result.property("value") == "foo"
+
+
 def test_iframe_is_interactable(session):
     session.url = inline(iframe("""
         <body onkeypress="document.querySelector('input').value += event.key">

--- a/webdriver/tests/element_send_keys/interactability.py
+++ b/webdriver/tests/element_send_keys/interactability.py
@@ -28,27 +28,6 @@ def test_body_is_interactable(session):
     assert session.active_element == element
     assert result.property("value") == "foo"
 
-
-def test_document_element_is_interactable(session):
-    session.url = inline("""
-        <html onkeypress="document.querySelector('input').value += event.key">
-          <input>
-        </html>
-    """)
-
-    body = session.find.css("body", all=False)
-    element = session.find.css(":root", all=False)
-    result = session.find.css("input", all=False)
-
-    # By default body is the active element
-    assert session.active_element == body
-
-    response = element_send_keys(session, element, "foo")
-    assert_success(response)
-    assert session.active_element == element
-    assert result.property("value") == "foo"
-
-
 def test_iframe_is_interactable(session):
     session.url = inline(iframe("""
         <body onkeypress="document.querySelector('input').value += event.key">


### PR DESCRIPTION
ChromeDriver was failing this test despite being W3C compliant in this regard. The reason Chrome's webdriver failed was due to Chrome's HTMLDocument not being focusable. In contrast, Firefox's webdriver passes this test because Firefox's HTMLDocument is focusable. According to the W3 spec (linked below), HTMLDocument need not be focusable (can be seen through the absence of the focus method). Therefore this test should be removed since it does not test spec-compliance.

W3 spec:
https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-1006298752