### PR TITLE
Make status-codes-create-entry.html not flaky in WebKit.

### DIFF
--- a/resource-timing/status-codes-create-entry.html
+++ b/resource-timing/status-codes-create-entry.html
@@ -14,7 +14,7 @@ async_test(t => {
   window.addEventListener("load", t.step_func(() => {
     const images = document.getElementsByTagName("img");
     for (let img of images) {
-      assert_equals(performance.getEntriesByName(img.src).length, 1, img.src);
+      assert_greater_than(performance.getEntriesByName(img.src).length, 0, img.src);
     }
     t.done();
   }));


### PR DESCRIPTION
WebKit will sometimes load an image with status code 200 twice if the server responds before HTML parsing is complete.
The intent of this test is that all resources have at least one entry, so this change still makes the test fail before
a browser is fixed and pass afterwards, but it's no longer flaky in WebKit after the fix.