### PR TITLE
[webnfc] Add test for calling push() twice

### DIFF
--- a/resources/chromium/nfc-mock.js
+++ b/resources/chromium/nfc-mock.js
@@ -182,6 +182,10 @@ var WebNFCTest = (() => {
       let error = this.getHWError();
       if (error)
         return error;
+      // Cancel previous pending push operation
+      if (this.pending_promise_func_) {
+        this.cancelPendingPushOperation();
+      }
 
       this.pushed_message_ = message;
       this.push_options_ = options;
@@ -301,18 +305,18 @@ var WebNFCTest = (() => {
       this.push_options_ = null;
       this.pending_promise_func_ = null;
       this.push_should_timeout_ = false;
+      this.push_completed_ = true;
     }
 
     // Sets message that is used to deliver NFC reading updates.
     setReadingMessage(message) {
       this.reading_messages_.push(message);
       // Ignore reading if NFCPushOptions.ignoreRead is true
-      let ignoreRead = false;
       if(this.push_options_ && this.push_options_.ignoreRead)
-        ignoreRead = this.push_options_.ignoreRead;
+        return;
       // Triggers onWatch if the new message matches existing watchers
       for (let watcher of this.watchers_) {
-        if (!ignoreRead && matchesWatchOptions(message, watcher.options)) {
+        if (matchesWatchOptions(message, watcher.options)) {
           this.client_.onWatch(
               [watcher.id], fake_tag_serial_number,
               toMojoNDEFMessage(message));

--- a/web-nfc/NFCWriter_push.https.html
+++ b/web-nfc/NFCWriter_push.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Web NFC: Test exceptions in NFCWriter.push</title>
+<title>Web NFC: NFCWriter.push Tests</title>
 <link rel="author" title="Intel" href="http://www.intel.com"/>
 <link rel="help" href="https://w3c.github.io/web-nfc/"/>
 <script src="/resources/testharness.js"></script>
@@ -336,4 +336,31 @@ nfc_test(async (t, mockNFC) => {
   assertNDEFMessagesEqual(test_text_data, mockNFC.pushedMessage());
 }, "NFCWriter.push should ignore reading data when ignoreRead is true.");
 
+nfc_test(async (t, mockNFC) => {
+  const writer1 = new NFCWriter();
+  const writer2 = new NFCWriter();
+
+  const nfcPushOptions1 = createNFCPushOptions('tag', 1000, false);
+  const nfcPushOptions2 = createNFCPushOptions('tag', Infinity, true);
+  const p1 = writer1.push(test_text_data, nfcPushOptions1);
+  const p2 = writer2.push(test_url_data, nfcPushOptions2);
+
+  await new Promise((resolve, reject) => {
+    // Make first push pending
+    mockNFC.setPendingPushCompleted(false);
+    let err = "";
+    p1.then(() => {
+      t.unreached_func("pending push should not be fulfilled");
+      reject();
+    }).catch(e => {
+      err = e.name;
+    });
+    p2.then(() => {
+      assertNDEFMessagesEqual(test_url_data, mockNFC.pushedMessage());
+      assertNFCPushOptionsEqual(nfcPushOptions2, mockNFC.pushOptions());
+      assert_equals(err, "AbortError", "the pending push should be aborted");
+      resolve();
+    });
+  });
+}, "NFCWriter.push should replace all previously configured push operations.");
 </script>

--- a/web-nfc/NFCWriter_push.https.html
+++ b/web-nfc/NFCWriter_push.https.html
@@ -350,8 +350,7 @@ nfc_test(async (t, mockNFC) => {
     mockNFC.setPendingPushCompleted(false);
     let err = "";
     p1.then(() => {
-      t.unreached_func("pending push should not be fulfilled");
-      reject();
+      reject("pending push should not be fulfilled");
     }).catch(e => {
       err = e.name;
     });


### PR DESCRIPTION
A push should replace all previously configured push operations.