### PR TITLE
[web-animations-1] Fix interpolation test for rotate

### DIFF
--- a/web-animations/animation-model/animation-types/property-types.js
+++ b/web-animations/animation-model/animation-types/property-types.js
@@ -1720,7 +1720,7 @@ const rotateListType = {
                        1000);
 
       testAnimationSamples(animation, idlName,
-        [{ time: 500, expected: 'y 45deg' }]);
+        [{ time: 500, expected: '0 1 0 45deg' }]);
     }, `${property} with rotation axes`);
 
     test(t => {
@@ -1733,7 +1733,7 @@ const rotateListType = {
                        1000);
 
       testAnimationSamples(animation, idlName,
-        [{ time: 250, expected: 'y 180deg' }]);
+        [{ time: 250, expected: '0 1 0 180deg' }]);
     }, `${property} with rotation axes and range over 360 degrees`);
 
     test(t => {
@@ -1775,8 +1775,8 @@ const rotateListType = {
                        { duration: 1000, fill: 'both', composite: 'add' });
 
       testAnimationSamples(animation, idlName,
-        [{ time: 0,    expected: 'y 45deg' },
-         { time: 1000, expected: 'y 135deg' }]);
+        [{ time: 0,    expected: '0 1 0 45deg' },
+         { time: 1000, expected: '0 1 0 135deg' }]);
     }, `${property} with underlying transform`);
 
     test(t => {
@@ -1816,8 +1816,8 @@ const rotateListType = {
                        { duration: 1000, fill: 'both', composite: 'accumulate' });
 
       testAnimationSamples(animation, idlName,
-        [{ time: 0,    expected: 'x 45deg' },
-         { time: 1000, expected: 'x 135deg' }]);
+        [{ time: 0,    expected: '1 0 0 45deg' },
+         { time: 1000, expected: '1 0 0 135deg' }]);
     }, `${property} with underlying transform`);
 
     test(t => {


### PR DESCRIPTION
The spec says the computed value does not include a collapsed axis
(https://drafts.csswg.org/css-transforms-2/#individual-transforms):

"Computed value: the keyword none, or an <angle> with an optional axis
consisting of a list of three `<number>`s"