### PR TITLE
Add tests for WritableStream.close()

### DIFF
--- a/streams/writable-streams/aborting.any.js
+++ b/streams/writable-streams/aborting.any.js
@@ -114,7 +114,8 @@ promise_test(() => {
   return writer.abort('a').then(value => {
     assert_equals(value, undefined, 'fulfillment value must be undefined');
   });
-}, 'Fulfillment value of ws.abort() call must be undefined even if the underlying sink returns a non-undefined value');
+}, 'Fulfillment value of writer.abort() call must be undefined even if the underlying sink returns a non-undefined ' +
+   'value');
 
 promise_test(t => {
   const ws = new WritableStream({

--- a/streams/writable-streams/brand-checks.any.js
+++ b/streams/writable-streams/brand-checks.any.js
@@ -14,6 +14,7 @@ function fakeWS() {
   return Object.setPrototypeOf({
     get locked() { return false; },
     abort() { return Promise.resolve(); },
+    close() { return Promise.resolve(); },
     getWriter() { return fakeWSDefaultWriter(); }
   }, WritableStream.prototype);
 }
@@ -63,6 +64,11 @@ promise_test(t => {
   return methodRejectsForAll(t, WritableStream.prototype, 'abort',
                              [fakeWS(), realWSDefaultWriter(), realWSDefaultController(), undefined, null]);
 }, 'WritableStream.prototype.abort enforces a brand check');
+
+promise_test(t => {
+  return methodRejectsForAll(t, WritableStream.prototype, 'close',
+                             [fakeWS(), realWSDefaultWriter(), realWSDefaultController(), undefined, null]);
+}, 'WritableStream.prototype.close enforces a brand check');
 
 test(() => {
   methodThrowsForAll(WritableStream.prototype, 'getWriter',

--- a/streams/writable-streams/close.any.js
+++ b/streams/writable-streams/close.any.js
@@ -411,3 +411,60 @@ promise_test(() => {
     return ready;
   });
 }, 'ready promise should be initialised as fulfilled for a writer on a closed stream');
+
+promise_test(t => {
+  const ws = new WritableStream();
+  ws.close();
+  const writer = ws.getWriter();
+  return writer.closed;
+}, 'close() on a writable stream should work');
+
+promise_test(t => {
+  const ws = new WritableStream();
+  ws.getWriter();
+  return promise_rejects(t, new TypeError(), ws.close(), 'close should reject');
+}, 'close() on a locked stream should reject');
+
+promise_test(t => {
+  const ws = new WritableStream({
+    start(controller) {
+      controller.error(error1);
+    }
+  });
+  return promise_rejects(t, error1, ws.close(), 'close should reject with error1');
+}, 'close() on an erroring stream should reject');
+
+promise_test(t => {
+  const ws = new WritableStream({
+    start(controller) {
+      controller.error(error1);
+    }
+  });
+  const writer = ws.getWriter();
+  return promise_rejects(t, error1, writer.closed, 'closed should reject with the error').then(() => {
+    writer.releaseLock();
+    return promise_rejects(t, new TypeError(), ws.close(), 'close should reject');
+  });
+}, 'close() on an errored stream should reject');
+
+promise_test(t => {
+  const ws = new WritableStream();
+  const writer = ws.getWriter();
+  return writer.close().then(() => {
+    return promise_rejects(t, new TypeError(), ws.close(), 'close should reject');
+  });
+}, 'close() on an closed stream should reject');
+
+promise_test(t => {
+  const ws = new WritableStream({
+    close() {
+      return new Promise(() => {});
+    }
+  });
+
+  const writer = ws.getWriter();
+  writer.close();
+  writer.releaseLock();
+
+  return promise_rejects(t, new TypeError(), ws.close(), 'close should reject');
+}, 'close() on a stream with a pending close should reject');

--- a/streams/writable-streams/close.any.js
+++ b/streams/writable-streams/close.any.js
@@ -20,7 +20,7 @@ promise_test(() => {
 
   const closePromise = writer.close();
   return closePromise.then(value => assert_equals(value, undefined, 'fulfillment value must be undefined'));
-}, 'fulfillment value of ws.close() call must be undefined even if the underlying sink returns a non-undefined ' +
+}, 'fulfillment value of writer.close() call must be undefined even if the underlying sink returns a non-undefined ' +
     'value');
 
 promise_test(() => {

--- a/streams/writable-streams/close.any.js
+++ b/streams/writable-streams/close.any.js
@@ -412,7 +412,7 @@ promise_test(() => {
   });
 }, 'ready promise should be initialised as fulfilled for a writer on a closed stream');
 
-promise_test(t => {
+promise_test(() => {
   const ws = new WritableStream();
   ws.close();
   const writer = ws.getWriter();

--- a/streams/writable-streams/properties.any.js
+++ b/streams/writable-streams/properties.any.js
@@ -45,6 +45,10 @@ const expected = {
       type: 'method',
       length: 1
     },
+    close: {
+      type: 'method',
+      length: 0
+    },
     getWriter: {
       type: 'method',
       length: 0


### PR DESCRIPTION
Add tests for the new convenience method `WritableStream.close()`. See whatwg/streams#1011 for the accompanying spec change.