### PR TITLE
Rename CSS Animation Worklet IDL file to match reffy-reports

### DIFF
--- a/animation-worklet/META.yml
+++ b/animation-worklet/META.yml
@@ -1,4 +1,4 @@
-spec: https://wicg.github.io/animation-worklet/
+spec: https://drafts.css-houdini.org/css-animationworklet/
 suggested_reviewers:
   - flackr
   - majido

--- a/animation-worklet/idlharness.any.js
+++ b/animation-worklet/idlharness.any.js
@@ -6,7 +6,7 @@
 // https://wicg.github.io/animation-worklet/
 
 idl_test(
-  ['animation-worklet'],
+  ['css-animation-worklet'],
   ['worklets', 'web-animations', 'html', 'cssom', 'dom'],
   idl_array => {
     idl_array.add_objects({

--- a/interfaces/css-animation-worklet.idl
+++ b/interfaces/css-animation-worklet.idl
@@ -1,7 +1,7 @@
 // GENERATED CONTENT - DO NOT EDIT
 // Content was automatically extracted by Reffy into reffy-reports
 // (https://github.com/tidoust/reffy-reports)
-// Source: CSS Animation Worklet API (https://wicg.github.io/animation-worklet/)
+// Source: CSS Animation Worklet API (https://drafts.css-houdini.org/css-animationworklet-1/)
 
 [Exposed=Window]
 partial namespace CSS {


### PR DESCRIPTION
Renamed in https://github.com/tidoust/reffy-reports/commit/b82ba0b160f3e2ddf4a96ac838c52894021f6f85.

Closes https://github.com/web-platform-tests/wpt/pull/19287.
Closes https://github.com/web-platform-tests/wpt/pull/19288.