### PR TITLE
tcdownload: returns 1 if 'No complete TaskCluster runs found for ref'

### DIFF
--- a/tools/ci/tcdownload.py
+++ b/tools/ci/tcdownload.py
@@ -71,7 +71,7 @@ def run(*args, **kwargs):
 
     if not taskgroups:
         logger.error("No complete TaskCluster runs found for ref %s" % kwargs["ref"])
-        return
+        return 1
 
     for taskgroup in taskgroups:
         taskgroup_url = "https://queue.taskcluster.net/v1/task-group/%s/list"


### PR DESCRIPTION
Typically in UNIX like systems, every command returns an exit semantic status (sometimes referred to as a return status or exit code).  A successful command returns a 0, while an unsuccessful one returns a non-zero value that usually can be interpreted as an error code. I propose a small change in the script to return 1 in  `'No complete TaskCluster runs found for ref'` situations.