### PR TITLE
[docs] Improve submission guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,31 +269,6 @@ For more details, see the [lint-tool documentation][lint-tool].
 
 [lint-tool]: https://web-platform-tests.org/writing-tests/lint-tool.html
 
-Test Review
-===========
-
-We can sometimes take a little while to go through pull requests
-because we have to go through all the tests and ensure that they match
-the specification correctly. But we look at all of them, and take
-everything that we can.
-
-META.yml files are used only to indicate who should be notified of pull
-requests.  If you are interested in receiving notifications of proposed
-changes to tests in a given directory, feel free to add yourself to the
-META.yml file. Anyone with expertise in the specification under test can
-approve a pull request.  In particular, if a test change has already
-been adequately reviewed "upstream" in another repository, it can be
-pushed here without any further review by supplying a link to the
-upstream review.
-
-Search filters to find things to review:
-
-* [Open PRs (excluding vendor exports)](https://github.com/web-platform-tests/wpt/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+-label%3A%22mozilla%3Agecko-sync%22+-label%3A%22chromium-export%22+-label%3A%22webkit-export%22+-label%3A%22servo-export%22+-label%3Avendor-imports)
-* [Reviewed but still open PRs (excluding vendor exports)](https://github.com/web-platform-tests/wpt/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+-label%3Amozilla%3Agecko-sync+-label%3Achromium-export+-label%3Awebkit-export+-label%3Aservo-export+-label%3Avendor-imports+review%3Aapproved+-label%3A%22do+not+merge+yet%22+-label%3A%22status%3Aneeds-spec-decision%22) (Merge? Something left to fix? Ping other reviewer?)
-* [Open PRs without reviewers](https://github.com/web-platform-tests/wpt/pulls?q=is%3Apr+is%3Aopen+label%3Astatus%3Aneeds-reviewers)
-* [Open PRs with label `infra` (excluding vendor exports)](https://github.com/web-platform-tests/wpt/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3Ainfra+-label%3A%22mozilla%3Agecko-sync%22+-label%3A%22chromium-export%22+-label%3A%22webkit-export%22+-label%3A%22servo-export%22+-label%3Avendor-imports)
-* [Open PRs with label `docs` (excluding vendor exports)](https://github.com/web-platform-tests/wpt/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3Adocs+-label%3A%22mozilla%3Agecko-sync%22+-label%3A%22chromium-export%22+-label%3A%22webkit-export%22+-label%3A%22servo-export%22+-label%3Avendor-imports)
-
 Getting Involved
 ================
 

--- a/docs/reviewing-tests/index.md
+++ b/docs/reviewing-tests/index.md
@@ -38,3 +38,24 @@ working on other things as tests frequently only get pushed upstream
 once the code lands in their implementation.
 
 To assist with test reviews, a [review checklist](checklist) is available.
+
+## Notifications
+
+META.yml files are used only to indicate who should be notified of pull
+requests.  If you are interested in receiving notifications of proposed
+changes to tests in a given directory, feel free to add yourself to the
+META.yml file. Anyone with expertise in the specification under test can
+approve a pull request.  In particular, if a test change has already
+been adequately reviewed "upstream" in another repository, it can be
+pushed here without any further review by supplying a link to the
+upstream review.
+
+## Finding contributions to review
+
+Here are a few search filters to find things to review:
+
+* [Open PRs (excluding vendor exports)](https://github.com/web-platform-tests/wpt/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+-label%3A%22mozilla%3Agecko-sync%22+-label%3A%22chromium-export%22+-label%3A%22webkit-export%22+-label%3A%22servo-export%22+-label%3Avendor-imports)
+* [Reviewed but still open PRs (excluding vendor exports)](https://github.com/web-platform-tests/wpt/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+-label%3Amozilla%3Agecko-sync+-label%3Achromium-export+-label%3Awebkit-export+-label%3Aservo-export+-label%3Avendor-imports+review%3Aapproved+-label%3A%22do+not+merge+yet%22+-label%3A%22status%3Aneeds-spec-decision%22) (Merge? Something left to fix? Ping other reviewer?)
+* [Open PRs without reviewers](https://github.com/web-platform-tests/wpt/pulls?q=is%3Apr+is%3Aopen+label%3Astatus%3Aneeds-reviewers)
+* [Open PRs with label `infra` (excluding vendor exports)](https://github.com/web-platform-tests/wpt/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3Ainfra+-label%3A%22mozilla%3Agecko-sync%22+-label%3A%22chromium-export%22+-label%3A%22webkit-export%22+-label%3A%22servo-export%22+-label%3Avendor-imports)
+* [Open PRs with label `docs` (excluding vendor exports)](https://github.com/web-platform-tests/wpt/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3Adocs+-label%3A%22mozilla%3Agecko-sync%22+-label%3A%22chromium-export%22+-label%3A%22webkit-export%22+-label%3A%22servo-export%22+-label%3Avendor-imports)

--- a/docs/reviewing-tests/index.md
+++ b/docs/reviewing-tests/index.md
@@ -39,6 +39,12 @@ once the code lands in their implementation.
 
 To assist with test reviews, a [review checklist](checklist) is available.
 
+[GitHub.com allows reviewers to formally signal their approval of a pull
+request through a dedicated user
+interface.](https://help.github.com/en/articles/about-pull-request-reviews)
+Every pull request submitted to WPT must be approved by at least one project
+collaborator before it can be merged.
+
 ## Notifications
 
 META.yml files are used only to indicate who should be notified of pull

--- a/docs/reviewing-tests/index.md
+++ b/docs/reviewing-tests/index.md
@@ -50,10 +50,7 @@ collaborator before it can be merged.
 META.yml files are used only to indicate who should be notified of pull
 requests.  If you are interested in receiving notifications of proposed
 changes to tests in a given directory, feel free to add yourself to the
-META.yml file. Anyone with expertise in the specification under test can
-approve a pull request.  In particular, if a test change has already
-been accepted in a trusted fork of WPT, it can be pushed here without any
-further review by supplying a link to the external review.
+META.yml file.
 
 ## Finding contributions to review
 

--- a/docs/reviewing-tests/index.md
+++ b/docs/reviewing-tests/index.md
@@ -52,9 +52,8 @@ requests.  If you are interested in receiving notifications of proposed
 changes to tests in a given directory, feel free to add yourself to the
 META.yml file. Anyone with expertise in the specification under test can
 approve a pull request.  In particular, if a test change has already
-been adequately reviewed "upstream" in another repository, it can be
-pushed here without any further review by supplying a link to the
-upstream review.
+been accepted in a trusted fork of WPT, it can be pushed here without any
+further review by supplying a link to the external review.
 
 ## Finding contributions to review
 

--- a/docs/writing-tests/github-intro.md
+++ b/docs/writing-tests/github-intro.md
@@ -249,7 +249,8 @@ GitHub UI.  Below is one method and others can be found on
 4. Wait for feedback on your pull request and once your pull request is
 accepted, delete your branch (see '[When Pull Request is Accepted](#cleanup)').
 
-That's it! Your pull request will go into a queue and will be reviewed soon.
+[This page on the submissions process](submission-process) has more detail
+about what to expect when contributing code to WPT.
 
 ## Refine
 

--- a/docs/writing-tests/submission-process.md
+++ b/docs/writing-tests/submission-process.md
@@ -33,6 +33,10 @@ on, e.g. `git checkout -b topic-name`
 For detailed guidelines on setup and each of these steps, please refer to the
 [Github Test Submission](../writing-tests/github-intro) documentation.
 
+We can sometimes take a little while to go through pull requests because we
+have to go through all the tests and ensure that they match the specification
+correctly. But we look at all of them, and take everything that we can.
+
 Hop on to the [mailing list][public-test-infra] or [IRC][]
 ([webclient][web irc], join channel `#testing`) if you have an issue.  There is
 no need to announce your review request, as soon as you make a Pull Request

--- a/docs/writing-tests/submission-process.md
+++ b/docs/writing-tests/submission-process.md
@@ -1,37 +1,30 @@
 # Submitting Tests
 
-Test submission is via the typical [GitHub workflow][github flow]:
+Test submission is via the typical [GitHub workflow][github flow]. For detailed
+guidelines on setup and each of these steps, please refer to the [Github Test
+Submission](github-intro) documentation.
 
-* Fork the [GitHub repository][repo] (and make sure you're still relatively in
-sync with it if you forked a while ago)
+* Fork the [GitHub repository][repo].
 
-* Create a branch for your changes. Being a key of effective Git flow, it is
-strongly recommended that the **topic branch** tradition be followed here,
-i.e. the branch naming convention is based on the "topic" you will be working
-on, e.g. `git checkout -b topic-name`
+* Create a feature branch for your changes.
 
-* Make your changes
+* Make your changes.
 
 * Run the `lint` script in the root of your checkout to detect common
-  mistakes in test submissions. This will also be run after submission
-  and any errors will prevent your PR being accepted. If it detects an
-  error that forms an essential part of your test, edit the list of
-  exceptions stored in `tools/lint/lint.whitelist`.
+  mistakes in test submissions. Usage of this tool is described in detail
+  [here](lint-tool).
 
 * Commit your changes.
 
 * Push your local branch to your GitHub repository.
 
-* Using the GitHub UI create a Pull Request for your branch.
+* Using the GitHub UI, create a Pull Request for your branch.
 
 * When you get review comments, make more commits to your branch to
   address the comments.
 
 * Once everything is reviewed and all issues are addressed, your pull
   request will be automatically merged.
-
-For detailed guidelines on setup and each of these steps, please refer to the
-[Github Test Submission](../writing-tests/github-intro) documentation.
 
 We can sometimes take a little while to go through pull requests because we
 have to go through all the tests and ensure that they match the specification

--- a/docs/writing-tests/submission-process.md
+++ b/docs/writing-tests/submission-process.md
@@ -11,8 +11,8 @@ Submission](github-intro) documentation.
 * Make your changes.
 
 * Run the `lint` script in the root of your checkout to detect common
-  mistakes in test submissions. Usage of this tool is described in detail
-  [here](lint-tool).
+  mistakes in test submissions. There is [detailed documentation for the lint
+  tool](lint-tool).
 
 * Commit your changes.
 


### PR DESCRIPTION
This resolves gh-5943. It also brings gh-5289 closer to completion.

This introduces the notion of a "trusted fork" without defining it. Should we
go into more detail on that? Should we explicitly list which projects have this
status?