### PR TITLE
Amend test_designMode to accept either empty string or br tag

### DIFF
--- a/webdriver/tests/element_clear/clear.py
+++ b/webdriver/tests/element_clear/clear.py
@@ -279,7 +279,7 @@ def test_designmode(session):
 
     response = element_clear(session, element)
     assert_success(response)
-    assert element.property("innerHTML") == "<br>"
+    assert element.property("innerHTML") == ""
     assert_element_has_focus(session.execute_script("return document.body"))
 
 

--- a/webdriver/tests/element_clear/clear.py
+++ b/webdriver/tests/element_clear/clear.py
@@ -279,7 +279,7 @@ def test_designmode(session):
 
     response = element_clear(session, element)
     assert_success(response)
-    assert element.property("innerHTML") == ""
+    assert element.property("innerHTML") in ["", "<br>"]
     assert_element_has_focus(session.execute_script("return document.body"))
 
 


### PR DESCRIPTION
This pull request is a continuation of [this](https://github.com/web-platform-tests/wpt/pull/17809) merged and then reverted pull request.

The innerHTML property should be an empty string according to the W3C spec here: [element clear](https://www.w3.org/TR/2018/REC-webdriver1-20180605/#element-clear).

The clear should follow the "To clear a content editable element" subroutine, which states:
>Set element’s innerHTML IDL attribute to an empty string.

In the reverted PR,I replaced the `<br>` tag with an empty string. This PR, however, accepts both. This change is necessary because, according to the spec, the element should return an empty string for its innerHTML after its contents are cleared, so the test should be able to pass if the element's innerHTML is an empty string (correct behavior with respect to the spec).

In the closed PR linked above, it's said that all Firefox, Chrome, and Safari show a `<br>` tag for empty content-editable elements in developer tools. I was able to reproduce this in Firefox but was unable to reproduce it in Chrome (Chrome gave the empty string `""` whereas Firefox gave the `<br>` tag). I did not attempt reproducing in Safari.