### PR TITLE
Add the FileAPI IDL as a dep for /html/dom/interfaces.https.html

### DIFF
--- a/html/dom/interfaces.https.html
+++ b/html/dom/interfaces.https.html
@@ -38,7 +38,7 @@ const waitForLoad = new Promise(resolve => { addEventListener('load', resolve); 
 
 idl_test(
   ['html'],
-  ['SVG', 'cssom', 'touch-events', 'uievents', 'dom', 'xhr'],
+  ['SVG', 'cssom', 'touch-events', 'uievents', 'dom', 'xhr', 'FileAPI'],
   async idlArray => {
     idlArray.add_objects({
       NodeList: ['document.getElementsByName("name")'],


### PR DESCRIPTION
`FileAPI` defines `FileList`, which is used on `HTMLInputElement.createInput("file")` - currently erroring with `Unrecognized type FileList`.