### PR TITLE
[common] Correct definition of alternate host name

### DIFF
--- a/common/get-host-info.sub.js
+++ b/common/get-host-info.sub.js
@@ -12,7 +12,7 @@ function get_host_info() {
   var ORIGINAL_HOST = '{{host}}';
   var REMOTE_HOST = (ORIGINAL_HOST === 'localhost') ? '127.0.0.1' : ('www1.' + ORIGINAL_HOST);
   var OTHER_HOST = '{{domains[www2]}}';
-  var NOTSAMESITE_HOST = (ORIGINAL_HOST === 'localhost') ? '127.0.0.1' : ('not-' + ORIGINAL_HOST);
+  var NOTSAMESITE_HOST = (ORIGINAL_HOST === 'localhost') ? '127.0.0.1' : ('{{hosts[alt][]}}');
 
   return {
     HTTP_PORT: HTTP_PORT,


### PR DESCRIPTION
The value of the "alternate" host is completely at the discretion of the
server operator (via the `alternate_hosts` configuration). It is not
guaranteed to have any resemblance to the primary host name. Despite
this, the shared `get-host-info.sub.js` file attempted to derive the
alternate host name in terms of the primary host name.

Replace that faulty derivation with the value which is present in the
server configuration.