### PR TITLE
Use TASK_EVENT from the environment when present

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -267,7 +267,10 @@ def fetch_event_data():
 def main():
     args = get_parser().parse_args()
 
-    event = fetch_event_data()
+    if "TASK_EVENT" in os.environ:
+        event = json.loads(os.environ["TASK_EVENT"])
+    else:
+        event = fetch_event_data()
 
     if event:
         set_variables(event)


### PR DESCRIPTION
This allows the Python code to work on PRs where the .taskcluster.yml hasn't yet been updated
to pass the event data through the tasK