### PR TITLE
Fix css-shapes tests to load ahem as a web font and wait for fonts ready

### DIFF
--- a/css/css-shapes/shape-outside/values/support/parsing-utils.js
+++ b/css/css-shapes/shape-outside/values/support/parsing-utils.js
@@ -450,6 +450,7 @@ function setupFonts(func) {
     return function () {
         var fontProperties = {
             'font-family': 'Ahem',
+            'src': 'url(/fonts/Ahem.ttf)',
             'font-size': '16px',
             'line-height': '1'
         };
@@ -459,7 +460,9 @@ function setupFonts(func) {
             document.body.style.setProperty(key, value);
         });
         try {
-            func.apply(this, arguments);
+            document.fonts.ready.then(() => {
+                func.apply(this, arguments);
+            });
         } finally {
             each(savedValues, function (key, value) {
                 if (value) {


### PR DESCRIPTION
The font-related code is in a shared utility file for these tests. Updated it to load Ahem as a web font and wait for fonts.ready before running tests.

Adding these changes to the tests themselves didn't work, presumably because generate_tests is used and it interferes somehow.