### PR TITLE
[GitHub Actions] Pin the version of Ubuntu and checkout action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,9 +2,9 @@ on: pull_request
 name: Synchronize the Pull Request Preview
 jobs:
   update-pr-preview:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1.0.0
+    - uses: actions/checkout@v1
       with:
         ref: refs/heads/master
         fetch-depth: 1

--- a/.github/workflows/push-build-publish-documentation-website.yml
+++ b/.github/workflows/push-build-publish-documentation-website.yml
@@ -2,9 +2,11 @@ on: push
 name: Build & Publish Documentation Website
 jobs:
   website-build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
     - name: website-build-and-publish
       uses: ./tools/docker/documentation
       env:

--- a/.github/workflows/push-build-release-manifest.yml
+++ b/.github/workflows/push-build-release-manifest.yml
@@ -2,9 +2,11 @@ on: push
 name: Build & Release Manifest
 jobs:
   manifest-build-and-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
     - name: manifest-build-and-tag
       uses: ./tools/docker/github
       env:


### PR DESCRIPTION
This is mostly to bring consistency to the checkout action, but it's
just as well to pin the version of Ubuntu used to control when we
upgrade instead of having sudden breakage to deal with.