### PR TITLE
MathML: Add tests for embellished operators

### DIFF
--- a/mathml/presentation-markup/operators/embellished-operator-001.html
+++ b/mathml/presentation-markup/operators/embellished-operator-001.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Embellished operators</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#embellished-operators">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#definition-of-space-like-elements">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#layout-of-mrow">
+<meta name="assert" content="Verify definition of embellished operators">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
+<style>
+  /* Default spacing of operator 'X' is 0.2777777777777778em so quite different
+     from the measured/specified 0em and 1em. */
+  math, math * {
+      font: 25px/1 Ahem;
+  }
+  mn {
+      color: black;
+  }
+  .testedElement mo {
+      color: yellow !important;
+  }
+  .testedElement, .testedElement * {
+      color: blue !important;
+      background: blue !important;
+  }
+</style>
+<script>
+  function spaceBeforeElement(id) {
+      var element = document.getElementById(id);
+      var mnBefore = element.previousElementSibling;
+      return element.getBoundingClientRect().left - mnBefore.getBoundingClientRect().right;
+  }
+
+  function spaceBeforeCoreOperator(id) {
+      var element = document.getElementById(id);
+      var coreMo = element.getElementsByTagName("mo")[0];
+      return coreMo.getBoundingClientRect().left - element.getBoundingClientRect().left;
+  }
+
+  setup({ explicit_done: true });
+  window.addEventListener("load", runTests);
+
+  function runTests() {
+      var epsilon = 1;
+      var emToPx = 25;
+
+      ["mrow", "mstyle", "mphantom", "mpadded"].forEach(tag => {
+          test(function() {
+              assert_true(MathMLFeatureDetection.has_operator_spacing());
+              assert_approx_equals(spaceBeforeElement(`${tag}-op`), 2 * emToPx, epsilon);
+              assert_approx_equals(spaceBeforeCoreOperator(`${tag}-op`), 0, epsilon);
+          }, `${tag} (embellished operator)`);
+
+          test(function() {
+              assert_true(MathMLFeatureDetection.has_operator_spacing());
+              assert_approx_equals(spaceBeforeElement(`${tag}-nonop`), 0, epsilon);
+              assert_approx_equals(spaceBeforeCoreOperator(`${tag}-nonop`), 2 * emToPx, epsilon);
+          }, `${tag} (not embellished operator)`);
+      });
+
+      done();
+  }
+</script>
+</head>
+<body>
+  <div id="log"></div>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mrow id="mrow-op" class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mtext class="space-like">X</mtext>
+      </mrow>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mrow id="mrow-nonop" class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn> <!-- "mn" is not space-like -->
+      </mrow>
+      <mn>X</mn>
+    </math>
+  </p>
+  <!-- mstyle is an embellished operator if its children consist
+       of one embellished operator and zero or more space-like elements. -->
+  <p>
+    <math>
+      <mn>X</mn>
+      <mstyle id="mstyle-op" class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+      </mstyle>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mstyle id="mstyle-nonop" class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn> <!-- "mn" is not space-like -->
+      </mstyle>
+      <mn>X</mn>
+    </math>
+  </p>
+  <!-- mphantom is an embellished operator if its children consist
+       of one embellished operator and zero or more space-like elements. -->
+  <p>
+    <math>
+      <mn>X</mn>
+      <mphantom id="mphantom-op" class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+      </mphantom>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mphantom id="mphantom-nonop" class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn> <!-- "mn" is not space-like -->
+      </mphantom>
+      <mn>X</mn>
+    </math>
+  </p>
+  <!-- mpadded is an embellished operator if its children consist
+       of one embellished operator and zero or more space-like elements. -->
+  <p>
+    <math>
+      <mn>X</mn>
+      <mpadded id="mpadded-op" class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+      </mpadded>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mpadded id="mpadded-nonop" class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn> <!-- "mn" is not space-like -->
+      </mpadded>
+      <mn>X</mn>
+    </math>
+  </p>
+</body>
+</html>

--- a/mathml/presentation-markup/operators/embellished-operator-002.html
+++ b/mathml/presentation-markup/operators/embellished-operator-002.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Embellished operators</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#embellished-operators">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#definition-of-space-like-elements">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#layout-of-mrow">
+<meta name="assert" content="Verify definition of embellished operators">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
+<style>
+  /* Default spacing of operator 'X' is 0.2777777777777778em so quite different
+     from the measured/specified 0em and 1em. */
+  math, math * {
+      font: 25px/1 Ahem;
+  }
+  mn {
+      color: black;
+  }
+  mtext.space-like {
+      color: lightblue !important;
+  }
+  .testedElement mo {
+      color: yellow !important;
+  }
+  .testedElement, .testedElement * {
+      color: blue !important;
+      background: blue !important;
+  }
+</style>
+<script>
+  function spaceBeforeElement(element) {
+      var mnBefore = element.previousElementSibling;
+      return element.getBoundingClientRect().left - mnBefore.getBoundingClientRect().right;
+  }
+
+  setup({ explicit_done: true });
+  window.addEventListener("load", runTests);
+
+  function runTests() {
+      var epsilon = 1;
+      var emToPx = 25;
+
+      ["msub", "msup", "msubsup", "munder", "mover", "munderover",
+       "mmultiscripts", "mfrac", "maction", "semantics"].forEach(tag => {
+           test(function() {
+               assert_true(MathMLFeatureDetection.has_operator_spacing());
+               var element = document.getElementsByTagName(tag)[0];
+               assert_approx_equals(spaceBeforeElement(element), 2 * emToPx, epsilon);
+           }, `${tag} (embellished operator)`);
+
+           test(function() {
+               assert_true(MathMLFeatureDetection.has_operator_spacing());
+               var element = document.getElementsByTagName(tag)[1];
+               assert_approx_equals(spaceBeforeElement(element), 0, epsilon);
+           }, `${tag} (not embellished operator)`);
+      });
+      done();
+  }
+</script>
+</head>
+<body>
+  <div id="log"></div>
+  <!-- <msub>, <msup>, <msubsup>, <munder>, <mover>, <munderover>,
+       <mmultiscripts>, <mfrac>, <semantics> or <maction> are embellished
+       operators if their first child exists and is an embellished operator -->
+  <p>
+    <math>
+      <mn>X</mn>
+      <msub class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+      </msub>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <msup class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+      </msup>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <msubsup class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+        <mn>X</mn>
+      </msubsup>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <munder class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+      </munder>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mover class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+      </mover>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <munderover class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+      </munderover>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mmultiscripts class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+        <mn>X</mn>
+        <mn>X</mn>
+        <mn>X</mn>
+      </mmultiscripts>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mfrac class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+      </mfrac>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <maction class="testedElement" actiontype="statusline">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>STATUS MESSAGE</mn>
+      </maction>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <semantics class="testedElement">
+        <mo lspace="2em" rspace="0em">X</mo>
+        <annotation>TEXT ANNOTATION</annotation>
+        <mn>X</mn>
+      </semantics>
+      <mn>X</mn>
+    </math>
+  </p>
+  <!-- <msub>, <msup>, <msubsup>, <munder>, <mover>, <munderover>,
+       <mmultiscripts>, <mfrac>, <semantics> or <maction> are not embellished
+       operators if their first child is not an embellished operator -->
+  <p>
+    <math>
+      <mn>X</mn>
+      <msub class="testedElement">
+        <mn>X</mn>
+        <mo lspace="2em" rspace="0em">X</mo>
+      </msub>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <msup class="testedElement">
+        <mn>X</mn>
+        <mo lspace="2em" rspace="0em">X</mo>
+      </msup>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <msubsup class="testedElement">
+        <mn>X</mn>
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+      </msubsup>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <munder class="testedElement">
+        <mn>X</mn>
+        <mo lspace="2em" rspace="0em">X</mo>
+      </munder>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mover class="testedElement">
+        <mn>X</mn>
+        <mo lspace="2em" rspace="0em">X</mo>
+      </mover>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <munderover class="testedElement">
+        <mn>X</mn>
+        <mo lspace="2em" rspace="0em">X</mo>
+      </munderover>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mmultiscripts class="testedElement">
+        <mn>X</mn>
+        <mo lspace="2em" rspace="0em">X</mo>
+        <mn>X</mn>
+        <mn>X</mn>
+        <mn>X</mn>
+      </mmultiscripts>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <mfrac class="testedElement">
+        <mn>X</mn>
+        <mo lspace="2em" rspace="0em">X</mo>
+      </mfrac>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <maction class="testedElement" actiontype="statusline">
+        <mn>X</mn>
+        <mo lspace="2em" rspace="0em">STATUS MESSAGE</mo>
+      </maction>
+      <mn>X</mn>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mn>X</mn>
+      <semantics class="testedElement">
+        <mrow>
+          <mn>X</mn>
+          <mo lspace="2em" rspace="0em">X</mo>
+        </mrow>
+        <annotation>TEXT ANNOTATION</annotation>
+      </semantics>
+      <mn>X</mn>
+    </math>
+  </p>
+</body>
+</html>

--- a/mathml/presentation-markup/spaces/space-like-001.html
+++ b/mathml/presentation-markup/spaces/space-like-001.html
@@ -10,6 +10,7 @@
 <meta name="assert" content="Verify definition of space-like elements">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
 <style>
   /* Default spacing of operator 'X' is 0.2777777777777778em so quite different
      from the measured/specified 0em and 1em. */
@@ -48,51 +49,61 @@
       var emToPx = 25;
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mtext"), emToPx, epsilon);
           assert_approx_equals(spaceAfter("mtext"), emToPx, epsilon);
       }, "mtext is space-like");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mspace"), emToPx, epsilon);
           assert_approx_equals(spaceAfter("mspace"), emToPx, epsilon);
       }, "mspace is space-like");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mrow1"), emToPx, epsilon);
           assert_approx_equals(spaceAfter("mrow1"), emToPx, epsilon);
       }, "space-like mrow");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mrow2"), 0, epsilon);
           assert_approx_equals(spaceAfter("mrow2"), 2 * emToPx, epsilon);
       }, "non-space-like mrow");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mstyle1"), emToPx, epsilon);
           assert_approx_equals(spaceAfter("mstyle1"), emToPx, epsilon);
       }, "space-like mstyle");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mstyle2"), 0, epsilon);
           assert_approx_equals(spaceAfter("mstyle2"), 2 * emToPx, epsilon);
       }, "non-space-like mstyle");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mphantom1"), emToPx, epsilon);
           assert_approx_equals(spaceAfter("mphantom1"), emToPx, epsilon);
       }, "space-like mphantom");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mphantom2"), 0, epsilon);
           assert_approx_equals(spaceAfter("mphantom2"), 2 * emToPx, epsilon);
       }, "non-space-like mphantom");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mpadded1"), emToPx, epsilon);
           assert_approx_equals(spaceAfter("mpadded1"), emToPx, epsilon);
       }, "space-like mpadded");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("mpadded2"), 0, epsilon);
           assert_approx_equals(spaceAfter("mpadded2"), 2 * emToPx, epsilon);
       }, "non-space-like mpadded");

--- a/mathml/presentation-markup/spaces/space-like-002.html
+++ b/mathml/presentation-markup/spaces/space-like-002.html
@@ -10,6 +10,7 @@
 <meta name="assert" content="Verify definition of space-like elements">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
 <style>
   /* Default spacing of operator 'X' is 0.2777777777777778em so quite different
      from the measured/specified 0em and 1em. */
@@ -48,31 +49,37 @@
       var emToPx = 25;
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("maction1"), emToPx, epsilon);
           assert_approx_equals(spaceAfter("maction1"), emToPx, epsilon);
       }, "space-like maction");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("maction2"), 0, epsilon);
           assert_approx_equals(spaceAfter("maction2"), 2 * emToPx, epsilon);
       }, "non-space like maction (no first child)");
 
       test(function() {
           assert_approx_equals(spaceBefore("maction3"), 0, epsilon);
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceAfter("maction3"), 2 * emToPx, epsilon);
       }, "non-space like maction (first child not space-like)");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("semantics1"), emToPx, epsilon);
           assert_approx_equals(spaceAfter("semantics1"), emToPx, epsilon);
       }, "space-like semantics");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("semantics2"), 0, epsilon);
           assert_approx_equals(spaceAfter("semantics2"), 2 * emToPx, epsilon);
       }, "non-space like semantics (no first child)");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("semantics3"), 0, epsilon);
           assert_approx_equals(spaceAfter("semantics3"), 2 * emToPx, epsilon);
       }, "non-space like semantics (first child not space-like)");

--- a/mathml/presentation-markup/spaces/space-like-003.html
+++ b/mathml/presentation-markup/spaces/space-like-003.html
@@ -10,6 +10,7 @@
 <meta name="assert" content="Verify definition of space-like elements">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
 <style>
   /* Default spacing of operator 'X' is 0.2777777777777778em so quite different
      from the measured/specified 0em and 1em. */
@@ -47,6 +48,7 @@
 
       Array.from(document.querySelectorAll(".testedElement")).forEach(el => {
           test(function() {
+              assert_true(MathMLFeatureDetection.has_operator_spacing());
               assert_approx_equals(spaceBefore(el), 0, epsilon);
               assert_approx_equals(spaceAfter(el), 2 * emToPx, epsilon);
           }, `${el.tagName} is not space-like`);

--- a/mathml/presentation-markup/spaces/space-like-004.html
+++ b/mathml/presentation-markup/spaces/space-like-004.html
@@ -10,6 +10,7 @@
 <meta name="assert" content="Verify definition of space-like elements">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
 <style>
   /* Default spacing of operator 'X' is 0.2777777777777778em so quite different
      from the measured/specified 0em and 1em. */
@@ -48,11 +49,13 @@
       var emToPx = 25;
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("complex1"), emToPx, epsilon);
           assert_approx_equals(spaceAfter("complex1"), emToPx, epsilon);
       }, "complex space-like subtree");
 
       test(function() {
+          assert_true(MathMLFeatureDetection.has_operator_spacing());
           assert_approx_equals(spaceBefore("complex2"), 0, epsilon);
           assert_approx_equals(spaceAfter("complex2"), 2 * emToPx, epsilon);
       }, "complex non-space-like subtree");

--- a/mathml/support/feature-detection.js
+++ b/mathml/support/feature-detection.js
@@ -4,12 +4,28 @@
 var MathMLFeatureDetection = {
     has_mspace: function() {
         if (!this.hasOwnProperty("_has_mspace")) {
-            document.body.insertAdjacentHTML("beforeend", "<math><mspace width='20px'></mspace></math>");
+            document.body.insertAdjacentHTML("beforeend", "<math><mspace></mspace><mspace width='20px'></mspace></math>");
             var math = document.body.lastElementChild;
+            // The width attribute will add 20px per MathML and none if not supported.
             this._has_mspace =
+                math.lastChild.getBoundingClientRect().width -
                 math.firstChild.getBoundingClientRect().width > 10;
             document.body.removeChild(math);
         }
         return this._has_mspace;
+    },
+
+    has_operator_spacing: function() {
+        if (!this.hasOwnProperty("_has_operator_spacing")) {
+            document.body.insertAdjacentHTML("beforeend", "<math><mrow><mn>1</mn><mo lspace='0px' rspace='0px'>+</mo><mn>2</mn><mo lspace='8px' rspace='8px'>+</mo><mn>3</mn></mspace></mrow></math>");
+            var math = document.body.lastElementChild;
+            var mo = math.getElementsByTagName("mo");
+            // lspace/rspace will add 16px per MathML and none if not supported.
+            this._has_operator_spacing =
+                mo[1].getBoundingClientRect().width -
+                mo[0].getBoundingClientRect().width > 10;
+            document.body.removeChild(math);
+        }
+        return this._has_operator_spacing;
     }
 };


### PR DESCRIPTION
See https://mathml-refresh.github.io/mathml-core/#embellished-operators
These tests assume that operator spacing is supported, so a feature detection
is added to prevent false negative results. This new detection is also used
for space-like tests which rely on the same assumption.

Minor tweak for mspace detection: compare `<mspace width="20px">` against
`<mspace>`, just in case the latter is nonzero in some browsers or tests.