### PR TITLE
Allow to run epiphany browser from inside a flatpak

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1079,14 +1079,20 @@ class Epiphany(Browser):
 
     product = "epiphany"
     requirements = "requirements_epiphany.txt"
+    flatpak = None
+    flatpak_args = None
 
     def install(self, dest=None, channel=None):
         raise NotImplementedError
 
     def find_binary(self, venv_path=None, channel=None):
+        if self.flatpak:
+            return "epiphany"
         return find_executable("epiphany")
 
     def find_webdriver(self, channel=None):
+        if self.flatpak:
+            return "WebKitWebDriver"
         return find_executable("WebKitWebDriver")
 
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):
@@ -1095,7 +1101,15 @@ class Epiphany(Browser):
     def version(self, binary=None, webdriver_binary=None):
         if binary is None:
             return None
-        output = call(binary, "--version")
+        if self.flatpak:
+            cmd = ["flatpak", "run"]
+            if self.flatpak_args:
+                cmd += self.flatpak_args
+            cmd += ["--command=%s" % binary,
+                    self.flatpak, "--version"]
+            output = call(*cmd)
+        else:
+            output = call(binary, "--version")
         if output:
             # Stable release output looks like: "Web 3.30.2"
             # Tech Preview output looks like "Web 3.31.3-88-g97db4f40f"

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -539,6 +539,10 @@ class Epiphany(BrowserSetup):
         raise NotImplementedError
 
     def setup_kwargs(self, kwargs):
+        if kwargs["flatpak"]:
+            self.browser.flatpak = kwargs["flatpak"]
+        if kwargs["flatpak_args"]:
+            self.browser.flatpak_args = kwargs["flatpak_args"]
         if kwargs["binary"] is None:
             binary = self.browser.find_binary()
 

--- a/tools/wptrunner/wptrunner/browsers/epiphany.py
+++ b/tools/wptrunner/wptrunner/browsers/epiphany.py
@@ -26,7 +26,9 @@ def check_args(**kwargs):
 def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
             "webdriver_binary": kwargs["webdriver_binary"],
-            "webdriver_args": kwargs.get("webdriver_args")}
+            "webdriver_args": kwargs.get("webdriver_args"),
+            "flatpak": kwargs["flatpak"],
+            "flatpak_args": kwargs.get("flatpak_args")}
 
 
 def capabilities(server_config, **kwargs):
@@ -69,6 +71,6 @@ def run_info_extras(**kwargs):
 
 class EpiphanyBrowser(WebKitBrowser):
     def __init__(self, logger, binary=None, webdriver_binary=None,
-                 webdriver_args=None):
+                 webdriver_args=None, flatpak=None, flatpak_args=None):
         WebKitBrowser.__init__(self, logger, binary, webdriver_binary,
-                               webdriver_args)
+                               webdriver_args, flatpak, flatpak_args)

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -4,7 +4,7 @@ from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
 from ..executors.executorwebkit import WebKitDriverWdspecExecutor  # noqa: F401
-from ..webdriver_server import WebKitDriverServer
+from ..webdriver_server import WebKitDriverServer, WebKitDriverServerFlatpak
 
 
 __wptrunner__ = {"product": "webkit",
@@ -30,7 +30,9 @@ def check_args(**kwargs):
 def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
             "webdriver_binary": kwargs["webdriver_binary"],
-            "webdriver_args": kwargs.get("webdriver_args")}
+            "webdriver_args": kwargs.get("webdriver_args"),
+            "flatpak": kwargs["flatpak"],
+            "flatpak_args": kwargs.get("flatpak_args")}
 
 
 def capabilities_for_port(server_config, **kwargs):
@@ -82,11 +84,19 @@ class WebKitBrowser(Browser):
     """
 
     def __init__(self, logger, binary, webdriver_binary=None,
-                 webdriver_args=None):
+                 webdriver_args=None, flatpak=None, flatpak_args=None):
         Browser.__init__(self, logger)
         self.binary = binary
-        self.server = WebKitDriverServer(self.logger, binary=webdriver_binary,
-                                         args=webdriver_args)
+        if flatpak:
+            self.server = WebKitDriverServerFlatpak(self.logger,
+                                                    binary=webdriver_binary,
+                                                    args=webdriver_args,
+                                                    flatpak_app=flatpak,
+                                                    flatpak_args=flatpak_args)
+        else:
+            self.server = WebKitDriverServer(self.logger, binary=webdriver_binary,
+                                             args=webdriver_args)
+
 
     def start(self, **kwargs):
         self.server.start(block=False)

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -226,6 +226,22 @@ class WebKitDriverServer(WebDriverServer):
         return [self.binary, "--port=%s" % str(self.port)] + self._args
 
 
+class WebKitDriverServerFlatpak(WebKitDriverServer):
+    def __init__(self, logger, binary=None, port=None, args=None, flatpak_app=None, flatpak_args=None):
+        WebKitDriverServer.__init__(self, logger, binary, port=port, args=args)
+        self._flatpak_args = flatpak_args
+        self._flatpak_app = flatpak_app
+
+    def make_command(self):
+        cmd = ["flatpak", "run"]
+        if self._flatpak_args:
+            cmd += self._flatpak_args
+        cmd += ["--command=%s" % self.binary,
+                 self._flatpak_app,
+                 "--port=%s" % str(self.port)]
+        return cmd + self._args
+
+
 def cmd_arg(name, value=None):
     prefix = "-" if platform.system() == "Windows" else "--"
     rv = prefix + name

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -323,9 +323,14 @@ scheme host and port.""")
                              help="Command-line argument to forward to the "
                                   "Sauce Connect binary (repeatable)")
 
-    webkit_group = parser.add_argument_group("WebKit-specific")
+    webkit_group = parser.add_argument_group("Epiphany and WebKit-specific")
     webkit_group.add_argument("--webkit-port", dest="webkit_port",
                              help="WebKit port")
+    webkit_group.add_argument("--flatpak", dest="flatpak",
+                             help="Run the WebDriver and browser inside flatpak FLATPAK. Example: --flatpak=org.gnome.Epiphany.Devel")
+    webkit_group.add_argument('--flatpak-arg',
+                              default=[], action="append", dest="flatpak_args",
+                              help="Extra arguments to pass to the command \"flatpak run\"")
 
     parser.add_argument("test_list", nargs="*",
                         help="List of URLs for tests to run, or paths including tests to run. "
@@ -502,7 +507,7 @@ def check_args(kwargs):
     else:
         kwargs["debug_info"] = None
 
-    if kwargs["binary"] is not None:
+    if kwargs["binary"] is not None and kwargs["flatpak"] is None:
         if not os.path.exists(kwargs["binary"]):
             print("Binary path %s does not exist" % kwargs["binary"], file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
This allows to run epiphany from inside a flatpak like the Epiphany Technology Preview

To run this first install the [Epiphany Technology Preview flatpak](https://webkitgtk.org/epiphany-tech-preview.flatpakref) and then run WPT like follows:
`
./wpt run --flatpak="org.gnome.Epiphany.Devel" epiphany
`

This should work also for running tests with the generic webkit browser (MiniBrowser) inside flatpak, but the Epiphany TP preview flatpak doesn't include the MiniBrowser.

If you need to pass extra arguments to "flatpak run" like `--socket=x11` or `--socket=wayland` then use `--flatpak-args="..."`

The way this works is by starting the WebKitWebDriver inside the flatpak environment, but the test machinery (WPT tools) run outside of flatpak.
