### PR TITLE
[wpt] Smarter discovery of Chrome binaries

### DIFF
--- a/docs/running-tests/chrome.md
+++ b/docs/running-tests/chrome.md
@@ -3,12 +3,16 @@
 When running Chrome, there are some useful command line arguments.
 
 You can inform `wpt` of the release channel of Chrome using `--channel`.
-However, `wpt` currently does not support installing Chrome or finding the
-Chrome binary of a specific channel, so you would also need to specify the path
-to the Chrome binary with `--binary`. For example, to run Chrome Dev on Linux:
+`wpt` is able to find the correct binary in the following cases:
+* On Linux for stable, beta and dev channels if
+  `google-chrome-{stable,beta,unstable}` are in `PATH`;
+* On Mac for stable and canary channels if the official DMGs are installed.
 
-```
-./wpt run --channel dev --binary `which google-chrome-unstable` chrome
+In other cases, you will need to specify the path to the Chrome binary with
+`--binary`. For example:
+
+```bash
+./wpt run --channel dev --binary /path/to/non-default/google-chrome chrome
 ```
 
 Note: when the channel is "dev", `wpt` will *automatically* enable all
@@ -19,7 +23,7 @@ Note: when the channel is "dev", `wpt` will *automatically* enable all
 If you want to enable a specific [runtime enabled feature][1], use
 `--binary-arg` to specify the flag(s) that you want to pass to Chrome:
 
-```
+```bash
 ./wpt run --binary-arg=--enable-blink-features=AsyncClipboard chrome clipboard-apis/
 ```
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -545,6 +545,8 @@ class Chrome(Browser):
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):
         if dest is None:
             dest = os.pwd
+        if browser_binary is None:
+            browser_binary = self.find_binary(channel)
         url = self._latest_chromedriver_url(browser_binary)
         self.logger.info("Downloading ChromeDriver from %s" % url)
         unzip(get(url).raw, dest)

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -439,17 +439,6 @@ class Chrome(Browser):
     product = "chrome"
     requirements = "requirements_chrome.txt"
 
-    @property
-    def binary(self):
-        if uname[0] == "Linux":
-            return "/usr/bin/google-chrome"
-        if uname[0] == "Darwin":
-            return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-        if uname[0] == "Windows":
-            return os.path.expandvars("$SYSTEMDRIVE\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
-        self.logger.warning("Unable to find the browser binary.")
-        return None
-
     def install(self, dest=None, channel=None):
         raise NotImplementedError
 
@@ -488,7 +477,25 @@ class Chrome(Browser):
         return platform
 
     def find_binary(self, venv_path=None, channel=None):
-        raise NotImplementedError
+        if uname[0] == "Linux":
+            name = "google-chrome"
+            if channel == "stable":
+                name += "-stable"
+            elif channel == "beta":
+                name += "-beta"
+            elif channel == "dev":
+                name += "-unstable"
+            # No Canary on Linux.
+            return find_executable(name)
+        if uname[0] == "Darwin":
+            if channel == "canary":
+                return "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
+            # All other channels share the same path on macOS.
+            return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        if uname[0] == "Windows":
+            return os.path.expandvars(r"$SYSTEMDRIVE\Program Files (x86)\Google\Chrome\Application\chrome.exe")
+        self.logger.warning("Unable to find the browser binary.")
+        return None
 
     def find_webdriver(self, channel=None):
         return find_executable("chromedriver")
@@ -548,7 +555,10 @@ class Chrome(Browser):
         return find_executable("chromedriver", dest)
 
     def version(self, binary=None, webdriver_binary=None):
-        binary = binary or self.binary
+        if not binary:
+            self.logger.warning("No browser binary provided.")
+            return None
+
         if uname[0] == "Windows":
             return _get_fileversion(binary, self.logger)
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -264,6 +264,13 @@ class Chrome(BrowserSetup):
     browser_cls = browser.Chrome
 
     def setup_kwargs(self, kwargs):
+        browser_channel = kwargs["browser_channel"]
+        if kwargs["binary"] is None:
+            binary = self.browser.find_binary(channel=browser_channel)
+            if binary:
+                kwargs["binary"] = binary
+            else:
+                raise WptrunError("Unable to locate Chrome binary")
         if kwargs["webdriver_binary"] is None:
             webdriver_binary = self.browser.find_webdriver()
 
@@ -272,7 +279,10 @@ class Chrome(BrowserSetup):
 
                 if install:
                     logger.info("Downloading chromedriver")
-                    webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path, browser_binary=kwargs["binary"])
+                    webdriver_binary = self.browser.install_webdriver(
+                        dest=self.venv.bin_path,
+                        browser_binary=kwargs["binary"]
+                    )
             else:
                 logger.info("Using webdriver binary %s" % webdriver_binary)
 
@@ -351,7 +361,7 @@ class EdgeChromium(BrowserSetup):
         if kwargs["binary"] is None:
             binary = self.browser.find_binary(channel=browser_channel)
             if binary:
-                kwargs["binary"] = self.browser.find_binary()
+                kwargs["binary"] = binary
             else:
                 raise WptrunError("Unable to locate Edge binary")
         if kwargs["webdriver_binary"] is None:


### PR DESCRIPTION
Previously, the default binary path for Chrome was hard-coded regardless
of the channel, making it cumbersome to test non-stable channels (in
addition to `--channel`, users had to specify `--binary`). With this
change, `./wpt run` tries to find the channel-specific binary in lieu of
the `--binary` argument:

* On Linux, find google-chrome-{stable,beta,unstable} in PATH.
* On Mac, find "Google Chrome{, Canary}.app".

(Compatible with the official Linux and macOS packages)

This change does not affect existing CI setups, because we always
specify `--binary` on CI.

Also update the doc to reflect the change.