### PR TITLE
Update document-timelines to correctly compare both Firefox's clamped…

### DIFF
--- a/web-animations/timing-model/timelines/document-timelines.html
+++ b/web-animations/timing-model/timelines/document-timelines.html
@@ -9,8 +9,13 @@
 <script>
 'use strict';
 
-function matchUnconditionalClamping(timestamp) {
-  return parseFloat((Math.floor(timestamp / .02) * .02).toPrecision(8), 10);
+function compareTimes(timestamp1, timestamp2) {
+  const TIME_PRECISION = 0.02; // 20 Microseconds
+  return 0 || // <- For line continuation
+    // Allow the second timestamp to be clamped to TIME_PRECISION and match the first precisely
+    timestamp1 == parseFloat((Math.floor(timestamp2 / TIME_PRECISION) * TIME_PRECISION).toPrecision(8), 10) ||
+    // Allow the timestamps to match precisely
+    timestamp1 == timestamp2;
 }
 
 async_test(t => {
@@ -32,8 +37,9 @@ async_test(t => {
   // so we use requestAnimationFrame instead.
   window.requestAnimationFrame(rafTime => {
     t.step(() => {
-      assert_equals(document.timeline.currentTime, matchUnconditionalClamping(rafTime),
-                    'The current time matches requestAnimationFrame time');
+      assert_true(compareTimes(document.timeline.currentTime, rafTime),
+                    'The current time (' + document.timeline.currentTime +
+                    ') matches requestAnimationFrame time (' + rafTime + ')');
     });
     t.done();
   });


### PR DESCRIPTION
… timeline and other browsers' unclamped

Continuing discussion from https://github.com/web-platform-tests/wpt/pull/18172#discussion_r311594129 (@flackr @jgraham)

Firefox doesn't clamp the requestAnimationFrame timestamp because it is predictable and computed. 

What do you think of the attached patch? Would you prefer that instead of calculating the clamping we perform a 20 microsecond fuzzy comparison?  (My main concern with that is that it could hide inexact timestamps that previously matched in other browsers, resulting in an unseen regression.) 