### PR TITLE
Fix flakiness of service-workers/service-worker/getregistrations.http…

### DIFF
--- a/service-workers/service-worker/getregistrations.https.html
+++ b/service-workers/service-worker/getregistrations.https.html
@@ -104,19 +104,7 @@ promise_test(async t => {
   // test. So we have to wait until the cross origin register() is done, and not
   // just until the frame loads.
   const frame = await with_iframe_ready(frame_url);
-  t.add_cleanup(async () => {
-    // Wait until the cross-origin worker is unregistered.
-    let resolve;
-    const channel = new MessageChannel();
-    channel.port1.onmessage = e => {
-      if (e.data == 'unregistered')
-        resolve();
-    };
-    frame.contentWindow.postMessage('unregister', '*', [channel.port2]);
-    await new Promise(r => { resolve = r; });
-
-    frame.remove();
-  });
+  t.add_cleanup(() => frame.remove());
 
   const registrations = [
     await service_worker_unregister_and_register(t, script, scope)];
@@ -125,5 +113,15 @@ promise_test(async t => {
   assert_array_equals(
       value, registrations,
       'getRegistrations should only return same origin registrations.');
+
+  // Wait until the cross-origin worker is unregistered.
+  let resolve;
+  const channel = new MessageChannel();
+  channel.port1.onmessage = e => {
+    if (e.data == 'unregistered')
+      resolve();
+  };
+  frame.contentWindow.postMessage('unregister', '*', [channel.port2]);
+  await new Promise(r => { resolve = r; });
 }, 'getRegistrations promise resolves only with same origin registrations.');
 </script>


### PR DESCRIPTION
…s.html

The last test's cleanup step was very complex (involving waiting for a promise to get resolved) and WebKit's
completion handler in testharnessreport.js was often getting called before the promise resolution, leaving
the test frame in the output when we call notifyDone(). This seems like a potential bug in testharness.js.
To address the issue for now, do the unregistration in the test's body and only remove the test frame in
the cleanup step.