### PR TITLE
Added 24 tests and 2 reference to cover issue 3066

### DIFF
--- a/css/css-writing-modes/wm-propagation-body-032.html
+++ b/css/css-writing-modes/wm-propagation-body-032.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  body
+    {
+      writing-mode: vertical-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-033-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-033-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  img
+    {
+      vertical-align: top;
+    }
+
+  img + img
+    {
+      padding-left: 1em;
+    }
+  </style>
+
+  <div><img src="support/swatch-orange.png" width="100" height="100" alt="Image download support must be enabled"><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->

--- a/css/css-writing-modes/wm-propagation-body-033.html
+++ b/css/css-writing-modes/wm-propagation-body-033.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-033-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  body
+    {
+      writing-mode: vertical-lr;
+    }
+
+  div
+    {
+      background-color: orange;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-034.html
+++ b/css/css-writing-modes/wm-propagation-body-034.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  body
+    {
+      writing-mode: sideways-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-035-ref.html
+++ b/css/css-writing-modes/wm-propagation-body-035-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      bottom: 8px;
+      left: auto;
+      position: absolute;
+    }
+
+  img
+    {
+      vertical-align: bottom;
+    }
+
+  img + img
+    {
+      padding-left: 1em;
+    }
+  </style>
+
+  <div><img src="support/swatch-teal.png" width="100" height="100" alt="Image download support must be enabled"><img src="support/wm-propagation-body-005-exp-res.png" width="322" height="38" alt="Image download support must be enabled"></div>
+
+  <!--
+  The image says:
+  Test passes if there is a teal square in
+  the <strong>lower-left corner</strong> of the page.
+  -->

--- a/css/css-writing-modes/wm-propagation-body-035.html
+++ b/css/css-writing-modes/wm-propagation-body-035.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-035-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  body
+    {
+      writing-mode: sideways-lr;
+    }
+
+  div
+    {
+      background-color: teal;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-005-exp-res.png" width="322" height="38" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a teal square in
+  the <strong>lower-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-036.html
+++ b/css/css-writing-modes/wm-propagation-body-036.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1102175" title="Bug 1102175: &lt;body&gt; with writing-mode: vertical-rl does not align children to the right ">
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: horizontal-tb;
+    }
+
+  body
+    {
+      writing-mode: vertical-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-037.html
+++ b/css/css-writing-modes/wm-propagation-body-037.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-033-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: horizontal-tb;
+    }
+
+  body
+    {
+      writing-mode: vertical-lr;
+    }
+
+  div
+    {
+      background-color: orange;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-038.html
+++ b/css/css-writing-modes/wm-propagation-body-038.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: horizontal-tb;
+    }
+
+  body
+    {
+      writing-mode: sideways-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-039.html
+++ b/css/css-writing-modes/wm-propagation-body-039.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-035-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: horizontal-tb;
+    }
+
+  body
+    {
+      writing-mode: sideways-lr;
+    }
+
+  div
+    {
+      background-color: teal;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-005-exp-res.png" width="322" height="38" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a teal square in
+  the <strong>lower-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-040.html
+++ b/css/css-writing-modes/wm-propagation-body-040.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: horizontal-tb' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-033-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: vertical-rl;
+    }
+
+  body
+    {
+      writing-mode: horizontal-tb;
+    }
+
+  img#orange-square
+    {
+      height: 100px;
+      padding-right: 1em;
+      vertical-align: top;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-rl")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div><img id="orange-square" src="support/swatch-orange.png" alt="Image download support must be enabled"><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-041.html
+++ b/css/css-writing-modes/wm-propagation-body-041.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-033-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: vertical-rl;
+    }
+
+  body
+    {
+      writing-mode: vertical-lr;
+    }
+
+  div
+    {
+      background-color: orange;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-rl")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-042.html
+++ b/css/css-writing-modes/wm-propagation-body-042.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: vertical-rl;
+    }
+
+  body
+    {
+      writing-mode: sideways-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-rl")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-043.html
+++ b/css/css-writing-modes/wm-propagation-body-043.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-035-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: vertical-rl;
+    }
+
+  body
+    {
+      writing-mode: sideways-lr;
+    }
+
+  div
+    {
+      background-color: teal;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-rl")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-005-exp-res.png" width="322" height="38" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a teal square in
+  the <strong>lower-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-044.html
+++ b/css/css-writing-modes/wm-propagation-body-044.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: horizontal-tb' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-033-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: vertical-lr;
+    }
+
+  body
+    {
+      writing-mode: horizontal-tb;
+    }
+
+  img#orange-square
+    {
+      height: 100px;
+      padding-right: 1em;
+      vertical-align: top;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-lr")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div><img id="orange-square" src="support/swatch-orange.png" alt="Image download support must be enabled"><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-045.html
+++ b/css/css-writing-modes/wm-propagation-body-045.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: vertical-lr;
+    }
+
+  body
+    {
+      writing-mode: vertical-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-lr")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-046.html
+++ b/css/css-writing-modes/wm-propagation-body-046.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: vertical-lr;
+    }
+
+  body
+    {
+      writing-mode: sideways-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-lr")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-047.html
+++ b/css/css-writing-modes/wm-propagation-body-047.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-035-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: vertical-lr;
+    }
+
+  body
+    {
+      writing-mode: sideways-lr;
+    }
+
+  div
+    {
+      background-color: teal;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-lr")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-005-exp-res.png" width="322" height="38" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a teal square in
+  the <strong>lower-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-048.html
+++ b/css/css-writing-modes/wm-propagation-body-048.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: horizontal-tb' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-033-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: sideways-rl;
+    }
+
+  body
+    {
+      writing-mode: horizontal-tb;
+    }
+
+  img#orange-square
+    {
+      height: 100px;
+      padding-right: 1em;
+      vertical-align: top;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-rl")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div><img id="orange-square" src="support/swatch-orange.png" alt="Image download support must be enabled"><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-049.html
+++ b/css/css-writing-modes/wm-propagation-body-049.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: sideways-rl;
+    }
+
+  body
+    {
+      writing-mode: vertical-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-rl")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-050.html
+++ b/css/css-writing-modes/wm-propagation-body-050.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-033-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: sideways-rl;
+    }
+
+  body
+    {
+      writing-mode: vertical-lr;
+    }
+
+  div
+    {
+      background-color: orange;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-rl")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-051.html
+++ b/css/css-writing-modes/wm-propagation-body-051.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-035-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: sideways-rl;
+    }
+
+  body
+    {
+      writing-mode: sideways-lr;
+    }
+
+  div
+    {
+      background-color: teal;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-rl")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-005-exp-res.png" width="322" height="38" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a teal square in
+  the <strong>lower-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-052.html
+++ b/css/css-writing-modes/wm-propagation-body-052.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: horizontal-tb' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-033-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: sideways-lr;
+    }
+
+  body
+    {
+      writing-mode: horizontal-tb;
+    }
+
+  img#orange-square
+    {
+      height: 100px;
+      padding-right: 1em;
+      vertical-align: top;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-lr")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div><img id="orange-square" src="support/swatch-orange.png" alt="Image download support must be enabled"><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-053.html
+++ b/css/css-writing-modes/wm-propagation-body-053.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: sideways-lr;
+    }
+
+  body
+    {
+      writing-mode: vertical-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-lr")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-054.html
+++ b/css/css-writing-modes/wm-propagation-body-054.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: vertical-lr' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="wm-propagation-body-033-ref.html">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: sideways-lr;
+    }
+
+  body
+    {
+      writing-mode: vertical-lr;
+    }
+
+  div
+    {
+      background-color: orange;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-lr")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is an orange square
+  in the <strong>upper-left corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>

--- a/css/css-writing-modes/wm-propagation-body-055.html
+++ b/css/css-writing-modes/wm-propagation-body-055.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Writing Modes Test: 'writing-mode: sideways-rl' set to &lt;body&gt; element propagates to viewport</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#principal-flow" title="8. The Principal Writing Mode">
+  <!--
+  Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body
+  element cause an orthogonal flow?
+  https://github.com/w3c/csswg-drafts/issues/3066
+  -->
+  <link rel="match" href="block-flow-direction-025-ref.xht">
+
+  <meta name="flags" content="">
+  <meta name="assert" content="This test checks that when the root element has a &lt;body&gt; child element, then the principal writing mode is instead taken from the values of writing-mode and direction on the first such child element instead of taken from the root element. Also, a small script in this test verifies that the computed value of 'writing-mode' of the root element itself is not affected by such propagation.">
+
+  <!--
+  Tests 032 to 035: html's writing-mode is not specified
+
+  Tests 036 to 039: html's writing-mode is specified as horizontal-tb
+
+  Tests 040 to 043: html's writing-mode is specified as vertical-rl
+
+  Tests 044 to 047: html's writing-mode is specified as vertical-lr
+
+  Tests 048 to 051: html's writing-mode is specified as sideways-rl
+
+  Tests 052 to 055: html's writing-mode is specified as sideways-lr
+  -->
+
+  <style>
+  html
+    {
+      writing-mode: sideways-lr;
+    }
+
+  body
+    {
+      writing-mode: sideways-rl;
+    }
+
+  div
+    {
+      background-color: blue;
+      height: 100px;
+      width: 100px;
+    }
+
+  h1#second-test-condition
+    {
+      background-color: red;
+      color: yellow;
+    }
+  </style>
+
+  <script>
+  function verifyComputedValueDocRoot()
+  {
+  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-lr")
+    {
+    document.getElementById("second-test-condition").style.display = "none";
+    };
+
+    /*
+    If the computed value of 'writing-mode' of the root element
+    itself is not affected by such propagation, then the big FAIL
+    word will not be displayed.
+    */
+  }
+  </script>
+
+ <body onload="verifyComputedValueDocRoot();">
+
+  <div></div>
+
+  <p><img src="support/block-flow-direction-025-exp-res.png" width="359" height="36" alt="Image download support must be enabled">
+
+  <!--
+  The image says:
+  Test passes if there is a blue square in the
+  <strong>upper-right corner</strong> of the page.
+  -->
+
+  <h1 id="second-test-condition">FAIL</h1>


### PR DESCRIPTION
These 24 tests and 2 references are closely related to the resolving of 
[Issue 3066: [css-writing-modes] Does vertical writing mode of an HTML body element cause an orthogonal flow?
](https://github.com/w3c/csswg-drafts/issues/3066)  