### PR TITLE
Never create merge_commit_* tags

### DIFF
--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -184,10 +184,8 @@ def main():
 
     pr = get_pr(owner, repo, head_rev)
     if pr is None:
-        # This should only really happen during testing
-        tag_name = "merge_commit_%s" % head_rev
-    else:
-        tag_name = "merge_pr_%s" % pr
+        return Status.FAIL
+    tag_name = "merge_pr_%s" % pr
 
     manifest_path = os.path.expanduser(os.path.join("~", "meta", "MANIFEST.json"))
 


### PR DESCRIPTION
This has happened in production, creating a number of these tags.

The tags have already been deleted.