### PR TITLE
[fullscreen] wrap event listener callback in `t.step_func`

### DIFF
--- a/fullscreen/rendering/fullscreen-css-transition.html
+++ b/fullscreen/rendering/fullscreen-css-transition.html
@@ -17,11 +17,11 @@
       assert_equals(document.fullscreenElement, trans);
       assert_equals(getComputedStyle(trans).color, "rgb(0, 128, 0)", "Transition is in progress - still green");
     });
-    trans.addEventListener('click', e => {
+    trans.addEventListener('click', t.step_func(() => {
       trans.style.color = "red";
       trans.offsetTop;
       trans.requestFullscreen();
-    }, {once: true});
+    }), {once: true});
     test_driver.click(trans);
   });
 </script>


### PR DESCRIPTION
This is to avoid a harness error if `trans.requestFullscreen()` is not supported:
https://wpt.fyi/results/fullscreen/rendering/fullscreen-css-transition.html?run_id=314000010&run_id=293450006&run_id=308130006&run_id=291640006