### PR TITLE
IndexedDB: Add coverage for exceptions in EventListener::handleEvent

### DIFF
--- a/IndexedDB/fire-error-event-exception.html
+++ b/IndexedDB/fire-error-event-exception.html
@@ -21,6 +21,9 @@ function fire_error_event_test(func, description) {
       const request = store.add(0, 0);
       request.onsuccess = t.unreached_func('request should fail');
       func(t, db, tx, request);
+      tx.addEventListener('abort', t.step_func_done(() => {
+        assert_equals(tx.error.name, 'AbortError');
+      }));
     },
     description);
 }
@@ -31,9 +34,6 @@ fire_error_event_test((t, db, tx, request) => {
   request.onerror = () => {
     throw Error();
   };
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in error event handler on request');
 
 fire_error_event_test((t, db, tx, request) => {
@@ -41,17 +41,11 @@ fire_error_event_test((t, db, tx, request) => {
     e.preventDefault();
     throw Error();
   };
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in error event handler on request, with preventDefault');
 
 fire_error_event_test((t, db, tx, request) => {
   request.addEventListener('error', () => {
     throw Error();
-  });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in error event listener on request');
 
@@ -61,16 +55,10 @@ fire_error_event_test((t, db, tx, request) => {
       throw new Error();
     },
   });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in error event listener ("handleEvent" lookup) on request');
 
 fire_error_event_test((t, db, tx, request) => {
   request.addEventListener('error', {});
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in error event listener (non-callable "handleEvent") on request');
 
 fire_error_event_test((t, db, tx, request) => {
@@ -79,9 +67,6 @@ fire_error_event_test((t, db, tx, request) => {
   });
   request.addEventListener('error', () => {
     throw Error();
-  });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in second error event listener on request');
 
@@ -95,10 +80,9 @@ fire_error_event_test((t, db, tx, request) => {
     assert_true(is_transaction_active(tx, 's'),
                 'Transaction should be active until dispatch completes');
   }));
-  tx.onabort = t.step_func_done(() => {
+  tx.addEventListener('abort', t.step_func(() => {
     assert_true(second_listener_called);
-    assert_equals(tx.error.name, 'AbortError');
-  });
+  }));
 }, 'Exception in first error event listener on request, ' +
    'transaction active in second');
 
@@ -108,9 +92,6 @@ fire_error_event_test((t, db, tx, request) => {
   tx.onerror = () => {
     throw Error();
   };
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in error event handler on transaction');
 
 fire_error_event_test((t, db, tx, request) => {
@@ -118,17 +99,11 @@ fire_error_event_test((t, db, tx, request) => {
     e.preventDefault();
     throw Error();
   };
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in error event handler on transaction, with preventDefault');
 
 fire_error_event_test((t, db, tx, request) => {
   tx.addEventListener('error', () => {
     throw Error();
-  });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in error event listener on transaction');
 
@@ -138,9 +113,6 @@ fire_error_event_test((t, db, tx, request) => {
   });
   tx.addEventListener('error', () => {
     throw Error();
-  });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in second error event listener on transaction');
 
@@ -154,10 +126,9 @@ fire_error_event_test((t, db, tx, request) => {
     assert_true(is_transaction_active(tx, 's'),
                 'Transaction should be active until dispatch completes');
   }));
-  tx.onabort = t.step_func_done(() => {
+  tx.addEventListener('abort', t.step_func(() => {
     assert_true(second_listener_called);
-    assert_equals(tx.error.name, 'AbortError');
-  });
+  }));
 }, 'Exception in first error event listener on transaction, ' +
    'transaction active in second');
 
@@ -167,9 +138,6 @@ fire_error_event_test((t, db, tx, request) => {
   db.onerror = () => {
     throw Error();
   };
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in error event handler on connection');
 
 fire_error_event_test((t, db, tx, request) => {
@@ -177,17 +145,11 @@ fire_error_event_test((t, db, tx, request) => {
     e.preventDefault()
     throw Error();
   };
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in error event handler on connection, with preventDefault');
 
 fire_error_event_test((t, db, tx, request) => {
   db.addEventListener('error', () => {
     throw Error();
-  });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in error event listener on connection');
 
@@ -197,9 +159,6 @@ fire_error_event_test((t, db, tx, request) => {
   });
   db.addEventListener('error', () => {
     throw Error();
-  });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in second error event listener on connection');
 
@@ -213,10 +172,9 @@ fire_error_event_test((t, db, tx, request) => {
     assert_true(is_transaction_active(tx, 's'),
                 'Transaction should be active until dispatch completes');
   }));
-  tx.onabort = t.step_func_done(() => {
+  tx.addEventListener('abort', t.step_func(() => {
     assert_true(second_listener_called);
-    assert_equals(tx.error.name, 'AbortError');
-  });
+  }));
 }, 'Exception in first error event listener on connection, ' +
    'transaction active in second');
 

--- a/IndexedDB/fire-error-event-exception.html
+++ b/IndexedDB/fire-error-event-exception.html
@@ -56,6 +56,24 @@ fire_error_event_test((t, db, tx, request) => {
 }, 'Exception in error event listener on request');
 
 fire_error_event_test((t, db, tx, request) => {
+  request.addEventListener('error', {
+    get handleEvent() {
+      throw new Error();
+    },
+  });
+  tx.onabort = t.step_func_done(() => {
+    assert_equals(tx.error.name, 'AbortError');
+  });
+}, 'Exception in error event listener ("handleEvent" lookup) on request');
+
+fire_error_event_test((t, db, tx, request) => {
+  request.addEventListener('error', {});
+  tx.onabort = t.step_func_done(() => {
+    assert_equals(tx.error.name, 'AbortError');
+  });
+}, 'Exception in error event listener (non-callable "handleEvent") on request');
+
+fire_error_event_test((t, db, tx, request) => {
   request.addEventListener('error', () => {
     // no-op
   });

--- a/IndexedDB/fire-success-event-exception.html
+++ b/IndexedDB/fire-success-event-exception.html
@@ -42,6 +42,26 @@ fire_success_event_test((t, db, tx, request) => {
 }, 'Exception in success event listener on request');
 
 fire_success_event_test((t, db, tx, request) => {
+  request.addEventListener('success', {
+    get handleEvent() {
+      throw new Error();
+    },
+  });
+  tx.onabort = t.step_func_done(() => {
+    assert_equals(tx.error.name, 'AbortError');
+  });
+}, 'Exception in success event listener ("handleEvent" lookup) on request');
+
+fire_success_event_test((t, db, tx, request) => {
+  request.addEventListener('success', {
+    handleEvent: null,
+  });
+  tx.onabort = t.step_func_done(() => {
+    assert_equals(tx.error.name, 'AbortError');
+  });
+}, 'Exception in success event listener (non-callable "handleEvent") on request');
+
+fire_success_event_test((t, db, tx, request) => {
   request.addEventListener('success', () => {
     // no-op
   });

--- a/IndexedDB/fire-success-event-exception.html
+++ b/IndexedDB/fire-success-event-exception.html
@@ -19,6 +19,9 @@ function fire_success_event_test(func, description) {
       const store = tx.objectStore('s');
       const request = store.get(0);
       func(t, db, tx, request);
+      tx.addEventListener('abort', t.step_func_done(() => {
+        assert_equals(tx.error.name, 'AbortError');
+      }));
     },
     description);
 }
@@ -27,17 +30,11 @@ fire_success_event_test((t, db, tx, request) => {
   request.onsuccess = () => {
     throw Error();
   };
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in success event handler on request');
 
 fire_success_event_test((t, db, tx, request) => {
   request.addEventListener('success', () => {
     throw Error();
-  });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in success event listener on request');
 
@@ -47,17 +44,11 @@ fire_success_event_test((t, db, tx, request) => {
       throw new Error();
     },
   });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in success event listener ("handleEvent" lookup) on request');
 
 fire_success_event_test((t, db, tx, request) => {
   request.addEventListener('success', {
     handleEvent: null,
-  });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in success event listener (non-callable "handleEvent") on request');
 
@@ -67,9 +58,6 @@ fire_success_event_test((t, db, tx, request) => {
   });
   request.addEventListener('success', () => {
     throw Error();
-  });
-  tx.onabort = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in second success event listener on request');
 
@@ -83,10 +71,9 @@ fire_success_event_test((t, db, tx, request) => {
     assert_true(is_transaction_active(tx, 's'),
                 'Transaction should be active until dispatch completes');
   }));
-  tx.onabort = t.step_func_done(() => {
+  tx.addEventListener('abort', t.step_func(() => {
     assert_true(second_listener_called);
-    assert_equals(tx.error.name, 'AbortError');
-  });
+  }));
 }, 'Exception in first success event listener, tx active in second');
 
 </script>

--- a/IndexedDB/fire-upgradeneeded-event-exception.html
+++ b/IndexedDB/fire-upgradeneeded-event-exception.html
@@ -43,6 +43,32 @@ fire_upgradeneeded_event_test((t, open) => {
 
 fire_upgradeneeded_event_test((t, open) => {
   let tx;
+  open.addEventListener('upgradeneeded', {
+    get handleEvent() {
+      tx = open.transaction;
+      throw new Error();
+    },
+  });
+  open.onerror = t.step_func_done(() => {
+    assert_equals(tx.error.name, 'AbortError');
+  });
+}, 'Exception in upgradeneeded "handleEvent" lookup');
+
+fire_upgradeneeded_event_test((t, open) => {
+  let tx;
+  open.addEventListener('upgradeneeded', {
+    get handleEvent() {
+      tx = open.transaction;
+      return 10;
+    },
+  });
+  open.onerror = t.step_func_done(() => {
+    assert_equals(tx.error.name, 'AbortError');
+  });
+}, 'Exception in upgradeneeded due to non-callable "handleEvent"');
+
+fire_upgradeneeded_event_test((t, open) => {
+  let tx;
   open.addEventListener('upgradeneeded', () => {
     // No-op.
   });

--- a/IndexedDB/fire-upgradeneeded-event-exception.html
+++ b/IndexedDB/fire-upgradeneeded-event-exception.html
@@ -15,74 +15,55 @@ function fire_upgradeneeded_event_test(func, description) {
     del.onerror = t.unreached_func('deleteDatabase should succeed');
     const open = indexedDB.open(dbname, 1);
     open.onsuccess = t.unreached_func('open should fail');
+    let tx;
+    open.addEventListener('upgradeneeded', () => {
+      tx = open.transaction;
+    });
     func(t, open);
+    open.addEventListener('error', t.step_func_done(() => {
+      assert_equals(tx.error.name, 'AbortError');
+    }));
   }, description);
 }
 
 fire_upgradeneeded_event_test((t, open) => {
-  let tx;
   open.onupgradeneeded = () => {
-    tx = open.transaction;
     throw Error();
   };
-  open.onerror = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
-  });
 }, 'Exception in upgradeneeded handler');
 
 fire_upgradeneeded_event_test((t, open) => {
-  let tx;
   open.addEventListener('upgradeneeded', () => {
-    tx = open.transaction;
     throw Error();
-  });
-  open.onerror = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in upgradeneeded listener');
 
 fire_upgradeneeded_event_test((t, open) => {
-  let tx;
   open.addEventListener('upgradeneeded', {
     get handleEvent() {
-      tx = open.transaction;
       throw new Error();
     },
-  });
-  open.onerror = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in upgradeneeded "handleEvent" lookup');
 
 fire_upgradeneeded_event_test((t, open) => {
-  let tx;
   open.addEventListener('upgradeneeded', {
     get handleEvent() {
-      tx = open.transaction;
       return 10;
     },
-  });
-  open.onerror = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in upgradeneeded due to non-callable "handleEvent"');
 
 fire_upgradeneeded_event_test((t, open) => {
-  let tx;
   open.addEventListener('upgradeneeded', () => {
     // No-op.
   });
   open.addEventListener('upgradeneeded', () => {
-    tx = open.transaction;
     throw Error();
-  });
-  open.onerror = t.step_func_done(() => {
-    assert_equals(tx.error.name, 'AbortError');
   });
 }, 'Exception in second upgradeneeded listener');
 
 fire_upgradeneeded_event_test((t, open) => {
-  let tx;
   let second_listener_called = false;
   open.addEventListener('upgradeneeded', () => {
     open.result.createObjectStore('s');
@@ -90,14 +71,12 @@ fire_upgradeneeded_event_test((t, open) => {
   });
   open.addEventListener('upgradeneeded', t.step_func(() => {
     second_listener_called = true;
-    tx = open.transaction;
-    assert_true(is_transaction_active(tx, 's'),
+    assert_true(is_transaction_active(open.transaction, 's'),
                 'Transaction should be active until dispatch completes');
   }));
-  open.onerror = t.step_func_done(() => {
+  open.addEventListener('error', t.step_func(() => {
     assert_true(second_listener_called);
-    assert_equals(tx.error.name, 'AbortError');
-  });
+  }));
 }, 'Exception in first upgradeneeded listener, tx active in second');
 
 </script>


### PR DESCRIPTION
WebKit issue: [Non-callable "handleEvent" property is silently ignored](https://bugs.webkit.org/show_bug.cgi?id=200066).

Follow-up of #15122.