### PR TITLE
[css-transforms] translate percent, reference box

### DIFF
--- a/css/css-transforms/individual-transform/translate-fill-box.html
+++ b/css/css-transforms/individual-transform/translate-fill-box.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>transform-box: fill-box</title>
+<link rel="match" href="../transform-box/reference/greensquare200x200.html">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">
+<link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-box">
+<meta name="assert" content="translate percentages are relative to the reference box.">
+<style>
+svg {
+  background-color: red;
+}
+rect {
+  transform-box: fill-box;
+}
+#target1 {
+  rotate: 90deg;
+}
+#target2 {
+  translate: 50% -50%;
+}
+#target3 {
+  transform-origin: 25% 25%;
+  translate: 25% 25%;
+  rotate: 180deg;
+}
+#target4 {
+  transform-origin: 75px 75px;
+  translate: 25% 25%;
+  rotate: -180deg;
+}
+</style>
+<p>There should be a green 200x200 rectangle below, and no red.</p>
+<svg width="200" height="200">
+  <rect id="target1" x="100" y="100" width="100" height="100" fill="green"/>
+  <rect id="target2" x="50" y="50" width="100" height="100" fill="green"/>
+  <rect id="target3" x="25" y="25" width="100" height="100" fill="green"/>
+  <rect id="target4" x="25" y="25" width="100" height="100" fill="green"/>
+</svg>

--- a/css/css-transforms/individual-transform/translate-view-box.html
+++ b/css/css-transforms/individual-transform/translate-view-box.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>transform-box: view-box</title>
+<link rel="match" href="../transform-box/reference/greensquare200x200.html">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">
+<link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-box">
+<meta name="assert" content="translate percentages are relative to the reference box.">
+<style>
+svg {
+  background-color: red;
+}
+rect {
+  transform-box: view-box;
+}
+#target1 {
+  transform-origin: 25% 25%;
+  scale: 2;
+}
+#target2 {
+  translate: 50%;
+}
+#target3 {
+  translate: 0 50%;
+}
+#target4 {
+  transform-origin: 50% 50%;
+  rotate: 180deg;
+}
+</style>
+<p>There should be a green 200x200 rectangle below, and no red.</p>
+<svg width="200" height="200">
+  <rect id="target1" x="25" y="25" width="50" height="50" fill="green"/>
+  <rect id="target2" width="100" height="100" fill="green"/>
+  <rect id="target3" width="100" height="100" fill="green"/>
+  <rect id="target4" width="100" height="100" fill="green"/>
+</svg>


### PR DESCRIPTION
Percentages are relative to the width of the reference box (for the
first value) or the height (for the second value).
https://drafts.csswg.org/css-transforms-2/#propdef-translate

Tests are adapted from
css/css-transforms/transform-box/fill-box.html
css/css-transforms/transform-box/view-box.html