### PR TITLE
HTML: COEP and ImageBitmap

### DIFF
--- a/2dcontext/imagebitmap/no-coop-coep.https.window.js
+++ b/2dcontext/imagebitmap/no-coop-coep.https.window.js
@@ -1,0 +1,39 @@
+// META: script=/common/utils.js
+// META: script=/common/get-host-info.sub.js
+
+function taintedImageBitmap(t) {
+  return new Promise(resolve => {
+    const img = new Image();
+    img.src = `${get_host_info().HTTPS_REMOTE_ORIGIN}/images/blue.png`;
+    img.onload = t.step_func(() => {
+      resolve(createImageBitmap(img));
+    });
+    img.onerror = t.unreached_func();
+  });
+}
+
+async_test(t => {
+  const bc = new BroadcastChannel(token());
+  const popup = window.open(`resources/coop-coep-popup.html?channel=${bc.name}`);
+  const popupReady = new Promise(resolve => {
+    bc.onmessage = t.step_func(resolve);
+  });
+  const imageReady = taintedImageBitmap(t);
+  Promise.all([popupReady, imageReady]).then(t.step_func(([, bitmap]) => {
+    bc.onmessage = t.step_func_done(e => {
+      assert_equals(e.data, "Got failure as expected.");
+    });
+    bc.postMessage(bitmap);
+  }));
+}, "BroadcastChannel'ing a tainted ImageBitmap to a COOP+COEP popup");
+
+async_test(t => {
+  const sw = new SharedWorker("resources/coop-coep-worker.js");
+  const imageReady = taintedImageBitmap(t);
+  imageReady.then(t.step_func(bitmap => {
+    sw.port.onmessage = t.step_func_done(e => {
+      assert_equals(e.data, "Got failure as expected.");
+    });
+    sw.port.postMessage(bitmap);
+  }));
+}, "Messaging a tainted ImageBitMap to a COEP shared worker");

--- a/2dcontext/imagebitmap/resources/coop-coep-popup.html
+++ b/2dcontext/imagebitmap/resources/coop-coep-popup.html
@@ -1,0 +1,11 @@
+<script>
+const channel = new URLSearchParams(location.search).get("channel");
+const bc = new BroadcastChannel(channel);
+bc.onmessageerror = e => {
+  bc.postMessage("Got failure as expected.");
+}
+bc.onmessage = e => {
+  bc.postMessage("Got message, expected failure.");
+}
+bc.postMessage("Initialize");
+</script>

--- a/2dcontext/imagebitmap/resources/coop-coep-popup.html.headers
+++ b/2dcontext/imagebitmap/resources/coop-coep-popup.html.headers
@@ -1,0 +1,2 @@
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp

--- a/2dcontext/imagebitmap/resources/coop-coep-worker.js
+++ b/2dcontext/imagebitmap/resources/coop-coep-worker.js
@@ -1,0 +1,9 @@
+onconnect = e => {
+  const port = e.source;
+  port.onmessageerror = e => {
+    port.postMessage("Got failure as expected.");
+  }
+  port.onmessage = e => {
+    port.postMessage("Got message, expected failure.");
+  }
+}

--- a/2dcontext/imagebitmap/resources/coop-coep-worker.js.headers
+++ b/2dcontext/imagebitmap/resources/coop-coep-worker.js.headers
@@ -1,0 +1,1 @@
+Cross-Origin-Embedder-Policy: require-corp


### PR DESCRIPTION
These are two simple ImageBitmap tests. As far as I can tell Firefox does not support messaging ImageBitmap around. Chrome does, but something goes wrong with shared workers. Even if I change `bitmap` to something like `"x"` Chrome times out the test, whereas that will work in Firefox.