### PR TITLE
Avoid spurious timeouts in websocket test.

### DIFF
--- a/websockets/Create-Secure-extensions-empty.any.js
+++ b/websockets/Create-Secure-extensions-empty.any.js
@@ -7,15 +7,13 @@ var testClose = async_test("Create Secure WebSocket - wsocket.extensions should 
 var wsocket = CreateWebSocket(true, false, false);
 var isOpenCalled = false;
 
-wsocket.addEventListener('open', testOpen.step_func(function(evt) {
-  assert_equals(wsocket.extensions, "", "extensions should be empty");
+wsocket.addEventListener('open', testOpen.step_func_done(function(evt) {
   wsocket.close();
   isOpenCalled = true;
-  testOpen.done();
+  assert_equals(wsocket.extensions, "", "extensions should be empty");
 }), true);
 
-wsocket.addEventListener('close', testClose.step_func(function(evt) {
+wsocket.addEventListener('close', testClose.step_func_done(function(evt) {
   assert_true(isOpenCalled, "WebSocket connection should be closed");
   assert_equals(evt.wasClean, true, "wasClean should be true");
-  testClose.done();
 }), true);


### PR DESCRIPTION
If a test assertion fails, the rest of the code in that test step will not run. By changing the ordering, we ensure that the test does not timeout because the websocket is never closed the test condition fails.