### PR TITLE
Add a promise_test sequencing clarification

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -184,11 +184,11 @@ Note that in the promise chain constructed in `test_function` assertions don't
 need to be wrapped in `step` or `step_func` calls.
 
 Unlike Asynchronous Tests, Promise Tests don't start running until after the
-previous Promise Test finishes. [Under rare 
-circumstances](https://github.com/web-platform-tests/wpt/pull/17924), the
-next test may begin to execute before the returned promise has settled.
-Use [add_cleanup](#cleanup) to register any necessary cleanup actions such as 
-resetting global state that need to happen consistently before the next test 
+previous Promise Test finishes. [Under rare
+circumstances](https://github.com/web-platform-tests/wpt/pull/17924), the next
+test may begin to execute before the returned promise has settled. Use
+[add_cleanup](#cleanup) to register any necessary cleanup actions such as
+resetting global state that need to happen consistently before the next test
 starts.
 
 `promise_rejects` can be used to test Promises that need to reject:

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -184,9 +184,12 @@ Note that in the promise chain constructed in `test_function` assertions don't
 need to be wrapped in `step` or `step_func` calls.
 
 Unlike Asynchronous Tests, Promise Tests don't start running until after the
-previous Promise Test finishes. Use [add_cleanup](#cleanup) to register any 
-necessary cleanup actions such as resetting global state that need to happen 
-consistently before the next test starts.
+previous Promise Test finishes. [Under rare 
+circumstances](https://github.com/web-platform-tests/wpt/pull/17924), the
+next test may begin to execute before the returned promise has settled.
+Use [add_cleanup](#cleanup) to register any necessary cleanup actions such as 
+resetting global state that need to happen consistently before the next test 
+starts.
 
 `promise_rejects` can be used to test Promises that need to reject:
 

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -184,9 +184,9 @@ Note that in the promise chain constructed in `test_function` assertions don't
 need to be wrapped in `step` or `step_func` calls.
 
 Unlike Asynchronous Tests, Promise Tests don't start running until after the
-previous Promise Test finishes. Use `[add_cleanup](#cleanup)`
-to register any necessary cleanup actions such as resetting global state that need
-to happen consistently before the next test starts.
+previous Promise Test finishes. Use `[add_cleanup](#cleanup)` to register any 
+necessary cleanup actions such as resetting global state that need to happen 
+consistently before the next test starts.
 
 `promise_rejects` can be used to test Promises that need to reject:
 

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -184,7 +184,11 @@ Note that in the promise chain constructed in `test_function` assertions don't
 need to be wrapped in `step` or `step_func` calls.
 
 Unlike Asynchronous Tests, Promise Tests don't start running until after the
-previous Promise Test finishes.
+previous Promise Test finishes. However, be aware that a test is considered
+finished as soon as its status is resolved, and a failed test's chained actions
+may still be in progress when the next test starts. Use `[add_cleanup](#cleanup)`
+to register any needed cleanup actions such as resetting global state that need
+to happen consistently before the next test starts.
 
 `promise_rejects` can be used to test Promises that need to reject:
 

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -184,7 +184,7 @@ Note that in the promise chain constructed in `test_function` assertions don't
 need to be wrapped in `step` or `step_func` calls.
 
 Unlike Asynchronous Tests, Promise Tests don't start running until after the
-previous Promise Test finishes. Use `[add_cleanup](#cleanup)` to register any 
+previous Promise Test finishes. Use [add_cleanup](#cleanup) to register any 
 necessary cleanup actions such as resetting global state that need to happen 
 consistently before the next test starts.
 

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -184,10 +184,8 @@ Note that in the promise chain constructed in `test_function` assertions don't
 need to be wrapped in `step` or `step_func` calls.
 
 Unlike Asynchronous Tests, Promise Tests don't start running until after the
-previous Promise Test finishes. However, be aware that a test is considered
-finished as soon as its status is resolved, and a failed test's chained actions
-may still be in progress when the next test starts. Use `[add_cleanup](#cleanup)`
-to register any needed cleanup actions such as resetting global state that need
+previous Promise Test finishes. Use `[add_cleanup](#cleanup)`
+to register any necessary cleanup actions such as resetting global state that need
 to happen consistently before the next test starts.
 
 `promise_rejects` can be used to test Promises that need to reject:


### PR DESCRIPTION
I got bitten by a nasty race condition where a failed `promise_rejects` caused teardown logic to run after the next test had already started, interfering with the next test's state. Since this was unexpected, here's a proposed addition to the documentation to make this clearer. Let me know if I'm misunderstanding how this works, or if you think this should be changed in promise_test instead.

(For context, see https://github.com/web-platform-tests/wpt/pull/17898 which contains a fix to a test helper affected by this.)