### PR TITLE
MathML: Make box comparison more reliable by using an absolutely-posi…

### DIFF
--- a/mathml/support/box-comparison.js
+++ b/mathml/support/box-comparison.js
@@ -22,7 +22,7 @@ function compareSpaceWithAndWithoutStyle(tag, style, parentStyle, direction) {
 
     if (!direction)
       direction = "ltr";
-    document.body.insertAdjacentHTML("beforeend", `<div>\
+    document.body.insertAdjacentHTML("beforeend", `<div style="position: absolute;">\
 <math><mrow dir="${direction}">${MathMLFragments[tag]}</mrow></math>\
 <math><mrow dir="${direction}">${MathMLFragments[tag]}</mrow></math>\
 </div>`);
@@ -64,7 +64,7 @@ function compareSizeWithAndWithoutStyle(tag, style) {
     if (!FragmentHelper.isValidChildOfMrow(tag))
         throw `Invalid argument: ${tag}`;
 
-    document.body.insertAdjacentHTML("beforeend", `<div>\
+    document.body.insertAdjacentHTML("beforeend", `<div style="position: absolute;">\
 <math>${MathMLFragments[tag]}</math>\
 <math>${MathMLFragments[tag]}</math>\
 </div>`);


### PR DESCRIPTION
…tioned div.

It seems padding/border/margin-002 tests may fail because of interaction between
sibling divs. Although this probably need separate debugging/testing, these
tests are intended to verify each subtest individually, so make the testing divs
absolutely-positioned in order to isolate them from the rest of the layout.