### PR TITLE
Sync Mozilla CSS tests as of 2019-08-31

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/reftest.list
@@ -1,3 +1,9 @@
 == broken-column-rule-1.html broken-column-rule-1-ref.html
 == moz-multicol3-column-balancing-break-inside-avoid-1.html moz-multicol3-column-balancing-break-inside-avoid-1-ref.html
 == multicol-height-002.xht reference/multicol-height-002.xht
+
+# The following lines are duplicates of other lines from further up in this
+# manifest. They're listed again here so we can re-run these tests with
+# column-span enabled. These lines can be removed once the pref becomes
+# default-enabled (Bug 1426010).
+== broken-column-rule-1.html broken-column-rule-1-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-line-height-tests.py
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-line-height-tests.py
@@ -13,6 +13,8 @@ from __future__ import unicode_literals
 TEST_FILE = 'text-emphasis-line-height-{:03}{}.html'
 TEST_TEMPLATE = '''<!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, {pos}, {wm}, {tag}</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -26,12 +28,14 @@ TEST_TEMPLATE = '''<!DOCTYPE html>
 REF_FILE = 'text-emphasis-line-height-{:03}-ref.html'
 REF_TEMPLATE='''<!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Reference: text-emphasis line height, {pos}</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt {{ font-variant-east-asian: inherit; }} </style>
 <p>Pass if the emphasis marks are {dir} the black line:</p>
-<div style="line-height: 1; border-{pos}: 1px solid black; writing-mode: {wm}; ruby-position: {posval}"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 1; border-{pos}: 1px solid black; writing-mode: {wm}; ruby-position: {posval}"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
 '''
 
 STYLE1 = 'line-height: 1; border-{pos}: 1px solid black; ' + \
@@ -40,8 +44,8 @@ STYLE2 = 'text-emphasis: circle;'
 
 TAGS = [
     # (tag, start, end)
-    ('div', '<div style="{style1}{style2}">', '</div>'),
-    ('span', '<div style="{style1}"><span style="{style2}">', '</span></div>'),
+    ('div', '<div lang="ja" style="{style1}{style2}">', '</div>'),
+    ('span', '<div lang="ja" style="{style1}"><span style="{style2}">', '</span></div>'),
     ]
 POSITIONS = [
     # pos, text-emphasis-position, ruby-position,

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-position-property-tests.py
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-position-property-tests.py
@@ -17,6 +17,8 @@ TEST_FILE = 'text-emphasis-position-property-{:03}{}.html'
 REF_FILE = 'text-emphasis-position-property-{:03}-ref.html'
 TEST_TEMPLATE = '''<!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: {value}, {title}</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -24,7 +26,7 @@ TEST_TEMPLATE = '''<!DOCTYPE html>
 <meta name="assert" content="'text-emphasis-position: {value}' with 'writing-mode: {wm}' puts emphasis marks {position} the text.">
 <link rel="match" href="text-emphasis-position-property-{index:03}-ref.html">
 <p>Pass if the emphasis marks are {position} the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: {wm}; text-orientation: {orient}; text-emphasis-position: {value}">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: {wm}; text-orientation: {orient}; text-emphasis-position: {value}">試験テスト</div>
 '''
 
 SUFFIXES = ['', 'a', 'b', 'c', 'd', 'e', 'f', 'g']

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-ruby-tests.py
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-ruby-tests.py
@@ -12,6 +12,8 @@ from __future__ import unicode_literals
 TEST_FILE = 'text-emphasis-ruby-{:03}{}.html'
 TEST_TEMPLATE = '''<!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Test: text-emphasis and ruby, {wm}, {pos}</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -19,18 +21,20 @@ TEST_TEMPLATE = '''<!DOCTYPE html>
 <meta name="assert" content="emphasis marks are drawn outside the ruby">
 <link rel="match" href="text-emphasis-ruby-{index:03}-ref.html">
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: {wm}; ruby-position: {ruby_pos}; text-emphasis-position: {posval}">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: {wm}; ruby-position: {ruby_pos}; text-emphasis-position: {posval}">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>
 '''
 
 REF_FILE = 'text-emphasis-ruby-{:03}-ref.html'
 REF_TEMPLATE = '''<!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Reference: text-emphasis and ruby, {wm}, {pos}</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rtc {{ font-variant-east-asian: inherit; }} </style>
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: {wm}; ruby-position: {posval}">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: {wm}; ruby-position: {posval}">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>
 '''
 
 TEST_CASES = [

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-style-property-010-tests.sh
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-style-property-010-tests.sh
@@ -53,6 +53,8 @@ write_test_file() {
     cat <<EOF > $filename
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-010-tests.sh -->
 <title>CSS Test: text-emphasis, $1</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-style-property-tests.py
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/support/generate-text-emphasis-style-property-tests.py
@@ -13,6 +13,8 @@ from __future__ import unicode_literals
 TEST_FILE = 'text-emphasis-style-property-{:03}{}.html'
 TEST_TEMPLATE = '''<!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: {title}</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -20,18 +22,20 @@ TEST_TEMPLATE = '''<!DOCTYPE html>
 <meta name="assert" content="'text-emphasis-style: {value}' produces {code} as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-{index:03}-ref.html">
 <p>Pass if there is a '{char}' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: {value}">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: {value}">試験テスト</div>
 '''
 
 REF_FILE = 'text-emphasis-style-property-{:03}-ref.html'
 REF_TEMPLATE = '''<!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: {0}</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt {{ font-variant-east-asian: inherit; }} </style>
 <p>Pass if there is a '{1}' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>{1}</rt>験<rt>{1}</rt>テ<rt>{1}</rt>ス<rt>{1}</rt>ト<rt>{1}</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>{1}</rt>験<rt>{1}</rt>テ<rt>{1}</rt>ス<rt>{1}</rt>ト<rt>{1}</rt></ruby></div>
 '''
 
 DATA_SET = [

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-001-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a <strong>green</strong> '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; color: green"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 5; color: green"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-001.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="The color of emphasis marks should be the same as the text by default">
 <link rel="match" href="text-emphasis-color-property-001-ref.html">
 <p>Pass if there is a <strong>green</strong> '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: filled circle; color: green">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: filled circle; color: green">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-001a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-001a.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="The color of emphasis marks should be the same as the text for initial value">
 <link rel="match" href="text-emphasis-color-property-001-ref.html">
 <p>Pass if there is a <strong>green</strong> '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: filled circle; text-emphasis-color: initial; color: green">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: filled circle; text-emphasis-color: initial; color: green">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-001b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-001b.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="The color of emphasis marks should be the same as the text by default">
 <link rel="match" href="text-emphasis-color-property-001-ref.html">
 <p>Pass if there is a <strong>green</strong> '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis: filled circle; color: green">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: filled circle; color: green">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-002-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; color: green; } </style>
 <p>Pass if there is a <strong>green</strong> '&#x25CF;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-color-property-002.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="Emphasis marks should be rendered with color specified by text-emphasis-color.">
 <link rel="match" href="text-emphasis-color-property-002-ref.html">
 <p>Pass if there is a <strong>green</strong> '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: filled circle; text-emphasis-color: green">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: filled circle; text-emphasis-color: green">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Reference: text-emphasis line height, top</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are below the black line:</p>
-<div style="line-height: 1; border-top: 1px solid black; writing-mode: horizontal-tb; ruby-position: over"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 1; border-top: 1px solid black; writing-mode: horizontal-tb; ruby-position: over"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, top, horizontal-tb, div</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-001-ref.html">
 <p>Pass if the emphasis marks are below the black line:</p>
-<div style="line-height: 1; border-top: 1px solid black; writing-mode: horizontal-tb; text-emphasis-position: over right;text-emphasis: circle;">試験テスト</div>
+<div lang="ja" style="line-height: 1; border-top: 1px solid black; writing-mode: horizontal-tb; text-emphasis-position: over right;text-emphasis: circle;">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, top, horizontal-tb, span</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-001-ref.html">
 <p>Pass if the emphasis marks are below the black line:</p>
-<div style="line-height: 1; border-top: 1px solid black; writing-mode: horizontal-tb; text-emphasis-position: over right;"><span style="text-emphasis: circle;">試験テスト</span></div>
+<div lang="ja" style="line-height: 1; border-top: 1px solid black; writing-mode: horizontal-tb; text-emphasis-position: over right;"><span style="text-emphasis: circle;">試験テスト</span></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001z.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001z.html
@@ -17,4 +17,4 @@ textarea {
 }
 </style>
 <p>Pass if the emphasis marks are below the black line:</p>
-<textarea style="line-height: 1; border-top: 1px solid black; text-emphasis: circle;">試験テスト</textarea>
+<textarea lang="ja" style="line-height: 1; border-top: 1px solid black; text-emphasis: circle;">試験テスト</textarea>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-002-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Reference: text-emphasis line height, bottom</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are over the black line:</p>
-<div style="line-height: 1; border-bottom: 1px solid black; writing-mode: horizontal-tb; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 1; border-bottom: 1px solid black; writing-mode: horizontal-tb; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-002a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-002a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, bottom, horizontal-tb, div</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-002-ref.html">
 <p>Pass if the emphasis marks are over the black line:</p>
-<div style="line-height: 1; border-bottom: 1px solid black; writing-mode: horizontal-tb; text-emphasis-position: under right;text-emphasis: circle;">試験テスト</div>
+<div lang="ja" style="line-height: 1; border-bottom: 1px solid black; writing-mode: horizontal-tb; text-emphasis-position: under right;text-emphasis: circle;">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-002b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-002b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, bottom, horizontal-tb, span</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-002-ref.html">
 <p>Pass if the emphasis marks are over the black line:</p>
-<div style="line-height: 1; border-bottom: 1px solid black; writing-mode: horizontal-tb; text-emphasis-position: under right;"><span style="text-emphasis: circle;">試験テスト</span></div>
+<div lang="ja" style="line-height: 1; border-bottom: 1px solid black; writing-mode: horizontal-tb; text-emphasis-position: under right;"><span style="text-emphasis: circle;">試験テスト</span></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Reference: text-emphasis line height, right</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are to the left of the black line:</p>
-<div style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-rl; ruby-position: over"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-rl; ruby-position: over"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, right, vertical-rl, div</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-003-ref.html">
 <p>Pass if the emphasis marks are to the left of the black line:</p>
-<div style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-rl; text-emphasis-position: over right;text-emphasis: circle;">試験テスト</div>
+<div lang="ja" style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-rl; text-emphasis-position: over right;text-emphasis: circle;">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, right, vertical-rl, span</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-003-ref.html">
 <p>Pass if the emphasis marks are to the left of the black line:</p>
-<div style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-rl; text-emphasis-position: over right;"><span style="text-emphasis: circle;">試験テスト</span></div>
+<div lang="ja" style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-rl; text-emphasis-position: over right;"><span style="text-emphasis: circle;">試験テスト</span></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003c.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, right, vertical-lr, div</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-003-ref.html">
 <p>Pass if the emphasis marks are to the left of the black line:</p>
-<div style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-lr; text-emphasis-position: over right;text-emphasis: circle;">試験テスト</div>
+<div lang="ja" style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-lr; text-emphasis-position: over right;text-emphasis: circle;">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003d.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-003d.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, right, vertical-lr, span</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-003-ref.html">
 <p>Pass if the emphasis marks are to the left of the black line:</p>
-<div style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-lr; text-emphasis-position: over right;"><span style="text-emphasis: circle;">試験テスト</span></div>
+<div lang="ja" style="line-height: 1; border-right: 1px solid black; writing-mode: vertical-lr; text-emphasis-position: over right;"><span style="text-emphasis: circle;">試験テスト</span></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Reference: text-emphasis line height, left</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are to the right of the black line:</p>
-<div style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-rl; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-rl; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, left, vertical-rl, div</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-004-ref.html">
 <p>Pass if the emphasis marks are to the right of the black line:</p>
-<div style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-rl; text-emphasis-position: over left;text-emphasis: circle;">試験テスト</div>
+<div lang="ja" style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-rl; text-emphasis-position: over left;text-emphasis: circle;">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, left, vertical-rl, span</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-004-ref.html">
 <p>Pass if the emphasis marks are to the right of the black line:</p>
-<div style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-rl; text-emphasis-position: over left;"><span style="text-emphasis: circle;">試験テスト</span></div>
+<div lang="ja" style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-rl; text-emphasis-position: over left;"><span style="text-emphasis: circle;">試験テスト</span></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004c.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, left, vertical-lr, div</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-004-ref.html">
 <p>Pass if the emphasis marks are to the right of the black line:</p>
-<div style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-lr; text-emphasis-position: over left;text-emphasis: circle;">試験テスト</div>
+<div lang="ja" style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-lr; text-emphasis-position: over left;text-emphasis: circle;">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004d.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-004d.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-line-height-tests.py -->
 <title>CSS Test: text-emphasis line height, left, vertical-lr, span</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="text emphasis marks should expand the line height like ruby if necessary">
 <link rel="match" href="text-emphasis-line-height-004-ref.html">
 <p>Pass if the emphasis marks are to the right of the black line:</p>
-<div style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-lr; text-emphasis-position: over left;"><span style="text-emphasis: circle;">試験テスト</span></div>
+<div lang="ja" style="line-height: 1; border-left: 1px solid black; writing-mode: vertical-lr; text-emphasis-position: over left;"><span style="text-emphasis: circle;">試験テスト</span></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are over the text below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over right, horizontal-tb</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over right' with 'writing-mode: horizontal-tb' puts emphasis marks over the text.">
 <link rel="match" href="text-emphasis-position-property-001-ref.html">
 <p>Pass if the emphasis marks are over the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: over right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: over right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right over, horizontal-tb</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right over' with 'writing-mode: horizontal-tb' puts emphasis marks over the text.">
 <link rel="match" href="text-emphasis-position-property-001-ref.html">
 <p>Pass if the emphasis marks are over the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: right over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: right over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over left, horizontal-tb</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over left' with 'writing-mode: horizontal-tb' puts emphasis marks over the text.">
 <link rel="match" href="text-emphasis-position-property-001-ref.html">
 <p>Pass if the emphasis marks are over the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: over left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: over left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-001c.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left over, horizontal-tb</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left over' with 'writing-mode: horizontal-tb' puts emphasis marks over the text.">
 <link rel="match" href="text-emphasis-position-property-001-ref.html">
 <p>Pass if the emphasis marks are over the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: left over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: left over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are under the text below:</p>
-<div style="line-height: 5; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 5; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under right, horizontal-tb</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under right' with 'writing-mode: horizontal-tb' puts emphasis marks under the text.">
 <link rel="match" href="text-emphasis-position-property-002-ref.html">
 <p>Pass if the emphasis marks are under the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: under right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: under right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right under, horizontal-tb</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right under' with 'writing-mode: horizontal-tb' puts emphasis marks under the text.">
 <link rel="match" href="text-emphasis-position-property-002-ref.html">
 <p>Pass if the emphasis marks are under the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: right under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: right under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under left, horizontal-tb</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under left' with 'writing-mode: horizontal-tb' puts emphasis marks under the text.">
 <link rel="match" href="text-emphasis-position-property-002-ref.html">
 <p>Pass if the emphasis marks are under the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: under left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: under left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-002c.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left under, horizontal-tb</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left under' with 'writing-mode: horizontal-tb' puts emphasis marks under the text.">
 <link rel="match" href="text-emphasis-position-property-002-ref.html">
 <p>Pass if the emphasis marks are under the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: left under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: horizontal-tb; text-orientation: mixed; text-emphasis-position: left under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; writing-mode: vertical-rl; ruby-position: over"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-rl; ruby-position: over"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right over, vertical-rl</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right over' with 'writing-mode: vertical-rl' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-003-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: right over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: right over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over right, vertical-rl</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over right' with 'writing-mode: vertical-rl' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-003-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: over right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: over right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right under, vertical-rl</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right under' with 'writing-mode: vertical-rl' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-003-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: right under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: right under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003c.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under right, vertical-rl</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under right' with 'writing-mode: vertical-rl' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-003-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: under right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: under right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003d.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003d.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right over, vertical-lr</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right over' with 'writing-mode: vertical-lr' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-003-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: right over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: right over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003e.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over right, vertical-lr</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over right' with 'writing-mode: vertical-lr' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-003-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: over right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: over right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003f.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003f.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right under, vertical-lr</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right under' with 'writing-mode: vertical-lr' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-003-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: right under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: right under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003g.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-003g.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under right, vertical-lr</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under right' with 'writing-mode: vertical-lr' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-003-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: under right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: under right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; writing-mode: vertical-rl; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-rl; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left over, vertical-rl</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left over' with 'writing-mode: vertical-rl' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-004-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: left over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: left over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over left, vertical-rl</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over left' with 'writing-mode: vertical-rl' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-004-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: over left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: over left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left under, vertical-rl</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left under' with 'writing-mode: vertical-rl' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-004-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: left under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: left under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004c.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under left, vertical-rl</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under left' with 'writing-mode: vertical-rl' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-004-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: under left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: mixed; text-emphasis-position: under left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004d.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004d.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left over, vertical-lr</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left over' with 'writing-mode: vertical-lr' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-004-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: left over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: left over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004e.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over left, vertical-lr</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over left' with 'writing-mode: vertical-lr' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-004-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: over left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: over left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004f.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004f.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left under, vertical-lr</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left under' with 'writing-mode: vertical-lr' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-004-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: left under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: left under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004g.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-004g.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under left, vertical-lr</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under left' with 'writing-mode: vertical-lr' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-004-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: under left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: mixed; text-emphasis-position: under left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; writing-mode: vertical-rl; text-orientation: sideways; ruby-position: over"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-rl; text-orientation: sideways; ruby-position: over"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right over, vertical-rl, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right over' with 'writing-mode: vertical-rl' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-005-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: right over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: right over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over right, vertical-rl, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over right' with 'writing-mode: vertical-rl' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-005-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: over right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: over right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right under, vertical-rl, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right under' with 'writing-mode: vertical-rl' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-005-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: right under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: right under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005c.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under right, vertical-rl, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under right' with 'writing-mode: vertical-rl' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-005-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: under right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: under right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005d.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005d.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right over, vertical-lr, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right over' with 'writing-mode: vertical-lr' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-005-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: right over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: right over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005e.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over right, vertical-lr, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over right' with 'writing-mode: vertical-lr' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-005-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: over right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: over right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005f.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005f.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: right under, vertical-lr, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: right under' with 'writing-mode: vertical-lr' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-005-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: right under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: right under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005g.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-005g.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under right, vertical-lr, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under right' with 'writing-mode: vertical-lr' puts emphasis marks to the right of the text.">
 <link rel="match" href="text-emphasis-position-property-005-ref.html">
 <p>Pass if the emphasis marks are to the right of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: under right">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: under right">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; writing-mode: vertical-rl; text-orientation: sideways; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-rl; text-orientation: sideways; ruby-position: under"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left over, vertical-rl, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left over' with 'writing-mode: vertical-rl' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-006-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: left over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: left over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over left, vertical-rl, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over left' with 'writing-mode: vertical-rl' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-006-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: over left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: over left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left under, vertical-rl, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left under' with 'writing-mode: vertical-rl' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-006-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: left under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: left under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006c.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under left, vertical-rl, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under left' with 'writing-mode: vertical-rl' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-006-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: under left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-rl; text-orientation: sideways; text-emphasis-position: under left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006d.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006d.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left over, vertical-lr, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left over' with 'writing-mode: vertical-lr' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-006-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: left over">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: left over">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006e.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: over left, vertical-lr, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: over left' with 'writing-mode: vertical-lr' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-006-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: over left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: over left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006f.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006f.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: left under, vertical-lr, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: left under' with 'writing-mode: vertical-lr' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-006-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: left under">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: left under">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006g.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-position-property-006g.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-position-property-tests.py -->
 <title>CSS Test: text-emphasis-position: under left, vertical-lr, sideways</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-position: under left' with 'writing-mode: vertical-lr' puts emphasis marks to the left of the text.">
 <link rel="match" href="text-emphasis-position-property-006-ref.html">
 <p>Pass if the emphasis marks are to the left of the text below:</p>
-<div style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: under left">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle; writing-mode: vertical-lr; text-orientation: sideways; text-emphasis-position: under left">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-001.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="text-emphasis: none does not produce any emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-001-ref.html">
 <p>Pass if there is NO emphasis marks above the text below:</p>
-<div style="line-height: 5; text-emphasis: none">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: none">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-002.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="'text-emphasis: string' uses the given string as emphasis marks">
 <link rel="match" href="text-emphasis-style-property-002-ref.html">
 <p>Pass if there is a '^' above every character below:</p>
-<div style="line-height: 5; text-emphasis: '^'">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: '^'">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-003.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-003.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="'text-emphasis: circle' produces U+25CF as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-012-ref.html">
 <p>Pass if there is a '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis: circle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-003a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-003a.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="'text-emphasis: filled' produces U+25CF as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-012-ref.html">
 <p>Pass if there is a '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis: filled">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: filled">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-003b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-003b.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="'text-emphasis: filled circle' produces U+25CF as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-012-ref.html">
 <p>Pass if there is a '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis: filled circle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: filled circle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-004.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="Emphasis marks should be rendered with color specified by text-emphasis.">
 <link rel="match" href="text-emphasis-color-property-002-ref.html">
 <p>Pass if there is a <strong>green</strong> '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis: circle green">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: circle green">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-004a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-property-004a.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="Emphasis marks should be rendered with color specified by text-emphasis.">
 <link rel="match" href="text-emphasis-color-property-002-ref.html">
 <p>Pass if there is a <strong>green</strong> '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis: green circle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis: green circle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-001-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Reference: text-emphasis and ruby, horizontal-tb, top</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rtc { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: horizontal-tb; ruby-position: over">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: horizontal-tb; ruby-position: over">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-001.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Test: text-emphasis and ruby, horizontal-tb, top</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="emphasis marks are drawn outside the ruby">
 <link rel="match" href="text-emphasis-ruby-001-ref.html">
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: horizontal-tb; ruby-position: over; text-emphasis-position: over right">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: horizontal-tb; ruby-position: over; text-emphasis-position: over right">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-002-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Reference: text-emphasis and ruby, horizontal-tb, bottom</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rtc { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: horizontal-tb; ruby-position: under">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: horizontal-tb; ruby-position: under">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-002.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Test: text-emphasis and ruby, horizontal-tb, bottom</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="emphasis marks are drawn outside the ruby">
 <link rel="match" href="text-emphasis-ruby-002-ref.html">
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: horizontal-tb; ruby-position: under; text-emphasis-position: under right">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: horizontal-tb; ruby-position: under; text-emphasis-position: under right">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-003-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-003-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Reference: text-emphasis and ruby, vertical-rl, right</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rtc { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: vertical-rl; ruby-position: over">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-rl; ruby-position: over">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-003.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-003.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Test: text-emphasis and ruby, vertical-rl, right</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="emphasis marks are drawn outside the ruby">
 <link rel="match" href="text-emphasis-ruby-003-ref.html">
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: vertical-rl; ruby-position: over; text-emphasis-position: over right">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-rl; ruby-position: over; text-emphasis-position: over right">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-003a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-003a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Test: text-emphasis and ruby, vertical-lr, right</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="emphasis marks are drawn outside the ruby">
 <link rel="match" href="text-emphasis-ruby-003-ref.html">
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: vertical-lr; ruby-position: over; text-emphasis-position: over right">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-lr; ruby-position: over; text-emphasis-position: over right">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-004-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-004-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Reference: text-emphasis and ruby, vertical-rl, left</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rtc { font-variant-east-asian: inherit; } </style>
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: vertical-rl; ruby-position: under">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-rl; ruby-position: under">ルビ<ruby>と<rtc>&#x25CF;</rtc>圏<rt>けん</rt><rtc>&#x25CF;</rtc>点<rt>てん</rt><rtc>&#x25CF;</rtc>を<rtc>&#x25CF;</rtc></ruby>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-004.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Test: text-emphasis and ruby, vertical-rl, left</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="emphasis marks are drawn outside the ruby">
 <link rel="match" href="text-emphasis-ruby-004-ref.html">
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: vertical-rl; ruby-position: under; text-emphasis-position: over left">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-rl; ruby-position: under; text-emphasis-position: over left">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-004a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-ruby-004a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-ruby-tests.py -->
 <title>CSS Test: text-emphasis and ruby, vertical-lr, left</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="emphasis marks are drawn outside the ruby">
 <link rel="match" href="text-emphasis-ruby-004-ref.html">
 <p>Pass if the emphasis marks are outside the ruby:</p>
-<div style="line-height: 5; writing-mode: vertical-lr; ruby-position: under; text-emphasis-position: over left">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>
+<div lang="ja" style="line-height: 5; writing-mode: vertical-lr; ruby-position: under; text-emphasis-position: over left">ルビ<span style="text-emphasis: circle">と<ruby>圏<rt>けん</rt>点<rt>てん</rt></ruby>を</span>同時</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-001-ref.html
@@ -4,4 +4,4 @@
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <p>Pass if there is NO emphasis marks above the text below:</p>
-<div style="line-height: 5;">試験テスト</div>
+<div lang="ja" style="line-height: 5;">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-001.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="text-emphasis-style: none does not produce any emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-001-ref.html">
 <p>Pass if there is NO emphasis marks above the text below:</p>
-<div style="line-height: 5; text-emphasis-style: none">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: none">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-002-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: normal; } </style>
 <p>Pass if there is a '^' above every character below:</p>
-<div style="line-height: 5"><ruby>試<rt>^</rt>験<rt>^</rt>テ<rt>^</rt>ス<rt>^</rt>ト<rt>^</rt></ruby></div>
+<div lang="ja" style="line-height: 5"><ruby>試<rt>^</rt>験<rt>^</rt>テ<rt>^</rt>ス<rt>^</rt>ト<rt>^</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-002.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="'text-emphasis-style: string' uses the given string as emphasis marks">
 <link rel="match" href="text-emphasis-style-property-002-ref.html">
 <p>Pass if there is a '^' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: '^'">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: '^'">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-003-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-003-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: normal; } </style>
 <p>Pass if there is a '&#xFE45;' to the right of every character below:</p>
-<div style="writing-mode: vertical-rl; line-height: 5;"><ruby>試<rt>&#xFE45;</rt>験<rt>&#xFE45;</rt>テ<rt>&#xFE45;</rt>ス<rt>&#xFE45;</rt>ト<rt>&#xFE45;</rt></ruby></div>
+<div lang="ja" style="writing-mode: vertical-rl; line-height: 5;"><ruby>試<rt>&#xFE45;</rt>験<rt>&#xFE45;</rt>テ<rt>&#xFE45;</rt>ス<rt>&#xFE45;</rt>ト<rt>&#xFE45;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-003.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-003.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="'text-emphasis-style: filled' produces U+FE45 as emphasis marks in vertical writing modes.">
 <link rel="match" href="text-emphasis-style-property-003-ref.html">
 <p>Pass if there is a '&#xFE45;' to the right of every character below:</p>
-<div style="writing-mode: vertical-rl; line-height: 5; text-emphasis-style: filled">試験テスト</div>
+<div lang="ja" style="writing-mode: vertical-rl; line-height: 5; text-emphasis-style: filled">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-004-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-004-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: normal; } </style>
 <p>Pass if there is a '&#xFE46;' to the right of every character below:</p>
-<div style="writing-mode: vertical-rl; line-height: 5;"><ruby>試<rt>&#xFE46;</rt>験<rt>&#xFE46;</rt>テ<rt>&#xFE46;</rt>ス<rt>&#xFE46;</rt>ト<rt>&#xFE46;</rt></ruby></div>
+<div lang="ja" style="writing-mode: vertical-rl; line-height: 5;"><ruby>試<rt>&#xFE46;</rt>験<rt>&#xFE46;</rt>テ<rt>&#xFE46;</rt>ス<rt>&#xFE46;</rt>ト<rt>&#xFE46;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-004.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="'text-emphasis: open sesame' produces U+FE46 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-004-ref.html">
 <p>Pass if there is a '&#xFE46;' to the right of every character below:</p>
-<div style="writing-mode: vertical-rl; line-height: 5; text-emphasis-style: open">試験テスト</div>
+<div lang="ja" style="writing-mode: vertical-rl; line-height: 5; text-emphasis-style: open">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-005-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-005-ref.html
@@ -5,4 +5,4 @@
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: normal; text-orientation: upright; } </style>
 <p>Pass if the emphasis marks 'V' are upright:</p>
-<div style="writing-mode: vertical-rl; line-height: 5;"><ruby>試<rt>V</rt>験<rt>V</rt>テ<rt>V</rt>ス<rt>V</rt>ト<rt>V</rt></ruby></div>
+<div lang="ja" style="writing-mode: vertical-rl; line-height: 5;"><ruby>試<rt>V</rt>験<rt>V</rt>テ<rt>V</rt>ス<rt>V</rt>ト<rt>V</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-005.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-005.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="Emphasis marks must remain upright in vertical writing modes">
 <link rel="match" href="text-emphasis-style-property-005-ref.html">
 <p>Pass if the emphasis marks 'V' are upright:</p>
-<div style="writing-mode: vertical-rl; line-height: 5; text-emphasis-style: 'V'">試験テスト</div>
+<div lang="ja" style="writing-mode: vertical-rl; line-height: 5; text-emphasis-style: 'V'">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-005a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-005a.html
@@ -7,4 +7,4 @@
 <meta name="assert" content="Emphasis marks must remain upright in vertical writing modes">
 <link rel="match" href="text-emphasis-style-property-005-ref.html">
 <p>Pass if the emphasis marks 'V' are upright:</p>
-<div style="writing-mode: vertical-lr; line-height: 5; text-emphasis-style: 'V'">試験テスト</div>
+<div lang="ja" style="writing-mode: vertical-lr; line-height: 5; text-emphasis-style: 'V'">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Cc.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Cc.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-010-tests.sh -->
 <title>CSS Test: text-emphasis, Cc</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Cf.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Cf.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-010-tests.sh -->
 <title>CSS Test: text-emphasis, Cf</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Zl.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Zl.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-010-tests.sh -->
 <title>CSS Test: text-emphasis, Zl</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Zp.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Zp.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-010-tests.sh -->
 <title>CSS Test: text-emphasis, Zp</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Zs.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-010Zs.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-010-tests.sh -->
 <title>CSS Test: text-emphasis, Zs</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-011-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-011-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: filled dot</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#x2022;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x2022;</rt>験<rt>&#x2022;</rt>テ<rt>&#x2022;</rt>ス<rt>&#x2022;</rt>ト<rt>&#x2022;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x2022;</rt>験<rt>&#x2022;</rt>テ<rt>&#x2022;</rt>ス<rt>&#x2022;</rt>ト<rt>&#x2022;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-011.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-011.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: filled dot</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: filled dot' produces U+2022 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-011-ref.html">
 <p>Pass if there is a '&#x2022;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: filled dot">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: filled dot">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-011a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-011a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: dot filled</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: dot filled' produces U+2022 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-011-ref.html">
 <p>Pass if there is a '&#x2022;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: dot filled">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: dot filled">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-011b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-011b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: dot</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: dot' produces U+2022 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-011-ref.html">
 <p>Pass if there is a '&#x2022;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: dot">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: dot">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: filled circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#x25CF;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x25CF;</rt>験<rt>&#x25CF;</rt>テ<rt>&#x25CF;</rt>ス<rt>&#x25CF;</rt>ト<rt>&#x25CF;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: filled circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: filled circle' produces U+25CF as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-012-ref.html">
 <p>Pass if there is a '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: filled circle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: filled circle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: circle filled</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: circle filled' produces U+25CF as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-012-ref.html">
 <p>Pass if there is a '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: circle filled">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: circle filled">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: circle' produces U+25CF as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-012-ref.html">
 <p>Pass if there is a '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: circle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: circle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-012c.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: filled, horizontal</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: filled' produces U+25CF as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-012-ref.html">
 <p>Pass if there is a '&#x25CF;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: filled">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: filled">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-013-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-013-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: filled double-circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#x25C9;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x25C9;</rt>験<rt>&#x25C9;</rt>テ<rt>&#x25C9;</rt>ス<rt>&#x25C9;</rt>ト<rt>&#x25C9;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x25C9;</rt>験<rt>&#x25C9;</rt>テ<rt>&#x25C9;</rt>ス<rt>&#x25C9;</rt>ト<rt>&#x25C9;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-013.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-013.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: filled double-circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: filled double-circle' produces U+25C9 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-013-ref.html">
 <p>Pass if there is a '&#x25C9;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: filled double-circle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: filled double-circle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-013a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-013a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: double-circle filled</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: double-circle filled' produces U+25C9 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-013-ref.html">
 <p>Pass if there is a '&#x25C9;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: double-circle filled">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: double-circle filled">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-013b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-013b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: double-circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: double-circle' produces U+25C9 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-013-ref.html">
 <p>Pass if there is a '&#x25C9;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: double-circle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: double-circle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-014-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-014-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: filled triangle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#x25B2;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x25B2;</rt>験<rt>&#x25B2;</rt>テ<rt>&#x25B2;</rt>ス<rt>&#x25B2;</rt>ト<rt>&#x25B2;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x25B2;</rt>験<rt>&#x25B2;</rt>テ<rt>&#x25B2;</rt>ス<rt>&#x25B2;</rt>ト<rt>&#x25B2;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-014.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-014.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: filled triangle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: filled triangle' produces U+25B2 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-014-ref.html">
 <p>Pass if there is a '&#x25B2;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: filled triangle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: filled triangle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-014a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-014a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: triangle filled</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: triangle filled' produces U+25B2 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-014-ref.html">
 <p>Pass if there is a '&#x25B2;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: triangle filled">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: triangle filled">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-014b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-014b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: triangle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: triangle' produces U+25B2 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-014-ref.html">
 <p>Pass if there is a '&#x25B2;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: triangle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: triangle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-015-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-015-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: filled sesame</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#xFE45;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#xFE45;</rt>験<rt>&#xFE45;</rt>テ<rt>&#xFE45;</rt>ス<rt>&#xFE45;</rt>ト<rt>&#xFE45;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#xFE45;</rt>験<rt>&#xFE45;</rt>テ<rt>&#xFE45;</rt>ス<rt>&#xFE45;</rt>ト<rt>&#xFE45;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-015.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-015.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: filled sesame</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: filled sesame' produces U+FE45 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-015-ref.html">
 <p>Pass if there is a '&#xFE45;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: filled sesame">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: filled sesame">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-015a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-015a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: sesame filled</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: sesame filled' produces U+FE45 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-015-ref.html">
 <p>Pass if there is a '&#xFE45;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: sesame filled">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: sesame filled">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-015b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-015b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: sesame</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: sesame' produces U+FE45 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-015-ref.html">
 <p>Pass if there is a '&#xFE45;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: sesame">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: sesame">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-016-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-016-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: open dot</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#x25E6;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x25E6;</rt>験<rt>&#x25E6;</rt>テ<rt>&#x25E6;</rt>ス<rt>&#x25E6;</rt>ト<rt>&#x25E6;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x25E6;</rt>験<rt>&#x25E6;</rt>テ<rt>&#x25E6;</rt>ス<rt>&#x25E6;</rt>ト<rt>&#x25E6;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-016.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-016.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: open dot</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: open dot' produces U+25E6 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-016-ref.html">
 <p>Pass if there is a '&#x25E6;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: open dot">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: open dot">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-016a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-016a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: dot open</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: dot open' produces U+25E6 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-016-ref.html">
 <p>Pass if there is a '&#x25E6;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: dot open">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: dot open">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-017-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-017-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: open circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#x25CB;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x25CB;</rt>験<rt>&#x25CB;</rt>テ<rt>&#x25CB;</rt>ス<rt>&#x25CB;</rt>ト<rt>&#x25CB;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x25CB;</rt>験<rt>&#x25CB;</rt>テ<rt>&#x25CB;</rt>ス<rt>&#x25CB;</rt>ト<rt>&#x25CB;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-017.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-017.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: open circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: open circle' produces U+25CB as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-017-ref.html">
 <p>Pass if there is a '&#x25CB;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: open circle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: open circle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-017a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-017a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: circle open</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: circle open' produces U+25CB as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-017-ref.html">
 <p>Pass if there is a '&#x25CB;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: circle open">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: circle open">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-017b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-017b.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: open, horizontal</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: open' produces U+25CB as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-017-ref.html">
 <p>Pass if there is a '&#x25CB;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: open">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: open">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-018-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-018-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: open double-circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#x25CE;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x25CE;</rt>験<rt>&#x25CE;</rt>テ<rt>&#x25CE;</rt>ス<rt>&#x25CE;</rt>ト<rt>&#x25CE;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x25CE;</rt>験<rt>&#x25CE;</rt>テ<rt>&#x25CE;</rt>ス<rt>&#x25CE;</rt>ト<rt>&#x25CE;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-018.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-018.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: open double-circle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: open double-circle' produces U+25CE as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-018-ref.html">
 <p>Pass if there is a '&#x25CE;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: open double-circle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: open double-circle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-018a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-018a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: double-circle open</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: double-circle open' produces U+25CE as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-018-ref.html">
 <p>Pass if there is a '&#x25CE;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: double-circle open">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: double-circle open">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-019-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-019-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: open triangle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#x25B3;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#x25B3;</rt>験<rt>&#x25B3;</rt>テ<rt>&#x25B3;</rt>ス<rt>&#x25B3;</rt>ト<rt>&#x25B3;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#x25B3;</rt>験<rt>&#x25B3;</rt>テ<rt>&#x25B3;</rt>ス<rt>&#x25B3;</rt>ト<rt>&#x25B3;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-019.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-019.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: open triangle</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: open triangle' produces U+25B3 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-019-ref.html">
 <p>Pass if there is a '&#x25B3;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: open triangle">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: open triangle">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-019a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-019a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: triangle open</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: triangle open' produces U+25B3 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-019-ref.html">
 <p>Pass if there is a '&#x25B3;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: triangle open">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: triangle open">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-020-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-020-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Reference: text-emphasis-style: open sesame</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
 <style> rt { font-variant-east-asian: inherit; } </style>
 <p>Pass if there is a '&#xFE46;' above every character below:</p>
-<div style="line-height: 5;"><ruby>試<rt>&#xFE46;</rt>験<rt>&#xFE46;</rt>テ<rt>&#xFE46;</rt>ス<rt>&#xFE46;</rt>ト<rt>&#xFE46;</rt></ruby></div>
+<div lang="ja" style="line-height: 5;"><ruby>試<rt>&#xFE46;</rt>験<rt>&#xFE46;</rt>テ<rt>&#xFE46;</rt>ス<rt>&#xFE46;</rt>ト<rt>&#xFE46;</rt></ruby></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-020.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-020.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: open sesame</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: open sesame' produces U+FE46 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-020-ref.html">
 <p>Pass if there is a '&#xFE46;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: open sesame">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: open sesame">試験テスト</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-020a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-style-property-020a.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!-- This file was generated automatically by the script
+     ./support/generate-text-emphasis-style-property-tests.py -->
 <title>CSS Test: text-emphasis-style: sesame open</title>
 <link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
 <link rel="author" title="Mozilla" href="https://www.mozilla.org">
@@ -7,4 +9,4 @@
 <meta name="assert" content="'text-emphasis-style: sesame open' produces U+FE46 as emphasis marks.">
 <link rel="match" href="text-emphasis-style-property-020-ref.html">
 <p>Pass if there is a '&#xFE46;' above every character below:</p>
-<div style="line-height: 5; text-emphasis-style: sesame open">試験テスト</div>
+<div lang="ja" style="line-height: 5; text-emphasis-style: sesame open">試験テスト</div>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/b3cc8963e8718dbd40761f14664f45320c258bbd .

This contains changes from [bug 1577053](https://bugzilla.mozilla.org/show_bug.cgi?id=1577053) by @dholbert, reviewed by @jfkthame.