### PR TITLE
Force SIGKILL to kill the previous ended WebKitDriver

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -707,6 +707,7 @@ class TestRunnerManager(threading.Thread):
         if self.test_runner_proc is None:
             return
 
+        self.browser.stop(force=True)
         self.logger.debug("waiting for runner process to end")
         self.test_runner_proc.join(10)
         self.logger.debug("After join")

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -83,7 +83,10 @@ class WebDriverServer(object):
     def stop(self, force=False):
         self.logger.debug("Stopping WebDriver")
         if self.is_alive:
-            return self._proc.kill()
+            kill_result = self._proc.kill()
+            if force and kill_result != 0:
+                return self._proc.kill(9)
+            return kill_result
         return not self.is_alive
 
     @property


### PR DESCRIPTION
Ensure that a non-responding Browser will be stopped:

* Force a SIGKILL in the TestRunner.ensure_runner_stopped()
* The `WebDriverServer.stop_runner()` honors the force parameter.