### PR TITLE
Include typedefs as idlharness dependencies

### DIFF
--- a/credential-management/idlharness.https.window.js
+++ b/credential-management/idlharness.https.window.js
@@ -5,31 +5,32 @@
 
 'use strict';
 
-promise_test(async () => {
-  const idl = await fetch('/interfaces/credential-management.idl').then(r => r.text());
-  const html = await fetch('/interfaces/html.idl').then(r => r.text());
+idl_test(
+  ['credential-management'],
+  ['html', 'dom'],
+  idl_array => {
+    idl_array.add_objects({
+      CredentialsContainer: ['navigator.credentials'],
+      PasswordCredential: ['passwordCredential'],
+      FederatedCredential: ['federatedCredential'],
+    });
 
-  var idl_array = new IdlArray();
-  idl_array.add_idls(idl);
-  idl_array.add_dependency_idls(html);
-  idl_array.add_objects({
-    CredentialsContainer: ['navigator.credentials'],
-    PasswordCredential: [
-      `new PasswordCredential({
+    try {
+      self.passwordCredential = new PasswordCredential({
         id: "id",
         password: "pencil",
         iconURL: "https://example.com/",
         name: "name"
-      })`
-    ],
-    FederatedCredential: [
-      `new FederatedCredential({
+      });
+    } catch (e) {}
+
+    try {
+      self.federatedCredential = new FederatedCredential({
         id: "id",
         provider: "https://example.com",
         iconURL: "https://example.com/",
         name: "name"
-      })`
-    ]
-  });
-  idl_array.test();
-})
+      });
+    } catch (e) {}
+  }
+)

--- a/html/dom/interfaces.https.html
+++ b/html/dom/interfaces.https.html
@@ -38,7 +38,7 @@ const waitForLoad = new Promise(resolve => { addEventListener('load', resolve); 
 
 idl_test(
   ['html'],
-  ['SVG', 'cssom', 'touch-events', 'uievents', 'dom', 'xhr'],
+  ['SVG', 'cssom', 'touch-events', 'uievents', 'dom', 'xhr', 'FileAPI'],
   async idlArray => {
     idlArray.add_objects({
       NodeList: ['document.getElementsByName("name")'],

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -251,6 +251,15 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
         this.includes[k].forEach(v => all_deps.add(v));
     });
     this.partials.forEach(p => all_deps.add(p.name));
+    // Add 'TypeOfType' for each "typedef TypeOfType MyType;" entry.
+    Object.entries(this.members).forEach(([k, v]) => {
+        if (v instanceof IdlTypedef) {
+            let defs = v.idlType.union
+                ? v.idlType.idlType.map(t => t.idlType)
+                : [v.idlType.idlType];
+            defs.forEach(d => all_deps.add(d));
+        }
+    });
 
     // Add the attribute idlTypes of all the nested members of idls.
     const attrDeps = parsedIdls => {


### PR DESCRIPTION
For `typedef A B;` defining `B`, we should include `A` as a dependency.