### PR TITLE
Give more context for the /gen/ lint rule

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -820,7 +820,9 @@ WEB-PLATFORM.TEST:signed-exchange/resources/*.sxg
 WEB-PLATFORM.TEST:signed-exchange/appcache/resources/*.sxg
 WEB-PLATFORM.TEST:signed-exchange/resources/generate-test-sxgs.sh
 
+# Tests that depend on resources in /gen/ in Chromium:
 # https://github.com/web-platform-tests/wpt/issues/16455
+# Please consult with ecosystem-infra@chromium.org before adding more.
 MISSING DEPENDENCY: idle-detection/interceptor.https.html
 MISSING DEPENDENCY: sms/resources/helper.js
 MISSING DEPENDENCY: web-nfc/resources/nfc-helpers.js


### PR DESCRIPTION
The purpose is to avoid adding more exceptions without careful consideration.