### PR TITLE
HTML: Handle shadow host with delegatesFocus=true in Element.focus(), click and sequential focus navigation

### DIFF
--- a/shadow-dom/focus/click-focus-delegatesFocus-click-method.html
+++ b/shadow-dom/focus/click-focus-delegatesFocus-click-method.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: click on shadow host with delegatesFocus</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/shadow-utils.js"></script>
+
+<body>
+<div id="host">
+  <div id="slotted">slotted</div>
+</div>
+<div id="outside">outside</div>
+</body>
+
+<script>
+const host = document.getElementById("host");
+const slotted = document.getElementById("slotted");
+
+const shadowRoot = host.attachShadow({ mode: "open", delegatesFocus: true });
+const aboveSlot = document.createElement("div");
+aboveSlot.innerText = "aboveSlot";
+const slot = document.createElement("slot");
+shadowRoot.appendChild(aboveSlot);
+shadowRoot.appendChild(slot);
+
+const elementsInFlatTreeOrder = [host, aboveSlot, slot, slotted, outside];
+
+// Final structure:
+// <div #host> (delegatesFocus=true)
+//    #shadowRoot
+//      <div #aboveSlot>
+//      <slot #slot>
+//        (slotted) <div #slotted>
+// <div #outside>
+
+function setAllTabIndex(value) {
+  setTabIndex(elementsInFlatTreeOrder, value);
+}
+
+function removeAllTabIndex() {
+  removeTabIndex(elementsInFlatTreeOrder);
+}
+
+function resetTabIndexAndFocus() {
+  removeAllTabIndex();
+  resetFocus(document);
+  resetFocus(shadowRoot);
+}
+
+test(() => {
+  resetTabIndexAndFocus();
+  setAllTabIndex(0);
+  host.click();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, document.body);
+}, "call click() on host with delegatesFocus, all tabindex=0");
+
+test(() => {
+  resetTabIndexAndFocus();
+  setAllTabIndex(0);
+  slotted.click();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, document.body);
+}, "call click() on slotted element in delegatesFocus shadow tree, all tabindex=0");
+</script>

--- a/shadow-dom/focus/click-focus-delegatesFocus-tabindex-varies.html
+++ b/shadow-dom/focus/click-focus-delegatesFocus-tabindex-varies.html
@@ -56,14 +56,13 @@ function resetTabIndexAndFocus() {
   resetFocus(shadowRoot);
 }
 
-async_test(async (t) => {
+promise_test(async () => {
   resetTabIndexAndFocus();
   setTabIndex([aboveSlot], 2);
   setTabIndex([slot, slotted], 1);
   await test_driver.click(host);
-  t.step(() => { assert_equals(shadowRoot.activeElement, null); });
-  t.step(() => { assert_equals(document.activeElement, aboveSlot); });
-  t.done();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, aboveSlot);
 }, "click on host with delegatesFocus, #aboveSlot tabindex = 2, #slot and #slotted tabindex = 1");
 
 </script>

--- a/shadow-dom/focus/click-focus-delegatesFocus-tabindex-varies.html
+++ b/shadow-dom/focus/click-focus-delegatesFocus-tabindex-varies.html
@@ -61,8 +61,8 @@ promise_test(async () => {
   setTabIndex([aboveSlot], 2);
   setTabIndex([slot, slotted], 1);
   await test_driver.click(host);
-  assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, aboveSlot);
+  assert_equals(shadowRoot.activeElement, aboveSlot);
+  assert_equals(document.activeElement, host);
 }, "click on host with delegatesFocus, #aboveSlot tabindex = 2, #slot and #slotted tabindex = 1");
 
 </script>

--- a/shadow-dom/focus/click-focus-delegatesFocus-tabindex-varies.html
+++ b/shadow-dom/focus/click-focus-delegatesFocus-tabindex-varies.html
@@ -22,14 +22,21 @@ const shadowRoot = host.attachShadow({ mode: "open", delegatesFocus: true });
 const aboveSlot = document.createElement("div");
 aboveSlot.innerText = "aboveSlot";
 const slot = document.createElement("slot");
+// Add an unfocusable spacer, because test_driver.click will click on the
+// center point of #host, and we don't want the click to land on #aboveSlot
+// or #slot.
+const spacer = document.createElement("div");
+spacer.style = "height: 1000px;";
+shadowRoot.appendChild(spacer);
 shadowRoot.appendChild(aboveSlot);
 shadowRoot.appendChild(slot);
 
-const elementsInFlatTreeOrder = [host, aboveSlot, slot, slotted, outside];
+const elementsInFlatTreeOrder = [host, aboveSlot, spacer, slot, slotted, outside];
 
 // Final structure:
 // <div #host> (delegatesFocus=true)
 //    #shadowRoot
+//      <div #spacer>
 //      <div #aboveSlot>
 //      <slot #slot>
 //        (slotted) <div #slotted>
@@ -49,35 +56,14 @@ function resetTabIndexAndFocus() {
   resetFocus(shadowRoot);
 }
 
-test(() => {
+async_test(async (t) => {
   resetTabIndexAndFocus();
-  setAllTabIndex(0);
-  test_driver.click(host);
-  assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, document.body);
-}, "click on host with delegatesFocus, all tabindex=0");
+  setTabIndex([aboveSlot], 2);
+  setTabIndex([slot, slotted], 1);
+  await test_driver.click(host);
+  t.step(() => { assert_equals(shadowRoot.activeElement, null); });
+  t.step(() => { assert_equals(document.activeElement, aboveSlot); });
+  t.done();
+}, "click on host with delegatesFocus, #aboveSlot tabindex = 2, #slot and #slotted tabindex = 1");
 
-test(() => {
-  resetTabIndexAndFocus();
-  setAllTabIndex(0);
-  host.click();
-  assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, document.body);
-}, "call click() on host with delegatesFocus, all tabindex=0");
-
-test(() => {
-  resetTabIndexAndFocus();
-  setAllTabIndex(0);
-  test_driver.click(slotted);
-  assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, document.body);
-}, "click on slotted element in delegatesFocus shadow tree, all tabindex=0");
-
-test(() => {
-  resetTabIndexAndFocus();
-  setAllTabIndex(0);
-  slotted.click();
-  assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, document.body);
-}, "call click() on slotted element in delegatesFocus shadow tree, all tabindex=0");
 </script>

--- a/shadow-dom/focus/click-focus-delegatesFocus-tabindex-zero.html
+++ b/shadow-dom/focus/click-focus-delegatesFocus-tabindex-zero.html
@@ -56,14 +56,13 @@ function resetTabIndexAndFocus() {
   resetFocus(shadowRoot);
 }
 
-async_test(async (t) => {
+promise_test(async () => {
   resetTabIndexAndFocus();
   setAllTabIndex(0);
   removeTabIndex([spacer]);
   await test_driver.click(host);
-  t.step(() => { assert_equals(shadowRoot.activeElement, aboveSlot); });
-  t.step(() => { assert_equals(document.activeElement, host); });
-  t.done();
+  assert_equals(shadowRoot.activeElement, aboveSlot);
+  assert_equals(document.activeElement, host);
 }, "click on host with delegatesFocus, all tabindex=0 except spacer");
 
 </script>

--- a/shadow-dom/focus/click-focus-delegatesFocus-tabindex-zero.html
+++ b/shadow-dom/focus/click-focus-delegatesFocus-tabindex-zero.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: click on shadow host with delegatesFocus</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/shadow-utils.js"></script>
+
+<body>
+<div id="host">
+  <div id="slotted">slotted</div>
+</div>
+<div id="outside">outside</div>
+</body>
+
+<script>
+const host = document.getElementById("host");
+const slotted = document.getElementById("slotted");
+
+const shadowRoot = host.attachShadow({ mode: "open", delegatesFocus: true });
+const aboveSlot = document.createElement("div");
+aboveSlot.innerText = "aboveSlot";
+const slot = document.createElement("slot");
+// Add an unfocusable spacer, because test_driver.click will click on the
+// center point of #host, and we don't want the click to land on #aboveSlot
+// or #slot.
+const spacer = document.createElement("div");
+spacer.style = "height: 1000px;";
+shadowRoot.appendChild(spacer);
+shadowRoot.appendChild(aboveSlot);
+shadowRoot.appendChild(slot);
+
+const elementsInFlatTreeOrder = [host, aboveSlot, spacer, slot, slotted, outside];
+
+// Final structure:
+// <div #host> (delegatesFocus=true)
+//    #shadowRoot
+//      <div #spacer>
+//      <div #aboveSlot>
+//      <slot #slot>
+//        (slotted) <div #slotted>
+// <div #outside>
+
+function setAllTabIndex(value) {
+  setTabIndex(elementsInFlatTreeOrder, value);
+}
+
+function removeAllTabIndex() {
+  removeTabIndex(elementsInFlatTreeOrder);
+}
+
+function resetTabIndexAndFocus() {
+  removeAllTabIndex();
+  resetFocus(document);
+  resetFocus(shadowRoot);
+}
+
+async_test(async (t) => {
+  resetTabIndexAndFocus();
+  setAllTabIndex(0);
+  removeTabIndex([spacer]);
+  await test_driver.click(host);
+  t.step(() => { assert_equals(shadowRoot.activeElement, aboveSlot); });
+  t.step(() => { assert_equals(document.activeElement, host); });
+  t.done();
+}, "click on host with delegatesFocus, all tabindex=0 except spacer");
+
+</script>

--- a/shadow-dom/focus/click-focus-delegatesFocus.html
+++ b/shadow-dom/focus/click-focus-delegatesFocus.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: click on shadow host with delegatesFocus</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/shadow-utils.js"></script>
+
+<body>
+<div id="host">
+  <div id="slotted">slotted</div>
+</div>
+<div id="outside">outside</div>
+</body>
+
+<script>
+const host = document.getElementById("host");
+const slotted = document.getElementById("slotted");
+
+const shadowRoot = host.attachShadow({ mode: "open", delegatesFocus: true });
+const aboveSlot = document.createElement("div");
+aboveSlot.innerText = "aboveSlot";
+const slot = document.createElement("slot");
+shadowRoot.appendChild(aboveSlot);
+shadowRoot.appendChild(slot);
+
+const elementsInFlatTreeOrder = [host, aboveSlot, slot, slotted, outside];
+
+// Final structure:
+// <div #host> (delegatesFocus=true)
+//    #shadowRoot
+//      <div #aboveSlot>
+//      <slot #slot>
+//        (slotted) <div #slotted>
+// <div #outside>
+
+function setAllTabIndex(value) {
+  setTabIndex(elementsInFlatTreeOrder, value);
+}
+
+function removeAllTabIndex() {
+  removeTabIndex(elementsInFlatTreeOrder);
+}
+
+function resetTabIndexAndFocus() {
+  removeAllTabIndex();
+  resetFocus(document);
+  resetFocus(shadowRoot);
+}
+
+test(() => {
+  resetTabIndexAndFocus();
+  setAllTabIndex(0);
+  test_driver.click(host);
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, document.body);
+}, "click on host with delegatesFocus, all tabindex=0");
+
+test(() => {
+  resetTabIndexAndFocus();
+  setAllTabIndex(0);
+  host.click();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, document.body);
+}, "call click() on host with delegatesFocus, all tabindex=0");
+
+test(() => {
+  resetTabIndexAndFocus();
+  setAllTabIndex(0);
+  test_driver.click(slotted);
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, document.body);
+}, "click on slotted element in delegatesFocus shadow tree, all tabindex=0");
+
+test(() => {
+  resetTabIndexAndFocus();
+  setAllTabIndex(0);
+  slotted.click();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, document.body);
+}, "call click() on slotted element in delegatesFocus shadow tree, all tabindex=0");
+</script>

--- a/shadow-dom/focus/focus-method-delegatesFocus.html
+++ b/shadow-dom/focus/focus-method-delegatesFocus.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: focus on shadow host with delegatesFocus</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body>
+<div id="host">
+  <div id="slottedToSecondSlot" slot="secondSlot">slottedToSecondSlot</div>
+  <div id="slottedToFirstSlot" slot="firstSlot">slottedToFirstSlot</div>
+</div>
+<div id="outside">outside</div>
+</body>
+
+<script>
+const host = document.getElementById("host");
+const slottedToSecondSlot = document.getElementById("slottedToSecondSlot");
+const slottedToFirstSlot = document.getElementById("slottedToFirstSlot");
+const outside = document.getElementById("outside");
+
+const shadowRoot = host.attachShadow({ mode: "open", delegatesFocus: true });
+const aboveSlots = document.createElement("div");
+aboveSlots.innerText = "aboveSlots";
+const firstSlot = document.createElement("slot");
+firstSlot.name = "firstSlot";
+const secondSlot = document.createElement("slot");
+secondSlot.name = "secondSlot";
+const belowSlots = document.createElement("div");
+belowSlots.innerText = "belowSlots";
+shadowRoot.appendChild(aboveSlots);
+shadowRoot.appendChild(firstSlot);
+shadowRoot.appendChild(secondSlot);
+shadowRoot.appendChild(belowSlots);
+
+const elementsInFlatTreeOrder = [host, aboveSlots, firstSlot,
+  slottedToFirstSlot, secondSlot, slottedToSecondSlot, belowSlots, outside];
+
+// Final structure:
+// <div #host> (delegatesFocus=true)
+//    #shadowRoot
+//      <div #aboveSlots>
+//      <slot #firstSlot>
+//        (slotted) <div #slottedToFirstSlot>
+//      <slot #secondSlot>
+//        (slotted) <div #slottedToSecondSlot>
+//      <div #belowSlots>
+// <div #outside>
+
+function setTabIndex(elements, value) {
+  for (const el of elements) {
+    el.tabIndex = value;
+  }
+}
+
+function setAllTabIndex(value) {
+  setTabIndex(elementsInFlatTreeOrder, value);
+}
+
+function removeAllTabIndex() {
+  for (const el of elementsInFlatTreeOrder) {
+    el.removeAttribute("tabindex");
+  }
+}
+
+function resetFocus() {
+  removeAllTabIndex();
+  if (shadowRoot.activeElement)
+    shadowRoot.activeElement.blur();
+  if (document.activeElement)
+    document.activeElement.blur();
+}
+
+test(() => {
+  resetFocus();
+  setAllTabIndex(0);
+  // Structure:
+  // <div #host> (delegatesFocus=true) tabindex=0
+  //    #shadowRoot
+  //      <div #aboveSlots> tabindex=0
+  //      <slot #firstSlot> tabindex=0
+  //        (slotted) <div #slottedToFirstSlot> tabindex=0
+  //      <slot #secondSlot> tabindex=0
+  //        (slotted) <div #slottedToSecondSlot> tabindex=0
+  //      <div #belowSlots> tabindex=0
+  // <div #outside> tabindex=0
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // [aboveSlots, slottedToFirstSlot, slottedToSecondSlot, belowSlots]
+  host.focus();
+  assert_equals(shadowRoot.activeElement, aboveSlots);
+  assert_equals(document.activeElement, host);
+}, "focus() on host with delegatesFocus, all tabindex=0");
+
+test(() => {
+  resetFocus();
+  setAllTabIndex(0);
+  setTabIndex([host], -1);
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // [aboveSlots, slottedToFirstSlot, slottedToSecondSlot, belowSlots]
+  host.focus();
+  assert_equals(shadowRoot.activeElement, aboveSlots);
+  assert_equals(document.activeElement, host);
+}, "focus() on host with delegatesFocus & tabindex =-1, all other tabindex=0");
+
+test(() => {
+  resetFocus();
+  setTabIndex([aboveSlots, slottedToFirstSlot, slottedToSecondSlot, belowSlots], 0);
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // [aboveSlots, slottedToFirstSlot, slottedToSecondSlot, belowSlots]
+  host.focus();
+  assert_equals(shadowRoot.activeElement, aboveSlots);
+  assert_equals(document.activeElement, host);
+}, "focus() on host with delegatesFocus & no tabindex, all other tabindex=0");
+
+test(() => {
+  resetFocus();
+  setAllTabIndex(-1);
+  setTabIndex([host], 0);
+  // flattened tabindex-ordered focus navigation scope of #host: []
+  host.focus();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, null);
+}, "focus() on host with delegatesFocus & tabindex = 0, all other tabindex=-1");
+
+test(() => {
+  resetFocus();
+  removeAllTabIndex();
+  // flattened tabindex-ordered focus navigation scope of #host: []
+  host.focus();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, null);
+}, "focus() on host with delegatesFocus, all without tabindex");
+
+test(() => {
+  resetFocus();
+  // flattened tabindex-ordered focus navigation scope of #host: []
+  setAllTabIndex(-1);
+  host.focus();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, null);
+}, "focus() on host with delegatesFocus, all tabindex=-1");
+
+test(() => {
+  resetFocus();
+  setAllTabIndex(-1);
+  setTabIndex([host, belowSlots], 0);
+  // Structure:
+  // <div #host> (delegatesFocus=true) tabindex=0
+  //    #shadowRoot
+  //      <div #aboveSlots>
+  //      <slot #firstSlot>
+  //        (slotted) <div #slottedToFirstSlot>
+  //      <slot #secondSlot>
+  //        (slotted) <div #slottedToSecondSlot>
+  //      <div #belowSlots> tabindex=0
+  // <div #outside>
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // [belowSlots]
+  host.focus();
+  assert_equals(shadowRoot.activeElement, belowSlots);
+  assert_equals(document.activeElement, host);
+}, "focus() on host with delegatesFocus & tabindex=0, #belowSlots with tabindex=0");
+
+test(() => {
+  resetFocus();
+  setAllTabIndex(-1);
+  setTabIndex([host, outside], 0);
+  // Structure:
+  // <div #host> (delegatesFocus=true) tabindex=0
+  //    #shadowRoot
+  //      <div #aboveSlots>
+  //      <slot #firstSlot>
+  //        (slotted) <div #slottedToFirstSlot>
+  //      <slot #secondSlot>
+  //        (slotted) <div #slottedToSecondSlot>
+  //      <div #belowSlots>
+  // <div #outside> tabindex=0
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // []
+  host.focus();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, null);
+}, "focus() on host with delegatesFocus & tabindex=0, #outside with tabindex=0");
+
+test(() => {
+  resetFocus();
+  setTabIndex([host, aboveSlots, belowSlots], 0);
+  // Structure:
+  // <div #host> (delegatesFocus=true) tabindex=0
+  //    #shadowRoot
+  //      <div #aboveSlots> tabindex=0
+  //      <slot #firstSlot>
+  //        (slotted) <div #slottedToFirstSlot>
+  //      <slot #secondSlot>
+  //        (slotted) <div #slottedToSecondSlot>
+  //      <div #belowSlots> tabindex=0
+  // <div #outside>
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // [aboveSlots, belowSlots]
+  host.focus();
+  assert_equals(shadowRoot.activeElement, aboveSlots);
+  assert_equals(document.activeElement, host);
+}, "focus() on host with delegatesFocus & tabindex=0, #aboveSlots and #belowSlots with tabindex=0");
+
+test(() => {
+  resetFocus();
+  setAllTabIndex(-1);
+  setTabIndex([host, aboveSlots], 0);
+  setTabIndex([belowSlots], 1);
+  // Structure:
+  // <div #host> (delegatesFocus=true) tabindex=0
+  //    #shadowRoot
+  //      <div #aboveSlots> tabindex=0
+  //      <slot #firstSlot>
+  //        (slotted) <div #slottedToFirstSlot>
+  //      <slot #secondSlot>
+  //        (slotted) <div #slottedToSecondSlot>
+  //      <div #belowSlots> tabindex=1
+  // <div #outside>
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // [belowSlots, aboveSlots]
+  host.focus();
+  assert_equals(shadowRoot.activeElement, belowSlots);
+  assert_equals(document.activeElement, host);
+}, "focus() on host with delegatesFocus & tabindex=0, #aboveSlots with tabindex=0, #belowSlots with tabindex=1");
+
+test(() => {
+  resetFocus();
+  setTabIndex([host, firstSlot, slottedToFirstSlot, secondSlot, slottedToSecondSlot], 0);
+  // Structure:
+  // <div #host> (delegatesFocus=true) tabindex=0
+  //    #shadowRoot
+  //      <div #aboveSlots>
+  //      <slot #firstSlot> tabindex=0
+  //        (slotted) <div #slottedToFirstSlot> tabindex=0
+  //      <slot #secondSlot> tabindex=0
+  //        (slotted) <div #slottedToSecondSlot> tabindex=0
+  //      <div #belowSlots>
+  // <div #outside>
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // [slottedToFirstSlot, slottedToSecondSlot]
+  host.focus();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, slottedToFirstSlot);
+}, "focus() on host with delegatesFocus & tabindex=0, #firstSlot, #slottedToFirstSlot, #secondSlot, #slottedToSecondSlot with tabindex=0");
+
+test(() => {
+  resetFocus();
+  setTabIndex([firstSlot], 1);
+  setTabIndex([host, aboveSlots, slottedToFirstSlot], 0);
+  // Structure:
+  // <div #host> (delegatesFocus=true) tabindex=0
+  //    #shadowRoot
+  //      <div #aboveSlots> tabindex=0
+  //      <slot #firstSlot> tabindex=1
+  //        (slotted) <div #slottedToFirstSlot> tabindex=0
+  //      <slot #secondSlot>
+  //        (slotted) <div #slottedToSecondSlot>
+  //      <div #belowSlots>
+  // <div #outside>
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // [slottedToFirstSlot, aboveSlots]
+  host.focus();
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, slottedToFirstSlot);
+}, "focus() on host with delegatesFocus & tabindex=0, #firstSlot with tabindex=1, #slottedToFirstSlot and #aboveSlots with tabindex=0");
+
+test(() => {
+  resetFocus();
+  setTabIndex([slottedToFirstSlot], 1);
+  setTabIndex([host, aboveSlots], 0);
+  // Structure:
+  // <div #host> (delegatesFocus=true) tabindex=0
+  //    #shadowRoot
+  //      <div #aboveSlots> tabindex=0
+  //      <slot #firstSlot>
+  //        (slotted) <div #slottedToFirstSlot> tabindex=1
+  //      <slot #secondSlot>
+  //        (slotted) <div #slottedToSecondSlot>
+  //      <div #belowSlots>
+  // <div #outside>
+  // flattened tabindex-ordered focus navigation scope of #host:
+  // [aboveSlots, slottedToFirstSlot]
+  host.focus();
+  assert_equals(shadowRoot.activeElement, aboveSlots);
+  assert_equals(document.activeElement, host);
+}, "focus() on host with delegatesFocus & tabindex=0, #slottedTofirstSlot with tabindex=1, #aboveSlots with tabindex=0");
+</script>

--- a/shadow-dom/focus/focus-method-delegatesFocus.html
+++ b/shadow-dom/focus/focus-method-delegatesFocus.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>HTML Test: focus on shadow host with delegatesFocus</title>
+<title>HTML Test: focus() on shadow host with delegatesFocus</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/shadow-utils.js"></script>
 
 <body>
 <div id="host">
@@ -48,32 +49,23 @@ const elementsInFlatTreeOrder = [host, aboveSlots, firstSlot,
 //      <div #belowSlots>
 // <div #outside>
 
-function setTabIndex(elements, value) {
-  for (const el of elements) {
-    el.tabIndex = value;
-  }
-}
 
 function setAllTabIndex(value) {
   setTabIndex(elementsInFlatTreeOrder, value);
 }
 
 function removeAllTabIndex() {
-  for (const el of elementsInFlatTreeOrder) {
-    el.removeAttribute("tabindex");
-  }
+  removeTabIndex(elementsInFlatTreeOrder);
 }
 
-function resetFocus() {
+function resetTabIndexAndFocus() {
   removeAllTabIndex();
-  if (shadowRoot.activeElement)
-    shadowRoot.activeElement.blur();
-  if (document.activeElement)
-    document.activeElement.blur();
+  resetFocus(document);
+  resetFocus(shadowRoot);
 }
 
 test(() => {
-  resetFocus();
+  resetTabIndexAndFocus();
   setAllTabIndex(0);
   // Structure:
   // <div #host> (delegatesFocus=true) tabindex=0
@@ -85,65 +77,62 @@ test(() => {
   //        (slotted) <div #slottedToSecondSlot> tabindex=0
   //      <div #belowSlots> tabindex=0
   // <div #outside> tabindex=0
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // [aboveSlots, slottedToFirstSlot, slottedToSecondSlot, belowSlots]
+  // First focusable = #aboveSlots
   host.focus();
   assert_equals(shadowRoot.activeElement, aboveSlots);
   assert_equals(document.activeElement, host);
 }, "focus() on host with delegatesFocus, all tabindex=0");
 
 test(() => {
-  resetFocus();
+  resetTabIndexAndFocus();
   setAllTabIndex(0);
   setTabIndex([host], -1);
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // [aboveSlots, slottedToFirstSlot, slottedToSecondSlot, belowSlots]
+  // First focusable = #aboveSlots
   host.focus();
   assert_equals(shadowRoot.activeElement, aboveSlots);
   assert_equals(document.activeElement, host);
 }, "focus() on host with delegatesFocus & tabindex =-1, all other tabindex=0");
 
 test(() => {
-  resetFocus();
+  resetTabIndexAndFocus();
   setTabIndex([aboveSlots, slottedToFirstSlot, slottedToSecondSlot, belowSlots], 0);
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // [aboveSlots, slottedToFirstSlot, slottedToSecondSlot, belowSlots]
+  // First focusable = #aboveSlots
   host.focus();
   assert_equals(shadowRoot.activeElement, aboveSlots);
   assert_equals(document.activeElement, host);
 }, "focus() on host with delegatesFocus & no tabindex, all other tabindex=0");
 
 test(() => {
-  resetFocus();
+  resetTabIndexAndFocus();
   setAllTabIndex(-1);
   setTabIndex([host], 0);
-  // flattened tabindex-ordered focus navigation scope of #host: []
+  // First focusable = #aboveSlots
   host.focus();
-  assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, null);
+  assert_equals(shadowRoot.activeElement, aboveSlots);
+  assert_equals(document.activeElement, host);
 }, "focus() on host with delegatesFocus & tabindex = 0, all other tabindex=-1");
 
 test(() => {
-  resetFocus();
+  resetTabIndexAndFocus();
   removeAllTabIndex();
-  // flattened tabindex-ordered focus navigation scope of #host: []
+  // No focusable element under #host in the flat tree.
   host.focus();
   assert_equals(shadowRoot.activeElement, null);
   assert_equals(document.activeElement, null);
 }, "focus() on host with delegatesFocus, all without tabindex");
 
 test(() => {
-  resetFocus();
-  // flattened tabindex-ordered focus navigation scope of #host: []
+  resetTabIndexAndFocus();
+  // First focusable = #aboveSlots
   setAllTabIndex(-1);
   host.focus();
-  assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, null);
+  assert_equals(shadowRoot.activeElement, aboveSlots);
+  assert_equals(document.activeElement, host);
 }, "focus() on host with delegatesFocus, all tabindex=-1");
 
 test(() => {
-  resetFocus();
-  setAllTabIndex(-1);
+  resetTabIndexAndFocus();
+  removeAllTabIndex();
   setTabIndex([host, belowSlots], 0);
   // Structure:
   // <div #host> (delegatesFocus=true) tabindex=0
@@ -155,16 +144,15 @@ test(() => {
   //        (slotted) <div #slottedToSecondSlot>
   //      <div #belowSlots> tabindex=0
   // <div #outside>
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // [belowSlots]
+  // First focusable = #belowSlots
   host.focus();
   assert_equals(shadowRoot.activeElement, belowSlots);
   assert_equals(document.activeElement, host);
 }, "focus() on host with delegatesFocus & tabindex=0, #belowSlots with tabindex=0");
 
 test(() => {
-  resetFocus();
-  setAllTabIndex(-1);
+  resetTabIndexAndFocus();
+  removeAllTabIndex();
   setTabIndex([host, outside], 0);
   // Structure:
   // <div #host> (delegatesFocus=true) tabindex=0
@@ -176,15 +164,14 @@ test(() => {
   //        (slotted) <div #slottedToSecondSlot>
   //      <div #belowSlots>
   // <div #outside> tabindex=0
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // []
+  // No focusable element under #host in the flat tree.
   host.focus();
   assert_equals(shadowRoot.activeElement, null);
   assert_equals(document.activeElement, null);
 }, "focus() on host with delegatesFocus & tabindex=0, #outside with tabindex=0");
 
 test(() => {
-  resetFocus();
+  resetTabIndexAndFocus();
   setTabIndex([host, aboveSlots, belowSlots], 0);
   // Structure:
   // <div #host> (delegatesFocus=true) tabindex=0
@@ -196,94 +183,30 @@ test(() => {
   //        (slotted) <div #slottedToSecondSlot>
   //      <div #belowSlots> tabindex=0
   // <div #outside>
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // [aboveSlots, belowSlots]
+  // First focusable = #aboveSlots
   host.focus();
   assert_equals(shadowRoot.activeElement, aboveSlots);
   assert_equals(document.activeElement, host);
 }, "focus() on host with delegatesFocus & tabindex=0, #aboveSlots and #belowSlots with tabindex=0");
 
 test(() => {
-  resetFocus();
-  setAllTabIndex(-1);
-  setTabIndex([host, aboveSlots], 0);
-  setTabIndex([belowSlots], 1);
-  // Structure:
-  // <div #host> (delegatesFocus=true) tabindex=0
-  //    #shadowRoot
-  //      <div #aboveSlots> tabindex=0
-  //      <slot #firstSlot>
-  //        (slotted) <div #slottedToFirstSlot>
-  //      <slot #secondSlot>
-  //        (slotted) <div #slottedToSecondSlot>
-  //      <div #belowSlots> tabindex=1
-  // <div #outside>
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // [belowSlots, aboveSlots]
-  host.focus();
-  assert_equals(shadowRoot.activeElement, belowSlots);
-  assert_equals(document.activeElement, host);
-}, "focus() on host with delegatesFocus & tabindex=0, #aboveSlots with tabindex=0, #belowSlots with tabindex=1");
-
-test(() => {
-  resetFocus();
-  setTabIndex([host, firstSlot, slottedToFirstSlot, secondSlot, slottedToSecondSlot], 0);
+  resetTabIndexAndFocus();
+  setTabIndex([host, slottedToFirstSlot, slottedToSecondSlot, belowSlots], 0);
   // Structure:
   // <div #host> (delegatesFocus=true) tabindex=0
   //    #shadowRoot
   //      <div #aboveSlots>
-  //      <slot #firstSlot> tabindex=0
-  //        (slotted) <div #slottedToFirstSlot> tabindex=0
-  //      <slot #secondSlot> tabindex=0
-  //        (slotted) <div #slottedToSecondSlot> tabindex=0
-  //      <div #belowSlots>
-  // <div #outside>
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // [slottedToFirstSlot, slottedToSecondSlot]
-  host.focus();
-  assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, slottedToFirstSlot);
-}, "focus() on host with delegatesFocus & tabindex=0, #firstSlot, #slottedToFirstSlot, #secondSlot, #slottedToSecondSlot with tabindex=0");
-
-test(() => {
-  resetFocus();
-  setTabIndex([firstSlot], 1);
-  setTabIndex([host, aboveSlots, slottedToFirstSlot], 0);
-  // Structure:
-  // <div #host> (delegatesFocus=true) tabindex=0
-  //    #shadowRoot
-  //      <div #aboveSlots> tabindex=0
-  //      <slot #firstSlot> tabindex=1
-  //        (slotted) <div #slottedToFirstSlot> tabindex=0
-  //      <slot #secondSlot>
-  //        (slotted) <div #slottedToSecondSlot>
-  //      <div #belowSlots>
-  // <div #outside>
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // [slottedToFirstSlot, aboveSlots]
-  host.focus();
-  assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, slottedToFirstSlot);
-}, "focus() on host with delegatesFocus & tabindex=0, #firstSlot with tabindex=1, #slottedToFirstSlot and #aboveSlots with tabindex=0");
-
-test(() => {
-  resetFocus();
-  setTabIndex([slottedToFirstSlot], 1);
-  setTabIndex([host, aboveSlots], 0);
-  // Structure:
-  // <div #host> (delegatesFocus=true) tabindex=0
-  //    #shadowRoot
-  //      <div #aboveSlots> tabindex=0
   //      <slot #firstSlot>
-  //        (slotted) <div #slottedToFirstSlot> tabindex=1
+  //        (slotted) <div #slottedToFirstSlot> tabindex=0
   //      <slot #secondSlot>
-  //        (slotted) <div #slottedToSecondSlot>
-  //      <div #belowSlots>
+  //        (slotted) <div #slottedToSecondSlot> tabindex=0
+  //      <div #belowSlots> tabindex=0
   // <div #outside>
-  // flattened tabindex-ordered focus navigation scope of #host:
-  // [aboveSlots, slottedToFirstSlot]
+  // First focusable = #slottedToFirstSlot
   host.focus();
-  assert_equals(shadowRoot.activeElement, aboveSlots);
-  assert_equals(document.activeElement, host);
-}, "focus() on host with delegatesFocus & tabindex=0, #slottedTofirstSlot with tabindex=1, #aboveSlots with tabindex=0");
+  assert_equals(shadowRoot.activeElement, null);
+  assert_equals(document.activeElement, slottedToFirstSlot);
+}, "focus() on host with delegatesFocus & tabindex=0, #slottedToFirstSlot, #slottedToSecondSlot, #belowSlots  with tabindex=0");
+
 </script>
+

--- a/shadow-dom/focus/focus-method-delegatesFocus.html
+++ b/shadow-dom/focus/focus-method-delegatesFocus.html
@@ -191,6 +191,26 @@ test(() => {
 
 test(() => {
   resetTabIndexAndFocus();
+  setTabIndex([host, aboveSlots], 0);
+  setTabIndex([belowSlots], 1);
+  // Structure:
+  // <div #host> (delegatesFocus=true) tabindex=0
+  //    #shadowRoot
+  //      <div #aboveSlots> tabindex=0
+  //      <slot #firstSlot>
+  //        (slotted) <div #slottedToFirstSlot>
+  //      <slot #secondSlot>
+  //        (slotted) <div #slottedToSecondSlot>
+  //      <div #belowSlots> tabindex=1
+  // <div #outside>
+  // First focusable = #aboveSlots
+  host.focus();
+  assert_equals(shadowRoot.activeElement, aboveSlots);
+  assert_equals(document.activeElement, host);
+}, "focus() on host with delegatesFocus & tabindex=0, #aboveSlots with tabindex=0 and #belowSlots with tabindex=1");
+  
+test(() => {
+  resetTabIndexAndFocus();
   setTabIndex([host, slottedToFirstSlot, slottedToSecondSlot, belowSlots], 0);
   // Structure:
   // <div #host> (delegatesFocus=true) tabindex=0

--- a/shadow-dom/focus/focus-method-delegatesFocus.html
+++ b/shadow-dom/focus/focus-method-delegatesFocus.html
@@ -118,7 +118,7 @@ test(() => {
   // No focusable element under #host in the flat tree.
   host.focus();
   assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, null);
+  assert_equals(document.activeElement, document.body);
 }, "focus() on host with delegatesFocus, all without tabindex");
 
 test(() => {
@@ -167,7 +167,7 @@ test(() => {
   // No focusable element under #host in the flat tree.
   host.focus();
   assert_equals(shadowRoot.activeElement, null);
-  assert_equals(document.activeElement, null);
+  assert_equals(document.activeElement, document.body);
 }, "focus() on host with delegatesFocus & tabindex=0, #outside with tabindex=0");
 
 test(() => {

--- a/shadow-dom/focus/focus-tabindex-order-shadow-negative-delegatesFocus.html
+++ b/shadow-dom/focus/focus-tabindex-order-shadow-negative-delegatesFocus.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: focus - the sequential focus navigation order with shadow dom that delegates focus and all tabindex=-1 in shadow tree</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/shadow-utils.js"></script>
+<body>
+<script>
+// Structure:
+// <div #aboveHost tabindex=0>
+// <div #host tabindex=0>
+//    #shadowRoot (delegatesFocus)
+//      <div #aboveSlot tabindex=-1>
+//      <slot #slotAbove tabindex=-1>
+//        (slotted) <div #slottedAbove tabindex=-1>
+//      <slot #slotBelow tabindex=-1>
+//        (slotted) <div #slottedBelow tabindex=-1>
+//      <div #belowSlot tabindex=-1>
+// <div #belowHost tabindex=0>
+
+promise_test(() => {
+  let elementsInFlatTreeOrder;
+  let [aboveHost, host, aboveSlot, slotAbove, slottedAbove, slotBelow, slottedBelow, belowSlot, belowHost] = elementsInFlatTreeOrder = prepareDOM(document.body, true);
+  setTabIndex(elementsInFlatTreeOrder, -1);
+  setTabIndex([aboveHost, host, belowHost], 0);
+  resetFocus();
+  // Focus should only land on #aboveHost and #belowHost (all others are non-sequentially focusable).
+  return assertFocusOrder([aboveHost, belowHost]);
+}, "Order when all tabindex=-1 is and delegatesFocus = true");
+</script>
+</body>

--- a/shadow-dom/focus/focus-tabindex-order-shadow-varying-delegatesFocus.html
+++ b/shadow-dom/focus/focus-tabindex-order-shadow-varying-delegatesFocus.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: focus - the sequential focus navigation order with shadow dom that delegates focus and tabindex in shadow tree varies</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/shadow-utils.js"></script>
+<body>
+<script>
+// Structure:
+// <div #aboveHost tabindex=0>
+// <div #host tabindex=0>
+//    #shadowRoot (delegatesFocus)
+//      <div #aboveSlot tabindex=0>
+//      <slot #slotAbove tabindex=1>
+//        (slotted) <div #slottedAbove tabindex=3>
+//      <slot #slotBelow tabindex=2>
+//        (slotted) <div #slottedBelow tabindex=1>
+//      <div #belowSlot tabindex=-1>
+// <div #belowHost tabindex=0>
+
+promise_test(() => {
+  let elementsInFlatTreeOrder;
+  let [aboveHost, host, aboveSlot, slotAbove, slottedAbove, slotBelow, slottedBelow, belowSlot, belowHost] = elementsInFlatTreeOrder = prepareDOM(document.body, true);
+  setTabIndex(elementsInFlatTreeOrder, -1);
+  setTabIndex([aboveHost, host, aboveSlot, belowHost], 0);
+  setTabIndex([slotAbove, slottedBelow], 1);
+  setTabIndex([slotBelow], 2);
+  setTabIndex([slottedAbove], 3);
+  resetFocus();
+  return assertFocusOrder([aboveHost, slottedAbove, slottedBelow, aboveSlot, belowHost]);
+}, "Order when tabindex varies and delegatesFocus = true");
+</script>
+</body>

--- a/shadow-dom/focus/focus-tabindex-order-shadow-zero-delegatesFocus.html
+++ b/shadow-dom/focus/focus-tabindex-order-shadow-zero-delegatesFocus.html
@@ -28,7 +28,7 @@ promise_test(() => {
   resetFocus();
   // Focus should move in flat tree order since every one of them has tabindex ==0,
   // but doesn't include slots and #host.
-  return assertFocusOrder(elementsInFlatTreeOrder.filter(el => (el !== slotAbove && el !== slotBelow && el !== host)));
+  return assertFocusOrder([aboveHost, aboveSlot, slottedAbove, slottedBelow, belowSlot, belowHost]);
 }, "Order when all tabindex=0 is and delegatesFocus = true");
 </script>
 </body>

--- a/shadow-dom/focus/focus-tabindex-order-shadow-zero-delegatesFocus.html
+++ b/shadow-dom/focus/focus-tabindex-order-shadow-zero-delegatesFocus.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: focus - the sequential focus navigation order with shadow dom that delegates focus and all tabindex=0</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/shadow-utils.js"></script>
+<body>
+<script>
+// Structure:
+// <div #aboveHost tabindex=0>
+// <div #host tabindex=0>
+//    #shadowRoot (delegatesFocus)
+//      <div #aboveSlot tabindex=0>
+//      <slot #slotAbove tabindex=0>
+//        (slotted) <div #slottedAbove tabindex=0>
+//      <slot #slotBelow tabindex=0>
+//        (slotted) <div #slottedBelow tabindex=0>
+//      <div #belowSlot tabindex=0>
+// <div #belowHost tabindex=0>
+
+promise_test(() => {
+  let elementsInFlatTreeOrder;
+  let [aboveHost, host, aboveSlot, slotAbove, slottedAbove, slotBelow, slottedBelow, belowSlot, belowHost] = elementsInFlatTreeOrder = prepareDOM(document.body, true);
+  setTabIndex(elementsInFlatTreeOrder, 0);
+  resetFocus();
+  // Focus should move in flat tree order since every one of them has tabindex ==0,
+  // but doesn't include slots and #host.
+  return assertFocusOrder(elementsInFlatTreeOrder.filter(el => (el !== slotAbove && el !== slotBelow && el !== host)));
+}, "Order when all tabindex=0 is and delegatesFocus = true");
+</script>
+</body>


### PR DESCRIPTION
WPT for https://github.com/whatwg/html/pull/4796.
As noted there, the behavior in Chrome for focus() when the flattened tabindex-ordered focus navigation scope is empty (there's nothing to focus on) so it fails in some of the tests.