### PR TITLE
Fixed a comment copy/paste typo.

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -597,7 +597,7 @@
             }
         },
         {
-            "comment": "Cannot-be-a-base means no password",
+            "comment": "Cannot-be-a-base means no host",
             "href": "data:text/plain,Stuff",
             "new_value": "example.net",
             "expected": {
@@ -1074,7 +1074,7 @@
             }
         },
         {
-            "comment": "Cannot-be-a-base means no password",
+            "comment": "Cannot-be-a-base means no host",
             "href": "data:text/plain,Stuff",
             "new_value": "example.net",
             "expected": {


### PR DESCRIPTION
When trying to have the latest wpt pass on rust-url, I noticed a couple of typos in the comment.

I suppose it's not a big deal so I would understand if the pr gets rejected ^^ 