### PR TITLE
Remove explicit testharness(report).js includes in Bluetooth tests

### DIFF
--- a/bluetooth/adapter/adapter-absent-getAvailability.https.window.js
+++ b/bluetooth/adapter/adapter-absent-getAvailability.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/adapter/adapter-added-getAvailability.https.window.js
+++ b/bluetooth/adapter/adapter-added-getAvailability.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/adapter/adapter-powered-off-getAvailability.https.window.js
+++ b/bluetooth/adapter/adapter-powered-off-getAvailability.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/adapter/adapter-powered-on-getAvailability.https.window.js
+++ b/bluetooth/adapter/adapter-powered-on-getAvailability.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/adapter/adapter-powered-on-off-on-getAvailability.https.window.js
+++ b/bluetooth/adapter/adapter-powered-on-off-on-getAvailability.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/adapter/adapter-removed-getAvailability.https.window.js
+++ b/bluetooth/adapter/adapter-removed-getAvailability.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/adapter/cross-origin-iframe-getAvailability.sub.https.window.js
+++ b/bluetooth/adapter/cross-origin-iframe-getAvailability.sub.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/characteristicProperties.https.window.js
+++ b/bluetooth/characteristic/characteristicProperties.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/getDescriptor/gen-characteristic-is-removed.https.window.js
+++ b/bluetooth/characteristic/getDescriptor/gen-characteristic-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/getDescriptor/gen-descriptor-get-same-object.https.window.js
+++ b/bluetooth/characteristic/getDescriptor/gen-descriptor-get-same-object.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/getDescriptor/gen-service-is-removed.https.window.js
+++ b/bluetooth/characteristic/getDescriptor/gen-service-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/getDescriptors/gen-characteristic-is-removed-with-uuid.https.window.js
+++ b/bluetooth/characteristic/getDescriptors/gen-characteristic-is-removed-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/getDescriptors/gen-characteristic-is-removed.https.window.js
+++ b/bluetooth/characteristic/getDescriptors/gen-characteristic-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/getDescriptors/gen-descriptor-get-same-object.https.window.js
+++ b/bluetooth/characteristic/getDescriptors/gen-descriptor-get-same-object.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/getDescriptors/gen-service-is-removed-with-uuid.https.window.js
+++ b/bluetooth/characteristic/getDescriptors/gen-service-is-removed-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/getDescriptors/gen-service-is-removed.https.window.js
+++ b/bluetooth/characteristic/getDescriptors/gen-service-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/notifications/characteristic-is-removed.https.window.js
+++ b/bluetooth/characteristic/notifications/characteristic-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/notifications/service-is-removed.https.window.js
+++ b/bluetooth/characteristic/notifications/service-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/readValue/add-multiple-event-listeners.https.window.js
+++ b/bluetooth/characteristic/readValue/add-multiple-event-listeners.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/readValue/characteristic-is-removed.https.window.js
+++ b/bluetooth/characteristic/readValue/characteristic-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/readValue/event-is-fired.https.window.js
+++ b/bluetooth/characteristic/readValue/event-is-fired.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/readValue/gen-characteristic-is-removed.https.window.js
+++ b/bluetooth/characteristic/readValue/gen-characteristic-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/readValue/read-succeeds.https.window.js
+++ b/bluetooth/characteristic/readValue/read-succeeds.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/readValue/read-updates-value.https.window.js
+++ b/bluetooth/characteristic/readValue/read-updates-value.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/readValue/service-is-removed.https.window.js
+++ b/bluetooth/characteristic/readValue/service-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/service-same-from-2-characteristics.https.window.js
+++ b/bluetooth/characteristic/service-same-from-2-characteristics.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/service-same-object.https.window.js
+++ b/bluetooth/characteristic/service-same-object.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/startNotifications/gen-characteristic-is-removed.https.window.js
+++ b/bluetooth/characteristic/startNotifications/gen-characteristic-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/writeValue/buffer-is-detached.https.window.js
+++ b/bluetooth/characteristic/writeValue/buffer-is-detached.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/writeValue/characteristic-is-removed.https.window.js
+++ b/bluetooth/characteristic/writeValue/characteristic-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/writeValue/gen-characteristic-is-removed.https.window.js
+++ b/bluetooth/characteristic/writeValue/gen-characteristic-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/writeValue/service-is-removed.https.window.js
+++ b/bluetooth/characteristic/writeValue/service-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/characteristic/writeValue/write-succeeds.https.window.js
+++ b/bluetooth/characteristic/writeValue/write-succeeds.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/descriptor/readValue/gen-service-is-removed.https.window.js
+++ b/bluetooth/descriptor/readValue/gen-service-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/descriptor/readValue/read-succeeds.https.window.js
+++ b/bluetooth/descriptor/readValue/read-succeeds.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/descriptor/writeValue/buffer-is-detached.https.window.js
+++ b/bluetooth/descriptor/writeValue/buffer-is-detached.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/descriptor/writeValue/gen-service-is-removed.https.window.js
+++ b/bluetooth/descriptor/writeValue/gen-service-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/device/gattserverdisconnected-event/disconnected.https.window.js
+++ b/bluetooth/device/gattserverdisconnected-event/disconnected.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/device/gattserverdisconnected-event/disconnected_gc.https.window.js
+++ b/bluetooth/device/gattserverdisconnected-event/disconnected_gc.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/device/gattserverdisconnected-event/one-event-per-disconnection.https.window.js
+++ b/bluetooth/device/gattserverdisconnected-event/one-event-per-disconnection.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/device/gattserverdisconnected-event/reconnect-during-disconnected-event.https.window.js
+++ b/bluetooth/device/gattserverdisconnected-event/reconnect-during-disconnected-event.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/script-tests/base_test_js.template
+++ b/bluetooth/script-tests/base_test_js.template
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-disconnect-called-before.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-disconnect-called-before.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-disconnect-called-during-error.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-disconnect-called-during-error.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-disconnect-called-during-success.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-disconnect-called-during-success.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-disconnect-invalidates-objects.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-disconnect-invalidates-objects.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-disconnected-device.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-disconnected-device.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-discovery-complete-no-permission-absent-service.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-discovery-complete-no-permission-absent-service.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-discovery-complete-service-not-found.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-discovery-complete-service-not-found.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-garbage-collection-ran-during-error.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-garbage-collection-ran-during-error.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-garbage-collection-ran-during-success.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-garbage-collection-ran-during-success.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-get-different-service-after-reconnection.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-get-different-service-after-reconnection.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-get-same-object.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-get-same-object.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-invalid-service-name.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-invalid-service-name.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-no-permission-absent-service.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-no-permission-absent-service.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-no-permission-for-any-service.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-no-permission-for-any-service.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-no-permission-present-service.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-no-permission-present-service.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryService/gen-service-not-found.https.window.js
+++ b/bluetooth/server/getPrimaryService/gen-service-not-found.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnect-called-before-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnect-called-before-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnect-called-before.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnect-called-before.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-error-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-error-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-error.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-error.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-success-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-success-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-success.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-success.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnect-invalidates-objects-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnect-invalidates-objects-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnect-invalidates-objects.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnect-invalidates-objects.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnected-device-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnected-device-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-disconnected-device.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-disconnected-device.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-discovery-complete-no-permission-absent-service-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-discovery-complete-no-permission-absent-service-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-discovery-complete-service-not-found-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-discovery-complete-service-not-found-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-error-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-error-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-error.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-error.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-success-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-success-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-success.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-success.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-get-different-service-after-reconnection-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-get-different-service-after-reconnection-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-get-different-service-after-reconnection.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-get-different-service-after-reconnection.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-get-same-object-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-get-same-object-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-get-same-object.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-get-same-object.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-invalid-service-name.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-invalid-service-name.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-no-permission-absent-service-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-no-permission-absent-service-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-no-permission-for-any-service-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-no-permission-for-any-service-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-no-permission-for-any-service.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-no-permission-for-any-service.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-no-permission-present-service-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-no-permission-present-service-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/server/getPrimaryServices/gen-service-not-found-with-uuid.https.window.js
+++ b/bluetooth/server/getPrimaryServices/gen-service-not-found-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristic/gen-blocklisted-characteristic.https.window.js
+++ b/bluetooth/service/getCharacteristic/gen-blocklisted-characteristic.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristic/gen-characteristic-not-found.https.window.js
+++ b/bluetooth/service/getCharacteristic/gen-characteristic-not-found.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristic/gen-garbage-collection-ran-during-error.https.window.js
+++ b/bluetooth/service/getCharacteristic/gen-garbage-collection-ran-during-error.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristic/gen-get-same-object.https.window.js
+++ b/bluetooth/service/getCharacteristic/gen-get-same-object.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristic/gen-invalid-characteristic-name.https.window.js
+++ b/bluetooth/service/getCharacteristic/gen-invalid-characteristic-name.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristic/gen-reconnect-during.https.window.js
+++ b/bluetooth/service/getCharacteristic/gen-reconnect-during.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristic/gen-service-is-removed.https.window.js
+++ b/bluetooth/service/getCharacteristic/gen-service-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-blocklisted-characteristic-with-uuid.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-blocklisted-characteristic-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-characteristic-not-found-with-uuid.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-characteristic-not-found-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-garbage-collection-ran-during-error-with-uuid.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-garbage-collection-ran-during-error-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-garbage-collection-ran-during-error.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-garbage-collection-ran-during-error.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-get-same-object-with-uuid.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-get-same-object-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-get-same-object.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-get-same-object.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-invalid-characteristic-name.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-invalid-characteristic-name.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-reconnect-during-with-uuid.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-reconnect-during-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-reconnect-during.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-reconnect-during.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-service-is-removed-with-uuid.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-service-is-removed-with-uuid.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js

--- a/bluetooth/service/getCharacteristics/gen-service-is-removed.https.window.js
+++ b/bluetooth/service/getCharacteristics/gen-service-is-removed.https.window.js
@@ -1,5 +1,3 @@
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 // META: script=/resources/testdriver.js
 // META: script=/resources/testdriver-vendor.js
 // META: script=/bluetooth/resources/bluetooth-helpers.js


### PR DESCRIPTION
These are always included in multi-global tests, and including them
again leads to errors.

Discovered via https://github.com/web-platform-tests/wpt/pull/11024.