### PR TITLE
Clear-Site-Data: clients uncontrolled by service workers

### DIFF
--- a/clear-site-data/storage.https.html
+++ b/clear-site-data/storage.https.html
@@ -3,6 +3,7 @@
   <head>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="../service-workers/service-worker/resources/test-helpers.sub.js"></script>
     <script src="support/test_utils.sub.js"></script>
   </head>
 
@@ -13,6 +14,15 @@
         return datatype.name == "storage";
       })[0];
 
+      var serviceWorkerTestPageIFrame;
+      function fetchFromIFrame() {
+        return serviceWorkerTestPageIFrame.contentWindow
+          .fetch('support/controlled-endpoint.py')
+          .then((result) => {
+            return result.text();
+          });
+      }
+
       // The tests are set up asynchronously.
       setup({"explicit_done": true});
 
@@ -22,7 +32,41 @@
       test(function() {}, "Populate backends.");
 
       TestUtils.populateStorage()
+          .then(() => {
+            return new Promise(function(resolve, reject) {
+              promise_test(function(t) {
+                return navigator.serviceWorker.getRegistration("support/").then(function(reg) {
+                  return wait_for_state(t, reg.installing || reg.waiting || reg.active, 'activated');
+                }).then(resolve, reject);
+              });
+            });
+          })
+          .then(() => {
+            return new Promise(function (resolve) {
+              // Create iFrame in the service worker's scope. This page will make a request
+              // for another page that is only served by the service worker
+              serviceWorkerTestPageIFrame = document.createElement("iframe");
+              serviceWorkerTestPageIFrame.src = "support/page_using_service_worker.html";
+              serviceWorkerTestPageIFrame.onload = function() { resolve(); };
+              document.body.appendChild(serviceWorkerTestPageIFrame);
+            });
+          })
+          .then(() => {
+            const serviceWorkerResponseBody = fetchFromIFrame();
+
+            promise_test(function() {
+              return serviceWorkerResponseBody.then(function(body) {
+                assert_equals(body, "FROM_SERVICE_WORKER", "Response should be from service worker");
+              });
+            }, "Baseline: Service worker responds to request");
+
+            return serviceWorkerResponseBody;
+          })
           .then(function() {
+            const waitForControllerChange = new Promise(function(resolve) {
+              serviceWorkerTestPageIFrame.contentWindow
+                .navigator.serviceWorker.addEventListener("controllerchange", resolve);
+            });
             // Navigate to a resource with a Clear-Site-Data header in
             // an iframe, then verify that all backends of the "storage"
             // datatype have been deleted.
@@ -44,6 +88,19 @@
                   });
                 }, test_name);
               });
+
+              promise_test(function() {
+                return fetchFromIFrame().then(function(body) {
+                  assert_equals(body, "FROM_NETWORK", "Response should be from network and not from the service worker");
+                });
+              }, "Service worker no longer responds to requests");
+
+              promise_test(function() {
+                return waitForControllerChange.then(function() {
+                  assert_false(!!serviceWorkerTestPageIFrame.contentWindow.navigator.serviceWorker.controller,
+                    "Client should not have a controller");
+                });
+              }, "controllerchange event fires and client no longer has controller");
 
               done();
             });

--- a/clear-site-data/support/controlled-endpoint.py
+++ b/clear-site-data/support/controlled-endpoint.py
@@ -1,0 +1,3 @@
+def main(request, response):
+    return ([("Content-Type", "text/html")],
+            "FROM_NETWORK")

--- a/clear-site-data/support/page_using_service_worker.html
+++ b/clear-site-data/support/page_using_service_worker.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Clear-Site-Data + Service Workers Test Page</title>
+  </head>
+</html>

--- a/clear-site-data/support/service_worker.js
+++ b/clear-site-data/support/service_worker.js
@@ -1,1 +1,6 @@
-/* This file is intentionally left blank. */
+self.addEventListener('fetch', (e) => {
+  const url = new URL(e.request.url);
+  if (url.pathname.match('controlled-endpoint.py')) {
+    e.respondWith(new Response('FROM_SERVICE_WORKER'));
+  }
+});

--- a/clear-site-data/support/test_utils.sub.js
+++ b/clear-site-data/support/test_utils.sub.js
@@ -121,7 +121,7 @@ var TestUtils = (function() {
       "add": function() {
         return navigator.serviceWorker.register(
             "support/service_worker.js",
-            { scope: "support/scope-that-does-not-contain-this-test/"});
+            { scope: "support/"});
       },
       "isEmpty": function() {
         return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Adds a failing test, asserting that pages actively controlled by a service worker become uncontrolled after the Clear-Site-Data storage directive.

We agreed on this behavior in a spec issue and confirmed the need for this test at the TPAC Service Workers F2F.

https://github.com/w3c/ServiceWorker/issues/614
F2F notes: https://docs.google.com/document/d/1_Qfw5m3BJEaL1xIzTJd41HXjgJ9gq7mroBDXqSJIzic/edit