### PR TITLE
MathML: Avoid more false negative results for fraction reftests

### DIFF
--- a/mathml/presentation-markup/fractions/frac-bar-001.html
+++ b/mathml/presentation-markup/fractions/frac-bar-001.html
@@ -51,5 +51,7 @@
         </mfrac>
       </math>
     </div>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
   </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-created-dynamically-2.html
+++ b/mathml/presentation-markup/fractions/frac-created-dynamically-2.html
@@ -37,6 +37,8 @@
 </head>
 <body>
   <p>This test passes if it renders the same as an invalid fraction with 3 children.</p>
-  <math>
+  <math></math>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-created-dynamically-3.html
+++ b/mathml/presentation-markup/fractions/frac-created-dynamically-3.html
@@ -30,5 +30,7 @@
       <mn id="mn2">2</mn>
     </mfrac>
   </math>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-created-dynamically.html
+++ b/mathml/presentation-markup/fractions/frac-created-dynamically.html
@@ -32,6 +32,8 @@
 </head>
 <body>
   <p>This test passes if you see a fraction.</p>
-  <math>
+  <math></math>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-linethickness-001.html
+++ b/mathml/presentation-markup/fractions/frac-linethickness-001.html
@@ -41,5 +41,7 @@
         <mspace width="20px" height="10px" style="background: cyan"></mspace>
       </mfrac>
     </math>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
   </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-linethickness-004.html
+++ b/mathml/presentation-markup/fractions/frac-linethickness-004.html
@@ -26,5 +26,7 @@
         <mspace width="20px" height="10px" style="background: cyan"></mspace>
       </mfrac>
     </math>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
   </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-mrow-001.html
+++ b/mathml/presentation-markup/fractions/frac-mrow-001.html
@@ -22,5 +22,7 @@
         </mrow>
       </mfrac>
     </math>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
   </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-numalign-denomalign-001.html
+++ b/mathml/presentation-markup/fractions/frac-numalign-denomalign-001.html
@@ -52,5 +52,7 @@
         </mfrac>
       </math>
     </p>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
   </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-001.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-001.html
@@ -86,5 +86,7 @@
     </math>
   </p>
   <div id="frame"></div>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-002.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-002.html
@@ -86,5 +86,7 @@
     </math>
   </p>
   <div id="frame"></div>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-003.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-003.html
@@ -86,5 +86,7 @@
     </math>
   </p>
   <div id="frame"></div>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-004.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-004.html
@@ -86,5 +86,7 @@
     </math>
   </p>
   <div id="frame"></div>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-005.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-005.html
@@ -86,5 +86,7 @@
     </math>
   </p>
   <div id="frame"></div>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-006.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-006.html
@@ -86,5 +86,7 @@
     </math>
   </p>
   <div id="frame"></div>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
 </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-visibility-001.html
+++ b/mathml/presentation-markup/fractions/frac-visibility-001.html
@@ -18,5 +18,7 @@
         </mfrac>
       </math>
     </div>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
   </body>
 </html>

--- a/mathml/support/feature-detection.js
+++ b/mathml/support/feature-detection.js
@@ -2,9 +2,14 @@
 // It is indented to be used to prevent false negative test results.
 
 var MathMLFeatureDetection = {
+
     has_mspace: function() {
+        // https://mathml-refresh.github.io/mathml-core/#space-mspace
         if (!this.hasOwnProperty("_has_mspace")) {
-            document.body.insertAdjacentHTML("beforeend", "<math><mspace></mspace><mspace width='20px'></mspace></math>");
+            document.body.insertAdjacentHTML("beforeend", "<math>\
+<mspace></mspace>\
+<mspace width='20px'></mspace>\
+</math>");
             var math = document.body.lastElementChild;
             // The width attribute will add 20px per MathML and none if not supported.
             this._has_mspace =
@@ -16,16 +21,62 @@ var MathMLFeatureDetection = {
     },
 
     has_operator_spacing: function() {
+        // https://mathml-refresh.github.io/mathml-core/#dfn-lspace
+        // https://mathml-refresh.github.io/mathml-core/#layout-of-mrow
         if (!this.hasOwnProperty("_has_operator_spacing")) {
-            document.body.insertAdjacentHTML("beforeend", "<math><mrow><mn>1</mn><mo lspace='0px' rspace='0px'>+</mo><mn>2</mn><mo lspace='8px' rspace='8px'>+</mo><mn>3</mn></mspace></mrow></math>");
+            document.body.insertAdjacentHTML("beforeend", "<math>\
+<mrow>\
+  <mn>1</mn><mo lspace='0px' rspace='0px'>+</mo><mn>2</mn>\
+</mrow>\
+<mrow>\
+  <mn>1</mn><mo lspace='8px' rspace='8px'>+</mo><mn>2</mn>\
+</mrow>\
+</math>");
             var math = document.body.lastElementChild;
-            var mo = math.getElementsByTagName("mo");
+            var mrow = math.getElementsByTagName("mrow");
             // lspace/rspace will add 16px per MathML and none if not supported.
             this._has_operator_spacing =
-                mo[1].getBoundingClientRect().width -
-                mo[0].getBoundingClientRect().width > 10;
+                mrow[1].getBoundingClientRect().width -
+                mrow[0].getBoundingClientRect().width > 10;
             document.body.removeChild(math);
         }
         return this._has_operator_spacing;
+    },
+
+    has_mfrac: function() {
+        if (!this.hasOwnProperty("_has_mfrac")) {
+            // Use tall enough fraction to avoid side effect of min num/denum shifts.
+            document.body.insertAdjacentHTML("beforeend", "<math>\
+<mfrac>\
+  <mspace height='50px' depth='50px'></mspace>\
+  <mspace height='50px' depth='50px'></mspace>\
+</mfrac>\
+<mfrac>\
+  <mspace height='60px' depth='60px'></mspace>\
+  <mspace height='60px' depth='60px'></mspace>\
+</mfrac>\
+</math>");
+            var math = document.body.lastElementChild;
+            var mfrac = math.getElementsByTagName("mfrac");
+            // height/depth will add 40px per MathML, 20px if mfrac does not stack its children and none if mspace is not supported.
+            this._has_mfrac =
+                mfrac[1].getBoundingClientRect().height -
+                mfrac[0].getBoundingClientRect().height > 30;
+            document.body.removeChild(math);
+        }
+        return this._has_mfrac;
+    },
+
+    ensure_for_match_reftest: function(has_function) {
+        if (!document.querySelector("link[rel='match']"))
+            throw "This function must only be used for match reftest";
+        // Add a little red square at the top left corner if the feature is not supported in order to make match reftest fail.
+        if (!this[has_function]()) {
+            document.body.insertAdjacentHTML("beforeend", "\
+<div style='width: 10px !important; height: 10px !important;\
+            position: absolute !important;\
+            left: 0 !important; top: 0 !important;\
+            background: red !important; z-index: 1000 !important;'></div>");
+        }
     }
 };


### PR DESCRIPTION
This also introduces improvements to MathMLFeatureDetection:
* Introduce has_mfrac().
* Split mathml source into several lines for better readability.
* Add reference links to core spec.
* Fix detection for lspace/rspace (measure the mrow container instead of mo).
* Add helper function to check a feature for match reftest and otherwise
  force failure by displaying a red square at the top left corner.