### PR TITLE
[docs] Simplify README

### DIFF
--- a/resources/readme.md
+++ b/resources/readme.md
@@ -1,7 +1,7 @@
 # Resources
 
-This directory contains utilities intended for use by tests of the web
-platform. It does not contain tests for web platform features.
+This directory contains utilities intended for use by tests.
+It does not contain tests.
 
 ## `testharness.js`
 
@@ -11,4 +11,4 @@ making assertions and is intended to work for both simple synchronous
 tests, and tests of asynchronous behaviour.
 
 Complete documentation is available in the `docs/` directory of this repository
-and on the web at http://web-platform-tests.org/writing-tests.
+and on the web at https://web-platform-tests.org/writing-tests/.

--- a/resources/readme.md
+++ b/resources/readme.md
@@ -1,6 +1,6 @@
 # Resources
 
-This directory contains utilities intended for use by tests.
+This directory contains utilities intended for use by tests and maintained as project infrastructure.
 It does not contain tests.
 
 ## `testharness.js`

--- a/resources/readme.md
+++ b/resources/readme.md
@@ -1,5 +1,8 @@
 # Resources
 
+This directory contains utilities intended for use by tests of the web
+platform. It does not contain tests for web platform features.
+
 ## `testharness.js`
 
 `testharness.js` is a framework for writing low-level tests of
@@ -7,20 +10,5 @@ browser functionality in javascript. It provides a convenient API for
 making assertions and is intended to work for both simple synchronous
 tests, and tests of asynchronous behaviour.
 
-### Getting started
-
-To use `testharness.js` you must include two scripts, in the order given:
-
-``` html
-<script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
-```
-
-### Full documentation
-
-For detailed API documentation please visit [https://web-platform-tests.org/writing-tests/testharness-api.html](https://web-platform-tests.org/writing-tests/testharness-api.html).
-
-### Tutorials
-
-You can also read a tutorial on
-[Using testharness.js](http://darobin.github.com/test-harness-tutorial/docs/using-testharness.html).
+Complete documentation is available in the `docs/` directory of this repository
+and on the web at http://web-platform-tests.org/writing-tests.


### PR DESCRIPTION
Prior to this patch, the documentation for the "resources" directory was
incomplete and included a reference to external content which was
duplicative of existing instructions.

Reduce the contents of the "resources" documentation to minimally
describe the directory and direct readers to the canonical information
sources.