### PR TITLE
Fail if more than one PR is found when tagging a commit

### DIFF
--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -98,8 +98,9 @@ def get_pr(owner, repo, sha):
     if len(items) == 0:
         logger.error("No PR found for %s" % sha)
         return None
-    if len(items) > 1:
-        logger.warning("Found multiple PRs for %s" % sha)
+    if len(items) != 1:
+        logger.error("Found multiple PRs for %s" % sha)
+        return None
 
     pr = items[0]
 


### PR DESCRIPTION
If this condition ever happens something strange has happened and picking the first PR returned might not be correct.