### PR TITLE
Make MathML padding/margin/border-002 tests stricter.

### DIFF
--- a/mathml/relations/css-styling/padding-border-margin/border-002.html
+++ b/mathml/relations/css-styling/padding-border-margin/border-002.html
@@ -27,8 +27,8 @@
         if (FragmentHelper.isEmpty(tag)) {
             test(function() {
                 var s = compareSizeWithAndWithoutStyle(tag, style);
-                assert_approx_equals(s.width_delta, 30 + 40, epsilon, "left/right border");
-                assert_approx_equals(s.height_delta, 50 + 60, epsilon, "top/bottom border");
+                assert_approx_equals(s.element_width_delta, 30 + 40, epsilon, "left/right border");
+                assert_approx_equals(s.element_height_delta, 50 + 60, epsilon, "top/bottom border");
             }, `Border properties on ${tag}`);
             continue;
         }
@@ -39,6 +39,8 @@
             assert_approx_equals(s.right_delta, 40, epsilon, "right border");
             assert_approx_equals(s.top_delta, 50, epsilon, "top border");
             assert_approx_equals(s.bottom_delta, 60, epsilon, "bottom border");
+            assert_approx_equals(s.element_width_delta, 30 + 40, epsilon, "element width");
+            assert_approx_equals(s.element_height_delta, 50 + 60, epsilon, "element height");
         }, `Border properties on ${tag}`);
 
         test(function() {
@@ -47,6 +49,8 @@
             assert_approx_equals(s.right_delta, 40, epsilon, "right border");
             assert_approx_equals(s.top_delta, 50, epsilon, "top border");
             assert_approx_equals(s.bottom_delta, 60, epsilon, "bottom border");
+            assert_approx_equals(s.element_width_delta, 30 + 40, epsilon, "element width");
+            assert_approx_equals(s.element_height_delta, 50 + 60, epsilon, "element height");
         }, `Border properties on ${tag} (rtl)`);
     }
 

--- a/mathml/relations/css-styling/padding-border-margin/helper.js
+++ b/mathml/relations/css-styling/padding-border-margin/helper.js
@@ -30,16 +30,18 @@ function compareSpaceWithAndWithoutStyle(tag, style) {
     var styleElement = FragmentHelper.element(styleMath);
     styleElement.setAttribute("style", style);
     var styleChild = FragmentHelper.forceNonEmptyElement(styleElement);
-    var styleBox = styleMath.getBoundingClientRect();
+    var styleMathBox = styleMath.getBoundingClientRect();
+    var styleElementBox = styleElement.getBoundingClientRect();
     var styleChildBox = styleChild.getBoundingClientRect();
-    var styleSpace = spaceBetween(styleChildBox, styleBox);
+    var styleSpace = spaceBetween(styleChildBox, styleMathBox);
 
     var noStyleMath = div.lastElementChild;
     var noStyleElement = FragmentHelper.element(noStyleMath);
     var noStyleChild = FragmentHelper.forceNonEmptyElement(noStyleElement);
-    var noStyleBox = noStyleMath.getBoundingClientRect();
+    var noStyleMathBox = noStyleMath.getBoundingClientRect();
+    var noStyleElementBox = noStyleElement.getBoundingClientRect();
     var noStyleChildBox = noStyleChild.getBoundingClientRect();
-    var noStyleSpace = spaceBetween(noStyleChildBox, noStyleBox);
+    var noStyleSpace = spaceBetween(noStyleChildBox, noStyleMathBox);
 
     div.style = "display: none;"; // Hide the div after measurement.
 
@@ -47,7 +49,9 @@ function compareSpaceWithAndWithoutStyle(tag, style) {
         left_delta: styleSpace.left - noStyleSpace.left,
         right_delta: styleSpace.right - noStyleSpace.right,
         top_delta: styleSpace.top - noStyleSpace.top,
-        bottom_delta: styleSpace.bottom - noStyleSpace.bottom
+        bottom_delta: styleSpace.bottom - noStyleSpace.bottom,
+        element_width_delta: styleElementBox.width - noStyleElementBox.width,
+        element_height_delta: styleElementBox.height - noStyleElementBox.height
     };
 }
 
@@ -64,16 +68,20 @@ function compareSizeWithAndWithoutStyle(tag, style) {
     var styleMath = div.firstElementChild;
     var styleElement = FragmentHelper.element(styleMath);
     styleElement.setAttribute("style", style);
-    var styleBox = styleMath.getBoundingClientRect();
+    var styleMathBox = styleMath.getBoundingClientRect();
+    var styleElementBox = styleElement.getBoundingClientRect();
 
     var noStyleMath = div.lastElementChild;
     var noStyleElement = FragmentHelper.element(noStyleMath);
-    var noStyleBox = noStyleMath.getBoundingClientRect();
+    var noStyleMathBox = noStyleMath.getBoundingClientRect();
+    var noStyleElementBox = noStyleElement.getBoundingClientRect();
 
     div.style = "display: none;"; // Hide the div after measurement.
 
     return {
-        width_delta: styleBox.width - noStyleBox.width,
-        height_delta: styleBox.height - noStyleBox.height
+        width_delta: styleMathBox.width - noStyleMathBox.width,
+        height_delta: styleMathBox.height - noStyleMathBox.height,
+        element_width_delta: styleElementBox.width - noStyleElementBox.width,
+        element_height_delta: styleElementBox.height - noStyleElementBox.height
     };
 };

--- a/mathml/relations/css-styling/padding-border-margin/margin-002.html
+++ b/mathml/relations/css-styling/padding-border-margin/margin-002.html
@@ -29,6 +29,8 @@
                 var s = compareSizeWithAndWithoutStyle(tag, style);
                 assert_approx_equals(s.width_delta, 30 + 40, epsilon, "left/right margin");
                 assert_approx_equals(s.height_delta, 50 + 60, epsilon, "top/bottom margin");
+                assert_approx_equals(s.element_width_delta, 0, epsilon, "element width");
+                assert_approx_equals(s.element_height_delta, 0, epsilon, "element height");
             }, `Margin properties on ${tag}`);
             continue;
         }
@@ -39,6 +41,8 @@
             assert_approx_equals(s.right_delta, 40, epsilon, "right margin");
             assert_approx_equals(s.top_delta, 50, epsilon, "top margin");
             assert_approx_equals(s.bottom_delta, 60, epsilon, "bottom margin");
+            assert_approx_equals(s.element_width_delta, 0, epsilon, "element width");
+            assert_approx_equals(s.element_height_delta, 0, epsilon, "element height");
         }, `Margin properties on ${tag}`);
 
         test(function() {
@@ -47,6 +51,8 @@
             assert_approx_equals(s.right_delta, 40, epsilon, "right margin");
             assert_approx_equals(s.top_delta, 50, epsilon, "top margin");
             assert_approx_equals(s.bottom_delta, 60, epsilon, "bottom margin");
+            assert_approx_equals(s.element_width_delta, 0, epsilon, "element width");
+            assert_approx_equals(s.element_height_delta, 0, epsilon, "element height");
         }, `Margin properties on ${tag} (rtl)`);
     }
 

--- a/mathml/relations/css-styling/padding-border-margin/padding-002.html
+++ b/mathml/relations/css-styling/padding-border-margin/padding-002.html
@@ -27,8 +27,8 @@
         if (FragmentHelper.isEmpty(tag)) {
             test(function() {
                 var s = compareSizeWithAndWithoutStyle(tag, style);
-                assert_approx_equals(s.width_delta, 30 + 40, epsilon, "left/right padding");
-                assert_approx_equals(s.height_delta, 50 + 60, epsilon, "top/bottom padding");
+                assert_approx_equals(s.element_width_delta, 30 + 40, epsilon, "left/right padding");
+                assert_approx_equals(s.element_height_delta, 50 + 60, epsilon, "top/bottom padding");
             }, `Padding properties on ${tag}`);
             continue;
         }
@@ -39,6 +39,8 @@
             assert_approx_equals(s.right_delta, 40, epsilon, "right padding");
             assert_approx_equals(s.top_delta, 50, epsilon, "top padding");
             assert_approx_equals(s.bottom_delta, 60, epsilon, "bottom padding");
+            assert_approx_equals(s.element_width_delta, 30 + 40, epsilon, "element width");
+            assert_approx_equals(s.element_height_delta, 50 + 60, epsilon, "element height");
         }, `Padding properties on ${tag}`);
 
         test(function() {
@@ -47,6 +49,8 @@
             assert_approx_equals(s.right_delta, 40, epsilon, "right padding");
             assert_approx_equals(s.top_delta, 50, epsilon, "top padding");
             assert_approx_equals(s.bottom_delta, 60, epsilon, "bottom padding");
+            assert_approx_equals(s.element_width_delta, 30 + 40, epsilon, "element width");
+            assert_approx_equals(s.element_height_delta, 50 + 60, epsilon, "element height");
         }, `Padding properties on ${tag} (rtl)`);
     }
 


### PR DESCRIPTION
Currently, these tests only verify the metric changes on the parent.
This commit makes the tests stricter by checking that the size changes are
actually applied to the element itself (padding/border) or not (margin).