### PR TITLE
[css-backgrounds] border shorthands

### DIFF
--- a/css/css-backgrounds/parsing/border-color-shorthand.html
+++ b/css/css-backgrounds/parsing/border-color-shorthand.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 3: border-color sets longhands</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-color">
+<meta name="assert" content="border-color supports the full grammar '<color>{1,4}'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_shorthand_value('border-color', 'currentcolor', {
+  'border-top-color': 'currentcolor',
+  'border-right-color': 'currentcolor',
+  'border-bottom-color': 'currentcolor',
+  'border-left-color': 'currentcolor'
+});
+
+test_shorthand_value('border-color', 'red yellow', {
+  'border-top-color': 'red',
+  'border-right-color': 'yellow',
+  'border-bottom-color': 'red',
+  'border-left-color': 'yellow'
+});
+
+test_shorthand_value('border-color', 'red yellow green', {
+  'border-top-color': 'red',
+  'border-right-color': 'yellow',
+  'border-bottom-color': 'green',
+  'border-left-color': 'yellow'
+});
+
+test_shorthand_value('border-color', 'red yellow green blue', {
+  'border-top-color': 'red',
+  'border-right-color': 'yellow',
+  'border-bottom-color': 'green',
+  'border-left-color': 'blue'
+});
+</script>
+</body>
+</html>

--- a/css/css-backgrounds/parsing/border-image-shorthand.sub.html
+++ b/css/css-backgrounds/parsing/border-image-shorthand.sub.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 3: border-image sets longhands</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-image">
+<meta name="assert" content="border-image supports the full grammar ' <‘border-image-source’> || <‘border-image-slice’> [ / <‘border-image-width’> | / <‘border-image-width’>? / <‘border-image-outset’> ]? || <‘border-image-repeat’>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_shorthand_value('border-image', 'none', {
+  'border-image-source': 'none',
+  'border-image-slice': '100%',
+  'border-image-width': '1',
+  'border-image-outset': '0',
+  'border-image-repeat': 'stretch'
+});
+
+test_shorthand_value('border-image', 'url("http://{{host}}/") 1 2 3 4 fill', {
+  'border-image-source': 'url("http://{{host}}/")',
+  'border-image-slice': '1 2 3 4 fill',
+  'border-image-width': '1',
+  'border-image-outset': '0',
+  'border-image-repeat': 'stretch'
+});
+
+test_shorthand_value('border-image', 'repeat round', {
+  'border-image-source': 'none',
+  'border-image-slice': '100%',
+  'border-image-width': '1',
+  'border-image-outset': '0',
+  'border-image-repeat': 'repeat round'
+});
+
+test_shorthand_value('border-image', 'url("http://{{host}}/") fill 1 2% 3 4%', {
+  'border-image-source': 'url("http://{{host}}/")',
+  'border-image-slice': '1 2% 3 4% fill',
+  'border-image-width': '1',
+  'border-image-outset': '0',
+  'border-image-repeat': 'stretch'
+});
+
+test_shorthand_value('border-image', '1 2% 3 4% / 5% / 6', {
+  'border-image-source': 'none',
+  'border-image-slice': '1 2% 3 4%',
+  'border-image-width': '5%',
+  'border-image-outset': '6',
+  'border-image-repeat': 'stretch'
+});
+</script>
+</body>
+</html>

--- a/css/css-backgrounds/parsing/border-invalid.html
+++ b/css/css-backgrounds/parsing/border-invalid.html
@@ -3,9 +3,8 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Backgrounds and Borders Module Level 3: parsing border with invalid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-shorthands">
-<meta name="assert" content="border-width supports only the grammar '<line-width> || <line-style> || <color>'.">
+<meta name="assert" content="border supports only the grammar '<line-width> || <line-style> || <color>'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>

--- a/css/css-backgrounds/parsing/border-shorthand.html
+++ b/css/css-backgrounds/parsing/border-shorthand.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 3: border sets longhands</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-shorthands">
+<meta name="assert" content="border supports the full grammar '<line-width> || <line-style> || <color>'.">
+<meta name="assert" content="The border shorthand also resets border-image to its initial value.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_shorthand_value('border', '5px dotted blue', {
+  'border-top-width': '5px',
+  'border-right-width': '5px',
+  'border-bottom-width': '5px',
+  'border-left-width': '5px',
+  'border-top-style': 'dotted',
+  'border-right-style': 'dotted',
+  'border-bottom-style': 'dotted',
+  'border-left-style': 'dotted',
+  'border-top-color': 'blue',
+  'border-right-color': 'blue',
+  'border-bottom-color': 'blue',
+  'border-left-color': 'blue',
+
+  'border-image-source': 'none',
+  'border-image-slice': '100%',
+  'border-image-width': '1',
+  'border-image-outset': '0',
+  'border-image-repeat': 'stretch'
+});
+
+test_shorthand_value('border-top', 'thin', {
+  'border-top-width': 'thin',
+  'border-top-style': 'none',
+  'border-top-color': 'currentcolor'
+});
+
+test_shorthand_value('border-right', 'double', {
+  'border-right-width': 'medium',
+  'border-right-style': 'double',
+  'border-right-color': 'currentcolor'
+});
+
+test_shorthand_value('border-bottom', 'green', {
+  'border-bottom-width': 'medium',
+  'border-bottom-style': 'none',
+  'border-bottom-color': 'green'
+});
+
+test_shorthand_value('border-left', '1px dotted red', {
+  'border-left-width': '1px',
+  'border-left-style': 'dotted',
+  'border-left-color': 'red'
+});
+</script>
+</body>
+</html>

--- a/css/css-backgrounds/parsing/border-style-shorthand.html
+++ b/css/css-backgrounds/parsing/border-style-shorthand.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 3: border-style sets longhands</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-style">
+<meta name="assert" content="border-style supports the full grammar '<line-style>{1,4}'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_shorthand_value('border-style', 'none', {
+  'border-top-style': 'none',
+  'border-right-style': 'none',
+  'border-bottom-style': 'none',
+  'border-left-style': 'none'
+});
+
+test_shorthand_value('border-style', 'inset outset', {
+  'border-top-style': 'inset',
+  'border-right-style': 'outset',
+  'border-bottom-style': 'inset',
+  'border-left-style': 'outset'
+});
+
+test_shorthand_value('border-style', 'hidden dotted dashed', {
+  'border-top-style': 'hidden',
+  'border-right-style': 'dotted',
+  'border-bottom-style': 'dashed',
+  'border-left-style': 'dotted'
+});
+
+test_shorthand_value('border-style', 'solid double groove ridge', {
+  'border-top-style': 'solid',
+  'border-right-style': 'double',
+  'border-bottom-style': 'groove',
+  'border-left-style': 'ridge'
+});
+</script>
+</body>
+</html>

--- a/css/css-backgrounds/parsing/border-valid.html
+++ b/css/css-backgrounds/parsing/border-valid.html
@@ -3,9 +3,8 @@
 <head>
 <meta charset="utf-8">
 <title>CSS Backgrounds and Borders Module Level 3: parsing border with valid values</title>
-<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-shorthands">
-<meta name="assert" content="border-width supports the full grammar '<line-width> || <line-style> || <color>'.">
+<meta name="assert" content="border supports the full grammar '<line-width> || <line-style> || <color>'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>

--- a/css/css-backgrounds/parsing/border-width-shorthand.html
+++ b/css/css-backgrounds/parsing/border-width-shorthand.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 3: border-width sets longhands</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-width">
+<meta name="assert" content="border-width supports the full grammar '<line-width>{1,4}'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_shorthand_value('border-width', '5px', {
+  'border-top-width': '5px',
+  'border-right-width': '5px',
+  'border-bottom-width': '5px',
+  'border-left-width': '5px'
+});
+
+test_shorthand_value('border-width', 'thick thin', {
+  'border-top-width': 'thick',
+  'border-right-width': 'thin',
+  'border-bottom-width': 'thick',
+  'border-left-width': 'thin'
+});
+
+test_shorthand_value('border-width', 'thin medium thick', {
+  'border-top-width': 'thin',
+  'border-right-width': 'medium',
+  'border-bottom-width': 'thick',
+  'border-left-width': 'medium'
+});
+
+test_shorthand_value('border-width', '1px 2px 3px 4px', {
+  'border-top-width': '1px',
+  'border-right-width': '2px',
+  'border-bottom-width': '3px',
+  'border-left-width': '4px'
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Test the expansion of border shorthand properties
into equivalent longhand properties.

https://drafts.csswg.org/css-backgrounds/#border-shorthands
https://drafts.csswg.org/css-backgrounds/#border-image