### PR TITLE
Change test_designMode to check for empty string instead of br tag

### DIFF
--- a/webdriver/tests/element_clear/clear.py
+++ b/webdriver/tests/element_clear/clear.py
@@ -279,7 +279,7 @@ def test_designmode(session):
 
     response = element_clear(session, element)
     assert_success(response)
-    assert element.property("innerHTML") == "<br>"
+    assert element.property("innerHTML") == ""
     assert_element_has_focus(session.execute_script("return document.body"))
 
 


### PR DESCRIPTION
test_designMode incorrectly checks that the innerHTML after an element_clear is a `<br>` tag. Instead, the innerHTML property should be an empty string according to the W3C spec here: [element clear](https://www.w3.org/TR/2018/REC-webdriver1-20180605/#element-clear).

The clear should follow the "To clear a content editable element" subroutine, which states:
> 3. Set element’s innerHTML IDL attribute to an empty string.

Nowhere in the spec for element clear is the insertion of a `<br>` tag mentioned, so rather than accept both answers, to be spec compliant only an empty string should be accepted.