### PR TITLE
Do correct comparison for rtl tests

### DIFF
--- a/mathml/relations/css-styling/padding-border-margin/border-002.html
+++ b/mathml/relations/css-styling/padding-border-margin/border-002.html
@@ -22,7 +22,6 @@
             continue;
 
         var style = "border-left: 30px solid; border-right: 40px solid; border-top: 50px solid; border-bottom: 60px solid;";
-        var styleRTL = `direction: rtl; ${style}`;
 
         if (FragmentHelper.isEmpty(tag)) {
             test(function() {
@@ -44,7 +43,7 @@
         }, `Border properties on ${tag}`);
 
         test(function() {
-            var s = compareSpaceWithAndWithoutStyle(tag, styleRTL);
+            var s = compareSpaceWithAndWithoutStyle(tag, style, null, "rtl");
             assert_approx_equals(s.left_delta, 30, epsilon, "left border");
             assert_approx_equals(s.right_delta, 40, epsilon, "right border");
             assert_approx_equals(s.top_delta, 50, epsilon, "top border");

--- a/mathml/relations/css-styling/padding-border-margin/margin-002.html
+++ b/mathml/relations/css-styling/padding-border-margin/margin-002.html
@@ -22,7 +22,6 @@
             continue;
 
         var style = "margin-left: 30px; margin-right: 40px;  margin-top: 50px; margin-bottom: 60px;";
-        var styleRTL = `direction: rtl; ${style}`;
 
         if (FragmentHelper.isEmpty(tag)) {
             test(function() {
@@ -46,7 +45,7 @@
         }, `Margin properties on ${tag}`);
 
         test(function() {
-            var s = compareSpaceWithAndWithoutStyle(tag, styleRTL);
+            var s = compareSpaceWithAndWithoutStyle(tag, style, null, "rtl");
             assert_approx_equals(s.left_delta, 30, epsilon, "left margin");
             assert_approx_equals(s.right_delta, 40, epsilon, "right margin");
             assert_approx_equals(s.top_delta, 50, epsilon, "top margin");

--- a/mathml/relations/css-styling/padding-border-margin/padding-002.html
+++ b/mathml/relations/css-styling/padding-border-margin/padding-002.html
@@ -22,7 +22,6 @@
             continue;
 
         var style = "padding-left: 30px; padding-right: 40px;  padding-top: 50px; padding-bottom: 60px;";
-        var styleRTL = `direction: rtl; ${style}`;
 
         if (FragmentHelper.isEmpty(tag)) {
             test(function() {
@@ -44,7 +43,7 @@
         }, `Padding properties on ${tag}`);
 
         test(function() {
-            var s = compareSpaceWithAndWithoutStyle(tag, styleRTL);
+            var s = compareSpaceWithAndWithoutStyle(tag, style, "rtl");
             assert_approx_equals(s.left_delta, 30, epsilon, "left padding");
             assert_approx_equals(s.right_delta, 40, epsilon, "right padding");
             assert_approx_equals(s.top_delta, 50, epsilon, "top padding");

--- a/mathml/support/box-comparison.js
+++ b/mathml/support/box-comparison.js
@@ -15,14 +15,16 @@ function measureSpaceAround(id) {
     return spaceBetween(childBox, parentBox);
 }
 
-function compareSpaceWithAndWithoutStyle(tag, style, parentStyle) {
+function compareSpaceWithAndWithoutStyle(tag, style, parentStyle, direction) {
     if (!FragmentHelper.isValidChildOfMrow(tag) ||
         FragmentHelper.isEmpty(tag))
         throw `Invalid argument: ${tag}`;
 
+    if (!direction)
+      direction = "ltr";
     document.body.insertAdjacentHTML("beforeend", `<div>\
-<math><mrow>${MathMLFragments[tag]}</mrow></math>\
-<math><mrow>${MathMLFragments[tag]}</mrow></math>\
+<math><mrow dir="${direction}">${MathMLFragments[tag]}</mrow></math>\
+<math><mrow dir="${direction}">${MathMLFragments[tag]}</mrow></math>\
 </div>`);
     var div = document.body.lastElementChild;
 


### PR DESCRIPTION
Previously the comparison was not comparing padding with no padding
specified in rtl case. Fix this by splitting out the direction part.