### PR TITLE
Update rejects_if_not_active.https.html

### DIFF
--- a/payment-request/rejects_if_not_active.https.html
+++ b/payment-request/rejects_if_not_active.https.html
@@ -66,13 +66,28 @@ promise_test(async t => {
     iframe.addEventListener("load", resolve);
     iframe.src = "/payment-request/resources/page2.html";
   });
-  await promise_rejects(
-    t,
-    "AbortError",
-    showPromise,
-    "The iframe was navigated away, so showPromise must reject with AbortError"
-  );
-  // We are done, so clean up.
-  iframe.remove();
-}, "If a payment request is showing, but its document is navigated away (so no longer fully active), the payment request aborts.");
+
+  // The navigaton should have dismissed the previous payment request so it
+  // should be possible to show another one now.
+  const request2 = new iframe.contentWindow.PaymentRequest(
+    validMethods, validDetails);
+  const showPromise2 = request2.show();
+
+  // Stop the test in 1 second if it has not rejected, which means that a
+  // payment sheet is successfully shown.
+  t.step_timeout(() => {
+    request.abort();
+    // We are done, so clean up.
+    iframe.remove();
+    t.done();
+  }, 1000);
+
+  // This should never settle because the payment sheet should be pending.
+  await showPromise2.then(() => {
+    assert_true(false, "Second payment should be pending but is resolved.");
+  })
+  .catch(e => {
+    assert_true(false, "Second payment should be pending but is rejected.");
+  });
+}, "If a payment request is showing, but its document is navigated away (so no longer fully active), the payment sheet is dismissed.");
 </script>

--- a/payment-request/rejects_if_not_active.https.html
+++ b/payment-request/rejects_if_not_active.https.html
@@ -65,18 +65,22 @@ promise_test(async t => {
   await new Promise(resolve => {
     iframe.addEventListener("load", resolve);
     iframe.src = "/payment-request/resources/page2.html";
+    // An implementation may optionally reject |showPromise|.
+    showPromise.catch(e => {});
   });
 
   // The navigaton should have dismissed the previous payment request so it
   // should be possible to show another one now.
   const request2 = new iframe.contentWindow.PaymentRequest(
     validMethods, validDetails);
-  const showPromise2 = request2.show();
+  const [showPromise2] = await test_driver.bless(
+    "show 2nd payment request", () => {
+      return [request2.show()];
+    });
 
   // Stop the test in 1 second if it has not rejected, which means that a
   // payment sheet is successfully shown.
-  t.step_timeout(() => {
-    request.abort();
+  t.step_timeout(async () => {
     // We are done, so clean up.
     iframe.remove();
     t.done();


### PR DESCRIPTION
Update this test to match the new proposed spec behavior in https://github.com/w3c/payment-request/issues/872.

In Blink, after the iframe navigates, the original show promise will never settle. This causes the test to timeout. What we really want to check is that the original payment sheet is dismissed and a new payment sheet can be shown. This is what the test is updated to check.