### PR TITLE
Add selectedIndex=-1 test case to the-select-element suite

### DIFF
--- a/html/semantics/forms/the-select-element/selected-index.html
+++ b/html/semantics/forms/the-select-element/selected-index.html
@@ -30,12 +30,21 @@
     <option style="display:none"></option>
     <option></option>
   </select>
+
+  <select id=minus-one>
+    <option value=1>1</option>
+    <option value=2>2</option>
+  </select>
 </form>
 
 <script>
 function assertSelectedIndex(select, value) {
   assert_equals(select.selectedIndex, value);
   assert_equals(select.options.selectedIndex, value);
+}
+
+function assertSelectValue(select, value) {
+  assert_equals(select.value, value);
 }
 
 test(function () {
@@ -120,4 +129,15 @@ test(function () {
   select.options[1].selected = false;
   assertSelectedIndex(select, 0);
 }, "reset to display:none");
+
+test(function() {
+  var select = document.getElementById("minus-one");
+  assertSelectedIndex(select, 0);
+
+  select.selectedIndex = -1;
+
+  assertSelectedIndex(select, -1);
+  assertSelectValue(select, "");
+
+}, "set selectedIndex=-1");
 </script>


### PR DESCRIPTION
### Context
This test addition covers the issue raised in https://github.com/jsdom/jsdom/pull/2640

```js
// in jsdom
select.selectedIndex = -1;
assert.equal(select.value, select.options[0].value);  // it should be select.value === ""
```

So, we add one more test case of setting `selectedIndex=-1` to `the-select-element` suite.

---
This is my first contribution to the repo. So apologize if something was not done correctly. 🙇
