### PR TITLE
[web-animations-1] Update interpolation test for drop-shadow initial value

### DIFF
--- a/web-animations/animation-model/animation-types/property-types.js
+++ b/web-animations/animation-model/animation-types/property-types.js
@@ -2195,7 +2195,6 @@ const filterListType = {
     test(t => {
       const idlName = propertyToIDL(property);
       const target = createTestElement(t, setup);
-      target.style.color = "rgba(255, 0, 0, 0.4)";
       const animation = target.animate(
         { [idlName]:
           ['blur(0px)',
@@ -2204,9 +2203,9 @@ const filterListType = {
 
       testAnimationSamples(animation, idlName,
         [{ time: 500,
-           // The lacuna value of drop-shadow's color is taken from
-           // the color property.
-           expected: 'blur(5px) drop-shadow(rgba(85, 0, 170, 0.6) 5px 5px 5px' }]);
+           // Per the spec: The initial value for interpolation is all length values
+           // set to 0 and the used color set to transparent.
+           expected: 'blur(5px) drop-shadow(rgba(0, 0, 255, 0.4) 5px 5px 5px' }]);
     }, `${property}: interpolate different length of filter-function-list`
        + ' with drop-shadow function');
 


### PR DESCRIPTION
According to the spec
(https://drafts.fxtf.org/filter-effects-1/#funcdef-filter-drop-shadow):

The initial value for [drop-shadow] interpolation is all length values set to
0 and the used color set to transparent.