### PR TITLE
[fetch] Improve assertion

### DIFF
--- a/fetch/api/response/response-consume-empty.html
+++ b/fetch/api/response/response-consume-empty.html
@@ -89,7 +89,7 @@
         assert_false(response.bodyUsed, "bodyUsed is false at init");
         if (asText) {
           return response.text().then(function(bodyAsString) {
-            assert_equals(bodyAsString.length, 0, "Resolved value should be empty");
+            assert_equals(bodyAsString, "", "Resolved value should be empty");
             assert_true(response.bodyUsed, "bodyUsed is true after being consumed");
           });
         }


### PR DESCRIPTION
By asserting equality with the empty string, this test can provide
additional information in the event of failure: the actual value of the
response body.