### PR TITLE
[Azure Pipelines] reduce Edge parallel jobs from 20 to 10

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -247,9 +247,8 @@ jobs:
   condition: |
     or(eq(variables['Build.Reason'], 'Schedule'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_dev']))
-  # There are 12 agents in the pool, but use more jobs so that each takes <1h.
   strategy:
-    parallel: 20
+    parallel: 10 # chosen to make runtime ~2h
   timeoutInMinutes: 360
   pool:
     name: 'Hosted Windows Client'
@@ -283,9 +282,8 @@ jobs:
   condition: |
     or(eq(variables['Build.Reason'], 'Schedule'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_edge_canary']))
-  # There are 12 agents in the pool, but use more jobs so that each takes <1h.
   strategy:
-    parallel: 20
+    parallel: 10 # chosen to make runtime ~2h
   timeoutInMinutes: 360
   pool:
     name: 'Hosted Windows Client'


### PR DESCRIPTION
20 was chosen to make each job of a full EdgeHTML run fast enough, but
with Chromium-based Edge each job now finishes in <1h. Each job has some
overhead, so decrease the number of jobs to 10.