### PR TITLE
Revert "Change test_designMode to check for empty string instead of br tag"

### DIFF
--- a/webdriver/tests/element_clear/clear.py
+++ b/webdriver/tests/element_clear/clear.py
@@ -279,7 +279,7 @@ def test_designmode(session):
 
     response = element_clear(session, element)
     assert_success(response)
-    assert element.property("innerHTML") == ""
+    assert element.property("innerHTML") == "<br>"
     assert_element_has_focus(session.execute_script("return document.body"))
 
 


### PR DESCRIPTION
Reverts web-platform-tests/wpt#17809.

Subsequent discussion suggests that the earlier behaviour may be correct.