### PR TITLE
Avoid harness error in script-src-strict_dynamic_in_img-src.html

### DIFF
--- a/content-security-policy/script-src/script-src-strict_dynamic_in_img-src.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_in_img-src.html
@@ -14,15 +14,13 @@
     <div id='log'></div>
 
     <script nonce='dummy'>
-        window.addEventListener('securitypolicyviolation', function(e) {
-            assert_unreached('No CSP violation report has fired.');
-        });
-
         async_test(function(t) {
+            window.addEventListener('securitypolicyviolation',
+                t.unreached_func('securitypolicyviolation event fired.'));
             var e = document.createElement('img');
             e.id = 'whitelistedImage';
             e.src = '/content-security-policy/support/pass.png';
-            e.onerror = t.unreached_func('Error should not be triggered.');
+            e.onerror = t.unreached_func('error event fired.');
             e.onload = t.step_func_done();
             document.body.appendChild(e);
         }, '`strict-dynamic` does not drop whitelists in `img-src`.');


### PR DESCRIPTION
If "securitypolicyviolation" is fired, it results in a harness error:
https://wpt.fyi/results/content-security-policy/script-src/script-src-strict_dynamic_in_img-src.html?run_id=297090015&run_id=295220010&run_id=305100004

Make it another way to fail the (only) test instead.