### PR TITLE
[css-values] Reftest for percentage root font size and rem units

### DIFF
--- a/css/css-values/percentage-rem-low-ref.html
+++ b/css/css-values/percentage-rem-low-ref.html
@@ -2,4 +2,4 @@
 <meta charset="utf-8">
 <title>[Mismatch] REM value with :root set to low percentage</title>
 
-<div style="width:37.5px;height:37.5px;background-color:green;"></div>
+<div style="width:187.5px;height:187.5px;background-color:green;"></div>

--- a/css/css-values/percentage-rem-low-ref.html
+++ b/css/css-values/percentage-rem-low-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>REM value with :root set to low percentage</title>
+
+<p>Test passes if the square below is a 30px * 30px square.</p>
+<div style="width:30px;height:30px;background-color:green;"></div>

--- a/css/css-values/percentage-rem-low-ref.html
+++ b/css/css-values/percentage-rem-low-ref.html
@@ -1,5 +1,0 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>[Mismatch] REM value with :root set to low percentage</title>
-
-<div style="width:187.5px;height:187.5px;background-color:green;"></div>

--- a/css/css-values/percentage-rem-low-ref.html
+++ b/css/css-values/percentage-rem-low-ref.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>REM value with :root set to low percentage</title>
+<title>[Mismatch] REM value with :root set to low percentage</title>
 
-<p>Test passes if the square below is a 30px * 30px square.</p>
-<div style="width:30px;height:30px;background-color:green;"></div>
+<div style="width:37.5px;height:37.5px;background-color:green;"></div>

--- a/css/css-values/percentage-rem-low.html
+++ b/css/css-values/percentage-rem-low.html
@@ -19,5 +19,5 @@
     background-color: green;
   }
 </style>
-<p>Test passes if there is a filled green square.</p>
+<p style="font-size:initial;">Test passes if there is a filled green square.</p>
 <div class="rem"></div>

--- a/css/css-values/percentage-rem-low.html
+++ b/css/css-values/percentage-rem-low.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>REM value with :root set to low percentage</title>
+<link rel="author" title="Jon Ege Ronnenberg" href="mailto:jon.ronnenberg+wpt@gmail.com">
+<link rel="help" href="https://www.w3.org/TR/css-values-3/#rem">
+<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#length-percentage-size-value">
+<link rel="match" href="percentage-rem-low-ref.html">
+<meta name="assert" content="When :root font-size is 30%, a 6.25rem length must be 30px, if the browser default for :root font-size is 16px.">
+<style>
+  :root {
+    font-size: 30%; /* default is 16px in all desktop browsers */
+  }
+  .rem {
+    box-sizing: border-box;
+    width: 6.25rem;
+    height: 6.25rem;
+    background-color: green;
+  }
+</style>
+
+<p style="font-size: initial">Test passes if the square below is a 30px * 30px square.</p>
+<div class="rem"></div>

--- a/css/css-values/percentage-rem-low.html
+++ b/css/css-values/percentage-rem-low.html
@@ -13,7 +13,6 @@
     font-size: 25%;
   }
   .rem {
-    box-sizing: border-box;
     width: 25rem;
     height: 25rem;
     background-color: green;

--- a/css/css-values/percentage-rem-low.html
+++ b/css/css-values/percentage-rem-low.html
@@ -2,19 +2,20 @@
 <meta charset="utf-8">
 <title>REM value with :root set to low percentage</title>
 <link rel="author" title="Jon Ege Ronnenberg" href="mailto:jon.ronnenberg+wpt@gmail.com">
-<link rel="help" href="https://www.w3.org/TR/css-values-3/#rem">
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#length-percentage-size-value">
+<link rel="help" href="https://drafts.csswg.org/css-values/#rem">
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#length-percentage-size-value">
 <link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
-<link rel="mismatch" href="percentage-rem-low-ref.html">
-<meta name="assert" content="When :root font-size is 20%, a 31.25rem length must be 100px, if the browser default for :root font-size is 16px.">
+<meta name="assert" content="When :root font-size is 25%, a 25rem length must be 100px, if the browser default for :root font-size is 16px.">
 <style>
   :root {
-    font-size: 20%; /* default is 16px in all desktop browsers */
+     /* default is 16px in all desktop browsers */
+     /* the math for 100px is: 16px * 0.25 = 4px/rem -> 100px / 4px/rem = 25rem = 100px */
+    font-size: 25%;
   }
   .rem {
     box-sizing: border-box;
-    width: 31.25rem;
-    height: 31.25rem;
+    width: 25rem;
+    height: 25rem;
     background-color: green;
   }
 </style>

--- a/css/css-values/percentage-rem-low.html
+++ b/css/css-values/percentage-rem-low.html
@@ -4,7 +4,8 @@
 <link rel="author" title="Jon Ege Ronnenberg" href="mailto:jon.ronnenberg+wpt@gmail.com">
 <link rel="help" href="https://www.w3.org/TR/css-values-3/#rem">
 <link rel="help" href="https://www.w3.org/TR/css-fonts-3/#length-percentage-size-value">
-<link rel="match" href="percentage-rem-low-ref.html">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<link rel="mismatch" href="percentage-rem-low-ref.html">
 <meta name="assert" content="When :root font-size is 30%, a 6.25rem length must be 30px, if the browser default for :root font-size is 16px.">
 <style>
   :root {
@@ -18,5 +19,4 @@
   }
 </style>
 
-<p style="font-size: initial">Test passes if the square below is a 30px * 30px square.</p>
 <div class="rem"></div>

--- a/css/css-values/percentage-rem-low.html
+++ b/css/css-values/percentage-rem-low.html
@@ -6,15 +6,15 @@
 <link rel="help" href="https://www.w3.org/TR/css-fonts-3/#length-percentage-size-value">
 <link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
 <link rel="mismatch" href="percentage-rem-low-ref.html">
-<meta name="assert" content="When :root font-size is 30%, a 6.25rem length must be 30px, if the browser default for :root font-size is 16px.">
+<meta name="assert" content="When :root font-size is 20%, a 31.25rem length must be 100px, if the browser default for :root font-size is 16px.">
 <style>
   :root {
-    font-size: 30%; /* default is 16px in all desktop browsers */
+    font-size: 20%; /* default is 16px in all desktop browsers */
   }
   .rem {
     box-sizing: border-box;
-    width: 6.25rem;
-    height: 6.25rem;
+    width: 31.25rem;
+    height: 31.25rem;
     background-color: green;
   }
 </style>

--- a/css/css-values/percentage-rem-low.html
+++ b/css/css-values/percentage-rem-low.html
@@ -19,5 +19,5 @@
     background-color: green;
   }
 </style>
-
+<p>Test passes if there is a filled green square.</p>
 <div class="rem"></div>


### PR DESCRIPTION
> **rem unit**
>    Equal to the computed value of `font-size` on the root element.
>    If used in the `font-size` property of the root element, or in a document with no root element, `1rem` is equal to the initial value of the `font-size` property.

This test sets the `font-size` of the `:root` element to 20%, which according to spec means that `31.25rem` = `100px`. This test assumes that the initial value of the `font-size` property is 16px, as observed in desktop Chrome, Opera, Safari, Firefox, IE and Edge.

This test fails in current Chrome (78.0.3904.7) as explained here: https://lists.w3.org/Archives/Public/public-test-infra/2019JulSep/0002.html and https://bugs.chromium.org/p/chromium/issues/detail?id=308862.
And probably also Webkit Safari - see https://bugs.webkit.org/show_bug.cgi?id=117680
Test passes in Edge, IE10, IE11 and Firefox

Spec: https://www.w3.org/TR/css-values-3/#rem

Note about current browser differences: AFAIK Internet Explorer and Firefox has always passed this test. Webkit was the only engine to fail. Since blink was forked from Webkit, this test now also fails in Chrome, Opera etc. The percentage scale bug is pre blink.