### PR TITLE
Add missing parameter to offscreencanvas.transfer.to.imagebitmap.w

### DIFF
--- a/offscreen-canvas/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w.html
+++ b/offscreen-canvas/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w.html
@@ -127,7 +127,7 @@ function drawImageBitmap(image, x, y)
 }
 
 async_test(function(t) {
-    var worker = makeWorker();
+    var worker = makeWorker(t);
     worker.addEventListener('message', t.step_func_done(function(msg) {
         assert_true(msg.data);
     }));


### PR DESCRIPTION
The first call to makeWorker in offscreencanvas/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w.html is missing a parameter, which causes permanent test failure. This change adds the missing parameter (issue #19134)