### PR TITLE
MathML: make some padding/margin/border tests stricter.

### DIFF
--- a/mathml/relations/css-styling/padding-border-margin/border-001.html
+++ b/mathml/relations/css-styling/padding-border-margin/border-001.html
@@ -21,6 +21,10 @@
           assert_approx_equals(s.right, 30, epsilon, "right border");
           assert_approx_equals(s.top, 40, epsilon, "top border");
           assert_approx_equals(s.bottom, 50, epsilon, "bottom border");
+          var b = document.getElementById("mrow-border").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 20 + 50 + 30, epsilon, "element width");
+          assert_approx_equals(b.height, 40 + 50 + 50, epsilon, "element height");
       }, "Border properties on mrow");
 
       test(function() {
@@ -29,6 +33,10 @@
           assert_approx_equals(s.right, 20, epsilon, "right border");
           assert_approx_equals(s.top, 20, epsilon, "top border");
           assert_approx_equals(s.bottom, 20, epsilon, "bottom border");
+          var b = document.getElementById("mrow-border-shorthand").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 20 + 50 + 20, epsilon, "element width");
+          assert_approx_equals(b.height, 20 + 50 + 20, epsilon, "element height");
       }, "Border properties on mrow (shorthand)");
 
       test(function() {
@@ -37,6 +45,10 @@
           assert_approx_equals(s.right, 30, epsilon, "right border");
           assert_approx_equals(s.top, 40, epsilon, "top border");
           assert_approx_equals(s.bottom, 50, epsilon, "bottom border");
+          var b = document.getElementById("mrow-border-logical").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 20 + 50 + 30, epsilon, "element width");
+          assert_approx_equals(b.height, 40 + 50 + 50, epsilon, "element height");
       }, "Border properties on mrow (logical)");
 
       test(function() {
@@ -45,6 +57,10 @@
           assert_approx_equals(s.right, 20, epsilon, "right border");
           assert_approx_equals(s.top, 30, epsilon, "top border");
           assert_approx_equals(s.bottom, 30, epsilon, "bottom border");
+          var b = document.getElementById("mrow-border-logical-shorthand").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 20 + 50 + 20, epsilon, "element width");
+          assert_approx_equals(b.height, 30 + 50 + 30, epsilon, "element height");
       }, "Border properties on mrow (logical, shorthand)");
 
     done();

--- a/mathml/relations/css-styling/padding-border-margin/margin-001.html
+++ b/mathml/relations/css-styling/padding-border-margin/margin-001.html
@@ -21,6 +21,10 @@
           assert_approx_equals(s.right, 30, epsilon, "right margin");
           assert_approx_equals(s.top, 40, epsilon, "top margin");
           assert_approx_equals(s.bottom, 50, epsilon, "bottom margin");
+          var b = document.getElementById("mrow-margin").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 50, epsilon, "element width");
+          assert_approx_equals(b.height, 50, epsilon, "element height");
       }, "Margin properties on mrow");
 
       test(function() {
@@ -29,6 +33,10 @@
           assert_approx_equals(s.right, 20, epsilon, "right margin");
           assert_approx_equals(s.top, 20, epsilon, "top margin");
           assert_approx_equals(s.bottom, 20, epsilon, "bottom margin");
+          var b = document.getElementById("mrow-margin-shorthand").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 50, epsilon, "element width");
+          assert_approx_equals(b.height, 50, epsilon, "element height");
       }, "Margin properties on mrow (shorthand)");
 
       test(function() {
@@ -37,6 +45,10 @@
           assert_approx_equals(s.right, 30, epsilon, "right margin");
           assert_approx_equals(s.top, 40, epsilon, "top margin");
           assert_approx_equals(s.bottom, 50, epsilon, "bottom margin");
+          var b = document.getElementById("mrow-margin-logical").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 50, epsilon, "element width");
+          assert_approx_equals(b.height, 50, epsilon, "element height");
       }, "Margin properties on mrow (logical)");
 
       test(function() {
@@ -45,6 +57,10 @@
           assert_approx_equals(s.right, 20, epsilon, "right margin");
           assert_approx_equals(s.top, 30, epsilon, "top margin");
           assert_approx_equals(s.bottom, 30, epsilon, "bottom margin");
+          var b = document.getElementById("mrow-margin-logical-shorthand").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 50, epsilon, "element width");
+          assert_approx_equals(b.height, 50, epsilon, "element height");
       }, "Margin properties on mrow (logical, shorthand)");
 
     done();

--- a/mathml/relations/css-styling/padding-border-margin/padding-001.html
+++ b/mathml/relations/css-styling/padding-border-margin/padding-001.html
@@ -21,6 +21,10 @@
           assert_approx_equals(s.right, 30, epsilon, "right padding");
           assert_approx_equals(s.top, 40, epsilon, "top padding");
           assert_approx_equals(s.bottom, 50, epsilon, "bottom padding");
+          var b = document.getElementById("mrow-padding").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 20 + 50 + 30, epsilon, "element width");
+          assert_approx_equals(b.height, 40 + 50 + 50, epsilon, "element height");
       }, "Padding properties on mrow");
 
       test(function() {
@@ -29,6 +33,10 @@
           assert_approx_equals(s.right, 20, epsilon, "right padding");
           assert_approx_equals(s.top, 20, epsilon, "top padding");
           assert_approx_equals(s.bottom, 20, epsilon, "bottom padding");
+          var b = document.getElementById("mrow-padding-shorthand").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 20 + 50 + 20, epsilon, "element width");
+          assert_approx_equals(b.height, 20 + 50 + 20, epsilon, "element height");
       }, "Padding properties on mrow (shorthand)");
 
       test(function() {
@@ -37,6 +45,10 @@
           assert_approx_equals(s.right, 30, epsilon, "right padding");
           assert_approx_equals(s.top, 40, epsilon, "top padding");
           assert_approx_equals(s.bottom, 50, epsilon, "bottom padding");
+          var b = document.getElementById("mrow-padding-logical").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 20 + 50 + 30, epsilon, "element width");
+          assert_approx_equals(b.height, 40 + 50 + 50, epsilon, "element height");
       }, "Padding properties on mrow (logical)");
 
       test(function() {
@@ -45,6 +57,10 @@
           assert_approx_equals(s.right, 20, epsilon, "right padding");
           assert_approx_equals(s.top, 30, epsilon, "top padding");
           assert_approx_equals(s.bottom, 30, epsilon, "bottom padding");
+          var b = document.getElementById("mrow-padding-logical-shorthand").
+              getBoundingClientRect();
+          assert_approx_equals(b.width, 20 + 50 + 20, epsilon, "element width");
+          assert_approx_equals(b.height, 30 + 50 + 30, epsilon, "element height");
       }, "Padding properties on mrow (logical, shorthand)");
 
     done();


### PR DESCRIPTION
This checks that padding/border values are included in the mrow size but
margin values are not.