### PR TITLE
Add infrastructure expectations for Epiphany and WebKitGTK

### DIFF
--- a/infrastructure/metadata/infrastructure/assumptions/document-fonts-ready.html.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/document-fonts-ready.html.ini
@@ -1,0 +1,4 @@
+[document-fonts-ready.html]
+  [document.fonts.ready resolves after layout depending on loaded fonts]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=174030

--- a/infrastructure/metadata/infrastructure/assumptions/html-elements.html.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/html-elements.html.ini
@@ -6,9 +6,9 @@
 
   [Compare CSS span definitions (only valid if pre-reqs pass)]
     expected:
-      if product == "safari": FAIL # https://webkit.org/show_bug.cgi?id=187052
+      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=187052
 
 
   [Compare CSS div definitions (only valid if pre-reqs pass)]
     expected:
-      if product == "safari": FAIL # https://webkit.org/show_bug.cgi?id=187052
+      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=187052

--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -2,4 +2,9 @@
   [context]
     expected:
       if product == "edge_webdriver": FAIL
-      if product == "safari": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+
+[context.any.serviceworker.html]
+  [context]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=200815

--- a/infrastructure/metadata/infrastructure/server/order-of-metas.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/order-of-metas.any.js.ini
@@ -18,7 +18,7 @@
   [foo]
     expected:
       if product == "edge_webdriver": FAIL
-      if product == "safari": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
 
 
 [order-of-metas.window.html]

--- a/infrastructure/metadata/infrastructure/server/secure-context.https.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/secure-context.https.any.js.ini
@@ -2,4 +2,9 @@
   [secure-context]
     expected:
       if product == "edge_webdriver": FAIL
-      if product == "safari": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+
+[secure-context.https.any.serviceworker.html]
+  [secure-context]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=200815

--- a/infrastructure/metadata/infrastructure/server/title.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/title.any.js.ini
@@ -12,7 +12,7 @@
 
   [foobar]
     expected:
-      if product == "safari": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
 
 
 [title.any.worker.html]

--- a/infrastructure/metadata/infrastructure/server/wpt-server-http.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/server/wpt-server-http.sub.html.ini
@@ -1,0 +1,20 @@
+[wpt-server-http.sub.html]
+  [HTTPS protocol, punycode subdomain #1]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [HTTPS protocol, www subdomain #1]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [HTTPS protocol, www subdomain #2]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [HTTPS protocol, www subdomain #3]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [HTTPS protocol, punycode subdomain #2]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL

--- a/infrastructure/metadata/infrastructure/server/wpt-server-websocket.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/server/wpt-server-websocket.sub.html.ini
@@ -1,0 +1,41 @@
+[wpt-server-websocket.sub.html]
+  [WSS protocol, www subdomain #3]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [WSS protocol, punycode subdomain #1]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [WSS protocol, punycode subdomain #2]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [WSS protocol, www subdomain #1]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [WSS protocol, www subdomain #2]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [WSS protocol, www subdomain #3]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [WSS protocol, punycode subdomain #1]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [WSS protocol, punycode subdomain #2]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [WSS protocol, www subdomain #1]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+
+  [WSS protocol, www subdomain #2]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL
+

--- a/infrastructure/metadata/infrastructure/testdriver/actions/actionsWithKeyPressed.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/actionsWithKeyPressed.html.ini
@@ -1,6 +1,6 @@
 [actionsWithKeyPressed.html]
   expected:
-    if product == "safari": ERROR
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR
 
   [TestDriver actions: actions with key pressed]
     expected:

--- a/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
@@ -1,3 +1,3 @@
 [eventOrder.html]
   expected:
-    if product == "safari": ERROR
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiDevice.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiDevice.html.ini
@@ -1,3 +1,3 @@
 [multiDevice.html]
   expected:
-    if product == "safari": ERROR
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/actions/pause.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/pause.html.ini
@@ -1,3 +1,3 @@
 [pause.html]
   expected:
-    if product == "safari": ERROR
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/file_upload.sub.html.ini
@@ -1,3 +1,7 @@
 [file_upload.sub.html]
   expected:
     if product == "edge_webdriver": ERROR
+
+  [File upload using testdriver]
+    expected:
+      if product == "epiphany" or product == "webkit": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/generate_test_report.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/generate_test_report.html.ini
@@ -1,4 +1,4 @@
 [generate_test_report.html]
   expected:
     if product == "firefox": ERROR
-    if product == "safari": ERROR
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR


### PR DESCRIPTION
* Tested with WebKitGTK version 2.25.4 on Debian experimental.
* This allows infrastructure tests to pass with epiphany and/or webkitgtk minibrowser:
```
xvfb-run -a -s '-screen 0 1024x768x24' dbus-run-session ./wpt run --metadata=infrastructure/metadata --webdriver-arg='--host=127.0.0.1' epiphany infrastructure
```