### PR TITLE
[css-writing-modes] Fix writing mode test

### DIFF
--- a/css/css-writing-modes/relpos-inline-overflowing-block-vrl.html
+++ b/css/css-writing-modes/relpos-inline-overflowing-block-vrl.html
@@ -7,6 +7,6 @@
 <div style="position:relative; writing-mode:vertical-rl; width:100px; height:100px; background:green;">
   <div style="position:absolute; right:0; top:0; width:0.5em; height:1em; background:red;"></div>
   <div style="width:200px;">
-    <span style="position:relative; color:green; background:green;">XXX</span>
+    <span style="position:relative; color:green; background:green; display: inline-block">XXX</span>
   </div>
 </div>


### PR DESCRIPTION
Don't depend on the height of the content area of a inline, it's not
defined. Turn it into an inline block instead.