### PR TITLE
[GitHub Actions] trigger push workflows on push to master only

### DIFF
--- a/.github/workflows/push-build-publish-documentation-website.yml
+++ b/.github/workflows/push-build-publish-documentation-website.yml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches:
+      - master
 name: Build & Publish Documentation Website
 jobs:
   website-build-and-publish:

--- a/.github/workflows/push-build-release-manifest.yml
+++ b/.github/workflows/push-build-release-manifest.yml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches:
+      - master
 name: Build & Release Manifest
 jobs:
   manifest-build-and-tag:


### PR DESCRIPTION
These are being triggered on pushes to all branches now, including
epochs/* and triggers/* branches. That's not useful.