### PR TITLE
Test that writing location.hash automatically encodes hash

### DIFF
--- a/html/browsers/history/the-location-interface/location_hash.html
+++ b/html/browsers/history/the-location-interface/location_hash.html
@@ -10,6 +10,9 @@
     <iframe id="srcdoc-iframe"
        srcdoc="<div style='height: 200vh'></div><div id='test'></div>"></iframe>
     <script>
+//**This test assumes that assignments to location.hash will be synchronous - this is how all browsers implement it.
+//The spec (as of 25 March 2011) disagrees.
+
     test(function () {
       window.history.pushState(1, document.title, '#x=1');
       var hash = location.hash;
@@ -30,6 +33,30 @@
       assert_true(frameWin.scrollY > frameWin.innerHeight,
                   "Should have scrolled by more than one viewport height");
     }));
+
+    test(function() {
+      location.hash = "test";
+      assert_equals(location.hash, "#test");
+      location.hash = "";
+    }, "Setting hash should automatically include hash character");
+
+    test(function() {
+      location.hash = "#not encoded";
+      assert_equals(location.hash, "#not%20encoded");
+      location.hash = "";
+    }, "Setting hash should encode incompatible characters");
+
+    test(function() {
+      location.hash = "#already%20encoded";
+      assert_equals(location.hash, "#already%20encoded");
+      location.hash = "";
+    }, "Setting hash to an already encoded value should not double encode it");
+
+    test(function() {
+      location.hash = "#mixed encoding%20here";
+      assert_equals(location.hash, "#mixed%20encoding%20here");
+      location.hash = "";
+    }, "Setting hash which is partially encoded should only encode incompatible characters");
     </script>
   </body>
 </html>

--- a/html/browsers/history/the-location-interface/location_hash.html
+++ b/html/browsers/history/the-location-interface/location_hash.html
@@ -10,10 +10,12 @@
     <iframe id="srcdoc-iframe"
        srcdoc="<div style='height: 200vh'></div><div id='test'></div>"></iframe>
     <script>
-//**This test assumes that assignments to location.hash will be synchronous - this is how all browsers implement it.
-//The spec (as of 25 March 2011) disagrees.
+    function resetHash() {
+      location.hash = "";
+    }
 
-    test(function () {
+    test(function (t) {
+      t.add_cleanup(resetHash);
       window.history.pushState(1, document.title, '#x=1');
       var hash = location.hash;
 
@@ -34,28 +36,28 @@
                   "Should have scrolled by more than one viewport height");
     }));
 
-    test(function() {
+    test(function(t) {
+      t.add_cleanup(resetHash);
       location.hash = "test";
       assert_equals(location.hash, "#test");
-      location.hash = "";
     }, "Setting hash should automatically include hash character");
 
-    test(function() {
+    test(function(t) {
+      t.add_cleanup(resetHash);
       location.hash = "#not encoded";
       assert_equals(location.hash, "#not%20encoded");
-      location.hash = "";
     }, "Setting hash should encode incompatible characters");
 
-    test(function() {
+    test(function(t) {
+      t.add_cleanup(resetHash);
       location.hash = "#already%20encoded";
       assert_equals(location.hash, "#already%20encoded");
-      location.hash = "";
     }, "Setting hash to an already encoded value should not double encode it");
 
-    test(function() {
+    test(function(t) {
+      t.add_cleanup(resetHash);
       location.hash = "#mixed encoding%20here";
       assert_equals(location.hash, "#mixed%20encoding%20here");
-      location.hash = "";
     }, "Setting hash which is partially encoded should only encode incompatible characters");
     </script>
   </body>


### PR DESCRIPTION
Writing location.hash should invoke the standard URL encoding rules which encodes all non URL code points with percent-encoding.