### PR TITLE
[docs] Describe legacy submission preview system

### DIFF
--- a/docs/writing-tests/submission-process.md
+++ b/docs/writing-tests/submission-process.md
@@ -37,24 +37,25 @@ GitHub will inform interested parties.
 
 ## Previews
 
-The website [wpt-submissions.live](http://wpt-submissions.live) exists to help
-contributors demonstrate their proposed changes to others. If your pull request
-is open and has the GitHub label `pull-request-has-preview`, then it will be
-available at `http://wpt-submissions.live/{{pull request ID}}`, where "pull
-request ID" is the numeric identifier for the pull request.
+The website [http://w3c-test.org](http://w3c-test.org) exists to help
+contributors demonstrate their proposed changes to others. If you are [a GitHub
+collaborator](https://help.github.com/en/articles/permission-levels-for-a-user-account-repository)
+on WPT, then the content of your pull requests will be available at
+`http://w3c-test.org/submissions/{{pull request ID}}`, where "pull request ID"
+is the numeric identifier for the pull request.
 
 For example, a pull request at https://github.com/web-platform-tests/wpt/pull/3
-has a pull request ID `3`. Once that has been assigned the
-`pull-request-has-preview` label, then its contents can be viewed at
-http://wpt-submissions.live/3.
+has a pull request ID `3`. Its contents can be viewed at
+http://w3c-test.org/submissions/3.
 
-If you are [a GitHub
-collaborator](https://help.github.com/en/articles/permission-levels-for-a-user-account-repository)
-on WPT, the label and the preview will be created automatically. Because the
-WPT server will execute Python code in the mirrored submissions, previews are
-not created automatically for non-collaborators. Collaborators are encouraged
-to enable the preview by adding the label, provided they trust the authors not
-to submit malicious code.
+If you are *not* a GitHub collaborator, then your submission may be made
+available if a collaborator makes the following comment on your pull request:
+"w3c-test:mirror".
+
+Previews are not created automatically for non-collaborators because the WPT
+server will execute Python code in the mirrored submissions. Collaborators are
+encouraged to enable the preview by making the special comment only if they
+trust the authors not to submit malicious code.
 
 [repo]: https://github.com/web-platform-tests/wpt/
 [github flow]: https://guides.github.com/introduction/flow/


### PR DESCRIPTION
The replacement for w3c-test.org is not currently available at the
specified URL. Remove it from the documentation until it is available at
a stable location. Introduce an explanation of the legacy system.