### PR TITLE
[Azure Pipelines] Differentiate manual triggers for Edge Dev/Canary

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -242,11 +242,11 @@ jobs:
 
 # All `./wpt run` tests are run from epochs/* branches on a schedule. See
 # documentation at the top of this file for required setup.
-- job: results_edge
+- job: results_edge_dev
   displayName: 'all tests: Edge Dev'
   condition: |
     or(eq(variables['Build.Reason'], 'Schedule'),
-       and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge']))
+       and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_dev']))
   # There are 12 agents in the pool, but use more jobs so that each takes <1h.
   strategy:
     parallel: 20
@@ -271,12 +271,12 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish results'
     inputs:
-      artifactName: 'edge-results'
+      artifactName: 'edge-dev-results'
   - template: tools/ci/azure/cleanup_win10.yml
 - template: tools/ci/azure/fyi_hook.yml
   parameters:
-    dependsOn: results_edge
-    artifactName: edge-results
+    dependsOn: results_edge_dev
+    artifactName: edge-dev-results
 
 - job: results_edge_canary
   displayName: 'all tests: Edge Canary'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -282,7 +282,7 @@ jobs:
   displayName: 'all tests: Edge Canary'
   condition: |
     or(eq(variables['Build.Reason'], 'Schedule'),
-       and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge']))
+       and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_canary']))
   # There are 12 agents in the pool, but use more jobs so that each takes <1h.
   strategy:
     parallel: 20


### PR DESCRIPTION
As it is, it's only possible to run both of them:
https://github.com/web-platform-tests/wpt/issues/17342#issuecomment-521534275