### PR TITLE
Remove @boggydigital as SVG reviewer

### DIFF
--- a/svg/META.yml
+++ b/svg/META.yml
@@ -1,7 +1,6 @@
 spec: https://svgwg.org/svg2-draft/
 suggested_reviewers:
   - nikosandronikos
-  - boggydigital
   - ewilligers
   - AmeliaBR
   - svgeesus


### PR DESCRIPTION
@boggydigital has not accepted the org invite and thus cannot be assigned by @wpt-pr-bot.