### PR TITLE
[ci] Check out master when managing tags & labels

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,7 @@ jobs:
     - uses: actions/checkout@v1.0.0
       with:
         ref: refs/heads/master
+        fetch-depth: 1
     - name: update-pr-preview
       uses: ./tools/docker/github
       env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,7 +4,9 @@ jobs:
   update-pr-preview:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.0.0
+      with:
+        ref: refs/heads/master
     - name: update-pr-preview
       uses: ./tools/docker/github
       env:


### PR DESCRIPTION
Previously, we identified a problem when attempting to run a GitHub
Action for the "pull_request" event when the underlying branch had been
deleted [1]. By migrating to the latest GitHub Action beta release [2],
we've since gained more insight into the process and more control over
its behavior.

Alter the configuration for the new "checkout" Step to consistently
check out the `master` branch. Update the Action specifier to reference
a stable release of the Action.

[1] https://github.com/web-platform-tests/wpt/issues/18286
[2] https://github.com/web-platform-tests/wpt/pull/18359

---

Here's a demonstration of the expected behavior:

https://github.com/web-platform-tests/wpt-actions-test/pull/13

I closed that pull request and immediately deleted the branch. The Action for the subsequent "close" pull request event ran as intended (evidenced through that project's Actions administration interface and also by the fact that the "pull-request-has-preview" label was removed).