### PR TITLE
Fix visibility additive composition test

### DIFF
--- a/web-animations/animation-model/animation-types/property-types.js
+++ b/web-animations/animation-model/animation-types/property-types.js
@@ -617,7 +617,7 @@ const visibilityType = {
                                          composite });
       testAnimationSamples(animation, idlName,
                            [{ time: 0,    expected: 'visible' },
-                            { time: 1000, expected: 'visible' }]);
+                            { time: 1000, expected: 'hidden' }]);
     }, `${property}: onto "visible"`);
 
     test(t => {


### PR DESCRIPTION
https://drafts.csswg.org/web-animations-1/#animating-visibility does not define additive composition behavior for visibility, so the default replace behavior holds and therefore 'visible' + 'hidden' = 'hidden' I know (where the former is the underlying style).