### PR TITLE
Add missing comma in earlyoom argument list

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -109,7 +109,7 @@ def get_parser():
 def start_userspace_oom_killer():
     # Start userspace OOM killer: https://github.com/rfjakob/earlyoom
     # It will report memory usage every minute and prefer to kill browsers.
-    start(["sudo", "earlyoom", "-p", "-r", "60" "--prefer=(chrome|firefox)", "--avoid=python"])
+    start(["sudo", "earlyoom", "-p", "-r", "60", "--prefer=(chrome|firefox)", "--avoid=python"])
 
 
 def make_hosts_file():


### PR DESCRIPTION
Without the comma, the string literals are concatenated.

Spotted via `sudo earlyoom -p -r 60--prefer=(chrome|firefox) --avoid=python`
with a missing space in Taskcluster logs.

This was introduced in https://github.com/web-platform-tests/wpt/pull/15724.