### PR TITLE
Enhancement and bug fix for on[event] attributes on MathML elements

### DIFF
--- a/mathml/relations/html5-tree/clipboard-event-handlers.tentative.html
+++ b/mathml/relations/html5-tree/clipboard-event-handlers.tentative.html
@@ -24,23 +24,22 @@
   const EVENTS = ["copy", "cut", "paste"];
   const el = document.querySelector("math");
 
-  function addEventListenerTest(name) {
+  function dispatchEventTest(name) {
+    const mathEl = document.createElementNS(
+        "http://www.w3.org/1998/Math/MathML",
+        "math"
+    );
     async_test(test => {
-      el.addEventListener(
-        name,
-        test.step_func_done(e => {
-          assert_true(
-            true,
-            "MathML Elements should be able to receive ${name} events"
-          );
-        })
-      );
+      mathEl[`on${name}`] = test.step_func_done(e => {
+        assert_equals(e.currentTarget, mathEl,
+                      "The event must be fired at the <math> element");
+      });
       const event = new ClipboardEvent(name, {
         bubbles: true,
         cancellable: true
       });
-      el.dispatchEvent(event);
-    }, `math.addEventListener for ${name}`);
+      mathEl.dispatchEvent(event);
+    }, `${name}: dispatching an Event at a <math> element must trigger element.on${name}`);
   }
 
   function evaluatedHandlerTest(name) {
@@ -115,7 +114,7 @@
   }
 
   EVENTS.forEach(name => {
-    addEventListenerTest(name);
+    dispatchEventTest(name);
     evaluatedHandlerTest(name);
   });
 </script>

--- a/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
+++ b/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
@@ -124,18 +124,18 @@
           assert_equals(el[name], null, `The ${name} property must be null (remove attribute)`);
         }, `${name}: dynamic changes on the attribute`);
 
-        test(() => {
+        async_test(t => {
           const element = document.createElementNS(
             "http://www.w3.org/1998/Math/MathML",
             "math"
           );
-          element[name] = e => {
+          element[name] = t.step_func_done(e => {
             assert_equals(
               e.currentTarget,
               element,
               "The event must be fired at the <math> element"
             );
-          };
+          });
 
           element.dispatchEvent(new Event(withoutOn));
         }, `${name}: dispatching an Event at a <math> element must trigger element.${name}`);


### PR DESCRIPTION
* mathml/relations/html5-tree/math-global-event-handlers.tentative.html
  The test should be asynchronous and wait for the event to be dispatched,
  otherwise it always passes.

* clipboard-event-handlers.tentative.html
  Current test just uses addEventListener and dispatchEvent, so does not
  require any MathML-specific IDL at all. Modify the test to instead set
  the listener via element.on[event] = ...