### PR TITLE
Sync Mozilla CSS tests as of 2019-07-11

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-001p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-png-002p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-001e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-001i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-001o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-001p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-002e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-002i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-002o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-002p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-003e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-003e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-003i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-003i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-003o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-003o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-003p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-003p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-004e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-004e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-004i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-004i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-004o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-004o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-004p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-004p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-005e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-005e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-005i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-005i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-005o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-005o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-005p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-005p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-006e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-006e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-006i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-006i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-006o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-006o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-006p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-contain-svg-006p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-001p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-png-002p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-001e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-001i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-001o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-001p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-002e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-002i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-002o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-002p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-003e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-003e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-003i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-003i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-003o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-003o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-003p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-003p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-004e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-004e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-004i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-004i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-004o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-004o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-004p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-004p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-005e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-005e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-005i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-005i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-005o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-005o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-005p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-005p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-006e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-006e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-006i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-006i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-006o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-006o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-006p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-cover-svg-006p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-001p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-png-002p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-001e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-001i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-001o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-001p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-002e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-002i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-002o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-002p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-003e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-003e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-003i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-003i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-003o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-003o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-003p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-003p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-004e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-004e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-004i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-004i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-004o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-004o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-004p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-004p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-005e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-005e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-005i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-005i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-005o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-005o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-005p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-005p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-006e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-006e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-006i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-006i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-006o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-006o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-006p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-fill-svg-006p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-001p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-png-002p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-001e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-001i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-001o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-001p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-002e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-002i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-002o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-002p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-003e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-003e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-003i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-003i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-003o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-003o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-003p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-003p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-004e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-004e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-004i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-004i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-004o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-004o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-004p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-004p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-005e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-005e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-005i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-005i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-005o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-005o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-005p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-005p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-006e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-006e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-006i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-006i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-006o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-006o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-006p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-none-svg-006p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-001p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002c.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
     <script>
       function drawImageToCanvases(imageURI) {

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002e.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002i.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002o.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-png-002p.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-001e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-001e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-001i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-001i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-001o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-001o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-001p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-001p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-002e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-002e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-002i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-002i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-002o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-002o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-002p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-002p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-003e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-003e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-003i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-003i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-003o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-003o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-003p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-003p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-004e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-004e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-004i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-004i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-004o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-004o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-004p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-004p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-005e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-005e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-005i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-005i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-005o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-005o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-005p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-005p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-006e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-006e.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-006i.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-006i.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-006o.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-006o.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-006p.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/object-fit-scale-down-svg-006p.html
@@ -40,8 +40,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/support/template-object-fit-test.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/support/template-object-fit-test.html
@@ -41,8 +41,8 @@
       .tl { object-position: top 25% left 25% }
       .br { object-position: bottom 1px right 2px }
 
-      .tc { object-position: top 3px center }
-      .cr { object-position: center right 25% }
+      .tc { object-position: top 3px left 50% }
+      .cr { object-position: top 50% right 25% }
     </style>
   </head>
   <body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/masking/mask-position-3a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/masking/mask-position-3a.html
@@ -20,7 +20,7 @@
 
       #inner {
         background-color: purple;
-        mask-position: center bottom 80%;
+        mask-position: left 50% bottom 80%;
         mask-image: url(support/50x50-opaque-blue.svg);
         mask-repeat: no-repeat;
       }

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/masking/mask-position-4c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/masking/mask-position-4c.html
@@ -20,7 +20,7 @@
 
       #inner {
         background-color: purple;
-        mask-position: left bottom 50%;
+        mask-position: left 0% bottom 50%;
         mask-image: url(support/50x50-opaque-blue.svg);
         mask-repeat: no-repeat;
       }

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/masking/mask-position-6.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/masking/mask-position-6.html
@@ -25,19 +25,19 @@
       }
 
       #inner1 {
-        mask-position: left 20px bottom;
+        mask-position: left 20px bottom 0px;
       }
 
       #inner2 {
-        mask-position: left 40% bottom;
+        mask-position: left 40% bottom 0%;
       }
 
       #inner3 {
-        mask-position: right 60% bottom;
+        mask-position: right 60% bottom 0%;
       }
 
       #inner4 {
-        mask-position: right 30px bottom;
+        mask-position: right 30px bottom 0px;
       }
     </style>
   </head>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/masking/mask-position-7.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/masking/mask-position-7.html
@@ -25,19 +25,19 @@
       }
 
       #inner1 {
-        mask-position: right top 40%;
+        mask-position: right 0% top 40%;
       }
 
       #inner2 {
-        mask-position: right top 20px;
+        mask-position: right 0px top 20px;
       }
 
       #inner3 {
-        mask-position: right bottom 60%;
+        mask-position: right 0% bottom 60%;
       }
 
       #inner4 {
-        mask-position: right bottom 30px;
+        mask-position: right 0px bottom 30px;
       }
     </style>
   </head>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/a39b925a26ade6f6d05c51dde62764b149043a00 .

This contains changes from one bug:
* [bug 1559276](https://bugzilla.mozilla.org/show_bug.cgi?id=1559276), by @BorisChiou, reviewed by @emilio