### PR TITLE
Use locally-installed Ahem if available via ahem.css stylesheet.

### DIFF
--- a/fonts/ahem.css
+++ b/fonts/ahem.css
@@ -1,5 +1,6 @@
 @font-face {
     font-family: 'Ahem';
-    src: url('/fonts/Ahem.ttf');
+    src: local('Ahem'),
+         url('/fonts/Ahem.ttf');
 }
 


### PR DESCRIPTION
As discussed in web-platform-tests/rfcs#22, there is a desire to use locally-installed Ahem when available with fallback to web font if not.