### PR TITLE
Capitalize a test error message for consistency

### DIFF
--- a/resources/test/tests/unit/test-return-restrictions.html
+++ b/resources/test/tests/unit/test-return-restrictions.html
@@ -81,7 +81,7 @@ promise_test(() => {
       assert_equals(harness.status, 'ERROR');
       assert_equals(
         harness.message,
-        'test named "null" inappropriately returned a value'
+        'Test named "null" inappropriately returned a value'
       );
       assert_equals(tests.before, 'PASS');
       assert_equals(tests.null, 'PASS');
@@ -100,7 +100,7 @@ promise_test(() => {
       assert_equals(harness.status, 'ERROR');
       assert_equals(
         harness.message,
-        'test named "object" inappropriately returned a value'
+        'Test named "object" inappropriately returned a value'
       );
       assert_equals(tests.before, 'PASS');
       assert_equals(tests.object, 'PASS');
@@ -119,7 +119,7 @@ promise_test(() => {
       assert_equals(harness.status, 'ERROR');
       assert_equals(
         harness.message,
-        'test named "thenable" inappropriately returned a value, consider using `promise_test` instead'
+        'Test named "thenable" inappropriately returned a value, consider using `promise_test` instead'
       );
       assert_equals(tests.before, 'PASS');
       assert_equals(tests.thenable, 'PASS');
@@ -143,7 +143,7 @@ promise_test(() => {
       assert_equals(harness.status, 'ERROR');
       assert_equals(
         harness.message,
-        'test named "restricted" inappropriately returned a value'
+        'Test named "restricted" inappropriately returned a value'
       );
       assert_equals(tests.before, 'PASS');
       assert_equals(tests.restricted, 'PASS');

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -544,7 +544,7 @@ policies and contribution forms [3].
         var value = test_obj.step(func, test_obj, test_obj);
 
         if (value !== undefined) {
-            var msg = "test named \"" + test_name +
+            var msg = "Test named \"" + test_name +
                 "\" inappropriately returned a value";
 
             try {


### PR DESCRIPTION
Other messages are capitalized, including the one in `cleanup_done`
starting with "Test named".