### PR TITLE
[web-share] Use HTTPS URLs if possible

### DIFF
--- a/web-share/share-cancel-manual.html
+++ b/web-share/share-cancel-manual.html
@@ -17,7 +17,7 @@
           return callWhenButtonClicked(() => promise_rejects(
               t, 'AbortError',
               navigator.share({title: 'the title', text: 'the message',
-                               url: 'data:the url'})));
+                               url: 'https://example.com'})));
         }, 'share with user cancellation');
     </script>
   </body>

--- a/web-share/share-extra-argument-manual.html
+++ b/web-share/share-extra-argument-manual.html
@@ -12,9 +12,9 @@
         setup({explicit_timeout: true});
 
         setupManualShareTest(
-            {title: 'the title', text: 'the message', url: 'data:the url'});
+            {title: 'the title', text: 'the message', url: 'https://example.com'});
         callWhenButtonClicked(() => navigator.share(
-              {title: 'the title', text: 'the message', url: 'data:the url'},
+              {title: 'the title', text: 'the message', url: 'https://example.com'},
               'more than required'));
     </script>
   </body>

--- a/web-share/share-extra-field-manual.html
+++ b/web-share/share-extra-field-manual.html
@@ -12,9 +12,9 @@
         setup({explicit_timeout: true});
 
         setupManualShareTest(
-            {title: 'the title', text: 'the message', url: 'data:the url'});
+            {title: 'the title', text: 'the message', url: 'https://example.com'});
         callWhenButtonClicked(() => navigator.share(
-              {title: 'the title', text: 'the message', url: 'data:the url',
+              {title: 'the title', text: 'the message', url: 'https://example.com',
                unused: 'unexpected field'}));
     </script>
   </body>

--- a/web-share/share-without-user-gesture.https.html
+++ b/web-share/share-without-user-gesture.https.html
@@ -12,7 +12,7 @@
           return promise_rejects(
               t, 'NotAllowedError',
               navigator.share({title: 'the title', text: 'the message',
-                               url: 'data:the url'}));
+                               url: 'https://example.com'}));
         }, 'share without a user gesture');
     </script>
   </body>


### PR DESCRIPTION
Gecko currently does not support data URIs without comma (tracked by https://bugzilla.mozilla.org/show_bug.cgi?id=1579331). Since several tests here don't have to depend on data URI support, I suggest we replace them with `https://example.com` to reduce failures.