### PR TITLE
Add Dockerfile for WebKitGTK testing (based on Debian)

### DIFF
--- a/tools/docker/Dockerfile.webkitgtk
+++ b/tools/docker/Dockerfile.webkitgtk
@@ -1,0 +1,87 @@
+# This image for WebKitGTK tests is based on Debian stable to ensure binary
+# compatibility with ToT/trunk built-products from build.webkit.org bots.
+# See https://github.com/web-platform-tests/wpt/pull/18595#issuecomment-537267080
+FROM debian:10
+
+# No interactive frontend during docker build
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true
+
+# Install general requirements not in the base image
+RUN apt-get -qqy update \
+  && apt-get -qqy install \
+    bzip2 \
+    ca-certificates \
+    dbus-x11 \
+    earlyoom \
+    fluxbox \
+    gdebi \
+    git \
+    locales \
+    pulseaudio \
+    python \
+    python-pip \
+    python-virtualenv \
+    tzdata \
+    sudo \
+    unzip \
+    wget \
+    xvfb \
+    git-core
+
+# Configure buster-wpt-webkit-updates repository
+RUN apt-key adv --fetch-keys https://webkitgtk.org/debian/apt.key
+RUN printf 'deb [arch=amd64] https://webkitgtk.org/debian buster-wpt-webkit-updates main' \
+    > /etc/apt/sources.list.d/webkitgtk.list
+RUN printf 'Package: *\nPin: origin webkitgtk.org\nPin-Priority: 1999' \
+    > /etc/apt/preferences.d/99webkitgtk
+
+# Update and upgrade
+RUN apt-get update \
+  && apt-get -y upgrade
+
+# Install webkit packages from https://webkitgtk.org/debian
+RUN apt-get install -y -t buster-wpt-webkit-updates webkit2gtk-driver
+
+# Set the timezone
+ENV TZ "UTC"
+RUN echo "${TZ}" > /etc/timezone \
+  && dpkg-reconfigure --frontend noninteractive tzdata
+
+# Set the locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+  && dpkg-reconfigure --frontend noninteractive locales
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN useradd test \
+         --shell /bin/bash  \
+         --create-home \
+  && usermod -a -G sudo test \
+  && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \
+  && echo 'test:secret' | chpasswd
+
+ENV SCREEN_WIDTH 1280
+ENV SCREEN_HEIGHT 1024
+ENV SCREEN_DEPTH 24
+ENV DISPLAY :99.0
+
+USER test
+
+WORKDIR /home/test
+
+# Remove information on how to use sudo on login
+RUN sudo echo ""
+
+RUN mkdir -p /home/test/artifacts
+RUN mkdir -p /home/test/bin
+
+ENV PATH="/home/test/bin:/home/test/.local/bin:${PATH}"
+
+WORKDIR /home/test/
+
+COPY .bashrc /home/test/.bashrc
+
+COPY start.sh /home/test/start.sh
+COPY retry.py /home/test/bin/retry

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,0 +1,19 @@
+This docker images is used for testing Chrome, Firefox and running other tasks
+on Taskcluster. When any of the files in this directory change, the images must
+be updated as well. To do this, assuming you have docker installed:
+
+In this directory, run
+```sh
+docker build -t <tag> .
+docker push <tag>
+```
+
+Then update the `image` specified in the project's .taskcluster.yml file.
+
+To update the image used for WebKitGTK:
+```sh
+docker build -f Dockerfile.webkitgtk -t <tag> .
+docker push <tag>
+```
+
+(This image is not yet used in .taskcluster.yml.)

--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-# This script is embedded in the docker image, and so the image must be updated when changes
-# to the script are made. To do this, assuming you have docker installed:
-# In tools/docker/ :
-#   docker build .
-#   docker ps # and look for the id of the image you just built
-#   docker tag <image> <tag>
-#   docker push <tag>
-# Update the `image` specified in the project's .taskcluster.yml file
-
-
 set -ex
 
 REMOTE=${1:-https://github.com/web-platform-tests/wpt}


### PR DESCRIPTION
This PR is like #15580 but it adds a dockerfile based on Debian experimental instead of fedora rawhide, because webdriver testing with webkit is currently broken in fedora. Once the fedora situation gets better, this dockerfile can get replaced with one based on fedora like the one from #15580

To test this do the following:

0. Checkout this branch
1. Build the dockerfile
```
cd tools/docker
docker build -f Dockerfile.epiphany -t wpt_debian_epiphany .
```
2. Run epiphany infrastructure tests with:
```
docker run --rm -it  wpt_debian_epiphany /bin/bash --login -c "set -ex; ~/start.sh https://github.com/clopez/wpt pr-epiphany-infrastructure-expectations; cd ~/web-platform-tests; sudo sh -c './wpt make-hosts-file >> /etc/hosts'; NO_AT_BRIDGE=1 xvfb-run -a -s '-screen 0 1024x768x24' dbus-run-session ./wpt run --metadata=infrastructure/metadata --webdriver-arg='--host=127.0.0.1' epiphany infrastructure"
```
* Note that in the previous command its fetching from my branch of wpt with the epiphany expectations for infrastructure. See PR #18589 for the merge request of this.