### PR TITLE
Fix teardown of the TestRunnerManager

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -394,8 +394,8 @@ class TestRunnerManager(threading.Thread):
             finally:
                 self.logger.debug("TestRunnerManager main loop terminating, starting cleanup")
                 clean = isinstance(self.state, RunnerManagerState.stop)
-                self.stop_runner(force=not clean)
                 self.teardown()
+                self.stop_runner(force=not clean)
         self.logger.debug("TestRunnerManager main loop terminated")
 
     def wait_event(self):
@@ -696,6 +696,7 @@ class TestRunnerManager(threading.Thread):
 
     def teardown(self):
         self.logger.debug("TestRunnerManager teardown")
+        self.test_runner_proc.terminate()
         self.test_runner_proc = None
         self.command_queue.close()
         self.remote_queue.close()


### PR DESCRIPTION
This PR does 2 things:

1) Stop the WebDriver client before stop the WebDriver runner. This is important because allows to the WPT framework to finalize the WebDriver session properly. In other case the WebDriver process end before the WebDriver sessions is ended causing a `connection reset by peer` in `httplib` for the WebDriver client and finally this error breaks down in a  `UNEXPECTED` exception.
2) Terminate the test_runner_proc thread, to ensure no deadlocks situations where the Manager ends but not the subprocess for the test runner process.