### PR TITLE
[wptserve] Validate alternate_host configuration

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -48,6 +48,14 @@ def replace_end(s, old, new):
     return s[:-len(old)] + new
 
 
+def domains_are_distinct(a, b):
+    a = a.split(".")
+    b = b.split(".")
+    l = -1 * min(len(a), len(b))
+
+    return a[l:] != b[l:]
+
+
 class WrapperHandler(object):
 
     __meta__ = abc.ABCMeta
@@ -798,6 +806,14 @@ class ConfigBuilder(config.ConfigBuilder):
             *args,
             **kwargs
         )
+        with self as c:
+            browser_host = c.get("browser_host")
+            alternate_host = c.get("alternate_hosts", {}).get("alt")
+
+            if not domains_are_distinct(browser_host, alternate_host):
+                raise ValueError(
+                    "Alternate host must be distinct from browser host"
+                )
 
     def _get_ws_doc_root(self, data):
         if data["ws_doc_root"] is not None:

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -49,11 +49,12 @@ def replace_end(s, old, new):
 
 
 def domains_are_distinct(a, b):
-    a = a.split(".")
-    b = b.split(".")
-    l = -1 * min(len(a), len(b))
+    a_parts = a.split(".")
+    b_parts = b.split(".")
+    min_length = min(len(a_parts), len(b_parts))
+    slice_index = -1 * min_length
 
-    return a[l:] != b[l:]
+    return a_parts[slice_index:] != b_parts[slice_index:]
 
 
 class WrapperHandler(object):

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -84,3 +84,24 @@ def test_config_json_length():
     with ConfigBuilder() as c:
         data = json.dumps(c.as_dict())
     assert len(data) <= 0x7FFF
+
+def test_alternate_host_unspecified():
+    ConfigBuilder(browser_host="web-platform.test")
+
+@pytest.mark.parametrize("primary, alternate", [
+    ("web-platform.test", "web-platform.test"),
+    ("a.web-platform.test", "web-platform.test"),
+    ("web-platform.test", "a.web-platform.test"),
+    ("a.web-platform.test", "a.web-platform.test"),
+])
+def test_alternate_host_invalid(primary, alternate):
+    with pytest.raises(ValueError):
+        ConfigBuilder(browser_host=primary, alternate_hosts={"alt": alternate})
+
+@pytest.mark.parametrize("primary, alternate", [
+    ("web-platform.test", "not-web-platform.test"),
+    ("a.web-platform.test", "b.web-platform.test"),
+    ("web-platform-tests.dev", "web-platform-tests.live"),
+])
+def test_alternate_host_valid(primary, alternate):
+    ConfigBuilder(browser_host=primary, alternate_hosts={"alt": alternate})


### PR DESCRIPTION
Some values of `alternate_host` will invalidate tests. Script the server
to refuse to run if the operator supplies an inappropriate value.