### PR TITLE
Enable testdriver to return results to tests.

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 from six.moves.http_client import HTTPConnection
 import io
+import json
 import os
 import threading
 import traceback
@@ -615,15 +616,16 @@ class CallbackHandler(object):
         except KeyError:
             raise ValueError("Unknown action %s" % action)
         try:
-            action_handler(payload)
+            result = action_handler(payload)
         except Exception:
             self.logger.warning("Action %s failed" % action)
             self.logger.warning(traceback.format_exc())
             self._send_message("complete", "error")
             raise
         else:
-            self.logger.debug("Action %s completed" % action)
-            self._send_message("complete", "success")
+            self.logger.debug("Action %s completed with result %s" % (action, result))
+            return_message = {"result": result}
+            self._send_message("complete", "success", json.dumps(return_message))
 
         return False, None
 

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -3,6 +3,7 @@
 (function(){
     let pending_resolve = null;
     let pending_reject = null;
+    let result = null;
     window.addEventListener("message", function(event) {
         const data = event.data;
 
@@ -15,7 +16,8 @@
         }
 
         if (data.status === "success") {
-            pending_resolve();
+            result = JSON.parse(data.message).result
+            pending_resolve(result);
         } else {
             pending_reject();
         }


### PR DESCRIPTION
This resolves issue #10716, and is recreated from an earlier PR #11080.

The immediate use case for this is to support testing of WebAuthN, specifically a `getCredentials` function that can be used to inspect keys installed on a device. More info on this in the [testing API doc](https://docs.google.com/document/d/1bp2cMgjm2HSpvL9-WsJoIQMsBi1oKGQY6CvWD-9WmIQ/edit?disco=AAAACtNijZQ) and [proposed spec change](https://github.com/w3c/webauthn/pull/1256).