### PR TITLE
[docs] Remove duplicated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,27 +251,3 @@ If you spot an issue with a test and are not comfortable providing a
 pull request per above to fix it, please
 [file a new issue](https://github.com/web-platform-tests/wpt/issues/new).
 Thank you!
-
-Lint tool
----------
-
-We have a lint tool for catching common mistakes in test files. You
-can run it manually by starting the `lint` executable from the root of
-your local web-platform-tests working directory like this:
-
-```
-./wpt lint
-```
-
-The lint tool is also run automatically for every submitted pull
-request, and reviewers will not merge branches with tests that have
-lint errors, so you must fix any errors the lint tool reports.
-
-In the unusual case of error reports for things essential to a
-certain test or that for other exceptional reasons shouldn't prevent
-a merge of a test, update and commit the `lint.whitelist` file in the
-web-platform-tests root directory to suppress the error reports.
-
-For more details, see the [lint-tool documentation][lint-tool].
-
-[lint-tool]: https://web-platform-tests.org/writing-tests/lint-tool.html


### PR DESCRIPTION
Prior to this commit, an explanation of the project's linting tool was
available in both the project "readme" file and the project's "docs/"
directory. This duplication was susceptible to synchronization problems,
as evidenced by the readme's reference to an executable file which was
deleted two years ago [1].

In general, it's preferable to store technical instruction in the
"docs/" directory because of its hierarchical structure; the project's
web site is generated based on that structure, offering visitors a more
approachable way to traverse the information. The "flat" nature of the
readme file makes it less ideal for conveying information to a wide and
varied audience.

Remove the discussion of the linting tool from the "readme" file. This
removal does not reduce the amount of information available because the
same instructions are already present in the relevant location within
the `docs/` directory.

[1] 555c9bd074e6cb3ec96db11a9091d4a2d03c6879