### PR TITLE
Bail out early when there is no property

### DIFF
--- a/mathml/relations/html5-tree/clipboard-event-handlers.tentative.html
+++ b/mathml/relations/html5-tree/clipboard-event-handlers.tentative.html
@@ -30,6 +30,9 @@
         "math"
     );
     async_test(test => {
+      t.step(function() {
+        assert_true(MathMLElement.prototype.hasOwnProperty(name));
+      });
       mathEl[`on${name}`] = test.step_func_done(e => {
         assert_equals(e.currentTarget, mathEl,
                       "The event must be fired at the <math> element");

--- a/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
+++ b/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
@@ -42,9 +42,6 @@
           );
         }, `${name}: must be on the appropriate locations for GlobalEventHandlers`);
 
-        if (!MathMLElement.prototype.hasOwnProperty(name))
-            continue;
-
         test(() => {
           const location = document.createElementNS(
             "http://www.w3.org/1998/Math/MathML",
@@ -128,6 +125,9 @@
         }, `${name}: dynamic changes on the attribute`);
 
         async_test(t => {
+          t.step(function() {
+            assert_true(MathMLElement.prototype.hasOwnProperty(name));
+          });
           const element = document.createElementNS(
             "http://www.w3.org/1998/Math/MathML",
             "math"

--- a/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
+++ b/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
@@ -28,9 +28,9 @@
 
       for (const name of names) {
         const withoutOn = name.substring(2);
-        const location = MathMLElement.prototype;
 
         test(() => {
+          const location = MathMLElement.prototype;
           assert_true(
             location.hasOwnProperty(name),
             `${location.constructor.name} has an own property named "${name}"`
@@ -42,7 +42,7 @@
           );
         }, `${name}: must be on the appropriate locations for GlobalEventHandlers`);
 
-        if (!location.hasOwnProperty(name))
+        if (!MathMLElement.prototype.hasOwnProperty(name))
             continue;
 
         test(() => {

--- a/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
+++ b/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
@@ -28,9 +28,9 @@
 
       for (const name of names) {
         const withoutOn = name.substring(2);
+        const location = MathMLElement.prototype;
 
         test(() => {
-          const location = MathMLElement.prototype;
           assert_true(
             location.hasOwnProperty(name),
             `${location.constructor.name} has an own property named "${name}"`
@@ -41,6 +41,9 @@
             `Element.prototype must not contain a "${name}" property`
           );
         }, `${name}: must be on the appropriate locations for GlobalEventHandlers`);
+
+        if (!location.hasOwnProperty(name))
+            continue;
 
         test(() => {
           const location = document.createElementNS(


### PR DESCRIPTION
Bail out early when there is no property for the event handler, since
otherwise we get timeouts later on.