### PR TITLE
[payment-request] Fix style: use double quotes consistently

### DIFF
--- a/payment-request/payment-is-showing.https.html
+++ b/payment-request/payment-is-showing.https.html
@@ -11,24 +11,24 @@
 <script src="/resources/testdriver.js"></script>
 <body>
   <script>
-    'use strict';
+    "use strict";
     const applePayMethod = {
-      supportedMethods: 'https://apple.com/apple-pay',
+      supportedMethods: "https://apple.com/apple-pay",
       data: {
         version: 3,
-        merchantIdentifier: 'merchant.com.example',
-        countryCode: 'US',
-        merchantCapabilities: ['supports3DS'],
-        supportedNetworks: ['visa'],
+        merchantIdentifier: "merchant.com.example",
+        countryCode: "US",
+        merchantCapabilities: ["supports3DS"],
+        supportedNetworks: ["visa"],
       },
     };
-    const methods = [{supportedMethods: 'basic-card'}, applePayMethod];
+    const methods = [{supportedMethods: "basic-card"}, applePayMethod];
     const details = {
       total: {
-        label: 'Total',
+        label: "Total",
         amount: {
-          currency: 'USD',
-          value: '1.00',
+          currency: "USD",
+          value: "1.00",
         },
       },
     };
@@ -39,13 +39,13 @@
      * @param {String} src Optional resource URL to load.
      * @returns {Promise} Resolves when the src loads.
      */
-    async function attachIframe(src = 'blank.html') {
-      const iframe = document.createElement('iframe');
+    async function attachIframe(src = "blank.html") {
+      const iframe = document.createElement("iframe");
       iframe.allowPaymentRequest = true;
       iframe.src = src;
       document.body.appendChild(iframe);
       await new Promise(resolve => {
-        iframe.addEventListener('load', resolve, {once: true});
+        iframe.addEventListener("load", resolve, {once: true});
       });
       return iframe;
     }
@@ -56,10 +56,10 @@
      * @param {String} src Optional resource URL to load.
      * @returns {Promise} Resolves when the src loads.
      */
-    async function loadPopupInsideUserGesture(src = 'blank.html') {
-      const popupWindow = window.open(src, '', 'width=400,height=400');
+    async function loadPopupInsideUserGesture(src = "blank.html") {
+      const popupWindow = window.open(src, "", "width=400,height=400");
       await new Promise(resolve => {
-        popupWindow.addEventListener('load', resolve, {once: true});
+        popupWindow.addEventListener("load", resolve, {once: true});
       });
       popupWindow.focus();
       return popupWindow;
@@ -73,24 +73,24 @@
       // showing boolean" to true and then try to show a second payment sheet in
       // the same window. The second show() should reject.
       const [showPromise1, showPromise2] = await test_driver.bless(
-        'testing one payment sheet per window',
+        "testing one payment sheet per window",
         () => {
           return [request1.show(), request2.show()];
         },
       );
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         showPromise2,
-        'Attempting to show a second payment request must reject.',
+        "Attempting to show a second payment request must reject.",
       );
 
       await request1.abort();
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         showPromise1,
-        'request1 was aborted via .abort()',
+        "request1 was aborted via .abort()",
       );
 
       // Finally, request2 should have been "closed", so trying to show
@@ -99,17 +99,17 @@
       const rejectedPromise = request2.show();
       await promise_rejects(
         t,
-        'InvalidStateError',
+        "InvalidStateError",
         rejectedPromise,
-        'Attempting to show a second payment request must reject.',
+        "Attempting to show a second payment request must reject.",
       );
       // Finally, we confirm that request2's returned promises are unique.
       assert_not_equals(
         showPromise2,
         rejectedPromise,
-        'Returned Promises be unique',
+        "Returned Promises be unique",
       );
-    }, 'The top browsing context can only show one payment sheet at a time.');
+    }, "The top browsing context can only show one payment sheet at a time.");
 
     promise_test(async t => {
       const iframe = await attachIframe();
@@ -121,7 +121,7 @@
 
       // Let's get some blessed showPromises
       const [showPromise] = await test_driver.bless(
-        'testing top window show() blocked by payment sheet in iframe',
+        "testing top window show() blocked by payment sheet in iframe",
         () => {
           // iframe sets "is showing boolean", ignore the returned promise.
           iframeRequest.show();
@@ -132,9 +132,9 @@
 
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         showPromise,
-        'iframe is already showing a payment request.',
+        "iframe is already showing a payment request.",
       );
 
       // Cleanup
@@ -154,7 +154,7 @@
       // windowRequest.show() sets "is showing boolean" to true. Then we try to
       // show a payment request in the iframe, which should reject.
       const [iframeShowPromise] = await test_driver.bless(
-        'testing iframe show() blocked by payment sheet in top window',
+        "testing iframe show() blocked by payment sheet in top window",
         () => {
           windowRequest.show();
           return [iframeRequest.show()];
@@ -163,15 +163,15 @@
 
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         iframeShowPromise,
-        'The top window is already showing a payment request.',
+        "The top window is already showing a payment request.",
       );
 
       // Cleanup
       await windowRequest.abort();
       iframe.remove();
-    }, 'An iframe cannot show a payment request if the top-level window is already showing one.');
+    }, "An iframe cannot show a payment request if the top-level window is already showing one.");
 
     promise_test(async t => {
       // Create a PaymentReuqest in top-level window.
@@ -186,7 +186,7 @@
         popupShowPromise,
         windowShowPromise,
       ] = await test_driver.bless(
-        'testing top-level show() blocked by payment sheet in popup',
+        "testing top-level show() blocked by payment sheet in popup",
         async () => {
           const popupWindow = await loadPopupInsideUserGesture();
           const popupRequest = new popupWindow.PaymentRequest(methods, details);
@@ -205,11 +205,11 @@
 
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         windowShowPromise,
         "Expected window's showPromise to reject, request is already showing",
       );
-    }, 'Using a popup window prevents the top-browsing context from showing a payment request');
+    }, "Using a popup window prevents the top-browsing context from showing a payment request");
 
     promise_test(async t => {
       const iframe = await attachIframe();
@@ -222,7 +222,7 @@
       // Open a popup window
       const [popupWindow, popupRequest] =
       await test_driver.bless(
-        'open popup to test multiple context and window calls show() first',
+        "open popup to test multiple context and window calls show() first",
         async () => {
           const popupWindow = await loadPopupInsideUserGesture();
           const popupRequest = new popupWindow.PaymentRequest(methods, details);
@@ -238,7 +238,7 @@
         popupShowPromise,
         iframeShowPromise,
       ] = await test_driver.bless(
-        'test multiple nested browsing context',
+        "test multiple nested browsing context",
         () => {
           return [
             windowRequest.show(),
@@ -250,16 +250,16 @@
       // popupRequest and iframeRequest will both reject
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         popupShowPromise,
-        'Expected popupShowPromise to reject, request is already showing.',
+        "Expected popupShowPromise to reject, request is already showing.",
       );
 
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         iframeShowPromise,
-        'Expected iframeShowPromise to reject, request is already showing.',
+        "Expected iframeShowPromise to reject, request is already showing.",
       );
 
       await windowRequest.abort();
@@ -283,7 +283,7 @@
         windowShowPromise,
         iframeShowPromise
       ] = await test_driver.bless(
-        'test multiple browsing context and iframe calls show() first',
+        "test multiple browsing context and iframe calls show() first",
         async () => {
           const popupWindow = await loadPopupInsideUserGesture();
           const popupRequest = new popupWindow.PaymentRequest(methods, details);
@@ -300,16 +300,16 @@
       // windowShowPromise and iframeRequest will both reject
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         windowShowPromise,
-        'Expected windowShowPromise to reject, the popup is showing a payment request.',
+        "Expected windowShowPromise to reject, the popup is showing a payment request.",
       );
 
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         iframeShowPromise,
-        'Expected iframeShowPromise to reject, the popup is showing a payment request.',
+        "Expected iframeShowPromise to reject, the popup is showing a payment request.",
       );
 
       await popupRequest.abort();
@@ -326,7 +326,7 @@
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
 
       const [popupWindow, popupRequest] = await test_driver.bless(
-        'open popup to test multiple context and iframe calls show() first',
+        "open popup to test multiple context and iframe calls show() first",
         async () => {
           const w = await loadPopupInsideUserGesture();
           const r = new w.PaymentRequest(methods, details);
@@ -342,7 +342,7 @@
         popupShowPromise,
         windowShowPromise,
       ] = await test_driver.bless(
-        'test multiple browsing context and iframe calls show() first',
+        "test multiple browsing context and iframe calls show() first",
         async () => {
           return [
             iframeRequest.show(),
@@ -355,16 +355,16 @@
       // windowShowPromise and iframeRequest will both reject
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         windowShowPromise,
-        'Expected windowShowPromise to reject, the popup is showing a payment request.',
+        "Expected windowShowPromise to reject, the popup is showing a payment request.",
       );
 
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         popupShowPromise,
-        'Expected popupShowPromise to reject, the popup is showing a payment request.',
+        "Expected popupShowPromise to reject, the popup is showing a payment request.",
       );
 
       await iframeRequest.abort();
@@ -377,19 +377,19 @@
       const iframeWindow = iframe.contentWindow;
       const iframeRequest = new iframeWindow.PaymentRequest(methods, details);
       const iframeShowPromise = test_driver.bless(
-        'test navigating iframe after show()',
+        "test navigating iframe after show()",
         () => iframeRequest.show(),
       );
 
       // We navigate away, causing the payment sheet to close
       // and the request is showing boolean to become false.
-      iframe.src = 'blank.html?abc=123';
+      iframe.src = "blank.html?abc=123";
       await new Promise(resolve => (iframe.onload = resolve));
       await promise_rejects(
         t,
-        'AbortError',
+        "AbortError",
         iframeShowPromise,
-        'Navigating iframe away must cause the iframeShowPromise to reject.',
+        "Navigating iframe away must cause the iframeShowPromise to reject.",
       );
       iframe.remove();
 
@@ -402,7 +402,7 @@
     promise_test(async t => {
       const [popupWindow, popupRequest, popupShowPromise] =
         await test_driver.bless(
-          'trigger payment in a popup window',
+          "trigger payment in a popup window",
           async () => {
             const popupWindow = await loadPopupInsideUserGesture();
             const popupRequest = new popupWindow.PaymentRequest(methods, details);
@@ -411,7 +411,7 @@
 
       // We navigate away, causing the payment sheet to close
       // and the request is showing boolean to become false.
-      popupWindow.location = 'blank.html?abc=123';
+      popupWindow.location = "blank.html?abc=123";
       await new Promise(resolve => (popupWindow.onload = resolve));
 
       // Don't wait for |popupShowPromise| to reject because it may never do
@@ -419,7 +419,7 @@
       // to spin up a new payment request and make sure it succeeds.
       const request = new window.PaymentRequest(methods, details);
       const [showPromise] = await test_driver.bless(
-        'trigger payment in main window',
+        "trigger payment in main window",
         () => {
           return [request.show()];
         });


### PR DESCRIPTION
Per conversation with @marcoscaceres in https://github.com/web-platform-tests/wpt/pull/17262#issuecomment-500877728, we should use double quotes consistently. This change fixes up the inconsistency I introduced in that previous patch.