### PR TITLE
[css-transitions-2] Make null-effect test properly wait for the transition to start

### DIFF
--- a/css/css-transitions/CSSTransition-effect.tentative.html
+++ b/css/css-transitions/CSSTransition-effect.tentative.html
@@ -111,9 +111,10 @@ promise_test(async t => {
 
   // The transition needs to have a non-zero currentTime for the interruption
   // reversal logic to apply.
-  await singleFrame();
+  while (getComputedStyle(div).left == '0px') {
+    await singleFrame();
+  }
   assert_not_equals(transition.currentTime, 0);
-  assert_not_equals(getComputedStyle(div).left, '0px');
 
   // Without yielding to the rendering loop, set the current transition's
   // effect to null and interrupt the transition. This should work correctly.


### PR DESCRIPTION
Previously this test would just rAF a single frame and assume that the
transition had started and that the 'left' had changed. Instead, this PR
changes the test to explicitly wait for 'left' to change, so that we can
be sure the transition has started before we interrupt it.