### PR TITLE
MathML displaystyle: Test display="inline" and attribute value cases.

### DIFF
--- a/mathml/relations/css-styling/displaystyle-1.html
+++ b/mathml/relations/css-styling/displaystyle-1.html
@@ -19,6 +19,7 @@
 </style>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/attribute-values.js"></script>
 <script>
   setup({ explicit_done: true });
   var emToPx = 10 / 1000; // font-size: 10px, font.em = 1000
@@ -36,60 +37,67 @@
   });
 
   function runTests() {
-    test(function() {
-      verify_displaystyle("math_default", false, "default");
-      verify_displaystyle("math_inline", false, "explicit display inline");
-      verify_displaystyle("math_block", true, "explicit display block");
-      verify_displaystyle("math_false", false, "explicit displaystyle false");
-      verify_displaystyle("math_true", true, "explicit displaystyle true");
-      verify_displaystyle("math_block_false", false, "explicit display block and displaystyle false");
-      verify_displaystyle("math_block_true", true, "explicit display block and displaystyle true");
-    }, "math element");
-    test(function() {
-      verify_displaystyle("mstyle_false", false, "explicit displaystyle false");
-      verify_displaystyle("mstyle_true", true, "explicit displaystyle true");
-    }, "mstyle element");
-    test(function() {
-      verify_displaystyle("mtable_default", false, "default");
-      verify_displaystyle("mtable_false", false, "explicit displaystyle false");
-      verify_displaystyle("mtable_true", true, "explicit displaystyle true");
-    }, "mtable element");
-    test(function() {
-      verify_displaystyle("mfrac_sibling", true, "sibling");
-      verify_displaystyle("mfrac_numerator", false, "numerator");
-      verify_displaystyle("mfrac_denominator", false, "denominator");
-    }, "mfrac element");
-    test(function() {
-      verify_displaystyle("mroot_base", true, "base");
-      verify_displaystyle("mroot_index", false, "index");
-    }, "mroot element");
-    test(function() {
-      verify_displaystyle("msub_base", true, "base");
-      verify_displaystyle("msub_subscript", false, "subscript");
-    }, "msub element");
-    test(function() {
-      verify_displaystyle("msup_base", true, "base");
-      verify_displaystyle("msup_supscript", false, "supscript");
-    }, "msup element");
-    test(function() {
-      verify_displaystyle("msubsup_base", true, "base");
-      verify_displaystyle("msubsup_subscript", false, "subscript");
-      verify_displaystyle("msubsup_supscript", false, "supscript");
-    }, "msubsup element");
-    test(function() {
-      verify_displaystyle("munder_base", true, "base");
-      verify_displaystyle("munder_underscript", false, "underscript");
-    }, "munder element");
-    test(function() {
-      verify_displaystyle("mover_base", true, "base");
-      verify_displaystyle("mover_overscript", false, "overscript");
-    }, "mover element");
-    test(function() {
-      verify_displaystyle("munderover_base", true, "base");
-      verify_displaystyle("munderover_underscript", false, "underscript");
-      verify_displaystyle("munderover_overscript", false, "overscript");
-    }, "munderover element");
-    done();
+      for (transform in AttributeValueTransforms) {
+          TransformAttributeValues(transform, ["display", "displaystyle"]);
+          test(function() {
+              verify_displaystyle("math_default", false, "default");
+              verify_displaystyle("math_false", false, "explicit displaystyle false");
+              verify_displaystyle("math_true", true, "explicit displaystyle true");
+          }, `math element (${transform})`);
+          test(function() {
+              verify_displaystyle("math_inline", false, "explicit display inline");
+              verify_displaystyle("math_block", true, "explicit display block");
+              verify_displaystyle("math_block_false", false, "explicit display block and displaystyle false");
+              verify_displaystyle("math_block_true", true, "explicit display block and displaystyle true");
+              verify_displaystyle("math_inline_false", false, "explicit display inline and displaystyle false");
+              verify_displaystyle("math_inline_true", true, "explicit display inline and displaystyle true");
+          }, `math element (explicit display, ${transform})`);
+          test(function() {
+              verify_displaystyle("mstyle_false", false, "explicit displaystyle false");
+              verify_displaystyle("mstyle_true", true, "explicit displaystyle true");
+          }, `mstyle element (${transform})`);
+          test(function() {
+              verify_displaystyle("mtable_default", false, "default");
+              verify_displaystyle("mtable_false", false, "explicit displaystyle false");
+              verify_displaystyle("mtable_true", true, "explicit displaystyle true");
+          }, `mtable element (${transform})`);
+          test(function() {
+              verify_displaystyle("mfrac_sibling", true, "sibling");
+              verify_displaystyle("mfrac_numerator", false, "numerator");
+              verify_displaystyle("mfrac_denominator", false, "denominator");
+          }, `mfrac element (${transform})`);
+          test(function() {
+              verify_displaystyle("mroot_base", true, "base");
+              verify_displaystyle("mroot_index", false, "index");
+          }, `mroot element (${transform})`);
+          test(function() {
+              verify_displaystyle("msub_base", true, "base");
+              verify_displaystyle("msub_subscript", false, "subscript");
+          }, `msub element (${transform})`);
+          test(function() {
+              verify_displaystyle("msup_base", true, "base");
+              verify_displaystyle("msup_supscript", false, "supscript");
+          }, `msup element (${transform})`);
+          test(function() {
+              verify_displaystyle("msubsup_base", true, "base");
+              verify_displaystyle("msubsup_subscript", false, "subscript");
+              verify_displaystyle("msubsup_supscript", false, "supscript");
+          }, `msubsup element (${transform})`);
+          test(function() {
+              verify_displaystyle("munder_base", true, "base");
+              verify_displaystyle("munder_underscript", false, "underscript");
+          }, `munder element (${transform})`);
+          test(function() {
+              verify_displaystyle("mover_base", true, "base");
+              verify_displaystyle("mover_overscript", false, "overscript");
+          }, `mover element (${transform})`);
+          test(function() {
+              verify_displaystyle("munderover_base", true, "base");
+              verify_displaystyle("munderover_underscript", false, "underscript");
+              verify_displaystyle("munderover_overscript", false, "overscript");
+          }, `munderover element (${transform})`);
+      }
+      done();
   }
 </script>
 </head>
@@ -105,6 +113,12 @@
   </math>
   <math display="block" displaystyle="true">
     <mo id="math_block_true">&#x2AFF;</mo>
+  </math>
+  <math display="inline" displaystyle="false">
+    <mo id="math_inline_false">&#x2AFF;</mo>
+  </math>
+  <math display="inline" displaystyle="true">
+    <mo id="math_inline_true">&#x2AFF;</mo>
   </math>
   <math><mstyle displaystyle="false"><mo id="mstyle_false">&#x2AFF;</mo></mstyle></math>
   <math><mstyle displaystyle="true"><mo id="mstyle_true">&#x2AFF;</mo></mstyle></math>

--- a/mathml/relations/css-styling/displaystyle-2.html
+++ b/mathml/relations/css-styling/displaystyle-2.html
@@ -19,6 +19,7 @@
 </style>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/attribute-values.js"></script>
 <script>
   setup({ explicit_done: true });
   var emToPx = 10 / 1000; // font-size: 10px, font.em = 1000
@@ -36,45 +37,48 @@
   });
 
   function runTests() {
-    test(function() {
-      verify_displaystyle("cell_false", false, "cell with displaystyle false");
-      verify_displaystyle("cell_true", true, "cell with displaystyle true");
-    }, "mtable element");
-    test(function() {
-      verify_displaystyle("mfrac_numerator", true, "numerator");
-      verify_displaystyle("mfrac_denominator", true, "denominator");
-    }, "mfrac element");
-    test(function() {
-      verify_displaystyle("mroot_base", false, "base");
-      verify_displaystyle("mroot_index", true, "index");
-    }, "mroot element");
-    test(function() {
-      verify_displaystyle("msub_base", false, "base");
-      verify_displaystyle("msub_subscript", true, "subscript");
-    }, "msub element");
-    test(function() {
-      verify_displaystyle("msup_base", false, "base");
-      verify_displaystyle("msup_superscript", true, "superscript");
-    }, "msup element");
-    test(function() {
-      verify_displaystyle("msubsup_base", false, "base");
-      verify_displaystyle("msubsup_subscript", true, "subscript");
-      verify_displaystyle("msubsup_superscript", true, "superscript");
-    }, "msubsup element");
-    test(function() {
-      verify_displaystyle("munder_base", false, "base");
-      verify_displaystyle("munder_underscript", true, "underscript");
-    }, "munder element");
-    test(function() {
-      verify_displaystyle("mover_base", false, "base");
-      verify_displaystyle("mover_overscript", true, "overscript");
-    }, "mover element");
-    test(function() {
-      verify_displaystyle("munderover_base", false, "base");
-      verify_displaystyle("munderover_underscript", true, "underscript");
-      verify_displaystyle("munderover_overscript", true, "overscript");
-    }, "munderover element");
-    done();
+      for (transform in AttributeValueTransforms) {
+          TransformAttributeValues(transform, ["display", "displaystyle"]);
+          test(function() {
+              verify_displaystyle("cell_false", false, "cell with displaystyle false");
+              verify_displaystyle("cell_true", true, "cell with displaystyle true");
+          }, `mtable element (${transform})`);
+          test(function() {
+              verify_displaystyle("mfrac_numerator", true, "numerator");
+              verify_displaystyle("mfrac_denominator", true, "denominator");
+          }, `mfrac element (${transform})`);
+          test(function() {
+              verify_displaystyle("mroot_base", false, "base");
+              verify_displaystyle("mroot_index", true, "index");
+          }, `mroot element (${transform})`);
+          test(function() {
+              verify_displaystyle("msub_base", false, "base");
+              verify_displaystyle("msub_subscript", true, "subscript");
+          }, `msub element (${transform})`);
+          test(function() {
+              verify_displaystyle("msup_base", false, "base");
+              verify_displaystyle("msup_superscript", true, "superscript");
+          }, `msup element (${transform})`);
+          test(function() {
+              verify_displaystyle("msubsup_base", false, "base");
+              verify_displaystyle("msubsup_subscript", true, "subscript");
+              verify_displaystyle("msubsup_superscript", true, "superscript");
+          }, `msubsup element (${transform})`);
+          test(function() {
+              verify_displaystyle("munder_base", false, "base");
+              verify_displaystyle("munder_underscript", true, "underscript");
+          }, `munder element (${transform})`);
+          test(function() {
+              verify_displaystyle("mover_base", false, "base");
+              verify_displaystyle("mover_overscript", true, "overscript");
+          }, `mover element (${transform})`);
+          test(function() {
+              verify_displaystyle("munderover_base", false, "base");
+              verify_displaystyle("munderover_underscript", true, "underscript");
+              verify_displaystyle("munderover_overscript", true, "overscript");
+          }, `munderover element (${transform})`);
+      }
+      done();
   }
 </script>
 </head>

--- a/mathml/relations/html5-tree/display-1.html
+++ b/mathml/relations/html5-tree/display-1.html
@@ -9,52 +9,55 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/mathml/support/feature-detection.js"></script>
+<script src="/mathml/support/attribute-values.js"></script>
 <script>
   function getBox(aId) {
     return document.getElementById(aId).getBoundingClientRect();
   }
   window.addEventListener("DOMContentLoaded", function() {
-    var content = getBox("content");
+      for (transform in AttributeValueTransforms) {
+          TransformAttributeValues(transform, ["display", "displaystyle"]);
+          var content = getBox("content");
 
-    var before_block = getBox("before_block");
-    var mspace_block = getBox("mspace_block");
-    var after_block = getBox("after_block");
-    test(function() {
-      assert_true(MathMLFeatureDetection.has_mspace());
-      assert_approx_equals(before_block.left, content.left, 1,
-                           "content before must be left aligned");
-      assert_approx_equals((mspace_block.left + mspace_block.right) / 2,
-                           (content.left + content.right) / 2,
-                           1,
-                           "math must be centered.");
-      assert_approx_equals(after_block.left, content.left, 1,
-                           "content before must be left aligned");
-      assert_less_than_equal(before_block.bottom, mspace_block.top,
-                            "new line before math");
-      assert_less_than_equal(mspace_block.bottom, after_block.top,
-                            "new line after math");
-    }, "Test display math");
+          var before_block = getBox("before_block");
+          var mspace_block = getBox("mspace_block");
+          var after_block = getBox("after_block");
+          test(function() {
+              assert_true(MathMLFeatureDetection.has_mspace());
+              assert_approx_equals(before_block.left, content.left, 1,
+                                   "content before must be left aligned");
+              assert_approx_equals((mspace_block.left + mspace_block.right) / 2,
+                                   (content.left + content.right) / 2,
+                                   1,
+                                   "math must be centered.");
+              assert_approx_equals(after_block.left, content.left, 1,
+                                   "content before must be left aligned");
+              assert_less_than_equal(before_block.bottom, mspace_block.top,
+                                     "new line before math");
+              assert_less_than_equal(mspace_block.bottom, after_block.top,
+                                     "new line after math");
+          }, `Test display math ${transform}`);
 
-    var before_inline = getBox("before_inline");
-    var mspace_inline = getBox("mspace_inline");
-    var after_inline = getBox("after_inline");
-    test(function() {
-      assert_true(MathMLFeatureDetection.has_mspace());
-      assert_approx_equals((before_inline.top + before_inline.bottom) / 2,
-                           (mspace_inline.top + mspace_inline.bottom) / 2,
-                           1,
-                           "content before must be horizontally aligned with math");
-      assert_approx_equals((after_inline.top + after_inline.bottom) / 2,
-                           (mspace_inline.top + mspace_inline.bottom) / 2,
-                           1,
-                           "content after must be horizontally aligned with math");
-      assert_less_than_equal(before_inline.right, mspace_inline.left,
-                            "content before must be on the left of math");
-      assert_less_than_equal(mspace_inline.right, after_inline.left,
-                            "content after must be on the right of math");
-    }, "Test inline math");
-
-    done();
+          var before_inline = getBox("before_inline");
+          var mspace_inline = getBox("mspace_inline");
+          var after_inline = getBox("after_inline");
+          test(function() {
+              assert_true(MathMLFeatureDetection.has_mspace());
+              assert_approx_equals((before_inline.top + before_inline.bottom) / 2,
+                                   (mspace_inline.top + mspace_inline.bottom) / 2,
+                                   1,
+                                   "content before must be horizontally aligned with math");
+              assert_approx_equals((after_inline.top + after_inline.bottom) / 2,
+                                   (mspace_inline.top + mspace_inline.bottom) / 2,
+                                   1,
+                                   "content after must be horizontally aligned with math");
+              assert_less_than_equal(before_inline.right, mspace_inline.left,
+                                     "content before must be on the left of math");
+              assert_less_than_equal(mspace_inline.right, after_inline.left,
+                                     "content after must be on the right of math");
+          }, `Test inline math ${transform}`);
+      }
+      done();
   });
 </script>
 <style>
@@ -69,7 +72,7 @@
     background: black;
   }
   mspace {
-    background: black;
+    background: blue;
   }
 </style>
 </head>

--- a/mathml/support/attribute-values.js
+++ b/mathml/support/attribute-values.js
@@ -1,0 +1,31 @@
+AttributeValueTransforms = {
+    lowercase: function(value) { return value.toLowerCase(); },
+    uppercase: function(value) { return value.toUpperCase(); },
+    alternate_case: function(value) {
+        var transformedValue = "";
+        for (var i = 0; i < value.length; i++) {
+            transformedValue += i % 2 ?
+                value.charAt(i).toLowerCase() :
+                value.charAt(i).toUpperCase();
+        }
+        return transformedValue;
+    },
+    // TODO: Should we perform this transform too?
+    // https://github.com/mathml-refresh/mathml/issues/122
+    // add_leading_and_trimming_whitespace: function(value) {
+    //    var space = "\0020\0009\000A\000D";
+    //    return `${space}${space}${value}${space}${space}`;
+    // },
+};
+
+function TransformAttributeValues(transform, attributeNames) {
+    if (typeof attributeNames === "string")
+        attributeNames = [attributeNames];
+    attributeNames.forEach(name => {
+        Array.from(document.querySelectorAll(`[${name}]`)).forEach(element => {
+            var value = element.getAttribute(name);
+            var transformedValue = AttributeValueTransforms[transform](value);
+            element.setAttribute(name, transformedValue);
+        });
+    });
+}


### PR DESCRIPTION
This introduces a new helper function to easily apply transforms to attribute
values and uses it to test different string cases for the displaystyle and
display attribute values. This also add new asserts for a math with explicit
display="inline" and a displaystyle attribute.