### PR TITLE
[docs] Normalize spelling of "test suite"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ The web-platform-tests Project [![IRC chat](https://goo.gl/6nCIks)](http://irc.w
 ==============================
 
 The web-platform-tests Project is a W3C-coordinated attempt to build a
-cross-browser testsuite for the Web-platform stack. Writing tests in a way
+cross-browser test suite for the Web-platform stack. Writing tests in a way
 that allows them to be run in all browsers gives browser projects
 confidence that they are shipping software that is compatible with other
 implementations, and that later implementations will be compatible with

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # web-platform-tests documentation
 
 The web-platform-tests project is a W3C-coordinated attempt to build a
-cross-browser testsuite for [the Web-platform
+cross-browser test suite for [the Web-platform
 stack](https://platform.html5.org). Writing tests in a way that allows them to
 be run in all browsers gives browser projects confidence that they are shipping
 software which is compatible with other implementations, and that later
@@ -48,7 +48,7 @@ free to add yourself to the META.yml file!
 .. toctree::
    :maxdepth: 2
 
-   testsuite-design
+   test-suite-design
    running-tests/index
    writing-tests/index
    reviewing-tests/index

--- a/docs/test-suite-design.md
+++ b/docs/test-suite-design.md
@@ -1,6 +1,6 @@
-# Testsuite Design
+# Test Suite Design
 
-The vast majority of the testsuite is formed of HTML pages, which can
+The vast majority of the test suite is formed of HTML pages, which can
 be loaded in a browser and either programmatically provide a result or
 provide a set of steps to run the test and obtain the result.
 
@@ -12,7 +12,7 @@ and should be easy to run in any browser.
 
 Each top level directory in the repository corresponds to tests for a
 single specification, with the exception of `css/` which contains
-testsuites for CSS WG specifications. For W3C specs, these directories
+test suites for CSS WG specifications. For W3C specs, these directories
 are typically named after the shortname of the spec (i.e. the name
 used for snapshot publications under `/TR/`); for WHATWG specs, they
 are typically named after the subdomain of the spec (i.e. trimming

--- a/docs/writing-tests/general-guidelines.md
+++ b/docs/writing-tests/general-guidelines.md
@@ -41,7 +41,7 @@ Various support files are available in in the `/common/` and `/media/`
 directories (web-platform-tests) and `/support/` (in css/). Reusing
 existing resources is encouraged where possible, as is adding
 generally useful files to these common areas rather than to specific
-testsuites.
+test suites.
 
 
 #### Tools
@@ -169,7 +169,7 @@ see the [lint-tool documentation][lint-tool].
 
 ## CSS-Specific Requirements
 
-In order to be included in an official specification testsuite, tests
+In order to be included in an official specification test suite, tests
 for CSS have some additional requirements for:
 
 * [Metadata][css-metadata], and

--- a/docs/writing-tests/server-features.md
+++ b/docs/writing-tests/server-features.md
@@ -23,7 +23,7 @@ precise details of the response:
 * *pywebsocket*, an existing websockets server
 
 wptserve is a Python-based web server. By default it serves static
-files in the testsuite. For more sophisticated requirements, several
+files in the test suite. For more sophisticated requirements, several
 mechanisms are available to take control of the response. These are
 outlined below.
 


### PR DESCRIPTION
The documentation uses the terms "testsuite" and "test suite" interchangeably. Normalize on "test suite."

@sideshowbarker as per [your recommendation in gh-17634](https://github.com/web-platform-tests/wpt/pull/17634#discussion_r300269566)