### PR TITLE
Add `Cache-Control` headers for Ahem font and stylesheet

### DIFF
--- a/fonts/Ahem.ttf.headers
+++ b/fonts/Ahem.ttf.headers
@@ -1,1 +1,2 @@
 Access-Control-Allow-Origin: *
+Cache-Control: max-age=3600

--- a/fonts/CanvasTest.ttf.headers
+++ b/fonts/CanvasTest.ttf.headers
@@ -1,0 +1,1 @@
+Cache-Control: max-age=3600

--- a/fonts/CanvasTest.ttf.sub.headers
+++ b/fonts/CanvasTest.ttf.sub.headers
@@ -1,1 +1,0 @@
-Cache-Control: max-age=1000

--- a/fonts/ahem.css.headers
+++ b/fonts/ahem.css.headers
@@ -1,0 +1,2 @@
+Content-Type: text/css;charset=utf-8
+Cache-Control: max-age=3600


### PR DESCRIPTION
Use `Cache-Control: max-age=3600` like in resources/*.headers and
change CanvasTest.ttf.headers to also use this for consistency. It was
renamed to not have .sub. in the filename, which looks like a mistake.