### PR TITLE
[css-inline] Parsing line-height

### DIFF
--- a/css/css-inline/parsing/line-height-computed.html
+++ b/css/css-inline/parsing/line-height-computed.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Inline Layout: getComputedStyle().lineHeight</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#line-height-property">
+<meta name="assert" content="line-height computed value is normal or a length.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    font-size: 40px;
+  }
+</style>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+test_computed_value("line-height", "normal");
+
+test_computed_value("line-height", "0", "0px");
+test_computed_value("line-height", "2", "80px");
+test_computed_value("line-height", "0px");
+test_computed_value("line-height", "10px");
+test_computed_value("line-height", "0%", "0px");
+test_computed_value("line-height", "200%", "80px");
+test_computed_value("line-height", "calc(200% + 10px)", "90px");
+
+test_computed_value('line-height', 'calc(10px - 0.5em)', '0px');
+test_computed_value('line-height', 'calc(10px + 0.5em)', '30px');
+</script>
+</body>
+</html>

--- a/css/css-inline/parsing/line-height-invalid.html
+++ b/css/css-inline/parsing/line-height-invalid.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Inline Layout: parsing line-height with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#line-height-property">
+<meta name="assert" content="line-height supports only the grammar 'normal | <number> | <length-percentage>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("line-height", "auto");
+
+test_invalid_value("line-height", "-2");
+test_invalid_value("line-height", "-10px");
+test_invalid_value("line-height", "-200%");
+
+test_invalid_value("line-height", "2 10px");
+test_invalid_value("line-height", "200% 3");
+test_invalid_value("line-height", "auto 10px");
+test_invalid_value("line-height", "3 auto");
+</script>
+</body>
+</html>

--- a/css/css-inline/parsing/line-height-valid.html
+++ b/css/css-inline/parsing/line-height-valid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Inline Layout: parsing line-height with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#line-height-property">
+<meta name="assert" content="line-height supports the full grammar 'normal | <number> | <length-percentage>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("line-height", "normal");
+
+test_valid_value("line-height", "0");
+test_valid_value("line-height", "2");
+test_valid_value("line-height", "0px");
+test_valid_value("line-height", "10px");
+test_valid_value("line-height", "0%");
+test_valid_value("line-height", "200%");
+test_valid_value("line-height", "calc(200% + 10px)");
+</script>
+</body>
+</html>


### PR DESCRIPTION
line-height is 'normal' or a number or a length-percentage.

The computed value for line-height is normal or a length.