### PR TITLE
[GitHub Actions] increase the fetch depth to 50 (was 1)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         ref: refs/heads/master
-        fetch-depth: 1
+        fetch-depth: 50
     - name: update-pr-preview
       uses: ./tools/docker/github
       env:

--- a/.github/workflows/push-build-publish-documentation-website.yml
+++ b/.github/workflows/push-build-publish-documentation-website.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
       with:
-        fetch-depth: 1
+        fetch-depth: 50
     - name: website-build-and-publish
       uses: ./tools/docker/documentation
       env:

--- a/.github/workflows/push-build-release-manifest.yml
+++ b/.github/workflows/push-build-release-manifest.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
       with:
-        fetch-depth: 1
+        fetch-depth: 50
     - name: manifest-build-and-tag
       uses: ./tools/docker/github
       env:


### PR DESCRIPTION
When multiple commits land in short succession, a fetch depth of 1
will lead the checkout step of the first triggered workflow to fail:
https://github.com/web-platform-tests/wpt/runs/233269859

Use a fetch depth of 50, matching Azure Pipelines and Taskcluster:
https://github.com/web-platform-tests/wpt/blob/master/tools/ci/azure/checkout.yml
https://github.com/web-platform-tests/wpt/blob/master/tools/docker/start.sh