### PR TITLE
Expect Safari to pass infrastructure/testdriver/actions/pause.html

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/pause.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/pause.html.ini
@@ -1,3 +1,3 @@
 [pause.html]
   expected:
-    if product == "safari" or product == "epiphany" or product == "webkit": ERROR
+    if product == "epiphany" or product == "webkit": ERROR


### PR DESCRIPTION
It appears to pass now, whether it reliably passes is not clear.