### PR TITLE
Ensure that the rejection of the ready promise when calling cancel() does not cause a harness error

### DIFF
--- a/web-animations/timing-model/animations/canceling-an-animation.html
+++ b/web-animations/timing-model/animations/canceling-an-animation.html
@@ -66,6 +66,7 @@ test(t => {
   const promise = animation.ready;
   animation.cancel();
   assert_not_equals(animation.ready, promise);
+  promise_rejects(t, 'AbortError', promise, 'Cancel should abort ready promise');
 }, 'The ready promise should be replaced when the animation is canceled');
 
 promise_test(t => {


### PR DESCRIPTION
This addresses issue #18932.