### PR TITLE
Lint rule for using Ahem as a web font.

### DIFF
--- a/css/CSS2/linebox/inline-negative-margin-001.html
+++ b/css/CSS2/linebox/inline-negative-margin-001.html
@@ -6,6 +6,7 @@
 <link rel="help" href="https://crbug.com/979894">
 <link rel="help" href="https://drafts.csswg.org/css2/visudet.html#inline-width">
 <link rel="author" title="Koji Ishii" href="mailto:kojii@chromium.org">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html, body { margin: 0; }
 div {

--- a/css/CSS2/normal-flow/max-width-107.xht
+++ b/css/CSS2/normal-flow/max-width-107.xht
@@ -14,7 +14,7 @@
 
   <meta content="ahem" name="flags" />
   <meta content="'max-width' specifies a fixed maximum used width. If the used width is greater than max-width, then the computed value of max-width is used as the computed value for width." name="assert" />
-
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style type="text/css"><![CDATA[
   div
   {

--- a/css/css-fonts/font-family-name-025-ref.html
+++ b/css/css-fonts/font-family-name-025-ref.html
@@ -3,6 +3,7 @@
 <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font-family" />
 <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-family-prop" />
 <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font." />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style type="text/css">
 body { font-size: 36px; }
 span#verify { font-family: CSSTest Verify; }

--- a/css/css-fonts/font-family-name-025.html
+++ b/css/css-fonts/font-family-name-025.html
@@ -5,6 +5,7 @@
 <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-family-prop" />
 <link rel="match" href="font-family-name-025-ref.html" />
 <meta name="assert" content="The 'font-family' property set to and installed font renders the appropriate font. Postscript name should not match." />
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 body { font-size: 36px; }
 span#verify { font-family: CSSTest Verify; }

--- a/css/css-fonts/parsing/font-style-computed.html
+++ b/css/css-fonts/parsing/font-style-computed.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/computed-testcommon.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   #target {
     font-family: Ahem;

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-005.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-005.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
 <link rel="help" title="10.2 Aligning with auto margins" href="https://drafts.csswg.org/css-grid/#auto-margins">
 <meta name="assert" content="The 'top' and 'bottom' margins must be recomputed whenever the grid item's height changes.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   #grid {
       display: grid;

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-006.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-006.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
 <link rel="help" title="10.2 Aligning with auto margins" href="https://drafts.csswg.org/css-grid/#auto-margins">
 <meta name="assert" content="The 'top' and 'bottom' margins must be recomputed whenever the grid item's height changes.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   #grid {
       display: grid;

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-008.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-008.html
@@ -5,6 +5,7 @@
 <link rel="help" title="10.2 Aligning with auto margins" href="https://drafts.csswg.org/css-grid/#auto-margins">
 <link rel="match" href="../reference/grid-block-axis-alignment-auto-margins-008-ref.html">
 <meta name="assert" content="The 'top' and 'bottom' margins must be recomputed after the grid's intrinsic size is determined.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   #grid {
       display: grid;

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-005.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-005.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
 <link rel="help" title="10.2 Aligning with auto margins" href="https://drafts.csswg.org/css-grid/#auto-margins">
 <meta name="assert" content="The 'left' and 'right' margins must be recomputed whenever the grid items's width changes.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   #grid {
       display: grid;
@@ -35,6 +36,7 @@
     <div id="item2">XXXXX</div>
 </div>
 <script>
+document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-x", "50");
     item2.setAttribute("data-offset-x", "325");
     checkLayout('#grid');
@@ -44,4 +46,5 @@
     item1.setAttribute("data-offset-x", "50");
     item2.setAttribute("data-offset-x", "275");
     checkLayout('#grid');
+});
 </script>

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-006.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-006.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
 <link rel="help" title="10.2 Aligning with auto margins" href="https://drafts.csswg.org/css-grid/#auto-margins">
 <meta name="assert" content="The 'left' and 'right' margins must be recomputed whenever the grid items's width changes.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   #grid {
       display: grid;
@@ -34,6 +35,7 @@
     <div id="item2">XX</div>
 </div>
 <script>
+document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-x", "80");
     item2.setAttribute("data-offset-x", "340");
     checkLayout('#grid');
@@ -43,4 +45,5 @@
     item1.setAttribute("data-offset-x", "50");
     item2.setAttribute("data-offset-x", "325");
     checkLayout('#grid');
+});
 </script>

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-008.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-008.html
@@ -5,6 +5,7 @@
 <link rel="help" title="10.2 Aligning with auto margins" href="https://drafts.csswg.org/css-grid/#auto-margins">
 <link rel="match" href="../reference/grid-inline-axis-alignment-auto-margins-008-ref.html">
 <meta name="assert" content="The 'left' and 'right' margins must be recomputed after the grid's intrinsic size is determined.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   #grid {
       display: grid;

--- a/css/css-grid/reference/grid-block-axis-alignment-auto-margins-008-ref.html
+++ b/css/css-grid/reference/grid-block-axis-alignment-auto-margins-008-ref.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Reference: Aligning grid items using 'auto' margins</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   #grid {
       display: grid;

--- a/css/css-grid/reference/grid-inline-axis-alignment-auto-margins-008-ref.html
+++ b/css/css-grid/reference/grid-inline-axis-alignment-auto-margins-008-ref.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Reference: Aligning grid items using 'auto' margins</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   #grid {
       display: grid;

--- a/css/css-masking/clip-path/clip-path-inline-001.html
+++ b/css/css-masking/clip-path/clip-path-inline-001.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path" title="5.1 Clipping Shape: the clip-path property">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
 <meta content="ahem" name="flags">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   body {
     overflow: hidden;

--- a/css/css-masking/clip-path/clip-path-inline-002.html
+++ b/css/css-masking/clip-path/clip-path-inline-002.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path" title="5.1 Clipping Shape: the clip-path property">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
 <meta content="ahem" name="flags">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   body {
     overflow: hidden;

--- a/css/css-masking/clip-path/clip-path-inline-003.html
+++ b/css/css-masking/clip-path/clip-path-inline-003.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path" title="5.1 Clipping Shape: the clip-path property">
 <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
 <meta content="ahem" name="flags">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
   body {
     overflow: hidden;

--- a/css/css-text-decor/reference/text-underline-offset-001-notref.html
+++ b/css/css-text-decor/reference/text-underline-offset-001-notref.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Non-reference case for text-underline-offset</title>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         #main {
             margin: 2em;

--- a/css/css-text-decor/reference/text-underline-offset-002-ref.html
+++ b/css/css-text-decor/reference/text-underline-offset-002-ref.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Reference case for text-underline-offset</title>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         #main{
             border-bottom: 1px solid cyan;

--- a/css/css-text-decor/reference/text-underline-offset-scroll-001-notref.html
+++ b/css/css-text-decor/reference/text-underline-offset-scroll-001-notref.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Non-reference case for text-underline-offset</title>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         #text{
             border: black dashed;

--- a/css/css-text-decor/reference/text-underline-offset-scroll-001-ref.html
+++ b/css/css-text-decor/reference/text-underline-offset-scroll-001-ref.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Reference case for text-underline-offset</title>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         #text{
             border: black dashed;

--- a/css/css-text-decor/reference/text-underline-offset-vertical-001-ref.html
+++ b/css/css-text-decor/reference/text-underline-offset-vertical-001-ref.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Reference case for text-underline-offset</title>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         span{
             font: 20px/1 Ahem;

--- a/css/css-text-decor/reference/text-underline-offset-vertical-002-ref.html
+++ b/css/css-text-decor/reference/text-underline-offset-vertical-002-ref.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Reference case for text-underline-offset</title>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         div{
             font: 20px/1 Ahem;

--- a/css/css-text-decor/text-underline-offset-001.html
+++ b/css/css-text-decor/text-underline-offset-001.html
@@ -8,6 +8,7 @@
     <link rel="author" title="Mozilla" href="https://www.mozilla.org">
     <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
     <link rel="mismatch" href="reference/text-underline-offset-001-notref.html">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         #main {
             margin: 2em;

--- a/css/css-text-decor/text-underline-offset-002.html
+++ b/css/css-text-decor/text-underline-offset-002.html
@@ -7,6 +7,7 @@
     <link rel="author" title="Mozilla" href="https://www.mozilla.org">
     <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
     <link rel="match" href="reference/text-underline-offset-002-ref.html">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         #main{
             border-bottom: 1px solid cyan;

--- a/css/css-text-decor/text-underline-offset-scroll-001.html
+++ b/css/css-text-decor/text-underline-offset-scroll-001.html
@@ -9,6 +9,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
     <link rel="match" href="reference/text-underline-offset-scroll-001-ref.html">
     <link rel="mismatch" href="reference/text-underline-offset-scroll-001-notref.html">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         /*
          * Testing to make sure that positioning the underline

--- a/css/css-text-decor/text-underline-offset-vertical-001.html
+++ b/css/css-text-decor/text-underline-offset-vertical-001.html
@@ -8,6 +8,7 @@
     <link rel="author" title="Mozilla" href="https://www.mozilla.org">
     <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
     <link rel="match" href="reference/text-underline-offset-vertical-001-ref.html">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         span{
             margin-left: 5em;

--- a/css/css-text-decor/text-underline-offset-vertical-002.html
+++ b/css/css-text-decor/text-underline-offset-vertical-002.html
@@ -8,6 +8,7 @@
     <link rel="author" title="Mozilla" href="https://www.mozilla.org">
     <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
     <link rel="match" href="reference/text-underline-offset-vertical-002-ref.html">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
         div{
             font: 20px/1 Ahem;

--- a/css/css-text/hyphens/hyphens-overflow-001.html
+++ b/css/css-text/hyphens/hyphens-overflow-001.html
@@ -3,6 +3,7 @@
 <link rel="match" href="reference/hyphens-overflow-001-ref.html">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#hyphens-property">
 <link rel="author" href="mailto:kojii@chromium.org">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font-size: 10px;

--- a/css/css-text/hyphens/reference/hyphens-overflow-001-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-overflow-001-ref.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font-size: 10px;

--- a/css/css-text/tab-size/tab-size.html
+++ b/css/css-text/tab-size/tab-size.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>Test: CSS value type of the CSS property 'tab-size'</title>
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#tab-size-property">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 body {
   font-family: Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-001.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-001.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space at the beginning of the line are breaking opportunities when white-space is pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 50px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-002.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-002.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should be breaking opportunities when white-space is pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 25px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-003.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-003.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should be breaking opportunities when white-space is pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 25px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-004.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-004.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should not be collapsed, honoring white-space: pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 20px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-005.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-005.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should not be collapsed, honoring white-space: pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 20px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-006.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-006.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should not be collapsed, honoring white-space: pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 20px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-007.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-007.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should not be collapsed, honoring white-space: pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 20px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-008.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-008.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should not be collapsed, honoring white-space: pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 20px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-009.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-009.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should not be collapsed, honoring white-space: pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 20px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-010.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-010.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should not be collapsed, honoring white-space: pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 20px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-011.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-011.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should not be collapsed, honoring white-space: pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 20px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-012.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-012.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should be breaking opportunities when white-space is pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 25px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-013.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-013.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should be breaking opportunities when white-space is pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 25px/1 Ahem;

--- a/css/css-text/white-space/pre-wrap-leading-spaces-014.html
+++ b/css/css-text/white-space/pre-wrap-leading-spaces-014.html
@@ -8,6 +8,7 @@
 <link rel="match" href="reference/white-space-break-spaces-005-ref.html">
 <meta name="assert" content="Preserved white space after forced breaks become leading white-spaces and should be breaking opportunities when white-space is pre-wrap.">
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 20px/1 Ahem;

--- a/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-004-ref.html
+++ b/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-004-ref.html
@@ -3,6 +3,7 @@
 <title>CSS test Reference</title>
 <link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
 
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 25px/1 Ahem;

--- a/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-005.html
+++ b/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-005.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
 <link rel="match" href="reference/white-space-pre-wrap-trailing-spaces-004-ref.html">
 <meta name="assert" content="Preserved white space at the end of the line is hanged when white-space is pre-wrap.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 10px/1 Ahem;

--- a/css/css-ui/text-overflow-016.html
+++ b/css/css-ui/text-overflow-016.html
@@ -6,6 +6,7 @@
 <link rel="match" href="reference/text-overflow-016-ref.html">
 <meta name="flags" content="ahem">
 <meta name="assert" content="If there is insufficient space for the ellipsis, then clip the rendering of the ellipsis itself">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 .test, .test2 {
   overflow: hidden;

--- a/css/cssom-view/getBoundingClientRect-empty-inline.html
+++ b/css/cssom-view/getBoundingClientRect-empty-inline.html
@@ -3,6 +3,7 @@
 <link rel="author" title="Koji Ishii" href="mailto:kojii@chromium.org">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div {
   font: 10px/1 Ahem;
@@ -18,6 +19,7 @@ div {
     <span class="inline-block"></span>
   </div>
 <script>
+document.fonts.ready.then(() => {
 run(document.getElementById('empty'));
 function run(element) {
   test(() => {
@@ -28,5 +30,6 @@ function run(element) {
     assert_equals(rect.height, 10, "height");
   });
 }
+});
 </script>
 </body>

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -827,3 +827,137 @@ MISSING DEPENDENCY: web-nfc/resources/nfc-helpers.js
 MISSING DEPENDENCY: shape-detection/resources/shapedetection-helpers.js
 MISSING DEPENDENCY: webxr/resources/webxr_util.js
 MISSING DEPENDENCY: contacts/resources/helpers.js
+
+# Tests that are false positives for using Ahem as a system font
+AHEM SYSTEM FONT: acid/acid3/test.html
+AHEM SYSTEM FONT: resource-timing/resources/all_resource_types.htm
+AHEM SYSTEM FONT: resource-timing/resources/iframe-reload-TAO.sub.html
+
+# The following are imported from mozilla-central and can't be modified in WPT.
+# They do load Ahem as a web font, but they use their own copy which trips the
+# lint rule. Basically false positives.
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-003.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-031.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-034-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-044-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-028.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-030.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-038.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-004.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-029-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-020.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-removable-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-016-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-017-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-043-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-015-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/text-word-spacing-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-038-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-017.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-013.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-removable-4.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-031-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-039.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-044.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-025-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-removable-1.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-024.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-033.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-005.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-unremovable-3.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-042.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-036.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-047.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-012.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-021.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-unremovable-4.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-unremovable-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-010-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-006.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-036-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-024-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-removable-2.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-018.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-041-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-045.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-042-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-045-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-037-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-027-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-011-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-029.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-034.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-047-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-023.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-022-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-unremovable-2.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-039-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-016.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-002-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-049-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-005-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-022.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/text-word-spacing-001.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-048.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-033-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-removable-3.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-021-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-unremovable-1.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-001.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-025.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-009-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-046.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-040-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-008-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-015.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-019.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-030-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-043.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-023-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-002.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-027.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-006-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-004-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-035.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-049.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-028-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-001-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-032.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-035-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-014.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-019-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-018-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-011.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-008.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-037.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-020-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-032-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-026.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-040.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-003-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-007.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-041.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-014-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-046-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-010.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-009.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-013-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-048-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-012-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-026-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/text3/segment-break-transformation-rules-007-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/variables/variable-font-face-01-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/variables/variable-font-face-02-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/variables/variable-external-font-face-01-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-text-combine-upright-001b.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-text-combine-upright-001-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-text-combine-upright-002b.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-text-combine-upright-002-ref.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-text-combine-upright-001a.html
+AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/ruby/ruby-text-combine-upright-002a.html
+
+# TODO: The following should be deleted along with the Ahem web font cleanup
+# PR (https://github.com/web-platform-tests/wpt/pull/18702)
+AHEM SYSTEM FONT: infrastructure/assumptions/ahem-ref.html
+AHEM SYSTEM FONT: infrastructure/assumptions/ahem.html
+

--- a/mathml/presentation-markup/direction/direction-009-ref.html
+++ b/mathml/presentation-markup/direction/direction-009-ref.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8"/>
     <title>RTL ms lquote="X" rquote="p"</title>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
       math {
           font: 25px/1 Ahem;

--- a/preload/single-download-preload.html
+++ b/preload/single-download-preload.html
@@ -23,10 +23,10 @@
         background-image: url(resources/square.png?backgroundi&single-download-preload);
     }
     @font-face {
-      font-family:ahem;
+      font-family:myFont;
       src: url(/fonts/CanvasTest.ttf?single-download-preload);
     }
-    span { font-family: ahem, Arial; }
+    span { font-family: myFont, Arial; }
 </style>
 <link rel="stylesheet" href="resources/dummy.css?single-download-preload">
 <script src="resources/dummy.js?single-download-preload"></script>

--- a/quirks/reference/table-cell-width-calculation-abspos-ref.html
+++ b/quirks/reference/table-cell-width-calculation-abspos-ref.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 table {
   font-size: 10px;

--- a/quirks/table-cell-width-calculation-abspos.html
+++ b/quirks/table-cell-width-calculation-abspos.html
@@ -1,6 +1,7 @@
 <title>An out-of-flow imagef in the table cell width calculation quirk</title>
 <link rel="match" href="reference/table-cell-width-calculation-abspos-ref.html">
 <link rel="author" title="Koji Ishii" href="mailto:kojii@chromium.org">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 table {
   font-size: 10px;

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -680,6 +680,21 @@ def check_script_metadata(repo_root, path, f):
     return errors
 
 
+ahem_font_re = re.compile(b"font.*:.*ahem", flags=re.IGNORECASE)
+ahem_stylesheet_re = re.compile(b"\/fonts\/ahem\.css", flags=re.IGNORECASE)
+
+
+def check_ahem_system_font(repo_root, path, f):
+    # type: (str, str, IO[bytes]) -> List[rules.Error]
+    if not path.endswith((".html", ".htm", ".xht", ".xhtml")):
+        return []
+    contents = f.read()
+    errors = []
+    if ahem_font_re.search(contents) and not ahem_stylesheet_re.search(contents):
+        errors.append(rules.AhemSystemFont.error(path))
+    return errors
+
+
 def check_path(repo_root, path):
     # type: (str, str) -> List[rules.Error]
     """
@@ -918,7 +933,8 @@ def lint(repo_root, paths, output_format):
 path_lints = [check_file_type, check_path_length, check_worker_collision, check_ahem_copy,
               check_gitignore_file]
 all_paths_lints = [check_css_globally_unique]
-file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_metadata]
+file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_metadata,
+              check_ahem_system_font]
 
 # Don't break users of the lint that don't have git installed.
 try:

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -78,6 +78,11 @@ class AhemCopy(Rule):
     description = "Don't add extra copies of Ahem, use /fonts/Ahem.ttf"
 
 
+class AhemSystemFont(Rule):
+    name = "AHEM SYSTEM FONT"
+    description = "Don't use Ahem as a system font, use /fonts/ahem.css"
+
+
 # TODO: Add tests for this rule
 class IgnoredPath(Rule):
     name = "IGNORED PATH"

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -677,6 +677,45 @@ def test_print_function():
             assert errors == []
 
 
+def test_ahem_system_font():
+    code = b"""\
+<html>
+<style>
+body {
+  font-family: aHEm, sans-serif;
+}
+</style>
+</html>
+"""
+    error_map = check_with_files(code)
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if filename.endswith((".htm", ".html", ".xht", ".xhtml")):
+            assert errors == [
+                ("AHEM SYSTEM FONT", "Don't use Ahem as a system font, use /fonts/ahem.css", filename, None)
+            ]
+
+
+def test_ahem_web_font():
+    code = b"""\
+<html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+body {
+  font-family: aHEm, sans-serif;
+}
+</style>
+</html>
+"""
+    error_map = check_with_files(code)
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        if filename.endswith((".htm", ".html", ".xht", ".xhtml")):
+            assert errors == []
+
+
 open_mode_code = """
 def first():
     return {0}("test.png")

--- a/webvtt/rendering/cues-with-video/processing-model/2_tracks-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_tracks-ref.html
@@ -2,6 +2,7 @@
 <html class="reftest-wait">
 <title>Reference for WebVTT rendering, 2 tracks enabled at the same time</title>
 <script src="/common/reftest-wait.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/webvtt/rendering/cues-with-video/processing-model/2_tracks.html
+++ b/webvtt/rendering/cues-with-video/processing-model/2_tracks.html
@@ -2,6 +2,7 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, 2 tracks enabled at the same time</title>
 <link rel="match" href="2_tracks-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/webvtt/rendering/cues-with-video/processing-model/3_tracks-ref.html
+++ b/webvtt/rendering/cues-with-video/processing-model/3_tracks-ref.html
@@ -2,6 +2,7 @@
 <html class="reftest-wait">
 <title>Reference for WebVTT rendering, 3 tracks enabled at the same time</title>
 <script src="/common/reftest-wait.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/webvtt/rendering/cues-with-video/processing-model/3_tracks.html
+++ b/webvtt/rendering/cues-with-video/processing-model/3_tracks.html
@@ -2,6 +2,7 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, 3 tracks enabled at the same time</title>
 <link rel="match" href="3_tracks-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }


### PR DESCRIPTION
Add a lint rule to check for tests that use the Ahem font but do not
include the /fonts/ahem.css stylesheet (which loads this font as a web
font). This prevents tests from assuming that Ahem is installed as a
system font. Also includes some unit tests.

There are a few tests that are incorrectly flagged as violating this
rule, these were added to lint.whitelist.

A bunch of other tests were fixed to load Ahem as a web font.
