### PR TITLE
SVG Text: text-anchor computed value

### DIFF
--- a/svg/text/parsing/text-anchor-computed.svg
+++ b/svg/text/parsing/text-anchor-computed.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Text: getComputedStyle().textAnchor</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty"/>
+    <h:meta name="assert" content="text-anchor computed value is the specified keyword."/>
+  </metadata>
+  <text id="target"></text>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="/css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("text-anchor", "start");
+test_computed_value("text-anchor", "middle");
+test_computed_value("text-anchor", "end");
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
The computed value of text-anchor is the specified keyword.
https://svgwg.org/svg2-draft/text.html#TextAnchorProperty