### PR TITLE
[css-text] Make tests independent of any specific font

### DIFF
--- a/css/css-text/i18n/css3-text-line-break-baspglwj-001.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-001.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="When white-space allows wrapping, line breaking behavior defined for the WJ, ZW, and GL line-breaking classes in [UAX14] must be honored.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-002.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-002.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="When white-space allows wrapping, line breaking behavior defined for the WJ, ZW, and GL line-breaking classes in [UAX14] must be honored.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-003.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-003.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-004.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-004.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-005.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-005.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-006.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-006.html
@@ -10,17 +10,10 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>
-
 
 
 <div class="test">

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-007.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-007.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-008.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-008.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-009.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-009.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-010.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-010.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-011.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-011.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-012.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-012.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-014.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-014.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-015.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-015.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking space characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-016.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-016.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking hyphen characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-017.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-017.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking hyphen characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-018.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-018.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking hyphen characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-019.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-019.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA breaking hyphen characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-020.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-020.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA visible word divider characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-021.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-021.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA visible word divider characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-022.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-022.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA visible word divider characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-023.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-023.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA visible word divider characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-024.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-024.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA visible word divider characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-025.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-025.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA visible word divider characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-026.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-026.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after each of the BA visible word divider characters.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-030.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-030.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-031.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-031.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-032.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-032.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-033.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-033.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-034.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-034.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-035.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-035.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-036.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-036.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-037.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-037.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-038.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-038.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-039.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-039.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-040.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-040.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-041.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-041.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-042.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-042.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-043.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-043.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-044.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-044.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-045.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-045.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-046.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-046.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-047.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-047.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-048.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-048.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-049.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-049.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-050.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-050.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-051.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-051.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-052.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-052.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA historic word separator property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-060.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-060.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-061.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-061.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-062.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-062.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-063.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-063.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-064.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-064.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-065.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-065.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-066.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-066.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-067.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-067.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-068.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-068.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-069.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-069.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-070.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-070.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-071.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-071.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-072.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-072.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-073.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-073.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-074.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-074.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-075.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-075.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-076.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-076.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-077.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-077.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-078.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-078.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA danda property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-080.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-080.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The UA will break a line of text after any Unicode character with the BA tibetan property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-081.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-081.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The UA will break a line of text after any Unicode character with the BA tibetan property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-082.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-082.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The UA will break a line of text after any Unicode character with the BA tibetan property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-083.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-083.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The UA will break a line of text after any Unicode character with the BA tibetan property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-084.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-084.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The UA will break a line of text after any Unicode character with the BA tibetan property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-085.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-085.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The UA will break a line of text after any Unicode character with the BA tibetan property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-086.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-086.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The UA will break a line of text after any Unicode character with the BA tibetan property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-090.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-090.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-091.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-091.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-092.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-092.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-093.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-093.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-094.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-094.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-095.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-095.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-096.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-096.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-097.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-097.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-098.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-098.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-099.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-099.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-100.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-100.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-101.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-101.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-102.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-102.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-103.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-103.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-104.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-104.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-105.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-105.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-106.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-106.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-107.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-107.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-108.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-108.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-109.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-109.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-110.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-110.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-111.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-111.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-112.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-112.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-113.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-113.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-114.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-114.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-115.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-115.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-116.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-116.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-117.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-117.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-118.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-118.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will break a line of text after any Unicode character with the BA Other Terminating Punctuation property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-120.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-120.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the GL non-breaking property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-121.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-121.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the GL non-breaking property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-122.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-122.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the GL non-breaking property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-123.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-123.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the GL non-breaking property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-124.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-124.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the GL non-breaking property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-125.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-125.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the GL non-breaking property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-126.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-126.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the GL non-breaking property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-127.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-127.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the GL non-breaking property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-128.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-128.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the GL non-breaking property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-130.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-130.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the WJ Word Joiner property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>

--- a/css/css-text/i18n/css3-text-line-break-baspglwj-131.html
+++ b/css/css-text/i18n/css3-text-line-break-baspglwj-131.html
@@ -10,13 +10,7 @@
 <meta name='flags' content='dom'>
 <meta name="assert" content="[Exploratory] The browser will NOT break a line of text containing any Unicode character with the WJ Word Joiner property.">
 <style type='text/css'>
-@font-face {
-    font-family: 'csstest_ascii';
-    src: url('support/csstest-ascii-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-	}
-#breakable { font-family: csstest_ascii; font-size: 25px; width: 800px; line-height: 30px; }
+#breakable { font-family: monospace; font-size: 25px; width: 50ch; line-height: 30px; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
The tests were attempting to use a font that is not present in the repo,
and happened to work because most systems' default font's metric are
close enough. Using monospace and measurements in ch makes this reliable
rather than a happy coincidence.

Closes #17995