### PR TITLE
[docs] Correct errors in build process

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,11 +13,12 @@ help:
 
 .PHONY: help Makefile
 
-tools/wptserve:
+tools/%:
 	mkdir -p $(shell dirname $@)
-	ln -s ../../tools/wptserve $@
+	test -d ../$@
+	ln -s ../../$@ $@
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile tools/wptserve
+%: Makefile tools/wptserve tools/certs
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -28,6 +28,7 @@ if errorlevel 9009 (
 if not exist tools\ ( mkdir tools )
 
 if not exist tools\wptserve\ ( mklink /d tools\wptserve ..\..\tools\wptserve )
+if not exist tools\certs\ ( mklink /d tools\certs ..\..\tools\certs )
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 goto end

--- a/docs/writing-tests/reftest-tutorial.md
+++ b/docs/writing-tests/reftest-tutorial.md
@@ -19,7 +19,7 @@ You'll need to [configure your system to use WPT's
 tools](../running-tests/from-local-system), but you won't need them until
 towards the end of this tutorial. Although it includes some very brief
 instructions on using git, you can find more guidance in [the tutorial for git
-and GitHub](../appendix/github-intro).
+and GitHub](../writing-tests/github-intro).
 
 WPT's reftests are great for testing web-platform features that have some
 visual effect. [The reftests reference page](reftests) describes them in the
@@ -264,7 +264,7 @@ And now we can push the commit to our fork of WPT:
 The last step is to submit the test for review. WPT doesn't actually need the
 test we wrote in this tutorial, but if we wanted to submit it for inclusion in
 the repository, we would create a pull request on GitHub. [The guide on git and
-GitHub](../appendix/github-intro) has all the details on how to do that.
+GitHub](../writing-tests/github-intro) has all the details on how to do that.
 
 ## More practice
 


### PR DESCRIPTION
Ensure that the contents of the top-level `certs/` directory are
available to the Sphinx process at build time.

Correct references to recently-relocated document from a new tutorial.

In gh-17798, we learned that documentation patches are only validated when
submitted from a branch in the upstream repository. I've submitted this patch
from such a branch so we can verify that it has the intended effect prior to
merging.