### PR TITLE
[html] Use documented `nonexistent` instead of foo

### DIFF
--- a/html/dom/interfaces.https.html
+++ b/html/dom/interfaces.https.html
@@ -8,6 +8,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/common/subset-tests-by-key.js></script>
+<script src=/common/get-host-info.sub.js></script>
 <script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
 
@@ -200,7 +201,8 @@ idl_test(
       PeerConnection: [],
       MediaStreamEvent: [],
       ErrorEvent: [],
-      WebSocket: ['new WebSocket("wss://{{hosts[][nonexistent]}}")'],
+      // https://web-platform-tests.org/writing-tests/server-features.html?tests-involving-multiple-origins
+      WebSocket: ['new WebSocket("wss://nonexistent.' + get_host_info().ORIGINAL_HOST + '")'],
       CloseEvent: ['new CloseEvent("close")'],
       AbstractWorker: [],
       Worker: [],

--- a/html/dom/interfaces.sub.https.html
+++ b/html/dom/interfaces.sub.https.html
@@ -200,7 +200,7 @@ idl_test(
       PeerConnection: [],
       MediaStreamEvent: [],
       ErrorEvent: [],
-      WebSocket: ['new WebSocket("wss://foo")'],
+      WebSocket: ['new WebSocket("wss://{{hosts[][nonexistent]}}")'],
       CloseEvent: ['new CloseEvent("close")'],
       AbstractWorker: [],
       Worker: [],


### PR DESCRIPTION
The idlharness test needs a dummy WebSocket object with a failed
connection. This should be done using the documented `nonexistent`
subdomain instead of `foo` which could resolve successfully in certain
network environments.

Fixes #17977.