### PR TITLE
[wpt] Discard stderr when calling git

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -51,7 +51,7 @@ def get_git_cmd(repo_path):
         full_cmd = [u"git", cmd] + list(item.decode("utf8") if isinstance(item, bytes) else item for item in args)  # type: List[Text]
         try:
             logger.debug(" ".join(full_cmd))
-            return subprocess.check_output(full_cmd, cwd=repo_path, stderr=subprocess.STDOUT).decode("utf8").strip()
+            return subprocess.check_output(full_cmd, cwd=repo_path).decode("utf8").strip()
         except subprocess.CalledProcessError as e:
             logger.error("Git command exited with status %i" % e.returncode)
             logger.error(e.output)


### PR DESCRIPTION
git occasionally prints warning messages to stderr (e.g. when too many
files are modified and rename detection is disabled), which would mess
with the output parsing if they are redirected to stdout.

Fixes #18608 and #18860 .