### PR TITLE
Expect elementPosition.html to crash (not timeout) on macOS

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/elementPosition.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/elementPosition.html.ini
@@ -1,6 +1,6 @@
 [elementPosition.html]
   expected:
-    if os == "mac" and product == "chrome": TIMEOUT
+    if os == "mac" and product == "chrome": CRASH
 
   [TestDriver actions: element position]
     expected:


### PR DESCRIPTION
Matches results from https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=30189