### PR TITLE
Fix metadata expectations for actionsWithKeyPressed.html

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/actionsWithKeyPressed.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/actionsWithKeyPressed.html.ini
@@ -4,4 +4,4 @@
 
   [TestDriver actions: actions with key pressed]
     expected:
-      if os == "mac" and product == "chrome": FAIL
+      if os == "mac" and (product == "chrome" or product=="firefox"): FAIL


### PR DESCRIPTION
This always fails on Mac at least in Chrome and Firefox; probably the test is just wrong on that platform.
Ensure the metadata is correct to unblock other PRs.