### PR TITLE
MathML: Use feature detection in more tests to avoid false negative results

### DIFF
--- a/mathml/presentation-markup/direction/direction-overall.html
+++ b/mathml/presentation-markup/direction/direction-overall.html
@@ -62,5 +62,7 @@
       </math>
     </p>
 
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mspace");</script>
   </body>
 </html>

--- a/mathml/presentation-markup/direction/direction-token-ref.html
+++ b/mathml/presentation-markup/direction/direction-token-ref.html
@@ -6,15 +6,11 @@
   </head>
   <body>
 
-    <!-- Test dir="rtl" on MathML token elements. The text contains RTL and
-         LTR characters, so the attribute is needed to specify the actual
-         direction. -->
-
-   <p><math><mtext dir="rtl">חוק \left חסר או חוק \right מיותר</mtext></math></p>
-   <p><math><ms dir="rtl">חוק \left חסר או חוק \right מיותר</ms></math></p>
-   <p><math><mo dir="rtl">חוק \left חסר או חוק \right מיותר</mo></math></p>
-   <p><math><mi dir="rtl">חוק \left חסר או חוק \right מיותר</mi></math></p>
-   <p><math><mn dir="rtl">חוק \left חסר או חוק \right מיותר</mn></math></p>
+   <p><math><mtext style="direction: rtl;">חוק \left חסר או חוק \right מיותר</mtext></math></p>
+   <p><math><ms style="direction: rtl;">חוק \left חסר או חוק \right מיותר</ms></math></p>
+   <p><math><mo style="direction: rtl;">חוק \left חסר או חוק \right מיותר</mo></math></p>
+   <p><math><mi style="direction: rtl;">חוק \left חסר או חוק \right מיותר</mi></math></p>
+   <p><math><mn style="direction: rtl;">חוק \left חסר או חוק \right מיותר</mn></math></p>
 
   </body>
 </html>

--- a/mathml/presentation-markup/direction/direction-token.html
+++ b/mathml/presentation-markup/direction/direction-token.html
@@ -21,5 +21,8 @@
    <p><math><mi dir="rtl">חוק \left חסר או חוק \right מיותר</mi></math></p>
    <p><math><mn dir="rtl">חוק \left חסר או חוק \right מיותר</mn></math></p>
 
+   <script src="/mathml/support/feature-detection.js"></script>
+   <script>MathMLFeatureDetection.ensure_for_match_reftest("has_dir");</script>
+
   </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-color-002.html
+++ b/mathml/presentation-markup/fractions/frac-color-002.html
@@ -28,5 +28,7 @@
         </mfrac>
       </math>
     </div>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mfrac");</script>
   </body>
 </html>

--- a/mathml/presentation-markup/fractions/frac-linethickness-002.html
+++ b/mathml/presentation-markup/fractions/frac-linethickness-002.html
@@ -7,6 +7,7 @@
     <meta name="assert" content="Verifies fraction with positive, negative, percent and named space linethickness values.">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="/mathml/support/feature-detection.js"></script>
     <style type="text/css">
       @font-face {
         font-family: TestFont;
@@ -37,19 +38,23 @@
         var epsilon = 2;
 
         test(function() {
+          assert_true(MathMLFeatureDetection.has_mspace());
           assert_approx_equals(LineThickness("positive"),  5.67 * 10, epsilon);
         }, "Positive");
 
         test(function() {
+          assert_true(MathMLFeatureDetection.has_mspace());
           /* Negative values are treated as 0 */
           assert_approx_equals(LineThickness("negative"),  0, epsilon);
         }, "Negative");
 
         test(function() {
+          assert_true(MathMLFeatureDetection.has_mspace());
           assert_approx_equals(LineThickness("percent"), defaultRuleThickness * 234 / 100, epsilon);
         }, "Percentage");
 
         test(function() {
+          assert_true(MathMLFeatureDetection.has_mspace());
           /* Namedspace values are invalid in MathML Core. */
           assert_approx_equals(LineThickness("namedspace"), defaultRuleThickness, epsilon);
         }, "Named space");

--- a/mathml/relations/css-styling/display-1.html
+++ b/mathml/relations/css-styling/display-1.html
@@ -12,5 +12,7 @@
   <div style="background: green; color: red; width: 200px; height: 200px;">
     <math style="display: none;"><mspace width="200px" height="200px" style="background: red"/></math>
   </div>
+  <script src="/mathml/support/feature-detection.js"></script>
+  <script>MathMLFeatureDetection.ensure_for_match_reftest("has_mspace");</script>
 </body>
 </html>

--- a/mathml/relations/css-styling/displaystyle-1.html
+++ b/mathml/relations/css-styling/displaystyle-1.html
@@ -56,6 +56,7 @@
       verify_displaystyle("mtable_true", true, "explicit displaystyle true");
     }, "mtable element");
     test(function() {
+      verify_displaystyle("mfrac_sibling", true, "sibling");
       verify_displaystyle("mfrac_numerator", false, "numerator");
       verify_displaystyle("mfrac_denominator", false, "denominator");
     }, "mfrac element");
@@ -105,7 +106,7 @@
   <math displaystyle="true"><mtable><mtr><mtd><mo id="mtable_default">&#x2AFF;</mo></mtd></mtr></mtable></math>
   <math><mtable displaystyle="true"><mtr><mtd><mo id="mtable_true">&#x2AFF;</mo></mtd></mtr></mtable></math>
   <math displaystyle="true"><mtable displaystyle="false"><mtr><mtd><mo id="mtable_false">&#x2AFF;</mo></mtd></mtr></mtable></math>
-  <math displaystyle="true"><mfrac><mo id="mfrac_numerator">&#x2AFF;</mo><mo id="mfrac_denominator">&#x2AFF;</mo></mfrac></math>
+  <math displaystyle="true"><mo id="mfrac_sibling">&#x2AFF;</mo><mfrac><mo id="mfrac_numerator">&#x2AFF;</mo><mo id="mfrac_denominator">&#x2AFF;</mo></mfrac></math>
   <math displaystyle="true"><mroot><mo id="mroot_base">&#x2AFF;</mo><mo id="mroot_index">&#x2AFF;</mo></mroot></math>
   <math displaystyle="true"><msub><mo id="msub_base">&#x2AFF;</mo><mo id="msub_subscript">&#x2AFF;</mo></msub></math>
   <math displaystyle="true"><msup><mo id="msup_base">&#x2AFF;</mo><mo id="msup_supscript">&#x2AFF;</mo></msup></math>

--- a/mathml/relations/css-styling/dynamic-dir-1.html
+++ b/mathml/relations/css-styling/dynamic-dir-1.html
@@ -99,5 +99,7 @@
         </mrow>
       </math>
     </p>
+    <script src="/mathml/support/feature-detection.js"></script>
+    <script>MathMLFeatureDetection.ensure_for_match_reftest("has_dir");</script>
 </body>
 </html>

--- a/mathml/relations/css-styling/lengths-2.html
+++ b/mathml/relations/css-styling/lengths-2.html
@@ -10,6 +10,7 @@
 <meta name="assert" content="Verify various cases of the MathML length syntax.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
 <style>
   @font-face {
     font-family: TestFont;
@@ -35,6 +36,7 @@
 
   function runTests() {
     test(function() {
+      assert_true(MathMLFeatureDetection.has_mspace());
       assert_equals(getBox("unitCm").width, 96, "cm");
       assert_equals(getBox("unitEm").width, 120, "em");
       assert_equals(getBox("unitEx").width, 500, "ex");
@@ -47,6 +49,7 @@
     }, "Units");
 
     test(function() {
+      assert_true(MathMLFeatureDetection.has_mspace());
       assert_equals(getBox("spaceCm").width, 96, "cm");
       assert_equals(getBox("spaceEm").width, 120, "em");
       assert_equals(getBox("spaceEx").width, 500, "ex");
@@ -59,6 +62,7 @@
     }, "Trimming of space");
 
     test(function() {
+      assert_true(MathMLFeatureDetection.has_mspace());
       assert_approx_equals(getBox("n0").width, 0, epsilon, "n0");
       assert_approx_equals(getBox("n1").width, 90, epsilon, "n1");
       assert_approx_equals(getBox("n2").width, 8, epsilon, "n2");
@@ -72,6 +76,7 @@
     }, "Non-negative numbers");
 
     test(function() {
+      assert_true(MathMLFeatureDetection.has_mspace());
       var topRef = getBox("ref").top;
       assert_approx_equals(getBox("N0").top - topRef, -0, epsilon, "N0");
       assert_approx_equals(topRef - getBox("N1").top, -90, epsilon, "N1");
@@ -86,6 +91,7 @@
     }, "Non-positive numbers");
 
     test(function() {
+      assert_true(MathMLFeatureDetection.has_mspace());
       // Namedspace values are invalid in MathML Core.
       ["veryverythinmathspace",
        "verythinmathspace",
@@ -110,6 +116,7 @@
     }, "Legacy namedspaces");
 
     test(function() {
+      assert_true(MathMLFeatureDetection.has_mspace());
       // These values are invalid in MathML Core.
       assert_equals(getBox("unitNone").width, 30, "Unitless");
       assert_approx_equals(getBox("n3").width, 0, epsilon, "n3");

--- a/mathml/relations/html5-tree/display-1.html
+++ b/mathml/relations/html5-tree/display-1.html
@@ -8,6 +8,7 @@
 <meta name="assert" content="Verify that the display attribute on the math element is supported and impacts centering and line breaking with surrounding content.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
 <script>
   function getBox(aId) {
     return document.getElementById(aId).getBoundingClientRect();
@@ -19,6 +20,7 @@
     var mspace_block = getBox("mspace_block");
     var after_block = getBox("after_block");
     test(function() {
+      assert_true(MathMLFeatureDetection.has_mspace());
       assert_approx_equals(before_block.left, content.left, 1,
                            "content before must be left aligned");
       assert_approx_equals((mspace_block.left + mspace_block.right) / 2,
@@ -37,6 +39,7 @@
     var mspace_inline = getBox("mspace_inline");
     var after_inline = getBox("after_inline");
     test(function() {
+      assert_true(MathMLFeatureDetection.has_mspace());
       assert_approx_equals((before_inline.top + before_inline.bottom) / 2,
                            (mspace_inline.top + mspace_inline.bottom) / 2,
                            1,

--- a/mathml/support/feature-detection.js
+++ b/mathml/support/feature-detection.js
@@ -67,6 +67,20 @@ var MathMLFeatureDetection = {
         return this._has_mfrac;
     },
 
+    has_dir: function() {
+        if (!this.hasOwnProperty("_has_dir")) {
+            document.body.insertAdjacentHTML("beforeend", "<math style='direction: ltr !important;'>\
+<mtext dir='rtl'></mtext>\
+</math>");
+            var math = document.body.lastElementChild;
+            this._has_dir =
+                window.getComputedStyle(math.firstElementChild).
+                getPropertyValue('direction') === 'rtl';
+            document.body.removeChild(math);
+        }
+        return this._has_dir;
+    },
+
     ensure_for_match_reftest: function(has_function) {
         if (!document.querySelector("link[rel='match']"))
             throw "This function must only be used for match reftest";


### PR DESCRIPTION
* direction-token-ref.html: use style="direction: rtl;" for the reference instead of dir="rtl", otherwise nothing is actually tested. This matches how it is in WebKit's repository.
* displaystyle-1.html: Verify that the sibling of the mfrac actually draws large operator bigger, otherwise test passes when displaystyle/largeop are not supported at all.
* feature-detection.js: Add feature detection for the dir attribute.