### PR TITLE
SVG: Parsing of vector-effect

### DIFF
--- a/svg/coordinate-systems/inheritance.svg
+++ b/svg/coordinate-systems/inheritance.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>Inheritance of Coordinate Systems and Transformations properties</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty"/>
+    <h:meta name="assert" content="vector-effect does not inherit."/>
+    <h:meta name="assert" content="vector-effect has initial value 'none'."/>
+  </metadata>
+  <g id="container">
+    <g id="target"></g>
+  </g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/inheritance-testcommon.js"/>
+  <script><![CDATA[
+
+assert_not_inherited('vector-effect', 'none', 'non-scaling-stroke');
+
+  ]]></script>
+</svg>

--- a/svg/coordinate-systems/parsing/vector-effect-computed.svg
+++ b/svg/coordinate-systems/parsing/vector-effect-computed.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Vector effects: getComputedStyle().vectorEffect</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty"/>
+    <h:meta name="assert" content="vector-effect computed value is as specified."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("vector-effect", "none");
+test_computed_value("vector-effect", "non-scaling-stroke");
+
+// These values are at risk: https://github.com/w3c/svgwg/issues/306
+test_computed_value("vector-effect", "non-scaling-size");
+test_computed_value("vector-effect", "non-rotation");
+test_computed_value("vector-effect", "fixed-position");
+
+  ]]></script>
+</svg>

--- a/svg/coordinate-systems/parsing/vector-effect-invalid.svg
+++ b/svg/coordinate-systems/parsing/vector-effect-invalid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Vector effects: parsing vector-effect with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty"/>
+    <h:meta name="assert" content="vector-effect supports only the grammar 'none | non-scaling-stroke | non-scaling-size | non-rotation | fixed-position'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("vector-effect", "auto");
+
+test_invalid_value("vector-effect", "none, non-scaling-stroke");
+test_invalid_value("vector-effect", "non-scaling-stroke none");
+
+  ]]></script>
+</svg>

--- a/svg/coordinate-systems/parsing/vector-effect-valid.svg
+++ b/svg/coordinate-systems/parsing/vector-effect-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Vector effects: parsing vector-effect with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty"/>
+    <h:meta name="assert" content="vector-effect supports the full grammar 'none | non-scaling-stroke | non-scaling-size | non-rotation | fixed-position'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("vector-effect", "none");
+test_valid_value("vector-effect", "non-scaling-stroke");
+
+// These values are at risk: https://github.com/w3c/svgwg/issues/306
+test_valid_value("vector-effect", "non-scaling-size");
+test_valid_value("vector-effect", "non-rotation");
+test_valid_value("vector-effect", "fixed-position");
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
vector-effect has initial value none and does not inherit. It accepts
none | non-scaling-stroke | non-scaling-size | non-rotation | fixed-position
https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty

Values other than none and non-scaling-stroke are at risk.
https://github.com/w3c/svgwg/issues/306