### PR TITLE
Add a webkitgtk_minibrowser product/browser.

### DIFF
--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -145,4 +145,5 @@ Additional browser-specific documentation:
   chrome_android
   android_webview
   safari
+  webkitgtk_minibrowser
 ```

--- a/docs/running-tests/webkitgtk_minibrowser.md
+++ b/docs/running-tests/webkitgtk_minibrowser.md
@@ -1,0 +1,32 @@
+# WebKitGTK MiniBrowser
+
+
+To be able to run tests with the WebKitGTK MiniBrowser you need the
+following packages installed:
+
+* Fedora: `webkit2gtk3-devel`
+* Debian or Ubuntu: `webkit2gtk-driver`
+
+
+The WebKitGTK MiniBrowser is not installed on the default binary path.
+The `wpt` script will try to automatically locate it, but if you need
+to run it manually you can find it on any of this paths:
+
+* Fedora: `/usr/libexec/webkit2gtk-4.0/MiniBrowser`
+* Debian or Ubuntu: `/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser`
+  * Note: if the machine architecture is not `x86_64`, then it will be located
+    inside:  
+    `/usr/lib/${TRIPLET}/webkit2gtk-4.0/MiniBrowser`  
+    where `TRIPLET=$(gcc -dumpmachine)`
+
+
+Known issues:
+
+* On a docker container WebKitWebDriver fails to listen on localhost,
+because the docker container doesn't provide an IPv6 localhost address.
+To workaround this issue, manually tell it to only listen on IPv4 localhost
+by passing this parameter to wpt run: `--webdriver-arg=--host=127.0.0.1`  
+Example:
+```bash
+./wpt run --webdriver-arg=--host=127.0.0.1 webkitgtk_minibrowser TESTS
+```

--- a/docs/running-tests/webkitgtk_minibrowser.md
+++ b/docs/running-tests/webkitgtk_minibrowser.md
@@ -15,8 +15,8 @@ to run it manually you can find it on any of this paths:
 * Fedora: `/usr/libexec/webkit2gtk-4.0/MiniBrowser`
 * Debian or Ubuntu: `/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser`
   * Note: if the machine architecture is not `x86_64`, then it will be located
-    inside:  
-    `/usr/lib/${TRIPLET}/webkit2gtk-4.0/MiniBrowser`  
+    inside:
+    `/usr/lib/${TRIPLET}/webkit2gtk-4.0/MiniBrowser`
     where `TRIPLET=$(gcc -dumpmachine)`
 
 
@@ -25,7 +25,7 @@ Known issues:
 * On a docker container WebKitWebDriver fails to listen on localhost,
 because the docker container doesn't provide an IPv6 localhost address.
 To workaround this issue, manually tell it to only listen on IPv4 localhost
-by passing this parameter to wpt run: `--webdriver-arg=--host=127.0.0.1`  
+by passing this parameter to wpt run: `--webdriver-arg=--host=127.0.0.1`
 Example:
 ```bash
 ./wpt run --webdriver-arg=--host=127.0.0.1 webkitgtk_minibrowser TESTS

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1104,6 +1104,38 @@ class WebKit(Browser):
         return None
 
 
+class WebKitGTKMiniBrowser(WebKit):
+
+    def find_binary(self, venv_path=None, channel=None):
+        libexecpaths = ["/usr/libexec/webkit2gtk-4.0",
+                        "/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0"]
+        # If GCC is available use it to detect this machine triplet,
+        # and try to look into its multi-arch libexecdir.
+        gcc = find_executable("gcc")
+        if gcc:
+            try:
+                triplet = call(gcc, "-dumpmachine").strip()
+            except subprocess.CalledProcessError:
+                triplet = None
+            if triplet:
+                libexecpaths.insert(0, "/usr/lib/%s/webkit2gtk-4.0" % triplet)
+        return find_executable("MiniBrowser", os.pathsep.join(libexecpaths))
+
+    def find_webdriver(self, channel=None):
+        return find_executable("WebKitWebDriver")
+
+    def version(self, binary=None, webdriver_binary=None):
+        if binary is None:
+            return None
+        try: # WebKitGTK MiniBrowser before 2.26.0 doesn't support --version
+            output = call(binary, "--version").strip()
+        except subprocess.CalledProcessError:
+            output = None
+        if output:
+            return output.split()[1]
+        return None
+
+
 class Epiphany(Browser):
     """Epiphany-specific interface."""
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1107,18 +1107,17 @@ class WebKit(Browser):
 class WebKitGTKMiniBrowser(WebKit):
 
     def find_binary(self, venv_path=None, channel=None):
-        libexecpaths = ["/usr/libexec/webkit2gtk-4.0",
-                        "/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0"]
-        # If GCC is available use it to detect this machine triplet,
-        # and try to look into its multi-arch libexecdir.
+        libexecpaths = ["/usr/libexec/webkit2gtk-4.0"] # Fedora path
+        triplet = "x86_64-linux-gnu"
+        # Try to use GCC to detect this machine triplet
         gcc = find_executable("gcc")
         if gcc:
             try:
                 triplet = call(gcc, "-dumpmachine").strip()
             except subprocess.CalledProcessError:
-                triplet = None
-            if triplet:
-                libexecpaths.insert(0, "/usr/lib/%s/webkit2gtk-4.0" % triplet)
+                pass
+        # Add Debian/Ubuntu path
+        libexecpaths.append("/usr/lib/%s/webkit2gtk-4.0" % triplet)
         return find_executable("MiniBrowser", os.pathsep.join(libexecpaths))
 
     def find_webdriver(self, channel=None):
@@ -1130,10 +1129,14 @@ class WebKitGTKMiniBrowser(WebKit):
         try: # WebKitGTK MiniBrowser before 2.26.0 doesn't support --version
             output = call(binary, "--version").strip()
         except subprocess.CalledProcessError:
-            output = None
+            return None
+        # Example output: "WebKitGTK 2.26.1"
         if output:
-            return output.split()[1]
-        return None
+            m = re.match(r"WebKitGTK (.+)", output)
+        if not m:
+            self.logger.warning("Failed to extract version from: %s" % output)
+            return None
+        return m.group(1)
 
 
 class Epiphany(Browser):

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1107,7 +1107,7 @@ class WebKit(Browser):
 class WebKitGTKMiniBrowser(WebKit):
 
     def find_binary(self, venv_path=None, channel=None):
-        libexecpaths = ["/usr/libexec/webkit2gtk-4.0"] # Fedora path
+        libexecpaths = ["/usr/libexec/webkit2gtk-4.0"]  # Fedora path
         triplet = "x86_64-linux-gnu"
         # Try to use GCC to detect this machine triplet
         gcc = find_executable("gcc")
@@ -1126,17 +1126,18 @@ class WebKitGTKMiniBrowser(WebKit):
     def version(self, binary=None, webdriver_binary=None):
         if binary is None:
             return None
-        try: # WebKitGTK MiniBrowser before 2.26.0 doesn't support --version
+        try:  # WebKitGTK MiniBrowser before 2.26.0 doesn't support --version
             output = call(binary, "--version").strip()
         except subprocess.CalledProcessError:
             return None
         # Example output: "WebKitGTK 2.26.1"
         if output:
             m = re.match(r"WebKitGTK (.+)", output)
-        if not m:
-            self.logger.warning("Failed to extract version from: %s" % output)
-            return None
-        return m.group(1)
+            if not m:
+                self.logger.warning("Failed to extract version from: %s" % output)
+                return None
+            return m.group(1)
+        return None
 
 
 class Epiphany(Browser):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -583,6 +583,29 @@ class WebKit(BrowserSetup):
         pass
 
 
+class WebKitGTKMiniBrowser(BrowserSetup):
+    name = "webkitgtk_minibrowser"
+    browser_cls = browser.WebKitGTKMiniBrowser
+
+    def install(self, channel=None):
+        raise NotImplementedError
+
+    def setup_kwargs(self, kwargs):
+        if kwargs["binary"] is None:
+            binary = self.browser.find_binary()
+
+            if binary is None:
+                raise WptrunError("Unable to find MiniBrowser binary")
+            kwargs["binary"] = binary
+
+        if kwargs["webdriver_binary"] is None:
+            webdriver_binary = self.browser.find_webdriver()
+
+            if webdriver_binary is None:
+                raise WptrunError("Unable to find WebKitWebDriver in PATH")
+            kwargs["webdriver_binary"] = webdriver_binary
+
+
 class Epiphany(BrowserSetup):
     name = "epiphany"
     browser_cls = browser.Epiphany
@@ -623,6 +646,7 @@ product_setup = {
     "sauce": Sauce,
     "opera": Opera,
     "webkit": WebKit,
+    "webkitgtk_minibrowser": WebKitGTKMiniBrowser,
     "epiphany": Epiphany,
 }
 

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -35,3 +35,58 @@ def test_safari_version_errors(mocked_check_output):
     mocked_check_output.return_value = 'dummy'
     mocked_check_output.side_effect = subprocess.CalledProcessError(1, 'cmd')
     assert safari.version(webdriver_binary="safaridriver") is None
+
+
+@mock.patch('subprocess.check_output')
+def test_webkitgtk_minibrowser_version(mocked_check_output):
+    webkitgtk_minibrowser = browser.WebKitGTKMiniBrowser(logger)
+
+    mocked_check_output.return_value = 'WebKitGTK 2.26.1\n'
+    assert webkitgtk_minibrowser.version(binary='MiniBrowser') == '2.26.1'
+
+
+@mock.patch('subprocess.check_output')
+def test_webkitgtk_minibrowser_version_errors(mocked_check_output):
+    webkitgtk_minibrowser = browser.WebKitGTKMiniBrowser(logger)
+
+    # No binary
+    assert webkitgtk_minibrowser.version() is None
+
+    # `MiniBrowser --version` return gibberish
+    mocked_check_output.return_value = 'gibberish'
+    assert webkitgtk_minibrowser.version(binary='MiniBrowser') is None
+
+    # `MiniBrowser --version` fails (as it does for MiniBrowser <= 2.26.0)
+    mocked_check_output.return_value = 'dummy'
+    mocked_check_output.side_effect = subprocess.CalledProcessError(1, 'cmd')
+    assert webkitgtk_minibrowser.version(binary='MiniBrowser') is None
+
+@mock.patch('os.path.isfile')
+def test_webkitgtk_minibrowser_find_binary(mocked_os_path_isfile):
+    webkitgtk_minibrowser = browser.WebKitGTKMiniBrowser(logger)
+
+    # No MiniBrowser found
+    mocked_os_path_isfile.side_effect = lambda path: path == '/etc/passwd'
+    assert webkitgtk_minibrowser.find_binary() is None
+
+    # Found on the default Fedora path
+    fedora_minibrowser_path = '/usr/libexec/webkit2gtk-4.0/MiniBrowser'
+    mocked_os_path_isfile.side_effect = lambda path: path == fedora_minibrowser_path
+    assert webkitgtk_minibrowser.find_binary() == fedora_minibrowser_path
+
+    # Found on the default Debian path for AMD64 (gcc not available)
+    debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+    mocked_os_path_isfile.side_effect = lambda path: path == debian_minibrowser_path_amd64
+    assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_amd64
+
+    # Found on the default Debian path for AMD64 (gcc available but gives an error)
+    debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+    mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_amd64, '/usr/bin/gcc']
+    with mock.patch('subprocess.check_output', return_value = 'error', side_effect = subprocess.CalledProcessError(1, 'cmd')):
+        assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_amd64
+
+    # Found on the default Debian path for ARM64 (gcc available)
+    debian_minibrowser_path_arm64 ='/usr/lib/aarch64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+    mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_arm64, '/usr/bin/gcc']
+    with mock.patch('subprocess.check_output', return_value = 'aarch64-linux-gnu'):
+        assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_arm64

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -86,7 +86,7 @@ def test_webkitgtk_minibrowser_find_binary(mocked_os_path_isfile):
         assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_amd64
 
     # Found on the default Debian path for ARM64 (gcc available)
-    debian_minibrowser_path_arm64 ='/usr/lib/aarch64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+    debian_minibrowser_path_arm64 = '/usr/lib/aarch64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
     mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_arm64, '/usr/bin/gcc']
     with mock.patch('subprocess.check_output', return_value = 'aarch64-linux-gnu'):
         assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_arm64

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -1,6 +1,8 @@
 import mock
 import subprocess
 import logging
+import sys
+import pytest
 
 from tools.wpt import browser
 
@@ -61,37 +63,37 @@ def test_webkitgtk_minibrowser_version_errors(mocked_check_output):
     mocked_check_output.side_effect = subprocess.CalledProcessError(1, 'cmd')
     assert webkitgtk_minibrowser.version(binary='MiniBrowser') is None
 
+
+# The test below doesn't work on Windows because distutils find_binary()
+# on Windows only works if the binary name ends with a ".exe" suffix.
+# But, WebKitGTK itself doesn't support Windows, so lets skip the test.
+@pytest.mark.skipif(sys.platform.startswith('win'), reason='test not needed on Windows')
 @mock.patch('os.path.isfile')
 def test_webkitgtk_minibrowser_find_binary(mocked_os_path_isfile):
-    # This test doesn't work on Windows because distutils find_binary()
-    # on Windows only works if the binary name ends with a ".exe" suffix.
-    # But, WebKitGTK itself doesn't support Windows, so lets mock a Linux
-    # platform here to make the test itself pass on Windows.
-    with mock.patch('sys.platform', 'linux2'):
-        webkitgtk_minibrowser = browser.WebKitGTKMiniBrowser(logger)
+    webkitgtk_minibrowser = browser.WebKitGTKMiniBrowser(logger)
 
-        # No MiniBrowser found
-        mocked_os_path_isfile.side_effect = lambda path: path == '/etc/passwd'
-        assert webkitgtk_minibrowser.find_binary() is None
+    # No MiniBrowser found
+    mocked_os_path_isfile.side_effect = lambda path: path == '/etc/passwd'
+    assert webkitgtk_minibrowser.find_binary() is None
 
-        # Found on the default Fedora path
-        fedora_minibrowser_path = '/usr/libexec/webkit2gtk-4.0/MiniBrowser'
-        mocked_os_path_isfile.side_effect = lambda path: path == fedora_minibrowser_path
-        assert webkitgtk_minibrowser.find_binary() == fedora_minibrowser_path
+    # Found on the default Fedora path
+    fedora_minibrowser_path = '/usr/libexec/webkit2gtk-4.0/MiniBrowser'
+    mocked_os_path_isfile.side_effect = lambda path: path == fedora_minibrowser_path
+    assert webkitgtk_minibrowser.find_binary() == fedora_minibrowser_path
 
-        # Found on the default Debian path for AMD64 (gcc not available)
-        debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
-        mocked_os_path_isfile.side_effect = lambda path: path == debian_minibrowser_path_amd64
+    # Found on the default Debian path for AMD64 (gcc not available)
+    debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+    mocked_os_path_isfile.side_effect = lambda path: path == debian_minibrowser_path_amd64
+    assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_amd64
+
+    # Found on the default Debian path for AMD64 (gcc available but gives an error)
+    debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+    mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_amd64, '/usr/bin/gcc']
+    with mock.patch('subprocess.check_output', return_value = 'error', side_effect = subprocess.CalledProcessError(1, 'cmd')):
         assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_amd64
 
-        # Found on the default Debian path for AMD64 (gcc available but gives an error)
-        debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
-        mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_amd64, '/usr/bin/gcc']
-        with mock.patch('subprocess.check_output', return_value = 'error', side_effect = subprocess.CalledProcessError(1, 'cmd')):
-            assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_amd64
-
-            # Found on the default Debian path for ARM64 (gcc available)
-            debian_minibrowser_path_arm64 = '/usr/lib/aarch64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
-            mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_arm64, '/usr/bin/gcc']
-            with mock.patch('subprocess.check_output', return_value = 'aarch64-linux-gnu'):
-                assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_arm64
+        # Found on the default Debian path for ARM64 (gcc available)
+        debian_minibrowser_path_arm64 = '/usr/lib/aarch64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+        mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_arm64, '/usr/bin/gcc']
+        with mock.patch('subprocess.check_output', return_value = 'aarch64-linux-gnu'):
+            assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_arm64

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -63,30 +63,35 @@ def test_webkitgtk_minibrowser_version_errors(mocked_check_output):
 
 @mock.patch('os.path.isfile')
 def test_webkitgtk_minibrowser_find_binary(mocked_os_path_isfile):
-    webkitgtk_minibrowser = browser.WebKitGTKMiniBrowser(logger)
+    # This test doesn't work on Windows because distutils find_binary()
+    # on Windows only works if the binary name ends with a ".exe" suffix.
+    # But, WebKitGTK itself doesn't support Windows, so lets mock a Linux
+    # platform here to make the test itself pass on Windows.
+    with mock.patch('sys.platform', 'linux2'):
+        webkitgtk_minibrowser = browser.WebKitGTKMiniBrowser(logger)
 
-    # No MiniBrowser found
-    mocked_os_path_isfile.side_effect = lambda path: path == '/etc/passwd'
-    assert webkitgtk_minibrowser.find_binary() is None
+        # No MiniBrowser found
+        mocked_os_path_isfile.side_effect = lambda path: path == '/etc/passwd'
+        assert webkitgtk_minibrowser.find_binary() is None
 
-    # Found on the default Fedora path
-    fedora_minibrowser_path = '/usr/libexec/webkit2gtk-4.0/MiniBrowser'
-    mocked_os_path_isfile.side_effect = lambda path: path == fedora_minibrowser_path
-    assert webkitgtk_minibrowser.find_binary() == fedora_minibrowser_path
+        # Found on the default Fedora path
+        fedora_minibrowser_path = '/usr/libexec/webkit2gtk-4.0/MiniBrowser'
+        mocked_os_path_isfile.side_effect = lambda path: path == fedora_minibrowser_path
+        assert webkitgtk_minibrowser.find_binary() == fedora_minibrowser_path
 
-    # Found on the default Debian path for AMD64 (gcc not available)
-    debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
-    mocked_os_path_isfile.side_effect = lambda path: path == debian_minibrowser_path_amd64
-    assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_amd64
-
-    # Found on the default Debian path for AMD64 (gcc available but gives an error)
-    debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
-    mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_amd64, '/usr/bin/gcc']
-    with mock.patch('subprocess.check_output', return_value = 'error', side_effect = subprocess.CalledProcessError(1, 'cmd')):
+        # Found on the default Debian path for AMD64 (gcc not available)
+        debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+        mocked_os_path_isfile.side_effect = lambda path: path == debian_minibrowser_path_amd64
         assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_amd64
 
-    # Found on the default Debian path for ARM64 (gcc available)
-    debian_minibrowser_path_arm64 = '/usr/lib/aarch64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
-    mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_arm64, '/usr/bin/gcc']
-    with mock.patch('subprocess.check_output', return_value = 'aarch64-linux-gnu'):
-        assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_arm64
+        # Found on the default Debian path for AMD64 (gcc available but gives an error)
+        debian_minibrowser_path_amd64 = '/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+        mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_amd64, '/usr/bin/gcc']
+        with mock.patch('subprocess.check_output', return_value = 'error', side_effect = subprocess.CalledProcessError(1, 'cmd')):
+            assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_amd64
+
+            # Found on the default Debian path for ARM64 (gcc available)
+            debian_minibrowser_path_arm64 = '/usr/lib/aarch64-linux-gnu/webkit2gtk-4.0/MiniBrowser'
+            mocked_os_path_isfile.side_effect = lambda path: path in [debian_minibrowser_path_arm64, '/usr/bin/gcc']
+            with mock.patch('subprocess.check_output', return_value = 'aarch64-linux-gnu'):
+                assert webkitgtk_minibrowser.find_binary() == debian_minibrowser_path_arm64

--- a/tools/wptrunner/wptrunner/browsers/__init__.py
+++ b/tools/wptrunner/wptrunner/browsers/__init__.py
@@ -38,4 +38,5 @@ product_list = ["android_webview",
                 "servodriver",
                 "opera",
                 "webkit",
+                "webkitgtk_minibrowser",
                 "epiphany"]

--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -1,0 +1,74 @@
+from .base import get_timeout_multiplier   # noqa: F401
+from .webkit import WebKitBrowser
+from ..executors import executor_kwargs as base_executor_kwargs
+from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
+                                           WebDriverRefTestExecutor)  # noqa: F401
+from ..executors.executorwebkit import WebKitDriverWdspecExecutor  # noqa: F401
+
+__wptrunner__ = {"product": "webkitgtk_minibrowser",
+                 "check_args": "check_args",
+                 "browser": "WebKitGTKMiniBrowser",
+                 "browser_kwargs": "browser_kwargs",
+                 "executor": {"testharness": "WebDriverTestharnessExecutor",
+                              "reftest": "WebDriverRefTestExecutor",
+                              "wdspec": "WebKitDriverWdspecExecutor"},
+                 "executor_kwargs": "executor_kwargs",
+                 "env_extras": "env_extras",
+                 "env_options": "env_options",
+                 "run_info_extras": "run_info_extras",
+                 "timeout_multiplier": "get_timeout_multiplier"}
+
+
+def check_args(**kwargs):
+    pass
+
+
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
+    return {"binary": kwargs["binary"],
+            "webdriver_binary": kwargs["webdriver_binary"],
+            "webdriver_args": kwargs.get("webdriver_args")}
+
+
+def capabilities(server_config, **kwargs):
+    args = kwargs.get("binary_args", [])
+    if "--automation" not in args:
+        args.append("--automation")
+
+    return {
+        "browserName": "MiniBrowser",
+        "browserVersion": "2.20",
+        "platformName": "ANY",
+        "webkitgtk:browserOptions": {
+            "binary": kwargs["binary"],
+            "args": args,
+            "certificates": [
+                {"host": server_config["browser_host"],
+                 "certificateFile": kwargs["host_cert_path"]}]}}
+
+
+def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
+                    **kwargs):
+    executor_kwargs = base_executor_kwargs(test_type, server_config,
+                                           cache_manager, run_info_data, **kwargs)
+    executor_kwargs["close_after_done"] = True
+    executor_kwargs["capabilities"] = capabilities(server_config, **kwargs)
+    return executor_kwargs
+
+
+def env_extras(**kwargs):
+    return []
+
+
+def env_options():
+    return {}
+
+
+def run_info_extras(**kwargs):
+    return {"webkit_port": "gtk"}
+
+
+class WebKitGTKMiniBrowser(WebKitBrowser):
+    def __init__(self, logger, binary=None, webdriver_binary=None,
+                 webdriver_args=None):
+        WebKitBrowser.__init__(self, logger, binary, webdriver_binary,
+                               webdriver_args)

--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -36,8 +36,6 @@ def capabilities(server_config, **kwargs):
 
     return {
         "browserName": "MiniBrowser",
-        "browserVersion": "2.20",
-        "platformName": "ANY",
         "webkitgtk:browserOptions": {
             "binary": kwargs["binary"],
             "args": args,


### PR DESCRIPTION
 * The current "webkit" product is a bit of confusing because
   it is a too much generic name, and it can be used for
   running webkitgtk or wpewebkit based browsers (but not for
   safari/mac based ones)

 * This adds a webkitgtk_minibrowser product that makes much
   clearer what is the product about. It also defines default
   values for all variables that previously the user had to
   fill when running the "webkit" product. Now it simply
   suffices with running: "/wpt run webkitgtk_minibrowser"
