### PR TITLE
[css-transforms] Avoid using assert_own_property on testing style properties.

### DIFF
--- a/css/css-transforms/css-transform-property-existence.html
+++ b/css/css-transforms/css-transform-property-existence.html
@@ -13,29 +13,21 @@
     <div id="test"></div>
     <div id="log"></div>
     <script>
-      test(function() {
-        assert_not_equals(document.getElementById("test").style.transform, undefined, "expect transform is not undefined");
-      }, "Check the existence of transform.");
-
-      test(function() {
-        assert_own_property(document.getElementById("test").style, "transform-origin", "expect transform-origin");
-      }, "Check the existence of transform-origin.");
-
-      test(function() {
-        assert_own_property(document.getElementById("test").style, "transform-style", "expect transform-style");
-      }, "Check the existence of transform-style.");
-
-      test(function() {
-        assert_own_property(document.getElementById("test").style, "perspective", "expect perspective");
-      }, "Check the existence of perspective.");
-
-      test(function() {
-        assert_own_property(document.getElementById("test").style, "perspective-origin", "expect perspective-origin");
-      }, "Check the existence of perspective-origin.");
-
-      test(function() {
-        assert_own_property(document.getElementById("test").style, "backface-visibility", "expect backface-visibility");
-      }, "Check the existence of backface-visibility.");
+      [
+        'transform',
+        'transform-origin',
+        'transform-style',
+        'perspective',
+        'perspective-origin',
+        'backface-visibility',
+      ].forEach(property => {
+        test(() => {
+          assert_true(
+            property in document.getElementById('test').style,
+            `expect ${property}`,
+          );
+        }, `Check the existence of ${property}.`);
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
These `assert_own_property` tests cause these CSS tests to fail on Firefox only, and I think these properties are not supposted to be own properties, so use a similar way as https://github.com/web-platform-tests/wpt/pull/16892, to test the existence of these properties.

cc @emilio 