### PR TITLE
WebKit export of bugs.webkit.org/show_bug.cgi?id=198032

### DIFF
--- a/css/css-sizing/min-width-max-width-precedence.html
+++ b/css/css-sizing/min-width-max-width-precedence.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>CSS Test: check precedence between min-width and max-width</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visudet.html#min-max-widths" />
+<meta name="assert" content="Test that the used value of 'width' is resolved properly." />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.tooltip {
+  height: 68px;
+  position: relative;
+  max-width: 200px;
+  min-width: 260px;
+  background-color: red;
+}
+
+#outer {
+  background-color: blue;
+  position: absolute;
+  height: 136px;
+}
+</style>
+
+<div id="outer">
+  <div id="inner" class="tooltip" role="tooltip"></div>
+</div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(document.querySelector("#outer")).width, '260px');
+}, "When used value is resolved, min-width should win over max-width");
+</script>


### PR DESCRIPTION
This test is included in the WebKit commit below.

    Always min-width should win over max-width.
    https://bugs.webkit.org/show_bug.cgi?id=198032
    
    Reviewed by Darin Adler.
    
    In the spec, https://www.w3.org/TR/CSS21/visudet.html#min-max-widths,
    the following algorithm describes how the two properties influence
    the used value of the 'width' property.
    
    1. The tentative used width is calculated (without 'min-width' and 'max-width')
    following the rules under "Calculating widths and margins" above.
    2. If the tentative used width is greater than 'max-width',
    the rules above are applied again, but this time using the computed value of 'max-width'
    as the computed value for 'width'.
    3. If the resulting width is smaller than 'min-width', the rules above are applied again,
    but this time using the value of 'min-width' as the computed value for 'width'.