### PR TITLE
Allow the Ahem stylesheet to be loaded from support/ahem.css

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -836,11 +836,6 @@ AHEM SYSTEM FONT: acid/acid3/test.html
 AHEM SYSTEM FONT: resource-timing/resources/all_resource_types.htm
 AHEM SYSTEM FONT: resource-timing/resources/iframe-reload-TAO.sub.html
 
-# These tests are imported from mozilla-central and can't be modified in WPT.
-# They do load Ahem as a web font, but they use their own copy which trips the
-# lint rule. Basically false positives.
-AHEM SYSTEM FONT: css/vendor-imports/mozilla/mozilla-central-reftests/*
-
 # TODO: The following should be deleted along with the Ahem web font cleanup
 # PR (https://github.com/web-platform-tests/wpt/pull/18702)
 AHEM SYSTEM FONT: infrastructure/assumptions/ahem-ref.html

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -681,7 +681,10 @@ def check_script_metadata(repo_root, path, f):
 
 
 ahem_font_re = re.compile(b"font.*:.*ahem", flags=re.IGNORECASE)
-ahem_stylesheet_re = re.compile(b"\/fonts\/ahem\.css", flags=re.IGNORECASE)
+# Ahem can appear either in the global location or in the support
+# directory for legacy Mozilla imports
+ahem_stylesheet_re = re.compile(b"\/fonts\/ahem\.css|support\/ahem.css",
+                                flags=re.IGNORECASE)
 
 
 def check_ahem_system_font(repo_root, path, f):


### PR DESCRIPTION
This means that the use of Ahem in the CSS vendor-imports/mozilla
directory can be linted, which prevents those tests accidentially
including Ahem without the import. It also provides the theoretical
ability for other directories to override the Ahem stylesheet without
removing all linting, which may be useful.