### PR TITLE
Add placeholder WindowProxy definition

### DIFF
--- a/html/dom/idlharness.https.html
+++ b/html/dom/idlharness.https.html
@@ -47,6 +47,7 @@ idl_test(
         documentWithHandlers[callback.name] = handler;
       }
     }
+    idlArray.add_untested_idls('typedef Window WindowProxy;');
 
     idlArray.add_objects({
       NodeList: ['document.getElementsByName("name")'],


### PR DESCRIPTION
`WindowProxy` isn't defined anywhere in the IDL in WPT's interfaces dir. This fixes the `Unrecognized type WindowProxy` error in the test.