### PR TITLE
HTML: <img>'s historical progress events

### DIFF
--- a/html/semantics/embedded-content/the-img-element/historical-progress-event.window.js
+++ b/html/semantics/embedded-content/the-img-element/historical-progress-event.window.js
@@ -1,7 +1,7 @@
 async_test(t => {
   const img = new Image();
   t.add_cleanup(() => img.remove());
-  img.onloadstart = img.onprogress = img.onloadend = t.unreached_func("no progress events supported");
+  img.onloadstart = img.onprogress = img.onloadend = t.unreached_func("progress event fired");
   img.onload = t.step_func_done(e => {
     assert_true(e instanceof Event);
     assert_false(e instanceof ProgressEvent);

--- a/html/semantics/embedded-content/the-img-element/historical-progress-event.window.js
+++ b/html/semantics/embedded-content/the-img-element/historical-progress-event.window.js
@@ -1,0 +1,11 @@
+async_test(t => {
+  const img = new Image();
+  t.add_cleanup(() => img.remove());
+  img.onloadstart = img.onprogress = img.onloadend = t.unreached_func("no progress events supported");
+  img.onload = t.step_func_done(e => {
+    assert_true(e instanceof Event);
+    assert_false(e instanceof ProgressEvent);
+  });
+  img.src = "/images/rrgg-256x256.png";
+  document.body.append(img);
+}, "<img> does not support ProgressEvent or loadstart/progress/loadend");

--- a/html/semantics/embedded-content/the-img-element/historical-progress-event.window.js
+++ b/html/semantics/embedded-content/the-img-element/historical-progress-event.window.js
@@ -9,3 +9,8 @@ async_test(t => {
   img.src = "/images/rrgg-256x256.png";
   document.body.append(img);
 }, "<img> does not support ProgressEvent or loadstart/progress/loadend");
+
+test(t => {
+  assert_equals(document.body.onloadend, undefined);
+  assert_equals(window.onloadend, undefined);
+}, "onloadend is not exposed");


### PR DESCRIPTION
For https://github.com/whatwg/html/pull/4842.