### PR TITLE
MathML: Add tests for children not participating to their parent layout

### DIFF
--- a/mathml/relations/css-styling/not-participating-to-parent-layout.html
+++ b/mathml/relations/css-styling/not-participating-to-parent-layout.html
@@ -7,8 +7,9 @@
 <meta name="assert" content="Verify that display: none and out-of-flow positioned elements do not participate to layout of their parent.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/mathml/support/mathml-fragments.js"></script>
+<script src="/mathml/support/feature-detection.js"></script>
 <script src="/mathml/support/layout-comparison.js"></script>
+<script src="/mathml/support/mathml-fragments.js"></script>
 <script>
   var epsilon = 1;
 
@@ -47,10 +48,14 @@
             var epsilon = 1;
 
             test(function() {
+                // FIXME(fwang): Feature detection should be done per-tag.
+                assert_true(MathMLFeatureDetection.has_mspace());
                 assert_approx_equals(elementContainerWidth, referenceContainerWidth, epsilon);
             }, `${tag} preferred width calculation is not affected by children with "${style}" style`);
 
             test(function() {
+                // FIXME(fwang): Feature detection should be done per-tag.
+                assert_true(MathMLFeatureDetection.has_mspace());
                 compareLayout(element, reference, epsilon);
             }, `${tag} layout is not affected by children with "${style}" style`);
 

--- a/mathml/relations/css-styling/not-participating-to-parent-layout.html
+++ b/mathml/relations/css-styling/not-participating-to-parent-layout.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Elements not participating to the layout of their parent</title>
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#layout-algorithms">
+<meta name="assert" content="Verify that display: none and out-of-flow positioned elements do not participate to layout of their parent.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/mathml/support/mathml-fragments.js"></script>
+<script src="/mathml/support/layout-comparison.js"></script>
+<script>
+  var epsilon = 1;
+
+  setup({ explicit_done: true });
+  window.addEventListener("load", runTests);
+
+  function runTests() {
+
+    for (tag in MathMLFragments) {
+        if (!FragmentHelper.isValidChildOfMrow(tag) ||
+            FragmentHelper.isEmpty(tag))
+            continue;
+        ["display: none",
+         "position: absolute",
+         "position: fixed"
+        ].forEach(style => {
+            document.body.insertAdjacentHTML("beforeend", `<div style="position: absolute;">\
+<div style="display: inline-block"><math>${MathMLFragments[tag]}</math></div>\
+<div style="display: inline-block"><math>${MathMLFragments[tag]}</math></div>\
+</div>`);
+            var div = document.body.lastElementChild;
+
+            var elementContainer = div.firstElementChild;
+            var elementContainerWidth = elementContainer.getBoundingClientRect().width;
+            var element = FragmentHelper.element(elementContainer);
+            FragmentHelper.forceNonEmptyElement(element);
+            var allowInvalid = true;
+            var child = FragmentHelper.appendChild(element, allowInvalid);
+            child.setAttribute("style", style);
+
+            var referenceContainer = div.lastElementChild;
+            var referenceContainerWidth = referenceContainer.getBoundingClientRect().width;
+            var reference = FragmentHelper.element(referenceContainer);
+            FragmentHelper.forceNonEmptyElement(reference);
+
+            var epsilon = 1;
+
+            test(function() {
+                assert_approx_equals(elementContainerWidth, referenceContainerWidth, epsilon);
+            }, `${tag} preferred width calculation is not affected by children with "${style}" style`);
+
+            test(function() {
+                compareLayout(element, reference, epsilon);
+            }, `${tag} layout is not affected by children with "${style}" style`);
+
+            div.style = "display: none;"; // Hide the div after measurement.
+        });
+    }
+
+    done();
+  }
+</script>
+</head>
+<body>
+  <div id="log"></div>
+</body>
+</html>

--- a/mathml/relations/css-styling/not-participating-to-parent-layout.html
+++ b/mathml/relations/css-styling/not-participating-to-parent-layout.html
@@ -22,6 +22,7 @@
         if (!FragmentHelper.isValidChildOfMrow(tag) ||
             FragmentHelper.isEmpty(tag))
             continue;
+        // TODO: Add floats too?
         ["display: none",
          "position: absolute",
          "position: fixed"

--- a/mathml/support/mathml-fragments.js
+++ b/mathml/support/mathml-fragments.js
@@ -138,17 +138,25 @@ var FragmentHelper = {
         return fragment.getElementsByClassName('element')[0];
     },
 
-    forceNonEmptyElement: function(fragment) {
+    appendChild: function(fragment, allowInvalid) {
         var element = this.element(fragment) || fragment;
-        if (element.firstElementChild)
-            return element.firstElementChild;
-        if (element.classList.contains("mathml-container"))
-            return element.appendChild(this.createElement("mrow"));
         if (element.classList.contains("foreign-container")) {
             var el = document.createElement("span");
             el.textContent = "a";
             return element.appendChild(el);
         }
-        throw "Cannot make the element nonempty";
+        if (element.classList.contains("mathml-container") || allowInvalid) {
+            var el = this.createElement("mi");
+            el.textContent = "a";
+            return element.appendChild(el);
+        }
+        throw "Cannot append child to the element";
+    },
+
+    forceNonEmptyElement: function(fragment) {
+        var element = this.element(fragment) || fragment;
+        if (element.firstElementChild)
+            return element.firstElementChild;
+        return this.appendChild(fragment);
     }
 }


### PR DESCRIPTION
This commit adds new tests to verify that children with "display: none",
"position: absolute" or "position: fixed" don't affect preferred width
calculation or layout of their parents.

- mathml/support/mathml-fragments.js:  Add function to append a non empty
 child (optionally making the element invalid) and use that function for
 forceNonEmptyElement.

- mathml/support/layout-comparison.js: Introduce new helpers function to
  extract the children participating to their parent layout. Modify
  compareLayout so that it browser that list of children instead and allow
  comparison in horizontal+LTR mode.