### PR TITLE
URL encode | in /html/dom/interfaces.https.html test

### DIFF
--- a/html/dom/interfaces.https.html
+++ b/html/dom/interfaces.https.html
@@ -2,9 +2,10 @@
 <meta charset=utf-8>
 <title>HTML IDL tests</title>
 <meta name=timeout content=long>
-<meta name="variant" content="?include=(Document|Window)">
+<!-- Encoding | as %7C to avoid https://github.com/web-platform-tests/wpt/issues/17027 -->
+<meta name="variant" content="?include=(Document%7CWindow)">
 <meta name="variant" content="?include=HTML.*">
-<meta name="variant" content="?exclude=(Document|Window|HTML.*)">
+<meta name="variant" content="?exclude=(Document%7CWindow%7CHTML.*)">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/common/subset-tests-by-key.js></script>


### PR DESCRIPTION
Attempt to work around https://github.com/web-platform-tests/wpt/issues/17027