### PR TITLE
README: Document the URL to use the web-based runner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ After your `hosts` file is configured, the servers will be locally accessible at
 http://web-platform.test:8000/<br>
 https://web-platform.test:8443/ *
 
+To use the web-based runner point your browser to:
+
+http://web-platform.test:8000/tools/runner/index.html <br>
+https://web-platform.test:8443/tools/runner/index.html *
+
 \**See [Trusting Root CA](#trusting-root-ca)*
 
 Running Tests Automatically

--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -96,6 +96,11 @@ After your `hosts` file is configured, the servers will be locally accessible at
 http://web-platform.test:8000/<br>
 https://web-platform.test:8443/ *
 
+To use the web-based runner point your browser to:
+
+http://web-platform.test:8000/tools/runner/index.html<br>
+https://web-platform.test:8443/tools/runner/index.html *
+
 This server has all the capabilities of the publicly-deployed version--see
 [Running the Tests from the Web](from-web).
 


### PR DESCRIPTION
After starting the server with "./wpt serve" is not obvious where the web-based runner can be accessed. Document it.