### PR TITLE
Account for `video.play()` failing in media capture test

### DIFF
--- a/mediacapture-fromelement/capture.html
+++ b/mediacapture-fromelement/capture.html
@@ -13,8 +13,12 @@ function makeAsyncTest(filename) {
   promise_test(async test => {
     const video = document.createElement('video');
     video.src = "/media/" + filename;
-    video.onerror = this.unreached_func("<video> error");
-    video.play();
+    video.onerror = this.unreached_func("video error");
+    const playPromise = video.play();
+    assert_false(video.paused, "video paused");
+    if (playPromise) {
+      playPromise.catch(this.unreached_func("video.play() error"));
+    }
 
     const stream = video.captureStream();
 


### PR DESCRIPTION
This often fails in Safari:
https://wpt.fyi/results/mediacapture-fromelement/capture.html?run_id=297370005&run_id=319850011&run_id=297350007&run_id=314120009&run_id=291640006&run_id=303100001&run_id=306790008&run_id=305230003&run_id=277400002&run_id=293380001