### PR TITLE
Remove unused --channel=experimental for resources/ tests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -282,7 +282,6 @@ tasks:
             export TOXENV=py27;
             ./tools/ci/run_tc.py \
               --browser=firefox \
-              --channel=experimental \
               --xvfb \
               resources_unittest \
               tools/ci/ci_resources_unittest.sh


### PR DESCRIPTION
The argument is documented as "Chrome browser channel" and isn't used
here because Chrome isn't involved.