### PR TITLE
MathML: remove msqrt test from direction-overall.html

### DIFF
--- a/mathml/presentation-markup/direction/direction-overall-ref.html
+++ b/mathml/presentation-markup/direction/direction-overall-ref.html
@@ -36,16 +36,5 @@
       </math>
     </p>
 
-    <p>
-      msqrt:
-      <math>
-        <msqrt>
-          <mspace width="25px" height="25px" mathbackground="red"/>
-          <mspace width="25px" height="25px" mathbackground="green"/>
-          <mspace width="25px" height="25px" mathbackground="blue"/>
-        </msqrt>
-      </math>
-    </p>
-
   </body>
 </html>

--- a/mathml/presentation-markup/direction/direction-overall.html
+++ b/mathml/presentation-markup/direction/direction-overall.html
@@ -8,7 +8,6 @@
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-top-level-math-element">
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#horizontally-group-sub-expressions-mrow">
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#style-change-mstyle">
-    <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#radicals-msqrt-mroot">
     <meta name="assert" content="Verify dir attribute on various containers.">
     <link rel="match" href="direction-overall-ref.html">
   </head>
@@ -45,20 +44,6 @@
           <mspace width="25px" height="25px" mathbackground="green"/>
           <mspace width="25px" height="25px" mathbackground="blue"/>
         </mstyle>
-      </math>
-    </p>
-
-    <!-- dir="rtl" on <msqrt> should be ignored. The rectangle
-         inside this element should be displayed left-to-right. -->
-
-    <p>
-      msqrt:
-      <math>
-        <msqrt dir="rtl">
-          <mspace width="25px" height="25px" mathbackground="red"/>
-          <mspace width="25px" height="25px" mathbackground="green"/>
-          <mspace width="25px" height="25px" mathbackground="blue"/>
-        </msqrt>
       </math>
     </p>
 


### PR DESCRIPTION
This test is no longer valid now that dir is supported in the msqrt element.
The child positions are already tested in writing-mode-002.html.