### PR TITLE
Revert "Add async dispatch event flag to Chromedriver perform action"

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -114,17 +114,17 @@ class ActionSequence(object):
         """Perform all queued actions."""
         self.session.actions.perform([self.dict])
 
-    def _key_action(self, subtype, value, async_dispatch=False):
-        self._actions.append({"type": subtype, "value": value, "asyncDispatch": async_dispatch})
+    def _key_action(self, subtype, value):
+        self._actions.append({"type": subtype, "value": value})
 
-    def _pointer_action(self, subtype, button, async_dispatch=False):
-        self._actions.append({"type": subtype, "button": button, "asyncDispatch": async_dispatch})
+    def _pointer_action(self, subtype, button):
+        self._actions.append({"type": subtype, "button": button})
 
     def pause(self, duration):
         self._actions.append({"type": "pause", "duration": duration})
         return self
 
-    def pointer_move(self, x, y, duration=None, origin=None, async_dispatch=False):
+    def pointer_move(self, x, y, duration=None, origin=None):
         """Queue a pointerMove action.
 
         :param x: Destination x-axis coordinate of pointer in CSS pixels.
@@ -143,29 +143,28 @@ class ActionSequence(object):
             action["duration"] = duration
         if origin is not None:
             action["origin"] = origin
-        action["asyncDispatch"] = async_dispatch
         self._actions.append(action)
         return self
 
-    def pointer_up(self, button=0, async_dispatch=False):
+    def pointer_up(self, button=0):
         """Queue a pointerUp action for `button`.
 
         :param button: Pointer button to perform action with.
                        Default: 0, which represents main device button.
         """
-        self._pointer_action("pointerUp", button, async_dispatch)
+        self._pointer_action("pointerUp", button)
         return self
 
-    def pointer_down(self, button=0, async_dispatch=False):
+    def pointer_down(self, button=0):
         """Queue a pointerDown action for `button`.
 
         :param button: Pointer button to perform action with.
                        Default: 0, which represents main device button.
         """
-        self._pointer_action("pointerDown", button, async_dispatch)
+        self._pointer_action("pointerDown", button)
         return self
 
-    def click(self, element=None, button=0, async_dispatch=False):
+    def click(self, element=None, button=0):
         """Queue a click with the specified button.
 
         If an element is given, move the pointer to that element first,
@@ -176,33 +175,33 @@ class ActionSequence(object):
                        with. Default: 0, which represents main device button.
         """
         if element:
-            self.pointer_move(0, 0, origin=element, async_dispatch=async_dispatch)
-        return self.pointer_down(button, async_dispatch).pointer_up(button, async_dispatch)
+            self.pointer_move(0, 0, origin=element)
+        return self.pointer_down(button).pointer_up(button)
 
-    def key_up(self, value, async_dispatch=False):
+    def key_up(self, value):
         """Queue a keyUp action for `value`.
 
         :param value: Character to perform key action with.
         """
-        self._key_action("keyUp", value, async_dispatch)
+        self._key_action("keyUp", value)
         return self
 
-    def key_down(self, value, async_dispatch=False):
+    def key_down(self, value):
         """Queue a keyDown action for `value`.
 
         :param value: Character to perform key action with.
         """
-        self._key_action("keyDown", value, async_dispatch)
+        self._key_action("keyDown", value)
         return self
 
-    def send_keys(self, keys, async_dispatch=False):
+    def send_keys(self, keys):
         """Queue a keyDown and keyUp action for each character in `keys`.
 
         :param keys: String of keys to perform key actions with.
         """
         for c in keys:
-            self.key_down(c, async_dispatch)
-            self.key_up(c, async_dispatch)
+            self.key_down(c)
+            self.key_up(c)
         return self
 
 


### PR DESCRIPTION
This breaks the wdspec tests by causing them to send a nonstandard payload for actions.