### PR TITLE
Avoid harness error in applyContraints/getConstraints test

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -278,7 +278,6 @@ GENERATE_TESTS: domparsing/createContextualFragment.html
 GENERATE_TESTS: domxpath/001.html
 GENERATE_TESTS: domxpath/002.html
 GENERATE_TESTS: mediacapture-image/MediaStreamTrack-applyConstraints-reject.html
-GENERATE_TESTS: mediacapture-image/MediaStreamTrack-getConstraints-fast.html
 GENERATE_TESTS: mediacapture-image/setOptions-reject.html
 GENERATE_TESTS: html/semantics/scripting-1/the-template-element/template-element/template-as-a-descendant.html
 GENERATE_TESTS: html/syntax/parsing/Document.getElementsByTagName-foreign-01.html

--- a/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
+++ b/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
@@ -52,12 +52,12 @@ function makePromiseTest(name, c) {
       // this beahvior in the specs. TODO: remove this try/catch block.
     }
     const constraintsOut = videoTrack.getConstraints();
-    assert_object_equals(constraintsOut, constraintsIn, "constraints");
+    assert_object_equals(constraintsOut, constraintsIn, "constraints after applying");
 
     // Clear constraints by sending an empty constraint set.
     await videoTrack.applyConstraints({});
     const constraintsOut2 = videoTrack.getConstraints();
-    assert_object_equals(constraintsOut2, {}, "constraints");
+    assert_object_equals(constraintsOut2, {}, "constraints after applying empty constraint set");
   }, name);
 }
 

--- a/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
+++ b/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-applyconstraints">
+<link rel="help" href="https://w3c.github.io/mediacapture-image/#extensions">
 <body>
 <canvas id='canvas' width=10 height=10/>
 </body>

--- a/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
+++ b/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
@@ -35,45 +35,31 @@ context.fillRect(0, 0, 10, 10);
 
 // These tests verify that MediaStreamTrack.getConstraints() exists and that,
 // returns the constraints passed beforehand with applyConstraints.
-var makeAsyncTest = function(c) {
-  async_test(function(t) {
+function makePromiseTest(name, c) {
+  promise_test(async function() {
     var stream = canvas.captureStream();
     var videoTrack = stream.getVideoTracks()[0];
 
     const constraintsIn = { advanced : [ c ]};
 
-    // Method applyConstraints() will fail since there is no Image Capture
-    // service in this Layout Test, but |constraintsIn| should be cached.
-    videoTrack.applyConstraints(constraintsIn)
-        .then(() => { /* ignore */ })
-        .catch((e) => { /* ignore */ })
-        .then(() => {
-          const constraintsOut = videoTrack.getConstraints();
-          assert_object_equals(constraintsOut, constraintsIn, "constraints");
-          t.done();
-        });
+    await videoTrack.applyConstraints(constraintsIn);
+    const constraintsOut = videoTrack.getConstraints();
+    assert_object_equals(constraintsOut, constraintsIn, "constraints");
 
     // Clear constraints by sending an empty constraint set.
-    videoTrack.applyConstraints({})
-        .then(() => {
-          const constraintsOut = videoTrack.getConstraints();
-          assert_object_equals(constraintsOut, {}, "constraints");
-          t.done();
-        });
-  });
-};
+    await videoTrack.applyConstraints({});
+    const constraintsOut2 = videoTrack.getConstraints();
+    assert_object_equals(constraintsOut2, {}, "constraints");
+  }, name);
+}
 
 // Send each line of |constraints| in turn and then the whole dictionary.
 for (key in constraints) {
   var one_constraint = {};
   one_constraint[key] = constraints[key];
-  generate_tests(
-      makeAsyncTest,
-      [[ 'MediaStreamTrack.getConstraints(), key: ' + key, one_constraint ]]);
+  makePromiseTest('MediaStreamTrack.getConstraints(), key: ' + key, one_constraint);
 }
 
-generate_tests(makeAsyncTest, [[
-                 'MediaStreamTrack.getConstraints(), complete ', constraints
-               ]]);
+makePromiseTest('MediaStreamTrack.getConstraints(), complete ', constraints);
 
 </script>

--- a/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
+++ b/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
@@ -44,7 +44,13 @@ function makePromiseTest(name, c) {
 
     const constraintsIn = { advanced : [ c ]};
 
-    await videoTrack.applyConstraints(constraintsIn);
+    try {
+      await videoTrack.applyConstraints(constraintsIn);
+    } catch(e) {
+      // If applyConstraints() rejects, continue and assume that |constraintsIn|
+      // are stored anyway. Note that there doesn't appear to be any mention of
+      // this beahvior in the specs. TODO: remove this try/catch block.
+    }
     const constraintsOut = videoTrack.getConstraints();
     assert_object_equals(constraintsOut, constraintsIn, "constraints");
 


### PR DESCRIPTION
Because the promise callbacks containing the asserts weren't wrapped
in `t.step_func` a failed assert turned into a harness error:
https://staging.wpt.fyi/results/mediacapture-image/MediaStreamTrack-getConstraints-fast.html?run_id=227500002&run_id=259130004&run_id=253190002&run_id=247230003

This masked that the tests were actually failing.