### PR TITLE
Add webgpu/ test directory

### DIFF
--- a/webgpu/META.yml
+++ b/webgpu/META.yml
@@ -1,0 +1,5 @@
+spec: https://gpuweb.github.io/gpuweb/
+suggested_reviewers:
+  - kainino0x
+  - JusSn
+  - kvark

--- a/webgpu/README.md
+++ b/webgpu/README.md
@@ -1,0 +1,10 @@
+# WebGPU Conformance Test Suite
+
+The WebGPU CTS requires support for the WebGPU API. This requires both browser
+support and hardware support, so this API cannot run on most automated testing
+infrastructure. Tests inside this directory should always be skipped if
+appropriate GPU hardware is not available.
+
+The contents of this directory are automatically generated from TypeScript
+sources which live upstream in the [WebGPU CTS](https://github.com/gpuweb/cts).
+They are periodically built and pushed to WPT.


### PR DESCRIPTION
This creates the webgpu/ test directory for the WebGPU conformance test suite.

The readme explains how this directory works. There are no built contents in this directory yet; those will be uploaded after this lands.