### PR TITLE
HTML: cross-site SharedArrayBuffer ought to not work

### DIFF
--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/resources/iframe-failure.html
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/resources/iframe-failure.html
@@ -1,0 +1,3 @@
+<script>
+parent.postMessage(new SharedArrayBuffer(10), "*");
+</script>

--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/resources/iframe-failure.html.headers
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/resources/iframe-failure.html.headers
@@ -1,0 +1,2 @@
+Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Resource-Policy: cross-site

--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<div id=log></div>
+<script>
+async_test(t => {
+  const frame = document.createElement("iframe");
+  t.add_cleanup(() => frame.remove());
+  frame.src = get_host_info().HTTPS_NOTSAMESITE_ORIGIN + new URL("resources/iframe-failure.html", location).pathname;
+  window.onmessage = t.unreached_func("Got a message event, expected a messageerror event");
+  window.onmessageerror = t.step_func_done();
+  document.body.append(frame);
+}, "SharedArrayBuffer and a cross-site <iframe>");
+</script>

--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html.headers
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/window-failure.https.html.headers
@@ -1,0 +1,2 @@
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp


### PR DESCRIPTION
This is not great, but then Firefox does not ship SAB yet. I guess we did not test this since we did not have cross-site domains back in the day.

Please review #17761 first, this builds on that.