### PR TITLE
[cookie-store] Deflake service worker registration

### DIFF
--- a/cookie-store/serviceworker_cookieStore_arguments.tentative.https.html
+++ b/cookie-store/serviceworker_cookieStore_arguments.tentative.https.html
@@ -11,11 +11,11 @@
 (async () => {
   const scope = 'does/not/exist';
 
-  let registration = await navigator.serviceWorker.getRegistration(scope);
-  if (registration)
-    await registration.unregister();
-  registration = await navigator.serviceWorker.register(
+  const registration = await navigator.serviceWorker.register(
       'serviceworker_cookieStore_arguments.js', {scope});
+  add_completion_callback(() => {
+    registration.unregister();
+  });
 
   fetch_tests_from_worker(registration.installing);
 })();

--- a/cookie-store/serviceworker_cookieStore_basic.tentative.https.html
+++ b/cookie-store/serviceworker_cookieStore_basic.tentative.https.html
@@ -11,11 +11,11 @@
 (async () => {
   const scope = 'does/not/exist';
 
-  let registration = await navigator.serviceWorker.getRegistration(scope);
-  if (registration)
-    await registration.unregister();
-  registration = await navigator.serviceWorker.register(
+  const registration = await navigator.serviceWorker.register(
       'serviceworker_cookieStore_basic.js', {scope});
+  add_completion_callback(() => {
+    registration.unregister();
+  });
 
   fetch_tests_from_worker(registration.installing);
 })();

--- a/cookie-store/serviceworker_cookieStore_subscriptions.tentative.https.html
+++ b/cookie-store/serviceworker_cookieStore_subscriptions.tentative.https.html
@@ -12,11 +12,11 @@
   // Not using an explicit scope here in order for script URL to be in scope,
   // to cover implicit subscription URL construction.
 
-  let registration = await navigator.serviceWorker.getRegistration();
-  if (registration)
-    await registration.unregister();
-  registration = await navigator.serviceWorker.register(
+  const registration = await navigator.serviceWorker.register(
       'serviceworker_cookieStore_subscriptions.js');
+  add_completion_callback(() => {
+    registration.unregister();
+  });
 
   fetch_tests_from_worker(registration.installing);
 })();

--- a/cookie-store/serviceworker_cookieStore_subscriptions_basic.tentative.https.html
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_basic.tentative.https.html
@@ -11,11 +11,11 @@
 (async () => {
   const scope = 'scope';
 
-  let registration = await navigator.serviceWorker.getRegistration(scope);
-  if (registration)
-    await registration.unregister();
-  registration = await navigator.serviceWorker.register(
+  const registration = await navigator.serviceWorker.register(
       'serviceworker_cookieStore_subscriptions_basic.js', {scope});
+  add_completion_callback(() => {
+    registration.unregister();
+  });
 
   fetch_tests_from_worker(registration.installing);
 })();

--- a/cookie-store/serviceworker_cookieStore_subscriptions_empty.tentative.https.html
+++ b/cookie-store/serviceworker_cookieStore_subscriptions_empty.tentative.https.html
@@ -10,11 +10,11 @@
 (async () => {
   const scope = 'scope';
 
-  let registration = await navigator.serviceWorker.getRegistration(scope);
-  if (registration)
-    await registration.unregister();
-  registration = await navigator.serviceWorker.register(
+  const registration = await navigator.serviceWorker.register(
       'serviceworker_cookieStore_subscriptions_empty.js', {scope});
+  add_completion_callback(() => {
+    registration.unregister();
+  });
 
   fetch_tests_from_worker(registration.installing);
 })();


### PR DESCRIPTION
Instead of attempting to unregister previously installed service workers
at the beginning of a test, use `add_completion_callback` to unregister
them at test completion. This will deflake the tests when they are run
multiple times without restarts (`--rerun`).

The alternative is to do what many tests in service-workers do:
unregister service workers at the start, but wait for newly installed
service workers to become activated and use `registration.active`
instead of `registration.installing`, which is a bit more complex.

Fixes the flakiness observed in #17866 .