### PR TITLE
Fix ordering of script elements in `the-script-element/module/module-vs-script-*.html` tests

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/module-vs-script-2.html
+++ b/html/semantics/scripting-1/the-script-element/module/module-vs-script-2.html
@@ -13,5 +13,5 @@
       assert_array_equals(log, [window, undefined]);
     }));
 </script>
-<script type="module" src="this.js"></script>
 <script src="this.js"></script>
+<script type="module" src="this.js"></script>


### PR DESCRIPTION
As for title in `html/semantics/scripting-1/the-script-element/module/module-vs-script-1.html`, it says "Once as module script, once as classic script" and the title of `html/semantics/scripting-1/the-script-element/module/module-vs-script-2.html` says "Once as classic script, once as module script". So, it should be reasonable to make the second test have script elements
order in classic and then module.