### PR TITLE
[web-animations] Reject "float" in the keyframe-like object.

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -45,6 +45,8 @@ const gNonAnimatableProps = [
 
   'unsupportedProperty',
 
+  'float', // We use the string "cssFloat" to represent "float" property, and
+           // so reject "float" in the keyframe-like object.
   'font-size', // Supported property that uses dashes
 ];
 


### PR DESCRIPTION
Add `float` into gNonAnimatableProps so make sure it should be rejected.
This has been discussed in https://github.com/w3c/csswg-drafts/issues/4331.