### PR TITLE
[css-align] [css-multicol] Move column-gap parsing

### DIFF
--- a/css/css-align/parsing/column-gap-computed.html
+++ b/css/css-align/parsing/column-gap-computed.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Multi-column Layout: getComputedStyle().columnGap</title>
-<link rel="help" href="https://drafts.csswg.org/css-multicol/#propdef-column-gap">
+<title>CSS Box Alignment Level 3: getComputedStyle().columnGap</title>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">
 <meta name="assert" content="column-gap computed value is as specified.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-align/parsing/column-gap-invalid.html
+++ b/css/css-align/parsing/column-gap-invalid.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Multi-column Layout: parsing column-gap with invalid values</title>
-<link rel="help" href="https://drafts.csswg.org/css-multicol/#propdef-column-gap">
+<title>CSS Box Alignment Level 3: parsing column-gap with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">
 <meta name="assert" content="column-gap supports only the grammar '<length-percentage> | normal'.">
 <meta name="assert" content="column-gap rejects negative <length-percentage>.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-align/parsing/column-gap-valid.html
+++ b/css/css-align/parsing/column-gap-valid.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>CSS Multi-column Layout: parsing column-gap with valid values</title>
-<link rel="help" href="https://drafts.csswg.org/css-multicol/#propdef-column-gap">
+<title>CSS Box Alignment Level 3: parsing column-gap with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">
 <meta name="assert" content="column-gap supports the full grammar '<length-percentage> | normal'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-multicol/inheritance.html
+++ b/css/css-multicol/inheritance.html
@@ -34,7 +34,6 @@ reference.style.display = 'none';
 
 assert_not_inherited('column-count', 'auto', '2');
 assert_not_inherited('column-fill', 'balance', 'auto');
-assert_not_inherited('column-gap', 'normal', '10px');
 assert_not_inherited('column-rule-color', 'rgba(42, 53, 64, 0.75)', 'rgba(2, 3, 5, 0.5)');
 assert_not_inherited('column-rule-style', 'none', 'dashed');
 assert_not_inherited('column-rule-width', mediumWidth, '10px');


### PR DESCRIPTION
column-gap is now defined only in CSS Box Alignment,
so we move the column-gap parsing tests out of
CSS Multi-column Layout.

https://drafts.csswg.org/css-align-3/#column-row-gap