### PR TITLE
[import-maps] Re-implement dynamic resource

### DIFF
--- a/import-maps/builtin-support.tentative/static-import.js
+++ b/import-maps/builtin-support.tentative/static-import.js
@@ -1,1 +1,0 @@
-import "{{GET[url]}}";

--- a/import-maps/builtin-support.tentative/static-import.py
+++ b/import-maps/builtin-support.tentative/static-import.py
@@ -1,0 +1,5 @@
+def main(request, response):
+    return (
+        (('Content-Type', 'text/javascript'),),
+        'import "{}";\n'.format(request.GET.first('url'))
+    )

--- a/import-maps/core/static-import.js
+++ b/import-maps/core/static-import.js
@@ -1,1 +1,0 @@
-import "{{GET[url]}}";

--- a/import-maps/core/static-import.py
+++ b/import-maps/core/static-import.py
@@ -1,0 +1,5 @@
+def main(request, response):
+    return (
+        (('Content-Type', 'text/javascript'),),
+        'import "{}";\n'.format(request.GET.first('url'))
+    )

--- a/import-maps/resources/test-helper.js
+++ b/import-maps/resources/test-helper.js
@@ -153,7 +153,7 @@ function testStaticImport(importMapString, importMapBaseURL, specifier, expected
     const script = document.createElement("script");
     script.setAttribute("type", "module");
     script.setAttribute("src",
-        "static-import.js?pipe=sub(none)&url=" +
+        "static-import.py?url=" +
         encodeURIComponent("${specifier}"));
     script.addEventListener("load", handlers[Handler.ScriptLoadEvent]);
     script.addEventListener("error", handlers[Handler.ScriptErrorEvent]);


### PR DESCRIPTION
The "sub" functionality of wptserve's "pipe" feature has previously been
identified as a candidate for removal [1]. While it can generally be
replaced with a filename-based pattern, the optional argument can only
be specified with the query-string-based approach.

The file `static-import.js` in the import-maps test suite is the only
existing usage of the optional argument. Refactor it to use a Python
handler so that a future patch may replace the remaining "pipe"-based
usages with filename-based usages.

[1] https://github.com/web-platform-tests/wpt/issues/15680