### PR TITLE
Sync Mozilla CSS tests as of 2019-09-07

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-001-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="longbox"></div>  <!-- Saturate the margin space -->
     <div class="shape"></div>
     <div class="box"></div>
@@ -58,5 +58,5 @@
     <div class="box"></div>
     <div class="box"></div>
     <div class="longbox"></div>  <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-001.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
@@ -62,5 +62,5 @@
     <div class="box"></div>
     <div class="box"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-002-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="longbox"></div>  <!-- Saturate the margin space -->
     <div class="shape"></div>
     <div class="box"></div>
@@ -59,5 +59,5 @@
     <div class="box"></div>
     <div class="box"></div>
     <div class="longbox"></div>  <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-002.html
@@ -45,7 +45,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
@@ -63,5 +63,5 @@
     <div class="box"></div>
     <div class="box"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-001-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="top: 0; left: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="height: 24px; top: 20px; left: 128px;"></div> <!-- Box at corner -->
@@ -49,5 +49,5 @@
     <div class="box" style="height: 36px; top: 80px; left: 140px;"></div>
     <div class="box" style="height: 24px; top: 116px; left: 128px;"></div> <!-- Box at corner -->
     <div class="longbox" style="top: 140px; left: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-001.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
@@ -52,5 +52,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-002-ref.html
@@ -33,11 +33,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; left: 108px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px; top: 24px; left: 120px;"></div>
     <div class="box" style="height: 36px; top: 60px; left: 120px;"></div>
     <div class="box" style="height: 24px; top: 96px; left: 108px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-002.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-003-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-003-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="top: 0; right: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="height: 24px; top: 20px; right: 128px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="height: 36px; top: 80px; right: 140px;"></div>
     <div class="box" style="height: 24px; top: 116px; right: 128px;"></div> <!-- Box at corner -->
     <div class="longbox" style="top: 140px; right: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-003.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-003.html
@@ -45,7 +45,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-004-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-004-ref.html
@@ -34,11 +34,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; right: 108px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px; top: 24px; right: 120px;"></div>
     <div class="box" style="height: 36px; top: 60px; right: 120px;"></div>
     <div class="box" style="height: 24px; top: 96px; right: 108px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-004.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-005-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-005-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 128px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
     <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-005.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-005.html
@@ -45,7 +45,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-006-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-006-ref.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 128px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
     <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-006.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-006.html
@@ -46,7 +46,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -54,5 +54,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-007-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-007-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
     <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-007.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-007.html
@@ -45,7 +45,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-008-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-008-ref.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
     <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-008.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-008.html
@@ -46,7 +46,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -54,5 +54,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-009-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-009-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
     <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-009.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-009.html
@@ -45,7 +45,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-010-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-010-ref.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
     <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-010.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-010.html
@@ -46,7 +46,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -54,5 +54,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-011-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-011-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
     <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-011.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-011.html
@@ -45,7 +45,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-012-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-012-ref.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
     <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-012.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-012.html
@@ -46,7 +46,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -54,5 +54,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-032-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-032-ref.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box" style="height: 36px; top: 0px; left: 60px;"></div>
@@ -47,5 +47,5 @@
     <div class="box" style="height: 36px; top: 120px; left: 60px;"></div>
     <div class="box" style="height: 12px; top: 156px; left: 48px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 168px; left: 36px;"></div>  <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-032.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-032.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box" style="height: 36px;"></div>
@@ -50,5 +50,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-033-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-033-ref.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="long box" style="height: 60px; top: 0px; left: 0px;"></div> <!-- Fill the space above the first float -->
@@ -48,5 +48,5 @@
     <div class="box" style="height: 36px; top: 180px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 216px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 228px; left: 120px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-033.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-033.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="long box" style="height: 60px;"></div> <!-- Fill the space above the first float -->
@@ -51,5 +51,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div>
     <div class="box" style="height: 12px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-034-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-034-ref.html
@@ -38,7 +38,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box" style="height: 36px; top: 0px; right: 60px;"></div>
@@ -48,5 +48,5 @@
     <div class="box" style="height: 36px; top: 120px; right: 60px;"></div>
     <div class="box" style="height: 12px; top: 156px; right: 48px;"></div>
     <div class="box" style="height: 12px; top: 168px; right: 36px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-034.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-034.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box" style="height: 36px;"></div>
@@ -51,5 +51,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div>
     <div class="box" style="height: 12px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-035-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-035-ref.html
@@ -38,7 +38,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="long box" style="height: 60px; top: 0px; right: 0px;"></div> <!-- Fill the space above the first float -->
@@ -49,5 +49,5 @@
     <div class="box" style="height: 36px; top: 180px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 216px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 228px; right: 120px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-035.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-035.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="long box" style="height: 60px;"></div> <!-- Fill the space above the first float -->
@@ -52,5 +52,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div>
     <div class="box" style="height: 12px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-036-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-036-ref.html
@@ -33,7 +33,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px; top: 0px; left: 96px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 12px; left: 108px;"></div> <!-- Box at corner -->
@@ -41,5 +41,5 @@
     <div class="box" style="height: 36px; top: 60px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 96px; left: 108px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 108px; left: 96px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-036.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-036.html
@@ -36,7 +36,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -44,5 +44,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-037.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-037.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -45,5 +45,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-038.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-038.html
@@ -36,7 +36,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -44,5 +44,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-041-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-041-ref.html
@@ -33,7 +33,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px; top: 0px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 12px; left: 120px;"></div>
@@ -41,5 +41,5 @@
     <div class="box" style="height: 36px; top: 60px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 96px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 108px; left: 120px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-041.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-041.html
@@ -36,7 +36,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div>
     <div class="box" style="height: 12px;"></div>
@@ -44,5 +44,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div>
     <div class="box" style="height: 12px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-042-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-042-ref.html
@@ -34,7 +34,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px; top: 0px; right: 96px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 12px; right: 108px;"></div> <!-- Box at corner -->
@@ -42,5 +42,5 @@
     <div class="box" style="height: 36px; top: 60px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 96px; right: 108px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 108px; right: 96px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-042.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-042.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -45,5 +45,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-043.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-043.html
@@ -38,7 +38,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -46,5 +46,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-044.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-044.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -45,5 +45,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-047-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-047-ref.html
@@ -34,7 +34,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px; top: 0px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 12px; right: 120px;"></div>
@@ -42,5 +42,5 @@
     <div class="box" style="height: 36px; top: 60px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 96px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 108px; right: 120px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-047.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-047.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div>
     <div class="box" style="height: 12px;"></div>
@@ -45,5 +45,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div>
     <div class="box" style="height: 12px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-048-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-048-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-048.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-048.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
@@ -52,5 +52,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-049-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-049-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-049.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-049.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-050-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-050-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-050.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-050.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
@@ -52,5 +52,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-051-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-051-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-051.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-051.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-052-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-052-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-052.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-052.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
@@ -52,5 +52,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-053-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-053-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-053.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-053.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-054-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-054-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-054.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-054.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
@@ -52,5 +52,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-055-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-055-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-055.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-055.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 20px;"></div> <!-- Fill the border area due to the circle shifted -->
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 12px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 20px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-001-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the padding space -->
@@ -58,5 +58,5 @@
     <div class="longbox"></div> <!-- Saturate the padding space -->
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-001.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
@@ -62,5 +62,5 @@
     <div class="longbox"></div> <!-- Saturate the padding space -->
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-002-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the padding space -->
@@ -59,5 +59,5 @@
     <div class="longbox"></div> <!-- Saturate the padding space -->
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-002.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
@@ -62,5 +62,5 @@
     <div class="longbox"></div> <!-- Saturate the padding space -->
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-border-radius-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-border-radius-001-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="top: 0; left: 0;"></div> <!-- Saturate the margin and border space -->
     <div class="box" style="height: 24px; top: 20px; left: 128px;"></div> <!-- Box at corner -->
@@ -49,5 +49,5 @@
     <div class="box" style="height: 36px; top: 80px; left: 140px;"></div>
     <div class="box" style="height: 24px; top: 116px; left: 128px;"></div> <!-- Box at corner -->
     <div class="longbox" style="top: 140px; left: 0;"></div> <!-- Saturate the margin and border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-border-radius-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-border-radius-001.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin and border space -->
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
@@ -52,5 +52,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin and border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-border-radius-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-border-radius-002-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="top: 0; right: 0;"></div> <!-- Saturate the margin and border space -->
     <div class="box" style="height: 24px; top: 20px; right: 128px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="height: 36px; top: 80px; right: 140px;"></div>
     <div class="box" style="height: 24px; top: 116px; right: 128px;"></div> <!-- Box at corner -->
     <div class="longbox" style="top: 140px; right: 0;"></div> <!-- Saturate the margin and border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-border-radius-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-content-box-border-radius-002.html
@@ -45,7 +45,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin and border space -->
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin and border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-032-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-032-ref.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box" style="height: 36px; top: 0px; left: 40px;"></div>
@@ -45,5 +45,5 @@
     <div class="long box" style="height: 60px; top: 60px; left: 0px;"></div> <!-- Fill the space between two floats -->
     <div class="box" style="height: 36px; top: 120px; left: 40px;"></div>
     <div class="box" style="height: 24px; top: 156px; left: 32px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-032.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-032.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box" style="height: 36px;"></div>
@@ -48,5 +48,5 @@
     <div class="long box" style="height: 60px;"></div> <!-- Fill the space between two floats -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-033-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-033-ref.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="long box" style="height: 60px; top: 0px; left: 0px;"></div> <!-- Fill the space above the first float -->
@@ -48,5 +48,5 @@
     <div class="box" style="height: 36px; top: 180px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 216px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 228px; left: 120px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-033.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-033.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="long box" style="height: 60px;"></div> <!-- Fill the space above the first float -->
@@ -51,5 +51,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div>
     <div class="box" style="height: 12px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-034-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-034-ref.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box" style="height: 36px; top: 0px; right: 40px;"></div>
@@ -45,5 +45,5 @@
     <div class="long box" style="height: 60px; top: 60px; right: 0px;"></div> <!-- Fill the space between two floats -->
     <div class="box" style="height: 36px; top: 120px; right: 40px;"></div>
     <div class="box" style="height: 24px; top: 156px; right: 32px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-034.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-034.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box" style="height: 36px;"></div>
@@ -49,5 +49,5 @@
     <div class="long box" style="height: 60px;"></div> <!-- Fill the space between two floats -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-035-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-035-ref.html
@@ -38,7 +38,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="long box" style="height: 60px; top: 0px; right: 0px;"></div> <!-- Fill the space above the first float -->
@@ -49,5 +49,5 @@
     <div class="box" style="height: 36px; top: 180px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 216px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 228px; right: 120px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-035.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-035.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="long box" style="height: 60px;"></div> <!-- Fill the space above the first float -->
@@ -52,5 +52,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div>
     <div class="box" style="height: 12px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-036-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-036-ref.html
@@ -34,11 +34,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; left: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px; top: 24px; left: 80px;"></div>
     <div class="box" style="height: 36px; top: 60px; left: 80px;"></div>
     <div class="box" style="height: 24px; top: 96px; left: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-036.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-036.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-037-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-037-ref.html
@@ -34,11 +34,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; left: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px; top: 24px; left: 80px;"></div>
     <div class="box" style="height: 36px; top: 60px; left: 80px;"></div>
     <div class="box" style="height: 24px; top: 96px; left: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-037.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-037.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-038-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-038-ref.html
@@ -35,11 +35,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; right: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px; top: 24px; right: 80px;"></div>
     <div class="box" style="height: 36px; top: 60px; right: 80px;"></div>
     <div class="box" style="height: 24px; top: 96px; right: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-038.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-038.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-039-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-039-ref.html
@@ -34,11 +34,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; right: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px; top: 24px; right: 80px;"></div>
     <div class="box" style="height: 36px; top: 60px; right: 80px;"></div>
     <div class="box" style="height: 24px; top: 96px; right: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-039.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-039.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-040-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-040-ref.html
@@ -34,11 +34,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; left: 0px;"></div>
     <div class="box" style="height: 36px; top: 24px; left: 0px;"></div>
     <div class="box" style="height: 36px; top: 60px; left: 0px;"></div>
     <div class="box" style="height: 24px; top: 96px; left: 0px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-040.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-040.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-041.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-041.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-042-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-042-ref.html
@@ -35,11 +35,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; right: 0px;"></div>
     <div class="box" style="height: 36px; top: 24px; right: 0px;"></div>
     <div class="box" style="height: 36px; top: 60px; right: 0px;"></div>
     <div class="box" style="height: 24px; top: 96px; right: 0px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-042.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-042.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-043.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-043.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-044-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-044-ref.html
@@ -34,11 +34,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; left: 80px;"></div>
     <div class="box" style="height: 36px; top: 24px; left: 80px;"></div>
     <div class="box" style="height: 36px; top: 60px; left: 80px;"></div>
     <div class="box" style="height: 24px; top: 96px; left: 80px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-044.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-044.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-045-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-045-ref.html
@@ -35,11 +35,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; right: 80px;"></div>
     <div class="box" style="height: 36px; top: 24px; right: 80px;"></div>
     <div class="box" style="height: 36px; top: 60px; right: 80px;"></div>
     <div class="box" style="height: 24px; top: 96px; right: 80px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-045.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-045.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-046-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-046-ref.html
@@ -36,11 +36,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-046.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-046.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-047-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-047-ref.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-047.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-047.html
@@ -39,11 +39,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-048-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-048-ref.html
@@ -36,11 +36,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-048.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-048.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-049-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-049-ref.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-049.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-049.html
@@ -39,11 +39,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-050-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-050-ref.html
@@ -36,11 +36,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-050.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-050.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-051-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-051-ref.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-051.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-051.html
@@ -39,11 +39,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-016-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-016-ref.html
@@ -38,11 +38,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="height: 40px; top: 0; left: 0;"></div> <!-- Fill the margin and inset space -->
     <div class="box" style="height: 40px; top: 40px; left: 120px;"></div>
     <div class="box" style="height: 40px; top: 80px; left: 120px;"></div>
     <div class="long box" style="height: 40px; top: 120px; left: 0;"></div> <!-- Fill the margin and inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-016.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-016.html
@@ -41,11 +41,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="height: 40px;"></div> <!-- Fill the margin and inset space -->
     <div class="box" style="height: 40px;"></div>
     <div class="box" style="height: 40px;"></div>
     <div class="long box" style="height: 40px;"></div> <!-- Fill the margin and inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-017-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-017-ref.html
@@ -39,11 +39,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="height: 40px; top: 0; right: 0;"></div> <!-- Fill the margin and inset space -->
     <div class="box" style="height: 40px; top: 40px; right: 120px;"></div>
     <div class="box" style="height: 40px; top: 80px; right: 120px;"></div>
     <div class="long box" style="height: 40px; top: 120px; right: 0;"></div> <!-- Fill the margin and inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-017.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-017.html
@@ -42,11 +42,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="height: 40px;"></div> <!-- Fill the margin and inset space -->
     <div class="box" style="height: 40px;"></div>
     <div class="box" style="height: 40px;"></div>
     <div class="long box" style="height: 40px;"></div> <!-- Fill the margin and inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-020-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-020-ref.html
@@ -39,7 +39,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
@@ -47,5 +47,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-020.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-020.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-021-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-021-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
@@ -48,5 +48,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-021.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-021.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-022-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-022-ref.html
@@ -39,7 +39,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
@@ -47,5 +47,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-022.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-022.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-023-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-023-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
@@ -48,5 +48,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-023.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-023.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-024-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-024-ref.html
@@ -39,7 +39,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
@@ -47,5 +47,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-024.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-024.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-025-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-025-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
@@ -48,5 +48,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-025.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-025.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-026-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-026-ref.html
@@ -39,7 +39,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
@@ -47,5 +47,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-026.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-026.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-027-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-027-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
@@ -48,5 +48,5 @@
     <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
     <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-027.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-027.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 36px;"></div>
     <div class="box" style="block-size: 24px;"></div> <!-- Box at corner -->
     <div class="long box" style="block-size: 10px;"></div> <!-- Fill the inset space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-001-ref.html
@@ -33,7 +33,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box"></div>
@@ -50,5 +50,5 @@
     <div class="box"></div>
     <div class="box"></div>
     <div class="box"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-001.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box"></div>
@@ -54,5 +54,5 @@
     <div class="box"></div>
     <div class="box"></div>
     <div class="box"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-002-ref.html
@@ -34,7 +34,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box"></div>
@@ -51,5 +51,5 @@
     <div class="box"></div>
     <div class="box"></div>
     <div class="box"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-002.html
@@ -38,7 +38,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="box"></div>
@@ -55,5 +55,5 @@
     <div class="box"></div>
     <div class="box"></div>
     <div class="box"></div>
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-001-ref.html
@@ -34,7 +34,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px; top: 0px; left: 96px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 12px; left: 108px;"></div> <!-- Box at corner -->
@@ -42,5 +42,5 @@
     <div class="box" style="height: 36px; top: 60px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 96px; left: 108px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 108px; left: 96px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-001.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -45,5 +45,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-002-ref.html
@@ -34,11 +34,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; left: 108px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px; top: 24px; left: 120px;"></div>
     <div class="box" style="height: 36px; top: 60px; left: 120px;"></div>
     <div class="box" style="height: 24px; top: 96px; left: 108px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-002.html
@@ -37,11 +37,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-003-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-003-ref.html
@@ -35,7 +35,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px; top: 0px; right: 96px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 12px; right: 108px;"></div> <!-- Box at corner -->
@@ -43,5 +43,5 @@
     <div class="box" style="height: 36px; top: 60px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 96px; right: 108px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 108px; right: 96px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-003.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-003.html
@@ -38,7 +38,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -46,5 +46,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-004-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-004-ref.html
@@ -42,11 +42,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px; top: 0px; right: 108px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px; top: 24px; right: 120px;"></div>
     <div class="box" style="height: 36px; top: 60px; right: 120px;"></div>
     <div class="box" style="height: 24px; top: 96px; right: 108px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-004.html
@@ -45,11 +45,11 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-005-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-005-ref.html
@@ -34,7 +34,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px; top: 0px; left: 96px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 12px; left: 108px;"></div> <!-- Box at corner -->
@@ -42,5 +42,5 @@
     <div class="box" style="height: 36px; top: 60px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 96px; left: 120px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 108px; left: 120px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-005.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-005.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -45,5 +45,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-006-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-006-ref.html
@@ -34,7 +34,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px; top: 0px; left: 120px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 12px; left: 120px;"></div> <!-- Box at corner -->
@@ -42,5 +42,5 @@
     <div class="box" style="height: 36px; top: 60px; left: 120px;"></div>
     <div class="box" style="height: 12px; top: 96px; left: 108px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 108px; left: 96px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-006.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-006.html
@@ -37,7 +37,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
@@ -45,5 +45,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-008.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-008.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="bfc">
+  <main class="bfc">
     <span class="container">
       <div class="shape"></div>
     </span>
@@ -53,5 +53,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-001-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="shape"></div>
@@ -58,5 +58,5 @@
     <div class="box"></div>
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-001.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
@@ -62,5 +62,5 @@
     <div class="box"></div>
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-002-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="longbox"></div> <!-- Saturate the margin space -->
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="shape"></div>
@@ -59,5 +59,5 @@
     <div class="box"></div>
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-002.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin space -->
@@ -62,5 +62,5 @@
     <div class="box"></div>
     <div class="longbox"></div> <!-- Saturate the border space -->
     <div class="longbox"></div> <!-- Saturate the margin space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-border-radius-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-border-radius-001-ref.html
@@ -41,7 +41,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="top: 0; left: 0;"></div> <!-- Saturate the margin and border space -->
     <div class="box" style="height: 24px; top: 20px; left: 128px;"></div> <!-- Box at corner -->
@@ -49,5 +49,5 @@
     <div class="box" style="height: 36px; top: 80px; left: 140px;"></div>
     <div class="box" style="height: 24px; top: 116px; left: 128px;"></div> <!-- Box at corner -->
     <div class="longbox" style="top: 140px; left: 0;"></div> <!-- Saturate the margin and border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-border-radius-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-border-radius-001.html
@@ -44,7 +44,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin and border space -->
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
@@ -52,5 +52,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin and border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-border-radius-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-border-radius-002-ref.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox" style="top: 0; right: 0;"></div> <!-- Saturate the margin and border space -->
     <div class="box" style="height: 24px; top: 20px; right: 128px;"></div> <!-- Box at corner -->
@@ -50,5 +50,5 @@
     <div class="box" style="height: 36px; top: 80px; right: 140px;"></div>
     <div class="box" style="height: 24px; top: 116px; right: 128px;"></div> <!-- Box at corner -->
     <div class="longbox" style="top: 140px; right: 0;"></div> <!-- Saturate the margin and border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-border-radius-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-padding-box-border-radius-002.html
@@ -45,7 +45,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="longbox"></div> <!-- Saturate the margin and border space -->
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
@@ -53,5 +53,5 @@
     <div class="box" style="height: 36px;"></div>
     <div class="box" style="height: 24px;"></div> <!-- Box at corner -->
     <div class="longbox"></div> <!-- Saturate the margin and border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-018-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-018-ref.html
@@ -39,7 +39,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="height: 30px; top: 0; left: 0;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="height: 30px; top: 30px; left: 100px;"></div>
@@ -47,5 +47,5 @@
     <div class="box" style="height: 20px; top: 80px; left: 80px;"></div>
     <div class="box" style="height: 30px; top: 100px; left: 80px;"></div>
     <div class="long box" style="height: 30px; top: 130px; left: 0;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-018.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-018.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="height: 30px;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="height: 30px;"></div>
@@ -50,5 +50,5 @@
     <div class="box" style="height: 20px;"></div>
     <div class="box" style="height: 30px;"></div>
     <div class="long box" style="height: 30px;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-019-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-019-ref.html
@@ -39,7 +39,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="height: 30px; top: 0; right: 0;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="height: 30px; top: 30px; right: 80px;"></div>
@@ -47,5 +47,5 @@
     <div class="box" style="height: 20px; top: 80px; right: 120px;"></div>
     <div class="box" style="height: 30px; top: 100px; right: 100px;"></div>
     <div class="long box" style="height: 30px; top: 130px; right: 0;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-019.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-019.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="height: 30px;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="height: 30px;"></div>
@@ -51,5 +51,5 @@
     <div class="box" style="height: 20px;"></div>
     <div class="box" style="height: 30px;"></div>
     <div class="long box" style="height: 30px;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-020-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-020-ref.html
@@ -39,7 +39,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 80px;"></div>
@@ -47,5 +47,5 @@
     <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 100px;"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-020.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-020.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px;"></div>
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 20px;"></div>
     <div class="box" style="block-size: 30px;"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-021-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-021-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 100px;"></div>
@@ -48,5 +48,5 @@
     <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 80px;"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-021.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-021.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px;"></div>
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 20px;"></div>
     <div class="box" style="block-size: 30px;"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-022-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-022-ref.html
@@ -39,7 +39,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 100px;"></div>
@@ -47,5 +47,5 @@
     <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 80px;"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-022.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-022.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px;"></div>
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 20px;"></div>
     <div class="box" style="block-size: 30px;"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-023-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-023-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 80px;"></div>
@@ -48,5 +48,5 @@
     <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 100px;"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-023.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-023.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px;"></div>
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 20px;"></div>
     <div class="box" style="block-size: 30px;"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-024-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-024-ref.html
@@ -39,7 +39,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 80px;"></div>
@@ -47,5 +47,5 @@
     <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
     <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 100px;"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-024.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-024.html
@@ -42,7 +42,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px;"></div>
@@ -50,5 +50,5 @@
     <div class="box" style="block-size: 20px;"></div>
     <div class="box" style="block-size: 30px;"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-025-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-025-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 100px;"></div>
@@ -48,5 +48,5 @@
     <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 80px;"></div>
     <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 80px;"></div>
     <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-025.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-025.html
@@ -43,7 +43,7 @@
   }
   </style>
 
-  <body class="container">
+  <main class="container">
     <div class="shape"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
     <div class="box" style="block-size: 30px;"></div>
@@ -51,5 +51,5 @@
     <div class="box" style="block-size: 20px;"></div>
     <div class="box" style="block-size: 30px;"></div>
     <div class="long box" style="block-size: 30px;"></div> <!-- Fill the margin and partial border space -->
-  </body>
+  </main>
 </html>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/7f0c7ef868ff063e9953b4a1111f3b96da9cd335 .

This contains changes from [bug 1579295](https://bugzilla.mozilla.org/show_bug.cgi?id=1579295) by @aethanyc, reviewed by @jfkthame.