### PR TITLE
Recognize valid IDL buffer source primitive types

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1193,6 +1193,18 @@ IdlArray.prototype.assert_type_is = function(value, type)
         case "object":
             assert_in_array(typeof value, ["object", "function"], "wrong type: not object or function");
             return;
+            
+        case "Int8Array":
+        case "Int16Array":
+        case "Int32Array":
+        case "Uint8Array":
+        case "Uint16Array":
+        case "Uint32Array":
+        case "Uint8ClampedArray":
+        case "Float32Array":
+        case "Float64Array":
+            assert_equals(typeof value, "object");
+            return;
     }
 
     if (!(type in this.members))


### PR DESCRIPTION
Buffer source types defined here:
https://heycam.github.io/webidl/#idl-buffer-source-types

These types are never explicitly mentioned in IDL, so will not be pulled in as dependencies. As a result, we see `Unrecognized type Uint8ClampedArray` and similar when these types are referenced.

This PR simply recognizes those types and makes a simple typeof x === 'object' assertion.