### PR TITLE
[Taskcluster] pin Chrome Dev to 78.0.3904.17

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -124,8 +124,12 @@ def checkout_revision(rev):
 
 
 def install_chrome(channel):
+    deb_prefix = "https://dl.google.com/linux/direct/"
     if channel in ("experimental", "dev", "nightly"):
-        deb_archive = "google-chrome-unstable_current_amd64.deb"
+        # Pinned to 78 as 79 consistently fails reftests. TODO(foolip).
+        # See https://github.com/web-platform-tests/wpt/issues/19297.
+        deb_archive = "google-chrome-unstable_78.0.3904.17-1_amd64.deb"
+        deb_prefix = "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/"
     elif channel == "beta":
         deb_archive = "google-chrome-beta_current_amd64.deb"
     elif channel == "stable":
@@ -134,7 +138,7 @@ def install_chrome(channel):
         raise ValueError("Unrecognized release channel: %s" % channel)
 
     dest = os.path.join("/tmp", deb_archive)
-    resp = urlopen("https://dl.google.com/linux/direct/%s" % deb_archive)
+    resp = urlopen(deb_prefix + deb_archive)
     with open(dest, "w") as f:
         f.write(resp.read())
 


### PR DESCRIPTION
The URL pattern can be discovered by installing Chrome Dev and then running
`apt-get download --print-uris google-chrome-unstable`. These URLs are probably
not stable forever, but it was confirmed that the version used for a Taskcluster
run back in Feburary 28 is still available:
https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_74.0.3717.0-1_amd64.deb

The version pinned here is from the last successful Taskcluster run before
Chrome Dev 79: https://tools.taskcluster.net/groups/fwiwJe9RSQ22S1HaAZaE-g

Mitigation (not fix) for https://github.com/web-platform-tests/wpt/issues/19297.