### PR TITLE
html: Add a test for 'autofocus' as a global attribute

### DIFF
--- a/html/semantics/forms/autofocus/resources/utils.js
+++ b/html/semantics/forms/autofocus/resources/utils.js
@@ -1,0 +1,27 @@
+'use strict';
+
+function waitForEvent(target, type, options) {
+  return new Promise((resolve, reject) => {
+    target.addEventListener(type, resolve, options);
+  });
+}
+
+function waitForLoad(target) {
+  return waitForEvent(target, 'load');
+}
+
+function timeOut(test, ms) {
+  return new Promise((resolve, reject) => {
+    test.step_timeout(resolve, ms);
+  });
+}
+
+// If an element with autofocus is connected to a document and this function
+// is called, the autofocus result is deterministic after returning from the
+// function.
+// Exception: If the document has script-blocking style sheets, this function
+// doesn't work well.
+async function waitUntilStableAutofocusState(test) {
+  // TODO: Update this for https://github.com/web-platform-tests/wpt/pull/17929
+  await timeOut(test, 100);
+}

--- a/html/semantics/forms/autofocus/supported-elements.html
+++ b/html/semantics/forms/autofocus/supported-elements.html
@@ -9,29 +9,29 @@
 promise_test(async t => {
   let w = window.open('/common/blank.html');
   await waitForLoad(w);
+  t.add_cleanup(() => { w.close(); });
   w.document.body.innerHTML = '<div contenteditable=true autofocus></div>';
   await waitUntilStableAutofocusState(t);
   assert_equals(w.document.activeElement.tagName, 'DIV');
-  w.close();
 }, 'Contenteditable element should support autofocus');
 
 promise_test(async t => {
   let w = window.open('/common/blank.html');
   await waitForLoad(w);
+  t.add_cleanup(() => { w.close(); });
   w.document.body.innerHTML = '<span tabindex=0></span>';
   await waitUntilStableAutofocusState(t);
   assert_equals(w.document.activeElement.tagName, 'SPAN');
-  w.close();
 }, 'Element with tabindex should support autofocus');
 
 promise_test(async t => {
   let w = window.open('/common/blank.html');
   await waitForLoad(w);
+  t.add_cleanup(() => { w.close(); });
   let element = w.document.createElementNS('uri1', 'prefix:local');
   element.setAttribute('autofocus', '');
   w.document.body.appendChild(element);
   await waitUntilStableAutofocusState(t);
   assert_equals(w.document.activeElement.tagName, 'BODY');
-  w.close();
 }, 'Non-HTMLElement should not support autofocus');
 </script>

--- a/html/semantics/forms/autofocus/supported-elements.html
+++ b/html/semantics/forms/autofocus/supported-elements.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/utils.js"></script>
+<script>
+"use strict";
+
+promise_test(async t => {
+  let w = window.open('/common/blank.html');
+  await waitForLoad(w);
+  w.document.body.innerHTML = '<div contenteditable=true autofocus></div>';
+  await waitUntilStableAutofocusState(t);
+  assert_equals(w.document.activeElement.tagName, 'DIV');
+  w.close();
+}, 'Contenteditable element should support autofocus');
+
+promise_test(async t => {
+  let w = window.open('/common/blank.html');
+  await waitForLoad(w);
+  w.document.body.innerHTML = '<span tabindex=0></span>';
+  await waitUntilStableAutofocusState(t);
+  assert_equals(w.document.activeElement.tagName, 'SPAN');
+  w.close();
+}, 'Element with tabindex should support autofocus');
+
+promise_test(async t => {
+  let w = window.open('/common/blank.html');
+  await waitForLoad(w);
+  let element = w.document.createElementNS('uri1', 'prefix:local');
+  element.setAttribute('autofocus', '');
+  w.document.body.appendChild(element);
+  await waitUntilStableAutofocusState(t);
+  assert_equals(w.document.activeElement.tagName, 'BODY');
+  w.close();
+}, 'Non-HTMLElement should not support autofocus');
+</script>

--- a/svg/struct/scripted/autofocus-attribute.svg
+++ b/svg/struct/scripted/autofocus-attribute.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+    <title>Autofocus attribute</title>
+    <metadata>
+        <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#autofocusattribute"/>
+    </metadata>
+    <a id="a1" href="#"></a>
+    <a id="a2" href="#"></a>
+    <h:script src="/resources/testharness.js"/>
+    <h:script src="/resources/testharnessreport.js"/>
+    <h:script src="/html/semantics/forms/autofocus/resources/utils.js"/>
+    <script><![CDATA[
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+promise_test(async t => {
+  let w = window.open('/common/blank.html');
+  await waitForLoad(w);
+  t.add_cleanup(() => { w.close(); });
+  const svg_a = w.document.createElementNS(SVG_NS, 'a');
+  svg_a.setAttribute('href', '#');
+  svg_a.setAttribute('autofocus', 'autofocus');
+  w.document.body.appendChild(svg_a);
+  await waitUntilStableAutofocusState(t);
+  assert_equals(w.document.activeElement, svg_a);
+}, '<a> should support autofocus');
+
+promise_test(async t => {
+  let w = window.open('/common/blank.html');
+  await waitForLoad(w);
+  t.add_cleanup(() => { w.close(); });
+  const path = w.document.createElementNS(SVG_NS, 'path');
+  path.setAttribute('tabindex', '0');
+  path.setAttribute('autofocus', 'autofocus');
+  w.document.body.appendChild(path);
+  await waitUntilStableAutofocusState(t);
+  assert_equals(w.document.activeElement, path);
+}, 'Renderable element with tabindex should support autofocus');
+
+promise_test(async t => {
+  let w = window.open('/common/blank.html');
+  await waitForLoad(w);
+  t.add_cleanup(() => { w.close(); });
+  let element = w.document.createElementNS(SVG_NS, 'metadata');
+  element.setAttribute('tabindex', '0');
+  element.setAttribute('autofocus', 'autofocus');
+  w.document.body.appendChild(element);
+  await waitUntilStableAutofocusState(t);
+  assert_equals(w.document.activeElement.tagName, 'BODY');
+}, 'Never-rendered element with tabindex should not support autofocus');
+]]></script>
+</svg>

--- a/svg/struct/scripted/autofocus-attribute.svg
+++ b/svg/struct/scripted/autofocus-attribute.svg
@@ -5,8 +5,6 @@
     <metadata>
         <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#autofocusattribute"/>
     </metadata>
-    <a id="a1" href="#"></a>
-    <a id="a2" href="#"></a>
     <h:script src="/resources/testharness.js"/>
     <h:script src="/resources/testharnessreport.js"/>
     <h:script src="/html/semantics/forms/autofocus/resources/utils.js"/>
@@ -14,39 +12,43 @@
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
 promise_test(async t => {
-  let w = window.open('/common/blank.html');
+  let w = window.open('blank.svg');
   await waitForLoad(w);
   t.add_cleanup(() => { w.close(); });
-  const svg_a = w.document.createElementNS(SVG_NS, 'a');
-  svg_a.setAttribute('href', '#');
-  svg_a.setAttribute('autofocus', 'autofocus');
-  w.document.body.appendChild(svg_a);
+  const svgA = w.document.createElementNS(SVG_NS, 'a');
+  svgA.setAttribute('href', '#');
+  svgA.setAttribute('autofocus', 'autofocus');
+  w.document.documentElement.appendChild(svgA);
   await waitUntilStableAutofocusState(t);
-  assert_equals(w.document.activeElement, svg_a);
+  assert_equals(w.document.activeElement, svgA);
 }, '<a> should support autofocus');
 
 promise_test(async t => {
-  let w = window.open('/common/blank.html');
+  let w = window.open('blank.svg');
   await waitForLoad(w);
   t.add_cleanup(() => { w.close(); });
   const path = w.document.createElementNS(SVG_NS, 'path');
+  path.setAttribute('d', 'M0,0h8v8z');
   path.setAttribute('tabindex', '0');
   path.setAttribute('autofocus', 'autofocus');
-  w.document.body.appendChild(path);
+  w.document.documentElement.appendChild(path);
   await waitUntilStableAutofocusState(t);
   assert_equals(w.document.activeElement, path);
 }, 'Renderable element with tabindex should support autofocus');
 
 promise_test(async t => {
-  let w = window.open('/common/blank.html');
+  let w = window.open('blank.svg');
   await waitForLoad(w);
   t.add_cleanup(() => { w.close(); });
   let element = w.document.createElementNS(SVG_NS, 'metadata');
   element.setAttribute('tabindex', '0');
   element.setAttribute('autofocus', 'autofocus');
-  w.document.body.appendChild(element);
+  w.document.documentElement.appendChild(element);
   await waitUntilStableAutofocusState(t);
-  assert_equals(w.document.activeElement.tagName, 'BODY');
+  // https://html.spec.whatwg.org/C/#dom-documentorshadowroot-activeelement
+  // 6. If candidate's document element is non-null, then return that document
+  //    element.
+  assert_equals(w.document.activeElement.tagName, 'svg');
 }, 'Never-rendered element with tabindex should not support autofocus');
 ]]></script>
 </svg>

--- a/svg/struct/scripted/blank.svg
+++ b/svg/struct/scripted/blank.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"></svg>


### PR DESCRIPTION
For https://github.com/whatwg/html/pull/4830 and https://github.com/w3c/svgwg/pull/728