### PR TITLE
[Azure Pipelines] increase Safari parallel jobs from 4 to 5

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -318,7 +318,7 @@ jobs:
     or(eq(variables['Build.Reason'], 'Schedule'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_safari']))
   strategy:
-    parallel: 4 # chosen to make runtime ~2h
+    parallel: 5 # chosen to make runtime ~2h
   timeoutInMinutes: 360
   pool:
     vmImage: 'macOS-10.13'
@@ -352,7 +352,7 @@ jobs:
     or(eq(variables['Build.Reason'], 'Schedule'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_safari_preview']))
   strategy:
-    parallel: 4 # chosen to make runtime ~2h
+    parallel: 5 # chosen to make runtime ~2h
   timeoutInMinutes: 360
   pool:
     vmImage: 'macOS-10.13'


### PR DESCRIPTION
Reasons:

 1. The slowest STP job (job 1) now takes about 2h5m and is thus the
    slowest link in getting new aligned runs on wpt.fyi.
 2. Debugging issues is faster if runs are faster.
 3. It's happened a few times that Azure Pipelines loses connection
    with the agent. Less work in each job might make this less likely.