### PR TITLE
Remove unnecessary use of "sub" feature

### DIFF
--- a/content-security-policy/style-src/style-src-stylesheet-nonce-allowed.html
+++ b/content-security-policy/style-src/style-src-stylesheet-nonce-allowed.html
@@ -10,7 +10,7 @@
         document.addEventListener("securitypolicyviolation", t.unreached_func("Should not trigger a security policy violation"));
     </script>
 
-    <link nonce="nonceynonce" href="/content-security-policy/style-src/resources/style-src.css?pipe=sub" rel=stylesheet type=text/css>
+    <link nonce="nonceynonce" href="/content-security-policy/style-src/resources/style-src.css" rel=stylesheet type=text/css>
 </head>
 <body>
     <div id='log'></div>

--- a/content-security-policy/style-src/style-src-stylesheet-nonce-blocked.html
+++ b/content-security-policy/style-src/style-src-stylesheet-nonce-blocked.html
@@ -13,7 +13,7 @@
         assert_equals("style-src-elem", e.violatedDirective);
       }));
     </script>
-    <link nonce="not-nonceynonce" href="/content-security-policy/style-src/resources/style-src.css?pipe=sub" rel=stylesheet type=text/css>
+    <link nonce="not-nonceynonce" href="/content-security-policy/style-src/resources/style-src.css" rel=stylesheet type=text/css>
 </head>
 <body>
     <div id='log'></div>

--- a/fetch/api/policies/referrer-no-referrer-service-worker.https.html
+++ b/fetch/api/policies/referrer-no-referrer-service-worker.https.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <script>
-      service_worker_test("referrer-no-referrer.js?pipe=sub");
+      service_worker_test("referrer-no-referrer.js");
     </script>
   </body>
 </html>

--- a/fetch/api/policies/referrer-unsafe-url-service-worker.https.html
+++ b/fetch/api/policies/referrer-unsafe-url-service-worker.https.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <script>
-      service_worker_test("referrer-unsafe-url.js?pipe=sub");
+      service_worker_test("referrer-unsafe-url.js");
     </script>
   </body>
 </html>


### PR DESCRIPTION
The referenced files do not use the templating syntax recognized by WPT's "sub" feature, so they do not need to be included with the query string parameter which enables the feature.