### PR TITLE
[css-rhythm] Parsing tests for line-height-step

### DIFF
--- a/css/css-rhythm/parsing/line-height-step-computed.html
+++ b/css/css-rhythm/parsing/line-height-step-computed.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Rhythmic Sizing: getComputedStyle().lineHeightStep</title>
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#propdef-line-height-step">
+<meta name="assert" content="line-height-step computed value is an absolute length.">
+<meta name="assert" content="line-height-step is not negative.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #target {
+    font-size: 40px;
+  }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("line-height-step", "calc(10px + 0.5em)", "30px");
+test_computed_value("line-height-step", "calc(10px - 0.5em)", "0px");
+</script>
+</body>
+</html>

--- a/css/css-rhythm/parsing/line-height-step-invalid.html
+++ b/css/css-rhythm/parsing/line-height-step-invalid.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Rhythmic Sizing: parsing line-height-step with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#propdef-line-height-step">
+<meta name="assert" content="line-height-step supports only the grammar '<length>'.">
+<meta name="assert" content="line-height-step rejects negative lengths.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("line-height-step", "auto");
+test_invalid_value("line-height-step", "normal");
+
+test_invalid_value("line-height-step", "10");
+test_invalid_value("line-height-step", "10px 20px");
+test_invalid_value("line-height-step", "-1px");
+test_invalid_value("line-height-step", "4%");
+</script>
+</body>
+</html>

--- a/css/css-rhythm/parsing/line-height-step-valid.html
+++ b/css/css-rhythm/parsing/line-height-step-valid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Rhythmic Sizing: parsing line-height-step with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-rhythm/#propdef-line-height-step">
+<meta name="assert" content="line-height-step supports the full grammar '<length>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("line-height-step", "0", "0px");
+test_valid_value("line-height-step", "1px");
+test_valid_value("line-height-step", "calc(2em + 3ex)");
+</script>
+</body>
+</html>


### PR DESCRIPTION
line-height-step is a non-negative length.
https://drafts.csswg.org/css-rhythm/#propdef-line-height-step