### PR TITLE
Add idlharness test for element-timing

### DIFF
--- a/element-timing/idlharness.window.js
+++ b/element-timing/idlharness.window.js
@@ -1,0 +1,16 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// https://wicg.github.io/element-timing/
+
+'use strict';
+
+idl_test(
+  ['element-timing'],
+  ['performance-timeline', 'dom'],
+  idl_array => {
+    idl_array.add_objects({
+      // PerformanceElementTiming: [ TODO ]
+    });
+  }
+);

--- a/interfaces/element-timing.idl
+++ b/interfaces/element-timing.idl
@@ -1,0 +1,20 @@
+// Manually scraped.
+// Content will be automatically extracted by Reffy into reffy-reports
+// (https://github.com/tidoust/reffy-reports)
+// Source: Element Timing API (https://w3c.github.io/element-timing/)
+
+interface PerformanceElementTiming : PerformanceEntry {
+    readonly attribute DOMHighResTimeStamp renderTime;
+    readonly attribute DOMHighResTimeStamp loadTime;
+    readonly attribute DOMRectReadOnly intersectionRect;
+    readonly attribute DOMString identifier;
+    readonly attribute unsigned long naturalWidth;
+    readonly attribute unsigned long naturalHeight;
+    readonly attribute DOMString id;
+    readonly attribute Element? element;
+    readonly attribute DOMString url;
+};
+
+partial interface Element {
+    [CEReactions] attribute DOMString elementTiming;
+};


### PR DESCRIPTION
Basic test for `PerformanceElementTiming` API (wish has an [intent to ship](https://groups.google.com/a/chromium.org/forum/?utm_medium=email&utm_source=footer#!msg/blink-dev/DXSoS7dMmok/30ColVMUAQAJ) in Chromium).

@npm1 - FYI

@foolip - I manually scraped the [IDL from the spec](https://wicg.github.io/element-timing/). How do we go about getting it in reffy-reports?