### PR TITLE
Revert "[fetch] Improve assertion"

### DIFF
--- a/fetch/api/response/response-consume-empty.html
+++ b/fetch/api/response/response-consume-empty.html
@@ -89,7 +89,7 @@
         assert_false(response.bodyUsed, "bodyUsed is false at init");
         if (asText) {
           return response.text().then(function(bodyAsString) {
-            assert_equals(bodyAsString, "", "Resolved value should be empty");
+            assert_equals(bodyAsString.length, 0, "Resolved value should be empty");
             assert_true(response.bodyUsed, "bodyUsed is true after being consumed");
           });
         }


### PR DESCRIPTION
Reverts web-platform-tests/wpt#17946

Unfortunately, this change puts a non-deterministic string (multipart form boundary) into the error message, which is causing trouble to Chromium infra (we cannot create baselines for these tests).

We've skipped the whole test in Chromium for now: https://crrev.com/c/1713186 to unblock things.