### PR TITLE
Make status neutral return code 0 so that jobs stop failing

### DIFF
--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class Status(object):
     SUCCESS = 0
     FAIL = 1
-    NEUTRAL = 78
+    NEUTRAL = 0
 
 
 def run(cmd, return_stdout=False, **kwargs):

--- a/tools/ci/tests/test_update_pr_preview.py
+++ b/tools/ci/tests/test_update_pr_preview.py
@@ -66,7 +66,7 @@ def assert_success(returncode):
 
 
 def assert_neutral(returncode):
-    assert returncode == 78
+    assert returncode == 0
 
 
 def assert_fail(returncode):

--- a/tools/ci/update_pr_preview.py
+++ b/tools/ci/update_pr_preview.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 class Status(object):
     SUCCESS = 0
     FAIL = 1
-    NEUTRAL = 78
+    NEUTRAL = 0
 
 
 def request(url, method_name, data=None, json_data=None, ignore_body=False):

--- a/tools/ci/website_build.sh
+++ b/tools/ci/website_build.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-neutral_status=78
+neutral_status=0
 source_revision=$(git rev-parse HEAD)
 # The token available in the `GITHUB_TOKEN` variable may be used to push to the
 # repository, but GitHub Pages will not rebuild the website in response to such


### PR DESCRIPTION
GitHub seems to have broken the feature where an action returning
status 78 is deemed neutral, so to stop it looking like everything
failed, use a success status instead (i.e. return code 0); this
can be reverted when GitHub fix their bug.