### PR TITLE
Add support for running tests with Chrome for iOS

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -191,4 +191,4 @@ class HTTPWireProtocol(object):
         return self.connection.getresponse()
 
     def _has_unread_data(self):
-        return self._conn and select.select([self._conn.sock], [], [], 0)[0]
+        return self._conn and self._conn.sock and select.select([self._conn.sock], [], [], 0)[0]

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -590,6 +590,29 @@ class ChromeAndroid(Browser):
         return None
 
 
+class ChromeiOS(Browser):
+    """Chrome-specific interface for iOS.
+    """
+
+    product = "chrome_ios"
+    requirements = "requirements_chrome_ios.txt"
+
+    def install(self, dest=None, channel=None):
+        raise NotImplementedError
+
+    def find_binary(self, venv_path=None, channel=None):
+        raise NotImplementedError
+
+    def find_webdriver(self, channel=None):
+        raise NotImplementedError
+
+    def install_webdriver(self, dest=None, channel=None, browser_binary=None):
+        raise NotImplementedError
+
+    def version(self, binary=None, webdriver_binary=None):
+        return None
+
+
 class Opera(Browser):
     """Opera-specific interface.
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -310,6 +310,14 @@ class ChromeAndroid(BrowserSetup):
                 raise WptrunError("Unable to locate or install chromedriver binary")
 
 
+class ChromeiOS(BrowserSetup):
+    name = "chrome_ios"
+    browser_cls = browser.ChromeiOS
+
+    def setup_kwargs(self, kwargs):
+        if kwargs["webdriver_binary"] is None:
+            raise WptrunError("Unable to locate or install chromedriver binary")
+
 class Opera(BrowserSetup):
     name = "opera"
     browser_cls = browser.Opera
@@ -505,6 +513,7 @@ product_setup = {
     "firefox": Firefox,
     "chrome": Chrome,
     "chrome_android": ChromeAndroid,
+    "chrome_ios": ChromeiOS,
     "edgechromium": EdgeChromium,
     "edge": Edge,
     "edge_webdriver": EdgeWebDriver,

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -318,6 +318,7 @@ class ChromeiOS(BrowserSetup):
         if kwargs["webdriver_binary"] is None:
             raise WptrunError("Unable to locate or install chromedriver binary")
 
+
 class Opera(BrowserSetup):
     name = "opera"
     browser_cls = browser.Opera

--- a/tools/wptrunner/requirements_chrome_ios.txt
+++ b/tools/wptrunner/requirements_chrome_ios.txt
@@ -1,0 +1,1 @@
+mozprocess==1.0.0

--- a/tools/wptrunner/wptrunner/browsers/__init__.py
+++ b/tools/wptrunner/wptrunner/browsers/__init__.py
@@ -24,6 +24,7 @@ module global scope.
 
 product_list = ["chrome",
                 "chrome_android",
+                "chrome_ios",
                 "edgechromium",
                 "edge",
                 "edge_webdriver",

--- a/tools/wptrunner/wptrunner/browsers/chrome_ios.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_ios.py
@@ -1,5 +1,3 @@
-import subprocess
-
 from .base import Browser, ExecutorBrowser, require_arg
 from .base import get_timeout_multiplier   # noqa: F401
 from ..webdriver_server import CWTChromeDriverServer

--- a/tools/wptrunner/wptrunner/browsers/chrome_ios.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_ios.py
@@ -1,0 +1,82 @@
+import subprocess
+
+from .base import Browser, ExecutorBrowser, require_arg
+from .base import get_timeout_multiplier   # noqa: F401
+from ..webdriver_server import CWTChromeDriverServer
+from ..executors import executor_kwargs as base_executor_kwargs
+from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
+                                           WebDriverRefTestExecutor)  # noqa: F401
+from ..executors.executorchrome import ChromeDriverWdspecExecutor  # noqa: F401
+
+
+__wptrunner__ = {"product": "chrome_ios",
+                 "check_args": "check_args",
+                 "browser": "ChromeiOSBrowser",
+                 "executor": {"testharness": "WebDriverTestharnessExecutor",
+                              "reftest": "WebDriverRefTestExecutor"},
+                 "browser_kwargs": "browser_kwargs",
+                 "executor_kwargs": "executor_kwargs",
+                 "env_extras": "env_extras",
+                 "env_options": "env_options",
+                 "timeout_multiplier": "get_timeout_multiplier"}
+
+def check_args(**kwargs):
+    require_arg(kwargs, "webdriver_binary")
+
+
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
+    return {"webdriver_binary": kwargs["webdriver_binary"],
+            "webdriver_args": kwargs.get("webdriver_args")}
+
+
+def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
+                    **kwargs):
+    executor_kwargs = base_executor_kwargs(test_type, server_config, cache_manager, run_info_data,
+                                           **kwargs)
+    executor_kwargs["close_after_done"] = True
+    executor_kwargs["capabilities"] = {}
+    return executor_kwargs
+
+
+def env_extras(**kwargs):
+    return []
+
+
+def env_options():
+    return {}
+
+
+class ChromeiOSBrowser(Browser):
+    """ChromeiOS is backed by CWTChromeDriver, which is supplied through
+    ``wptrunner.webdriver.CWTChromeDriverServer``.
+    """
+
+    init_timeout = 120
+
+    def __init__(self, logger, webdriver_binary, webdriver_args=None):
+        """Creates a new representation of Chrome."""
+        Browser.__init__(self, logger)
+        self.server = CWTChromeDriverServer(self.logger,
+                                            binary=webdriver_binary,
+                                            args=webdriver_args)
+
+    def start(self, **kwargs):
+        self.server.start(block=False)
+
+    def stop(self, force=False):
+        self.server.stop(force=force)
+
+    def pid(self):
+        return self.server.pid
+
+    def is_alive(self):
+        # TODO(ato): This only indicates the driver is alive,
+        # and doesn't say anything about whether a browser session
+        # is active.
+        return self.server.is_alive()
+
+    def cleanup(self):
+        self.stop()
+
+    def executor_browser(self):
+        return ExecutorBrowser, {"webdriver_url": self.server.url}

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -9,8 +9,9 @@ import traceback
 import mozprocess
 
 
-__all__ = ["SeleniumServer", "ChromeDriverServer", "EdgeChromiumDriverServer", "OperaDriverServer",
-           "GeckoDriverServer", "InternetExplorerDriverServer", "EdgeDriverServer",
+__all__ = ["SeleniumServer", "ChromeDriverServer", "CWTChromeDriverServer",
+           "EdgeChromiumDriverServer", "OperaDriverServer", "GeckoDriverServer",
+           "InternetExplorerDriverServer", "EdgeDriverServer",
            "ServoDriverServer", "WebKitDriverServer", "WebDriverServer"]
 
 
@@ -127,6 +128,14 @@ class ChromeDriverServer(WebDriverServer):
                 cmd_arg("port", str(self.port)),
                 cmd_arg("url-base", self.base_path) if self.base_path else ""] + self._args
 
+class CWTChromeDriverServer(WebDriverServer):
+    def __init__(self, logger, binary, port=None, args=None):
+        WebDriverServer.__init__(self, logger, binary, port=port, args=args)
+
+    def make_command(self):
+        return [self.binary,
+                "--port=%s" % str(self.port)] + self._args
+
 class EdgeChromiumDriverServer(WebDriverServer):
     def __init__(self, logger, binary="msedgedriver", port=None,
                  base_path="", args=None):
@@ -239,7 +248,7 @@ def get_free_port():
             s.close()
 
 
-def wait_for_service(addr, timeout=15):
+def wait_for_service(addr, timeout=60):
     """Waits until network service given as a tuple of (host, port) becomes
     available or the `timeout` duration is reached, at which point
     ``socket.error`` is raised."""


### PR DESCRIPTION
This adds Chrome for iOS as a supported browser. Because of iOS-specific
constraints, running tests with Chrome on iOS requires a local build
of Chrome. Specifically:
1) Checkout chromium, and build the targets ios_cwt_chromedriver_tests and
   ios_cwt_chromedriver_tests_module.
2) Pass <CHROMIUM_SRC_DIR>/ios/chrome/test/wpt/tools/run_cwt_chromedriver.py
   as the --webdriver-binary argument to 'wpt run'

The default build directory, iOS simulator device type, and iOS version are
specified inside run_cwt_chromedriver.py, but can be overridden by passing
--webdriver-arg arguments to 'wpt run'. For example, to use an iPhone X
simulator instead of the default iPhone 8 simulator, pass the argument
--webdriver-arg='--device=iPhone X'.

The plan is to get these tests running on an FYI bot (using 'wpt run').