### PR TITLE
Install web-platform-tests cacert.crt in the system

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -86,6 +86,9 @@ tasks:
                       ${event.repository.url}
                       ${event.ref};
                     cd ~/web-platform-tests;
+                    sudo cp tools/certs/cacert.pem
+                        /usr/local/share/ca-certificates/cacert.crt;
+                    sudo update-ca-certificates;
                     ./tools/ci/run_tc.py
                       --checkout=${event.after}
                       --oom-killer


### PR DESCRIPTION
To avoid certification issues with the CA certificates used by the WPT in some type of browsers it is good idea to add the `tools/certs/cacert.pem` in the certificates DB of the system.

https://github.com/web-platform-tests/wpt/pull/18595#issuecomment-531163125

CC: @clopez , @foolip 