### PR TITLE
 MathML: add more tests to check that layout is determined from in-flow children

### DIFF
--- a/mathml/presentation-markup/fractions/frac-rendering-from-in-flow-ref.html
+++ b/mathml/presentation-markup/fractions/frac-rendering-from-in-flow-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>fraction rendering from in-flow children</title>
+  </head>
+  <body>
+    <math>
+      <mfrac>
+        <mspace width="64px" height="48px" style="background: lightblue"></mspace>
+        <mspace width="128px" height="96px" style="background: lightgreen"></mspace>
+      </mfrac>
+  </body>
+</html>

--- a/mathml/presentation-markup/fractions/frac-rendering-from-in-flow.html
+++ b/mathml/presentation-markup/fractions/frac-rendering-from-in-flow.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>fraction rendering from in-flow children</title>
+    <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#fractions-mfrac">
+    <meta name="assert" content="Verify rendering of fractions is only affected by in-flow children.">
+    <style>
+      .oof1 {
+          position: absolute;
+      }
+      .oof2 {
+          position: fixed;
+      }
+      .nobox {
+          display: none;
+      }
+    </style>
+    <link rel="match" href="frac-rendering-from-in-flow-ref.html">
+  </head>
+  <body>
+    <math>
+      <mfrac>
+        <mspace height="32px" width="24px" class="oof1"/>
+        <mspace height="16px" width="12px" class="oof2"/>
+        <mspace height="8px" width="4px" class="nobox"/>
+        <mspace width="64px" height="48px" style="background: lightblue"></mspace>
+        <mspace height="32px" width="24px" class="oof1"/>
+        <mspace height="16px" width="12px" class="oof2"/>
+        <mspace height="8px" width="4px" class="nobox"/>
+        <mspace width="128px" height="96px" style="background: lightgreen"></mspace>
+        <mspace height="32px" width="24px" class="oof1"/>
+        <mspace height="16px" width="12px" class="oof2"/>
+        <mspace height="8px" width="4px" class="nobox"/>
+      </mfrac>
+  </body>
+</html>

--- a/mathml/presentation-markup/operators/mo-movablelimits-from-in-flow-ref.html
+++ b/mathml/presentation-markup/operators/mo-movablelimits-from-in-flow-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>&lt;mo&gt; movablelimits</title>
+    <style>
+      math, math * {
+          font: 25px/1 Ahem;
+      }
+    </style>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  </head>
+  <body>
+    <math>
+      <msub>
+        <mo lspace="0px" rspace="0px">+</mo>
+        <mn>1</mn>
+      </msub>
+      <msup>
+        <mo lspace="0px" rspace="0px">+</mo>
+        <mn>1</mn>
+      </msup>
+      <msubsup>
+        <mo lspace="0px" rspace="0px">+</mo>
+        <mn>1</mn>
+        <mn>2</mn>
+      </msubsup>
+    </math>
+  </body>
+</html>

--- a/mathml/presentation-markup/operators/mo-movablelimits-from-in-flow.html
+++ b/mathml/presentation-markup/operators/mo-movablelimits-from-in-flow.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>&lt;mo&gt; movablelimits</title>
+    <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#operator-fence-separator-or-accent-mo">
+    <meta name="assert" content="Verify movablelimits is read from the first in-flow child.">
+    <style>
+      math, math * {
+          font: 25px/1 Ahem;
+      }
+      .oof1 {
+          position: absolute;
+      }
+      .oof2 {
+          position: fixed;
+      }
+      .nobox {
+          display: none;
+      }
+    </style>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <link rel="match" href="mo-movablelimits-ref.html">
+  </head>
+  <body>
+    <math>
+      <munder>
+        <mo class="oof1" movablelimits="false"></mo>
+        <mo class="oof2" movablelimits="false"></mo>
+        <mo class="nobox" movablelimits="false"></mo>
+        <mo lspace="0px" rspace="0px" movablelimits="true">+</mo>
+        <mn>1</mn>
+      </munder>
+      <mover>
+        <mo class="oof1" movablelimits="false"></mo>
+        <mo class="oof2" movablelimits="false"></mo>
+        <mo class="nobox" movablelimits="false"></mo>
+        <mo lspace="0px" rspace="0px" movablelimits="true">+</mo>
+        <mn>1</mn>
+      </mover>
+      <munderover>
+        <mo class="oof1" movablelimits="false"></mo>
+        <mo class="oof2" movablelimits="false"></mo>
+        <mo class="nobox" movablelimits="false"></mo>
+        <mo lspace="0px" rspace="0px" movablelimits="true">+</mo>
+        <mn>1</mn>
+        <mn>2</mn>
+      </munderover>
+    </math>
+  </body>
+</html>

--- a/mathml/presentation-markup/radicals/radical-rendering-from-in-flow-ref.html
+++ b/mathml/presentation-markup/radicals/radical-rendering-from-in-flow-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>radicals rendering from in-flow children</title>
+  </head>
+  <body>
+    <math>
+      <msqrt>
+        <mspace width="64px" height="8px" style="background: lightblue"></mspace>
+      </msqrt>
+      <mroot>
+        <mspace width="64px" height="12px" style="background: lightblue"></mspace>
+        <mspace width="128px" height="24px" style="background: lightgreen"></mspace>
+      </mroot>
+  </body>
+</html>

--- a/mathml/presentation-markup/radicals/radical-rendering-from-in-flow.html
+++ b/mathml/presentation-markup/radicals/radical-rendering-from-in-flow.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>radicals rendering from in-flow children</title>
+    <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#radicals-msqrt-mroot">
+    <meta name="assert" content="Verify rendering of radicals is only affected by in-flow children.">
+    <style>
+      .oof1 {
+          position: absolute;
+      }
+      .oof2 {
+          position: fixed;
+      }
+      .nobox {
+          display: none;
+      }
+    </style>
+    <link rel="match" href="radical-rendering-from-in-flow-ref.html">
+  </head>
+  <body>
+    <math>
+      <msqrt>
+        <mspace width="32px" class="oof1"/>
+        <mspace width="16px" class="oof2"/>
+        <mspace width="8px" class="nobox"/>
+        <mspace width="64px" height="8px" style="background: lightblue"></mspace>
+        <mspace width="32px" class="oof1"/>
+        <mspace width="16px" class="oof2"/>
+        <mspace width="8px" class="nobox"/>
+      </msqrt>
+      <mroot>
+        <mspace width="32px" class="oof1"/>
+        <mspace width="16px" class="oof2"/>
+        <mspace width="8px" class="nobox"/>
+        <mspace width="64px" height="12px" style="background: lightblue"></mspace>
+        <mspace width="32px" class="oof1"/>
+        <mspace width="16px" class="oof2"/>
+        <mspace width="8px" class="nobox"/>
+        <mspace width="128px" height="24px" style="background: lightgreen"></mspace>
+        <mspace width="32px" class="oof1"/>
+        <mspace width="16px" class="oof2"/>
+        <mspace width="8px" class="nobox"/>
+      </mroot>
+  </body>
+</html>


### PR DESCRIPTION
…w children

In particular:
- Painting of fraction bar, radical overbar and surd.
- movablelimits is read from the first child to decide munderover layout.