### PR TITLE
Fix timeout in payment-is-showing.https.html

### DIFF
--- a/payment-request/blank.html
+++ b/payment-request/blank.html
@@ -5,7 +5,9 @@
     <title>Blank Page</title>
     <script>
       window.onload = function(event) {
-        console.log("Loaded ", window.location.href);
+        // This is needed to ensure the onload event fires when this page is
+        // opened as a popup.
+        // See https://github.com/web-platform-tests/wpt/pull/18157
       };
     </script>
   </head>

--- a/payment-request/blank.html
+++ b/payment-request/blank.html
@@ -1,1 +1,14 @@
-<!DOCTYPE html> <meta charset="utf-8" />
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Blank Page</title>
+    <script>
+      window.onload = function(event) {
+        console.log("Loaded ", window.location.href);
+      };
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/payment-request/payment-is-showing.https.html
+++ b/payment-request/payment-is-showing.https.html
@@ -4,6 +4,7 @@
   rel="help"
   href="https://w3c.github.io/browser-payment-api/#dfn-payment-request-is-showing"
 />
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
@@ -399,31 +400,50 @@
     }, "Navigating an iframe as a nested browsing context sets 'payment request is showing boolean' to false.");
 
     promise_test(async t => {
-      const [popupWindow, popupRequest, showPromise] = await test_driver.bless(
-        'test navigating popup after show()',
-        async () => {
-          const popupWindow = await loadPopupInsideUserGesture();
-          const popupRequest = new popupWindow.PaymentRequest(methods, details);
-          return [popupWindow, popupRequest, popupRequest.show()];
-        },
-      );
+      const [popupWindow, popupRequest, popupShowPromise] =
+        await test_driver.bless(
+          'trigger payment in a popup window',
+          async () => {
+            const popupWindow = await loadPopupInsideUserGesture();
+            const popupRequest = new popupWindow.PaymentRequest(methods, details);
+            return [popupWindow, popupRequest, popupRequest.show()];
+          });
 
       // We navigate away, causing the payment sheet to close
       // and the request is showing boolean to become false.
       popupWindow.location = 'blank.html?abc=123';
       await new Promise(resolve => (popupWindow.onload = resolve));
-      await promise_rejects(
-        t,
-        'AbortError',
-        showPromise,
-        'Navigating away must cause the showPromise to reject with an AbortError',
-      );
-      popupWindow.close();
 
-      // Now we should be ok to spin up a new payment request.
+      // Don't wait for |popupShowPromise| to reject because it may never do
+      // (see https://github.com/w3c/payment-request/issues/872). Instead, try
+      // to spin up a new payment request and make sure it succeeds.
       const request = new window.PaymentRequest(methods, details);
-      request.show();
-      await request.abort();
+      const [showPromise] = await test_driver.bless(
+        'trigger payment in main window',
+        () => {
+          return [request.show()];
+        });
+
+      // If a payment sheet fails to show, it should reject immediately. If it
+      // hasn't rejected in 1 second, then the test has passed.
+      t.step_timeout(async () => {
+        // We're done. Clean up.
+        popupWindow.close();
+        await request.abort();
+        t.done();
+      }, 1000);
+
+      // If the navigation in popup window failed to close the original payment
+      // sheet there, |showPromise| should reject immediately and this indicates
+      // a failure of this test.
+      await showPromise.then(() => {
+        assert_true(false,
+          "Second payment sheet should be pending but is resolved.");
+      })
+      .catch(e => {
+        assert_true(false,
+          "Second payment sheet should be pending but is rejected.");
+      });
     }, "Navigating a popup as a nested browsing context sets 'payment request is showing boolean' to false.");
   </script>
 </body>


### PR DESCRIPTION
The changed test was timing out before because of three reasons:

1. The onload event of the popup never fired after navigation.
2. The test assumed that `popupShowPromise` would reject when the popup navigates. This is not true in all implementations (i.e. Chrome) and this behavior has been removed from the spec. See https://github.com/w3c/payment-request/issues/872
3. This test file contains many test cases that use `test_driver.bless()`. When run from the web-based runner, the human tester may not be able to click through all steps within the default timeout of 1 minute.

(1) is fixed by adding an onload handler to the popup page, though I don't fully understand why.

(2) is fixed by replacing the `promise_rejects` expectation with a `step_timeout` to check that a new payment sheet can be opened successfully. This is sufficient to verify that the old payment sheet was indeed closed.

(3) is fixed by increasing the timeout by adding `<meta name="timeout" content="long">`.