### PR TITLE
Removed expected change event from assert_events_equal in test_contenteditable

### DIFF
--- a/webdriver/tests/element_clear/clear.py
+++ b/webdriver/tests/element_clear/clear.py
@@ -267,7 +267,7 @@ def test_contenteditable(session, add_event_listeners, tracked_events):
     response = element_clear(session, element)
     assert_success(response)
     assert element.property("innerHTML") == ""
-    assert_events_equal(session, ["focus", "change", "blur"])
+    assert_events_equal(session, ["focus", "blur"])
     assert_element_has_focus(session.execute_script("return document.body"))
 
 


### PR DESCRIPTION
The definition of [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) is as follows:
>The change event is fired for \<input\>, \<select\>, and <textarea> elements when an alteration to the element's value is committed by the user. 

Therefore, since clear is occurring on a `<p>` tag, no `change` event should fire. This changelist makes this correction.