### PR TITLE
[css-transform] Fix link to transform-origin spec

### DIFF
--- a/css/css-transforms/animation/rotate-interpolation.html
+++ b/css/css-transforms/animation/rotate-interpolation.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>rotate interpolation</title>
-    <link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
     <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-rotate">
     <meta name="assert" content="rotate supports animation.">
     <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/animation/scale-interpolation.html
+++ b/css/css-transforms/animation/scale-interpolation.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>scale interpolation</title>
-    <link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
     <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">
     <meta name="assert" content="scale supports animation.">
     <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/animation/translate-interpolation.html
+++ b/css/css-transforms/animation/translate-interpolation.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>translate interpolation</title>
-    <link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
     <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">
     <meta name="assert" content="translate supports <length> and <percentage> animation.">
     <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/perspective-origin-invalid.html
+++ b/css/css-transforms/parsing/perspective-origin-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing perspective-origin with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#perspective-origin-property">
 <meta name="assert" content="perspective-origin supports only the '<position>' grammar.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/perspective-origin-valid.html
+++ b/css/css-transforms/parsing/perspective-origin-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing perspective-origin with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#perspective-origin-property">
 <meta name="assert" content="perspective-origin supports the full '<position>' grammar.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/rotate-parsing-invalid.html
+++ b/css/css-transforms/parsing/rotate-parsing-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing rotate with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-rotate">
 <meta name="assert" content="rotate supports only the grammar 'none | <number>{3}? <angle>'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/rotate-parsing-valid.html
+++ b/css/css-transforms/parsing/rotate-parsing-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing rotate with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-rotate">
 <meta name="assert" content="rotate supports the full grammar 'none | <number>{3}? <angle>'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/scale-parsing-invalid.html
+++ b/css/css-transforms/parsing/scale-parsing-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing scale with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">
 <meta name="assert" content="scale supports only the grammar 'none | <number>{1,3}'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/scale-parsing-valid.html
+++ b/css/css-transforms/parsing/scale-parsing-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing scale with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">
 <meta name="assert" content="scale supports the full grammar 'none | <number>{1,3}'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/transform-box-invalid.html
+++ b/css/css-transforms/parsing/transform-box-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 1: parsing transform-box with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-box-property">
 <meta name="assert" content="transform-box supports only the grammar 'content-box | border-box | fill-box | stroke-box | view-box'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/transform-box-valid.html
+++ b/css/css-transforms/parsing/transform-box-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 1: parsing transform-box with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-box-property">
 <meta name="assert" content="transform-box supports the full grammar 'content-box | border-box | fill-box | stroke-box | view-box'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/transform-invalid.html
+++ b/css/css-transforms/parsing/transform-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing transform with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#transform-property">
 <meta name="assert" content="transform supports only the grammar 'none | <transform-list>'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/transform-origin-computed.html
+++ b/css/css-transforms/parsing/transform-origin-computed.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: getComputedStyle().transformOrigin</title>
-<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#transform-origin-property">
+<link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-origin-property">
 <meta name="assert" content="transform-origin computed value is two or three absolute lengths">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-transforms/parsing/transform-origin-invalid.html
+++ b/css/css-transforms/parsing/transform-origin-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 1: parsing transform-origin with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-origin-property">
 <meta name="assert" content="transform-origin supports only the grammar from spec.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/transform-origin-valid.html
+++ b/css/css-transforms/parsing/transform-origin-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 1: parsing transform-origin with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms/#transform-origin-property">
 <meta name="assert" content="transform-origin supports the full grammar from spec.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/transform-valid.html
+++ b/css/css-transforms/parsing/transform-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing transform with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#transform-property">
 <meta name="assert" content="transform supports the full grammar 'none | <transform-list>'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/translate-parsing-invalid.html
+++ b/css/css-transforms/parsing/translate-parsing-invalid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing translate with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">
 <meta name="assert" content="translate supports only the grammar 'none | <length-percentage> [ <length-percentage> <length>? ]?'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/parsing/translate-parsing-valid.html
+++ b/css/css-transforms/parsing/translate-parsing-valid.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: parsing translate with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">
 <meta name="assert" content="translate supports the full grammar 'none | <length-percentage> [ <length-percentage> <length>? ]?'.">
 <script src="/resources/testharness.js"></script>

--- a/css/css-transforms/transforms-support-calc.html
+++ b/css/css-transforms/transforms-support-calc.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Transform Module Level 2: calc values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-transforms-2/">
 <link rel="help" href="https://drafts.csswg.org/css-values-3/#calc-notation">
 <meta name="assert" content="calc values are supported in css-transforms properties.">

--- a/css/css-transforms/translate-getComputedStyle.html
+++ b/css/css-transforms/translate-getComputedStyle.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>CSS Transform Module Level 2: translate getComputedStyle</title>
-  <link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
   <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">
   <meta name="assert" content="translate computed style does not resolve percentages.">
   <style type="text/css">


### PR DESCRIPTION
transform-origin is in CSS Transforms 1
https://drafts.csswg.org/css-transforms/#transform-origin-property

Remove unnecessary author tags.