### PR TITLE
Dummy change to share-sharePromise-internal-slot.https.html

### DIFF
--- a/web-share/share-sharePromise-internal-slot.https.html
+++ b/web-share/share-sharePromise-internal-slot.https.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
-    <link rel="help" href="https://github.com/w3c/web-share/pull/113" />
+    <meta charset="utf-8">
+    <link rel="help" href="https://github.com/w3c/web-share/pull/113">
     <title>WebShare Test: only one share at a time</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
Probing root cause for https://github.com/web-platform-tests/wpt/pull/19003.