### PR TITLE
Update MathML tests for lengths now that some numbers are invalid in …

### DIFF
--- a/mathml/relations/css-styling/lengths-2.html
+++ b/mathml/relations/css-styling/lengths-2.html
@@ -44,7 +44,6 @@
       assert_equals(getBox("unitPercentage").width, 60, "%");
       assert_equals(getBox("unitPt").width, 96, "pt");
       assert_equals(getBox("unitPx").width, 123, "px");
-      assert_equals(getBox("unitNone").width, 150, "Unitless");
     }, "Units");
 
     test(function() {
@@ -57,14 +56,12 @@
       assert_equals(getBox("spacePercentage").width, 60, "%");
       assert_equals(getBox("spacePt").width, 96, "pt");
       assert_equals(getBox("spacePx").width, 123, "px");
-      assert_equals(getBox("spaceNone").width, 150, "Unitless");
     }, "Trimming of space");
 
     test(function() {
       assert_approx_equals(getBox("n0").width, 0, epsilon, "n0");
       assert_approx_equals(getBox("n1").width, 90, epsilon, "n1");
       assert_approx_equals(getBox("n2").width, 8, epsilon, "n2");
-      assert_approx_equals(getBox("n3").width, 70, epsilon, "n3");
       assert_approx_equals(getBox("n4").width, 650, epsilon, "n4");
       assert_approx_equals(getBox("n5").width, 4320, epsilon, "n5");
       assert_approx_equals(getBox("n6").width, 1, epsilon, "n6");
@@ -79,7 +76,6 @@
       assert_approx_equals(getBox("N0").top - topRef, -0, epsilon, "N0");
       assert_approx_equals(topRef - getBox("N1").top, -90, epsilon, "N1");
       assert_approx_equals(topRef - getBox("N2").top, -8, epsilon, "N2");
-      assert_approx_equals(topRef - getBox("N3").top, -70, epsilon, "N3");
       assert_approx_equals(topRef - getBox("N4").top, -650, epsilon, "N4");
       assert_approx_equals(topRef - getBox("N5").top, -4320, epsilon, "N5");
       assert_approx_equals(topRef - getBox("N6").top, -1, epsilon, "N6");
@@ -113,6 +109,14 @@
       });
     }, "Legacy namedspaces");
 
+    test(function() {
+      // These values are invalid in MathML Core.
+      assert_equals(getBox("unitNone").width, 30, "Unitless");
+      assert_approx_equals(getBox("n3").width, 0, epsilon, "n3");
+      var topRef = getBox("ref").top;
+      assert_approx_equals(topRef - getBox("N3").top, 0, epsilon, "N3");
+    }, "Legacy numbers");
+
     done();
   }
 </script>
@@ -144,7 +148,6 @@
       <mstyle mathsize="200%"><mspace id="spacePercentage" width="&#x20;&#x9;&#xA;&#xD;&#x20;&#x9;&#xA;&#xD;3em&#x20;&#x9;&#xA;&#xD;&#x20;&#x9;&#xA;&#xD;"/></mstyle>
       <mspace id="spacePt" width="&#x20;&#x9;&#xA;&#xD;&#x20;&#x9;&#xA;&#xD;72pt&#x20;&#x9;&#xA;&#xD;&#x20;&#x9;&#xA;&#xD;"/>
       <mspace id="spacePx" width="&#x20;&#x9;&#xA;&#xD;&#x20;&#x9;&#xA;&#xD;123px&#x20;&#x9;&#xA;&#xD;&#x20;&#x9;&#xA;&#xD;"/>
-      <mstyle mathsize="5"><mspace id="spaceNone" width="&#x20;&#x9;&#xA;&#xD;&#x20;&#x9;&#xA;&#xD;3em&#x20;&#x9;&#xA;&#xD;&#x20;&#x9;&#xA;&#xD;"/></mstyle>
     </math>
   </p>
   <p>


### PR DESCRIPTION
…core.

Basically things like "7.em", "-7.em" or "5" are now invalid.

https://github.com/mathml-refresh/mathml/issues/24
https://github.com/mathml-refresh/mathml/issues/23