### PR TITLE
[wptserve] Support `.sub.` filename w/pipe param

### DIFF
--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -102,6 +102,10 @@ server: http://localhost:{0}""".format(self.server.port).encode("ascii")
         resp = self.request("/sub_url_base.sub.txt")
         self.assertEqual(resp.read().rstrip(), b"Before / After")
 
+    def test_sub_url_base_via_filename_with_query(self):
+        resp = self.request("/sub_url_base.sub.txt?pipe=slice(5,10)")
+        self.assertEqual(resp.read().rstrip(), b"e / A")
+
     def test_sub_uuid(self):
         resp = self.request("/sub_uuid.sub.txt")
         self.assertRegexpMatches(resp.read().rstrip(), b"Before [a-f0-9-]+ After")

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -105,17 +105,21 @@ class DirectoryHandler(object):
 
 def wrap_pipeline(path, request, response):
     query = parse_qs(request.url_parts.query)
+    pipe_string = ""
 
-    pipeline = None
-    if "pipe" in query:
-        pipeline = Pipeline(query["pipe"][-1])
-    elif ".sub." in path:
+    if ".sub." in path:
         ml_extensions = {".html", ".htm", ".xht", ".xhtml", ".xml", ".svg"}
         escape_type = "html" if os.path.splitext(path)[1] in ml_extensions else "none"
-        pipeline = Pipeline("sub(%s)" % escape_type)
+        pipe_string = "sub(%s)" % escape_type
 
-    if pipeline is not None:
-        response = pipeline(request, response)
+    if "pipe" in query:
+        if pipe_string:
+            pipe_string += "|"
+
+        pipe_string += query["pipe"][-1]
+
+    if pipe_string:
+        response = Pipeline(pipe_string)(request, response)
 
     return response
 


### PR DESCRIPTION
The substitution feature may be enabled using a filename pattern
(`.sub`) or a query string parameter (`pipe=sub`). Prior to this commit,
the former approach could not be used if any other "pipe" commands were
included in the query string. Update wptserve to interpret the `.sub.`
filename pattern as though it were expressed as the first "pipe" command
in the query string.