### PR TITLE
MathML: Remove workaround for WebKit's bug 174030

### DIFF
--- a/mathml/presentation-markup/fractions/frac-bar-001.html
+++ b/mathml/presentation-markup/fractions/frac-bar-001.html
@@ -25,10 +25,8 @@
     </style>
     <script src="/common/reftest-wait.js"></script>
     <script>
-      window.addEventListener("load", () => {
-        // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-        requestAnimationFrame(() => { document.fonts.ready.then(adjustPositionOfFraction); });
-      });
+      window.addEventListener("load", () => { document.fonts.ready.then(adjustPositionOfFraction); });
+
       function adjustPositionOfFraction()
       {
         requestAnimationFrame(() => {

--- a/mathml/presentation-markup/fractions/frac-linethickness-002.html
+++ b/mathml/presentation-markup/fractions/frac-linethickness-002.html
@@ -28,10 +28,7 @@
       }
 
       setup({ explicit_done: true });
-      window.addEventListener("load", function() {
-        // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-        requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-      });
+      window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
       function runTests() {
         var defaultRuleThickness = 100;

--- a/mathml/presentation-markup/fractions/frac-parameters-1.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-1.html
@@ -62,10 +62,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/fractions/frac-parameters-2.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-2.html
@@ -46,10 +46,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
 

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-001-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-001-ref.html
@@ -29,10 +29,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-001.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-001.html
@@ -47,10 +47,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-002-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-002-ref.html
@@ -29,10 +29,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-002.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-002.html
@@ -47,10 +47,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-003-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-003-ref.html
@@ -29,10 +29,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-003.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-003.html
@@ -47,10 +47,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-004-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-004-ref.html
@@ -29,10 +29,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-004.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-004.html
@@ -47,10 +47,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-005-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-005-ref.html
@@ -29,10 +29,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-005.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-005.html
@@ -47,10 +47,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-006-ref.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-006-ref.html
@@ -29,10 +29,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/fractions/frac-parameters-gap-006.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-gap-006.html
@@ -47,10 +47,7 @@
     div.style.height = `${refBox.height-4}px`;
     document.documentElement.classList.remove('reftest-wait');
   }
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 </script>
 </head>
 <body>

--- a/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html
+++ b/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html
@@ -28,10 +28,7 @@
 </style>
 <script type="text/javascript">
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
   function runTests()
   {
       ["Mrow", "Sqrt", "Style", "Error", "Phantom", "Math", "Menclose", "Mpadded"].forEach((tag) => {

--- a/mathml/presentation-markup/operators/mo-axis-height-1.html
+++ b/mathml/presentation-markup/operators/mo-axis-height-1.html
@@ -25,10 +25,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/radicals/root-parameters-1.html
+++ b/mathml/presentation-markup/radicals/root-parameters-1.html
@@ -50,10 +50,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/subsup-parameters-1.html
+++ b/mathml/presentation-markup/scripts/subsup-parameters-1.html
@@ -62,10 +62,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/subsup-parameters-2.html
+++ b/mathml/presentation-markup/scripts/subsup-parameters-2.html
@@ -27,10 +27,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   /*
     These two tests verify that:

--- a/mathml/presentation-markup/scripts/underover-parameters-1.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-1.html
@@ -38,10 +38,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/underover-parameters-2.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-2.html
@@ -38,10 +38,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/underover-parameters-3.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-3.html
@@ -41,10 +41,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => {   document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/scripts/underover-parameters-4.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-4.html
@@ -41,10 +41,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => {   document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/presentation-markup/tables/table-axis-height.html
+++ b/mathml/presentation-markup/tables/table-axis-height.html
@@ -26,10 +26,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {

--- a/mathml/relations/css-styling/displaystyle-013.html
+++ b/mathml/relations/css-styling/displaystyle-013.html
@@ -21,10 +21,7 @@
         document.getElementById("m6").removeAttribute("displaystyle");
         document.documentElement.removeAttribute("class");
       }
-      window.addEventListener("load", function() {
-        // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-        requestAnimationFrame(() => { document.fonts.ready.then(doTest); });
-      });
+      window.addEventListener("load", () => { document.fonts.ready.then(doTest); });
     </script>
     <link rel="stylesheet" href="/fonts/ahem.css">
     <style>

--- a/mathml/relations/css-styling/displaystyle-014.html
+++ b/mathml/relations/css-styling/displaystyle-014.html
@@ -18,10 +18,7 @@
                  setAttribute('mathbackground', 'red');
         document.documentElement.removeAttribute("class");
       }
-      window.addEventListener("load", function() {
-        // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-        requestAnimationFrame(() => { document.fonts.ready.then(doTest); });
-      });
+      window.addEventListener("load", () => { document.fonts.ready.then(doTest); });
     </script>
     <link rel="stylesheet" href="/fonts/ahem.css">
     <style>

--- a/mathml/relations/css-styling/displaystyle-1.html
+++ b/mathml/relations/css-styling/displaystyle-1.html
@@ -31,10 +31,7 @@
       assert_approx_equals(elementSize, expectedSize, epsilon, description);
   }
 
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
       for (transform in AttributeValueTransforms) {

--- a/mathml/relations/css-styling/displaystyle-2.html
+++ b/mathml/relations/css-styling/displaystyle-2.html
@@ -31,10 +31,7 @@
       assert_approx_equals(elementSize, expectedSize, epsilon, description);
   }
 
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
       for (transform in AttributeValueTransforms) {

--- a/mathml/relations/css-styling/lengths-2.html
+++ b/mathml/relations/css-styling/lengths-2.html
@@ -29,10 +29,7 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", function() {
-    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
-  });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
 
   function runTests() {
     test(function() {


### PR DESCRIPTION
Handling of document.fonts.ready has been fixed upstreamed.