### PR TITLE
[css-text] More variations on the word-break-keep-all-005 test

### DIFF
--- a/css/css-text/word-break/word-break-keep-all-007.html
+++ b/css/css-text/word-break/word-break-keep-all-007.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS-Text test: word-break keep-all + pre-wrap does not affect U+3000</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<meta name=flags content="">
+<meta name=assert content="U+3000, despite being called Ideographic Space, does not belong to the ID line breaking class, or any other class whose wrapping opportunities are suppressed by word-break:keep-all. A break after it should still be allowed. white-space:pre-wrap doesn't change that.">
+<link rel="match" href="reference/word-break-keep-all-005-ref.html">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#valdef-word-break-keep-all">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<style>
+div {
+  width: 4em;
+  word-break: keep-all;
+  white-space: pre-wrap;
+}
+</style>
+
+<p>This test passes if the four characters below are arranged in a two-by-two square.
+<div lang=ja>字字　字字</div>
+<!--
+If keep-all has no effect at all, breaks are allowed everywhere,
+and the result will be:
+  字字　字
+  字
+
+If keep-all correctly suppresses wrapping opportunities between CJK ideographs
+but also incorrectly suppresses the wrapping opportunity after U+3000,
+no wrapping is possible, and the result will be:
+  字字　字字
+-->

--- a/css/css-text/word-break/word-break-keep-all-008.html
+++ b/css/css-text/word-break/word-break-keep-all-008.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS-Text test: word-break keep-all + break-spaces does not affect U+3000</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<meta name=flags content="">
+<meta name=assert content="U+3000, despite being called Ideographic Space, does not belong to the ID line breaking class, or any other class whose wrapping opportunities are suppressed by word-break:keep-all. A break after it should still be allowed. white-space:break-spaces doesn't change that.">
+<link rel="match" href="reference/word-break-keep-all-005-ref.html">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#valdef-word-break-keep-all">
+<link rel=help href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<style>
+div {
+  width: 4em;
+  word-break: keep-all;
+  white-space: break-spaces;
+}
+</style>
+
+<p>This test passes if the four characters below are arranged in a two-by-two square.
+<div lang=ja>字字　字字</div>
+<!--
+If keep-all has no effect at all, breaks are allowed everywhere,
+and the result will be:
+  字字　字
+  字
+
+If keep-all correctly suppresses wrapping opportunities between CJK ideographs
+but also incorrectly suppresses the wrapping opportunity after U+3000,
+no wrapping is possible, and the result will be:
+  字字　字字
+-->


### PR DESCRIPTION
The white-space property should not make a difference, but as U+3000
could easily be misclassified as a space, its processing might be
affect. Check that it is not.