### PR TITLE
[Azure Pipelines] reduce cadence of stable Safari runs to daily

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -305,7 +305,7 @@ jobs:
 - job: results_safari
   displayName: 'all tests: Safari'
   condition: |
-    or(eq(variables['Build.SourceBranch'], 'refs/heads/epochs/six_hourly'),
+    or(eq(variables['Build.SourceBranch'], 'refs/heads/epochs/daily'),
        and(eq(variables['Build.Reason'], 'Manual'), variables['run_all_safari']))
   strategy:
     parallel: 5 # chosen to make runtime ~2h


### PR DESCRIPTION
It's now running more frequently than Chrome and Firefox:
https://wpt.fyi/runs?labels=master,stable&products=chrome,firefox,safari

These extra runs aren't very valuable, so let's reduce resource use.