### PR TITLE
Configure chrome_android and android_webview to use server_host env option.

### DIFF
--- a/docs/running-tests/android_webview.md
+++ b/docs/running-tests/android_webview.md
@@ -4,27 +4,42 @@ To run WPT on WebView on an Android device, some additional set-up is required.
 
 Currently, Android WebView support is experimental.
 
-* Please check [Chrome for Android](chrome_android) for the common
-  instructions for Android support first.
+## Prerequisites
 
-* Install an up-to-date version of system webview shell:
-  * Go to
-  [chromium-browser-snapshots](https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Android/)
-  * Find the subdirectory with the highest number and click it.
-  * Download `chrome-android.zip` file and unzip it.
-  * Install `SystemWebViewShell.apk`.
-  * On emulator, system webview shell may already be installed by default. Then
-    you may need to remove the existing apk:
-     * Choose a userdebug build.
-     * Run an emulator with
-       [writable system partition from command line](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/android_emulator.md/)
+#### Please check [Chrome for Android](chrome_android.md) for the common instructions for Android support first.
 
-* If you have an issue with ChromeDriver version, try removing
-  `_venv/bin/chromedriver` such that wpt runner can install a matching version
+#### Ensure you have a userdebug or eng Android build installed on the device.
+
+#### Install an up-to-date version of system webview shell.
+1. Go to [chromium-browser-snapshots](https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Android/)
+2. Find the subdirectory with the highest number and click it, this number can be found
+   in the "Commit Position" column of row "LAST_CHANGE" (at bottom of page).
+3. Download `chrome-android.zip` file and unzip it.
+4. Install `SystemWebViewShell.apk`.
+5. On emulator, system webview shell may already be installed by default. Then you may need to remove the existing apk:
+   * Choose a userdebug build.
+   * Run an emulator with
+     [writable system partition from command line](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/android_emulator.md/)
+
+#### If you have an issue with ChromeDriver version mismatch, try one of the following.
+  * Try removing `_venv/bin/chromedriver` such that wpt runner can install a matching version
   automatically. Failing that, please check your environment path and make
   sure that no other ChromeDriver is used.
+  * Download the [ChromeDriver binary](https://chromedriver.chromium.org/) matching your WebView's major version and specify it on the command line
+    ```
+    ./wpt run --webdriver-binary <binary path> ...
+    ```
 
-Example command line:
+#### Configure host remap rules in the [webview commandline file](https://cs.chromium.org/chromium/src/android_webview/docs/commandline-flags.md?l=57).
+```
+adb shell "echo '_ --host-resolver-rules=\"MAP nonexistent.*.test ~NOTFOUND, MAP *.test 127.0.0.1\"' > /data/local/tmp/webview-command-line"
+```
+
+#### Ensure that `adb` can be found on your system's PATH.
+
+## Running Tests
+
+#### Example command line:
 
 ```bash
 ./wpt run --test-type=testharness android_webview <TESTS>

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -106,7 +106,7 @@ otherwise install OpenSSL and ensure that it's on your $PATH.""")
 
 
 def check_environ(product):
-    if product not in ("chrome", "firefox", "firefox_android", "servo"):
+    if product not in ("android_webview", "chrome", "chrome_android", "firefox", "firefox_android", "servo"):
         config_builder = serve.build_config(os.path.join(wpt_root, "config.json"))
         # Override the ports to avoid looking for free ports
         config_builder.ssl = {"type": "none"}

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -67,7 +67,8 @@ def env_extras(**kwargs):
 
 
 def env_options():
-    return {}
+    # allow the use of host-resolver-rules in lieu of modifying /etc/hosts file
+    return {"server_host": "127.0.0.1"}
 
 
 #TODO: refactor common elements of SystemWebViewShell and ChromeAndroidBrowser

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -62,7 +62,8 @@ def env_extras(**kwargs):
 
 
 def env_options():
-    return {}
+    # allow the use of host-resolver-rules in lieu of modifying /etc/hosts file
+    return {"server_host": "127.0.0.1"}
 
 
 class ChromeAndroidBrowser(Browser):


### PR DESCRIPTION
This allows the wpt tests to be run without modifying the /etc/hosts file when the correct host-resolver-rules has been configured in the command line files.  Also updated android_webview documentation for running wpt.