### PR TITLE
Give more content to foreign-container

### DIFF
--- a/mathml/support/mathml-fragments.js
+++ b/mathml/support/mathml-fragments.js
@@ -144,8 +144,11 @@ var FragmentHelper = {
             return element.firstElementChild;
         if (element.classList.contains("mathml-container"))
             return element.appendChild(this.createElement("mrow"));
-        if (element.classList.contains("foreign-container"))
-            return element.appendChild(document.createElement("span"));
+        if (element.classList.contains("foreign-container")) {
+            var el = document.createElement("span");
+            el.textContent = "a";
+            return element.appendChild(el);
+        }
         throw "Cannot make the element nonempty";
     }
 }


### PR DESCRIPTION
Chromium has behavior different from Firefox. For an empty span in a
div with padding the empty span is positioned at (0, 0). The same
effect is seen for MathML, so add some text content to force
an inline flow.