### PR TITLE
Put GitHub event data in task.extra and download it

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -76,8 +76,6 @@ tasks:
                   public/results:
                     path: /home/test/artifacts
                     type: directory
-                env:
-                    TASK_EVENT: "${event_str}"
                 command:
                   - /bin/bash
                   - --login
@@ -106,6 +104,9 @@ tasks:
                         --test-type=${chunk[0]}
                         --this-chunk=${chunk[1]}
                         --total-chunks=${chunk[2]};
+              extra:
+                github_event: "${event_str}"
+
       - $if: tasks_for == "github-pull-request"
         # PR tasks that run the tests in various configurations
         then:
@@ -168,8 +169,6 @@ tasks:
                     public/results:
                       path: /home/test/artifacts
                       type: directory
-                  env:
-                    TASK_EVENT: "${event_str}"
                   # Fetch the GitHub-provided merge commit (rather than the pull
                   # request branch) so that the tasks simulate the behavior of the
                   # submitted patch after it is merged. Using the merge commit also
@@ -199,6 +198,9 @@ tasks:
                           --
                           --channel=${browser.channel}
                           ${operation.extra_args};
+                extra:
+                  github_event: "${event_str}"
+
       - $map:
           # This is the main point to define new CI checks other than stability checks
         - name: lint
@@ -334,8 +336,6 @@ tasks:
                     public/results:
                       path: /home/test/artifacts
                       type: directory
-                  env:
-                    TASK_EVENT: "${event_str}"
                   command:
                     - /bin/bash
                     - --login
@@ -347,3 +347,5 @@ tasks:
                         ${checkout_ref};
                       cd ~/web-platform-tests;
                       ${operation.script};
+                extra:
+                  github_event: "${event_str}"

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -48,6 +48,9 @@ except ImportError:
     from urllib.request import urlopen
 
 
+QUEUE_BASE = "https://queue.taskcluster.net/v1/task"
+
+
 root = os.path.abspath(
     os.path.join(os.path.dirname(__file__),
                  os.pardir,
@@ -245,14 +248,26 @@ def setup_repository():
         run(["git", "fetch", "--quiet", "origin", "%s:%s" % (branch, branch)])
 
 
+def fetch_event_data():
+    try:
+        task_id = os.environ["TASK_ID"]
+    except KeyError:
+        print("WARNING: Missing TASK_ID environment variable")
+        # For example under local testing
+        return None
+
+    resp = urlopen("%s/%s" % (QUEUE_BASE, task_id))
+
+    task_data = json.load(resp)
+    event_data = task_data.get("extra", {}).get("github_event")
+    if event_data is not None:
+        return json.loads(event_data)
+
+
 def main():
     args = get_parser().parse_args()
-    try:
-        event = json.loads(os.environ["TASK_EVENT"])
-    except KeyError:
-        print("WARNING: Missing TASK_EVENT environment variable")
-        # For example under local testing
-        event = {}
+
+    event = fetch_event_data()
 
     if event:
         set_variables(event)


### PR DESCRIPTION
This avoids the problem where over-large GH events (e.g. with many
changes) end up causing an exception in libcontainer when it tries to
pass the data to exec.

The tradeoff is that we add an extra HTTP request to the task setup.