### PR TITLE
Fix errors for MathML tests with in-flow children.

### DIFF
--- a/mathml/presentation-markup/operators/embellished-operator-001.html
+++ b/mathml/presentation-markup/operators/embellished-operator-001.html
@@ -117,7 +117,7 @@
       <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
       <mn>X</mn>
       <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
-      <mrow id="mrow-op-1" class="testedElement">
+      <mrow id="mrow-op-2" class="testedElement">
         <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
         <mo lspace="2em" rspace="0em">X</mo>
         <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>

--- a/mathml/presentation-markup/operators/embellished-operator-002.html
+++ b/mathml/presentation-markup/operators/embellished-operator-002.html
@@ -347,7 +347,6 @@
       <mn>X</mn>
       <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
       <maction class="testedElement" actiontype="statusline">
-        <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
         <mo lspace="2em" rspace="0em">X</mo>
         <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
         <mn>STATUS MESSAGE</mn>
@@ -364,7 +363,6 @@
       <mn>X</mn>
       <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
       <semantics class="testedElement">
-        <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
         <mo lspace="2em" rspace="0em">X</mo>
         <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
         <annotation>TEXT ANNOTATION</annotation>
@@ -640,7 +638,6 @@
       <mn>X</mn>
       <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
       <maction class="testedElement" actiontype="statusline">
-        <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
         <mn>X</mn>
         <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
         <mo lspace="2em" rspace="0em">STATUS MESSAGE</mo>
@@ -657,7 +654,6 @@
       <mn>X</mn>
       <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
       <semantics class="testedElement">
-        <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
         <mrow>
           <mn class="oof1">0</mn><mn class="oof2">1</mn><mn class="nobox">2</mn>
           <mn>X</mn>

--- a/mathml/support/box-navigation.js
+++ b/mathml/support/box-navigation.js
@@ -1,5 +1,5 @@
 function IsInFlow(element) {
-    var style = window.getComputedStyle(child);
+    var style = window.getComputedStyle(element);
     return style.getPropertyValue("display") !== "none" &&
         style.getPropertyValue("position") !== "absolute" &&
         style.getPropertyValue("position") !== "fixed";


### PR DESCRIPTION
- maction/semantics have special rules for their first child, so don't add out-of-flow at that position.
- fix wrong id
- fix IsInFlow helper function.