### PR TITLE
Attempt to fix flaky ChromeDriver crashes caused by action sequence

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -86,6 +86,7 @@ class WebDriverTestharnessProtocolPart(TestharnessProtocolPart):
         self.parent.base.execute_script(self.runner_script % format_map)
 
     def close_old_windows(self):
+        self.webdriver.actions.release()
         handles = [item for item in self.webdriver.handles if item != self.runner_handle]
         for handle in handles:
             try:


### PR DESCRIPTION
There are two problems here:

1. The input states of the session aren't cleared between tests if the browser is not restarted. This leads to flaky "invalid input state".
2. `pointerlock/pointerevent_pointermove_in_pointerlock.html` uses double as coordinates in action items (from `getBoundingClientRect`), while the spec requires int. This leads to "invalid argument".

Fixes #15486 .