### PR TITLE
Test that MediaQueryList calls EventListener::handleEvent

### DIFF
--- a/css/cssom-view/matchMediaAddListener-handleEvent.html
+++ b/css/cssom-view/matchMediaAddListener-handleEvent.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: CSSOM View matchMedia handleEvent via addListener</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/matchMedia.js"></script>
+<div id="log"></div>
+<script>
+setup({ allow_uncaught_exception: true });
+
+promise_test(async t => {
+    const iframe = await createIframe(t);
+    const mql = iframe.contentWindow.matchMedia(MEDIA_QUERY);
+
+    let _this;
+    let _event;
+    const eventListener = {
+        handleEvent(event) {
+            _this = this;
+            _event = event;
+        },
+    };
+
+    mql.addListener(eventListener);
+    triggerMQLEvent(iframe);
+    await waitForChangesReported();
+
+    assert_equals(_this, eventListener);
+    assert_equals(_event.matches, mql.matches);
+    assert_equals(_event.media, MEDIA_QUERY);
+}, "calls handleEvent method of event listener");
+
+promise_test(async t => {
+    const iframe = await createIframe(t);
+    const mql = iframe.contentWindow.matchMedia(MEDIA_QUERY);
+
+    let uncaughtError;
+    const errorHandler = event => {
+        uncaughtError = event.error;
+    };
+    window.addEventListener("error", errorHandler);
+    t.add_cleanup(() => {
+        window.removeEventListener("error", errorHandler);
+    });
+
+    const thrownError = { name: "test" };
+    mql.addListener({
+        get handleEvent() {
+            throw thrownError;
+        },
+    });
+
+    triggerMQLEvent(iframe);
+    await waitForChangesReported();
+    assert_equals(uncaughtError, thrownError);
+}, "rethrows errors when getting handleEvent");
+
+promise_test(async t => {
+    const iframe = await createIframe(t);
+    const mql = iframe.contentWindow.matchMedia(MEDIA_QUERY);
+
+    let calls = 0;
+    mql.addListener({
+        get handleEvent() {
+            calls++;
+            return function() {};
+        },
+    });
+    assert_equals(calls, 0);
+
+    triggerMQLEvent(iframe);
+    await waitForChangesReported();
+    assert_equals(calls, 1);
+
+    triggerMQLEvent(iframe);
+    await waitForChangesReported();
+    assert_equals(calls, 2);
+}, "looks up handleEvent method on every event dispatch");
+
+promise_test(async t => {
+    const iframe = await createIframe(t);
+    const mql = iframe.contentWindow.matchMedia(MEDIA_QUERY);
+
+    let calls = 0;
+    const eventListener = function() { calls++; };
+    Object.defineProperty(eventListener, "handleEvent", {
+        get: t.unreached_func("handleEvent method should not be looked up on functions"),
+    });
+    mql.addListener(eventListener);
+
+    triggerMQLEvent(iframe);
+    await waitForChangesReported();
+    assert_equals(calls, 1);
+}, "doesn't look up handleEvent method on callable event listeners");
+
+promise_test(async t => {
+    const iframe = await createIframe(t);
+    const mql = iframe.contentWindow.matchMedia(MEDIA_QUERY);
+
+    let uncaughtError;
+    const errorHandler = event => {
+        uncaughtError = event.error;
+    };
+    window.addEventListener("error", errorHandler);
+    t.add_cleanup(() => {
+        window.removeEventListener("error", errorHandler);
+    });
+
+    mql.addListener({ handleEvent: null });
+    triggerMQLEvent(iframe);
+    await waitForChangesReported();
+
+    assert_equals(uncaughtError.name, "TypeError");
+}, "throws if handleEvent is falsy and not callable");
+
+promise_test(async t => {
+    const iframe = await createIframe(t);
+    const mql = iframe.contentWindow.matchMedia(MEDIA_QUERY);
+
+    let uncaughtError;
+    const errorHandler = event => {
+        uncaughtError = event.error;
+    };
+    window.addEventListener("error", errorHandler);
+    t.add_cleanup(() => {
+        window.removeEventListener("error", errorHandler);
+    });
+
+    mql.addListener({ handleEvent: "str" });
+    triggerMQLEvent(iframe);
+    await waitForChangesReported();
+
+    assert_equals(uncaughtError.name, "TypeError");
+}, "throws if handleEvent is thruthy and not callable");
+</script>

--- a/css/cssom-view/resources/matchMedia.js
+++ b/css/cssom-view/resources/matchMedia.js
@@ -1,0 +1,32 @@
+const IFRAME_BASE_WIDTH = "200";
+const MEDIA_QUERY = `(max-width: ${IFRAME_BASE_WIDTH}px)`;
+
+function createIframe(t) {
+    const iframe = document.createElement("iframe");
+    iframe.srcdoc = "";
+    iframe.width = IFRAME_BASE_WIDTH;
+    iframe.height = "100";
+    iframe.style.border = "none";
+
+    t.add_cleanup(() => {
+        document.body.removeChild(iframe);
+    });
+
+    return new Promise(resolve => {
+        iframe.addEventListener("load", () => {
+            resolve(iframe);
+        });
+
+        document.body.appendChild(iframe);
+    });
+}
+
+function triggerMQLEvent(iframe) {
+    iframe.width = iframe.width === IFRAME_BASE_WIDTH ? "250" : IFRAME_BASE_WIDTH;
+}
+
+function waitForChangesReported() {
+    return new Promise(resolve => {
+        step_timeout(resolve, 75);
+    });
+}


### PR DESCRIPTION
WebKit issue: [MediaQueryList.addListener does not support Object with handleEvent() method](https://bugs.webkit.org/show_bug.cgi?id=156730).

Follow-up of #15122.