### PR TITLE
[tools] Disallow refs to some non-existent files

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -822,3 +822,11 @@ WEB-PLATFORM.TEST:signed-exchange/resources/generate-test-sxgs.sh
 
 SET TIMEOUT: inert/inert-retargeting.tentative.html
 SET TIMEOUT: inert/inert-retargeting-iframe.tentative.html
+
+# https://github.com/web-platform-tests/wpt/issues/16455
+MISSING DEPENDENCY: idle-detection/interceptor.https.html
+MISSING DEPENDENCY: sms/sms_provider.js
+MISSING DEPENDENCY: web-nfc/resources/nfc-helpers.js
+MISSING DEPENDENCY: shape-detection/resources/shapedetection-helpers.js
+MISSING DEPENDENCY: webxr/resources/webxr_util.js
+MISSING DEPENDENCY: contacts/resources/helpers.js

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -389,6 +389,7 @@ regexps = [item() for item in  # type: ignore
             rules.GenerateTestsRegexp,
             rules.PrintRegexp,
             rules.LayoutTestsRegexp,
+            rules.MissingDepsRegexp,
             rules.SpecialPowersRegexp]]
 
 def check_regexp_line(repo_root, path, f):

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -350,6 +350,13 @@ class LayoutTestsRegexp(Regexp):
     file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
     description = "eventSender/testRunner/internals used; these are LayoutTests-specific APIs (WebKit/Blink)"
 
+class MissingDepsRegexp(Regexp):
+    pattern = br"[^\w]/gen/"
+    name = "MISSING DEPENDENCY"
+    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    description = "Chromium-specific content referenced"
+    to_fix = "Reimplement the test to use well-documented testing interfaces"
+
 class SpecialPowersRegexp(Regexp):
     pattern = b"SpecialPowers"
     name = "SPECIALPOWERS API"

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -203,6 +203,36 @@ def test_internals():
                                1)]
 
 
+def test_missing_deps():
+    error_map = check_with_files(b"<script src='/gen/foo.js'></script>")
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind == "python":
+            assert errors == [("PARSE-FAILED", "Unable to parse file", filename, 1)]
+        else:
+            assert errors == [('MISSING DEPENDENCY',
+                               'Chromium-specific content referenced',
+                               filename,
+                               1)]
+
+
+def test_no_missing_deps():
+    error_map = check_with_files(b"""<head>
+<script src='/foo/gen/foo.js'></script>
+<script src='/gens/foo.js'></script>
+</head>""")
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if kind == "python":
+            assert errors == [("PARSE-FAILED", "Unable to parse file", filename, 1)]
+        else:
+            assert errors == []
+
+
 def test_meta_timeout():
     code = b"""
 <html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
The Chromium infrastructure generates files which it stores in a
top-level directory named "gen". In the absence of stable documentation
for how these files must be implemented, the tests which reference them
cannot be used by other implementations.