### PR TITLE
[motion-1] Drop a limit test of interpolation for offset shorthand

### DIFF
--- a/css/motion/animation/offset-interpolation.html
+++ b/css/motion/animation/offset-interpolation.html
@@ -92,15 +92,6 @@
         {at: 1, expect: 'path("M0 0H 300") 600px 0deg'},
         {at: 1.5, expect: 'path("M0 0H 300") 650px 0deg'},
       ]);
-
-      // Regression test for crbug.com/994489
-      test_interpolation({
-        property: 'offset',
-        from: 'path("M0 0H 200") 500px auto',
-        to: 'path("M0 0H 300") 600px 0deg',
-      }, [
-        {at: 3.40282e+038,  expect: 'path("M0 0H 3.4e+38") 3.36e+07px 0deg'},
-      ]);
     </script>
   </body>
 </html>


### PR DESCRIPTION
The CSS spec says that any arbitrary limit is OK, so different browsers
may use different limits for `offset-distance`.

This was added because of a Chromium regression, and it'd be great to move
it into Chromium repo.