### PR TITLE
Fix more broken links

### DIFF
--- a/payment-request/PaymentValidationErrors/retry-shows-error-member-manual.https.html
+++ b/payment-request/PaymentValidationErrors/retry-shows-error-member-manual.https.html
@@ -45,6 +45,6 @@ function retryShowsErrorMember(button) {
   </li>
 </ol>
 <small>
-  If you find a buggy test, please <a href="https://github.com/w3c/web-platform-tests/issues">file a bug</a>
+  If you find a buggy test, please <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a>
   and tag one of the <a href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml">owners</a>.
 </small>

--- a/payment-request/PaymentValidationErrors/retry-shows-payer-member-manual.https.html
+++ b/payment-request/PaymentValidationErrors/retry-shows-payer-member-manual.https.html
@@ -60,6 +60,6 @@ function retryShowsPayerMember(button, error) {
   </li>
 </ol>
 <small>
-  If you find a buggy test, please <a href="https://github.com/w3c/web-platform-tests/issues">file a bug</a>
+  If you find a buggy test, please <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a>
   and tag one of the <a href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml">owners</a>.
 </small>

--- a/payment-request/PaymentValidationErrors/retry-shows-shippingAddress-member-manual.https.html
+++ b/payment-request/PaymentValidationErrors/retry-shows-shippingAddress-member-manual.https.html
@@ -93,6 +93,6 @@ function retryShowsShippingAddressMember(button, error) {
   </li>
 </ol>
 <small>
-  If you find a buggy test, please <a href="https://github.com/w3c/web-platform-tests/issues">file a bug</a>
+  If you find a buggy test, please <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a>
   and tag one of the <a href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml">owners</a>.
 </small>

--- a/payment-request/payment-response/retry-method-manual.https.html
+++ b/payment-request/payment-response/retry-method-manual.https.html
@@ -291,6 +291,6 @@ function callingRetryReturnsUniquePromise(button){
   </li>
 </ol>
 <small>
-  If you find a buggy test, please <a href="https://github.com/w3c/web-platform-tests/issues">file a bug</a>
-  and tag one of the <a href="https://github.com/w3c/web-platform-tests/blob/master/payment-request/OWNERS">owners</a>.
+  If you find a buggy test, please <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a>
+  and tag one of the <a href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml">owners</a>.
 </small>

--- a/resources/test/variants.js
+++ b/resources/test/variants.js
@@ -5,7 +5,7 @@
      * Tests are executed in the absence of the global Promise constructor by
      * default in order to verify support for the Server browser engine.
      *
-     * https://github.com/w3c/web-platform-tests/issues/6266
+     * https://github.com/web-platform-tests/wpt/issues/6266
      */
     'default': {
       description: 'Global Promise constructor removed.',


### PR DESCRIPTION
Fixes #19296 (again).

---

I used this to fix the w3c/web-platform-tests links

```
grep -rl "https://github.com/w3c/web-platform-tests" . | xargs sed -i '' 's#https://github.com/w3c/web-platform-tests#https://github.com/web-platform-tests/wpt#g'
```

and for checking remaining instances of  `OWNERS`

```
git grep "/OWNERS"
lint.whitelist:SUPPORT-WRONG-DIR: css/OWNERS
lint.whitelist:SUPPORT-WRONG-DIR: css/*/OWNERS
tools/ci/jobs.py:                  "!.*/OWNERS",
```

@gsnedders should the lint.whitelist be updated? What about the jobs.py instance?