### PR TITLE
[docs] Explain behavior of failing assertions

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -297,6 +297,11 @@ only takes `actual` and `description` as arguments.
 The description parameter is used to present more useful error messages when
 a test fails.
 
+When assertions are violated, they throw a runtime exception. This interrupts
+test execution, so subsequent statements are not evaluated. A given test can
+only fail due to one such violation, so if you would like to assert multiple
+behaviors independently, you should use multiple tests.
+
 NOTE: All asserts must be located in a `test()` or a step of an
 `async_test()`, unless the test is a single page test. Asserts outside
 these places won't be detected correctly by the harness and may cause


### PR DESCRIPTION
The mechanism that assertions use to signal failure influences test
design and is therefore relevant to test authors.

This is in service of gh-7183.