### PR TITLE
Allowed trailing slashes for WPT test test_file_protocol

### DIFF
--- a/webdriver/tests/navigate_to/navigate.py
+++ b/webdriver/tests/navigate_to/navigate.py
@@ -40,4 +40,6 @@ def test_file_protocol(session, server_config):
     response = navigate_to(session, url)
     assert_success(response)
 
+    if session.url.endswith('/'):
+        url += '/'
     assert session.url == url


### PR DESCRIPTION
Chrome automatically adds a trailing slash if the suffix of the file protocol is a directory. Chromedriver currently fails this test due to this trailing slash (the rest of the URL is identical). This changelist considers urls with and without a trailing slash correct.

Please see the following previously merged changelist for precedence:  
[Allow trailing slash in test_get_current_url_file_protocol](https://github.com/web-platform-tests/wpt/pull/17679)