### PR TITLE
Sync Mozilla CSS tests as of 2019-09-22

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-008-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-margin-box-border-radius-008-ref.html
@@ -40,7 +40,7 @@
   }
   </style>
 
-  <body class="bfc">
+  <main class="bfc">
     <span class="container">
       <div class="shape"></div>
     </span>
@@ -50,5 +50,5 @@
     <div class="box" style="height: 36px; top: 60px; right: 120px;"></div>
     <div class="box" style="height: 12px; top: 96px; right: 120px;"></div> <!-- Box at corner -->
     <div class="box" style="height: 12px; top: 108px; right: 120px;"></div> <!-- Box at corner -->
-  </body>
+  </main>
 </html>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/772f7e11c7e59031e4d12df2a39844918b180beb .

This contains changes from [bug 1579295](https://bugzilla.mozilla.org/show_bug.cgi?id=1579295) by @aethanyc, reviewed by @jfkthame.