### PR TITLE
MathML: Add tests to check legacy mathsize values

### DIFF
--- a/mathml/relations/css-styling/mathsize-attribute-legacy-values-ref.html
+++ b/mathml/relations/css-styling/mathsize-attribute-legacy-values-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Legacy mathsize values</title>
+  </head>
+  <body>
+    <p>Test passes if you see four "A" of equal size:</p>
+    <math>
+      <mtext>A</mtext>
+      <mtext>A</mtext>
+      <mtext>A</mtext>
+      <mtext>A</mtext>
+    </math>
+  </body>
+</html>

--- a/mathml/relations/css-styling/mathsize-attribute-legacy-values.html
+++ b/mathml/relations/css-styling/mathsize-attribute-legacy-values.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Legacy mathsize values</title>
+    <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#css-styling">
+    <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#legacy-mathml-style-attributes">
+    <meta name="assert" content="Verify that legacy values for mathsize have no effect.">
+    <link rel="match" href="mathsize-attribute-legacy-values-ref.html">
+  </head>
+  <body>
+    <p>Test passes if you see four "A" of equal size:</p>
+    <math>
+      <mtext>A</mtext>
+      <mtext mathsize="small">A</mtext>
+      <mtext mathsize="medium">A</mtext>
+      <mtext mathsize="big">A</mtext>
+    </math>
+  </body>
+</html>


### PR DESCRIPTION
These values have been removed from MathML Core ( https://github.com/mathml-refresh/mathml/issues/7 )