### PR TITLE
Add webrtc-identity IDL and test

### DIFF
--- a/interfaces/webrtc-identity.idl
+++ b/interfaces/webrtc-identity.idl
@@ -1,0 +1,67 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content was automatically extracted by Reffy into reffy-reports
+// (https://github.com/tidoust/reffy-reports)
+// Source: Identity for WebRTC 1.0 (https://w3c.github.io/webrtc-identity/identity.html)
+
+[Global, Exposed=RTCIdentityProviderGlobalScope]
+interface RTCIdentityProviderGlobalScope : WorkerGlobalScope {
+    readonly        attribute RTCIdentityProviderRegistrar rtcIdentityProvider;
+};
+
+[Exposed=RTCIdentityProviderGlobalScope]
+interface RTCIdentityProviderRegistrar {
+    void register(RTCIdentityProvider idp);
+};
+
+dictionary RTCIdentityProvider {
+    required GenerateAssertionCallback generateAssertion;
+    required ValidateAssertionCallback validateAssertion;
+};
+
+callback GenerateAssertionCallback = Promise<RTCIdentityAssertionResult> (DOMString contents, DOMString origin, RTCIdentityProviderOptions options);
+
+callback ValidateAssertionCallback = Promise<RTCIdentityValidationResult> (DOMString assertion, DOMString origin);
+
+dictionary RTCIdentityAssertionResult {
+    required RTCIdentityProviderDetails idp;
+    required DOMString assertion;
+};
+
+dictionary RTCIdentityProviderDetails {
+    required DOMString domain;
+             DOMString protocol = "default";
+};
+
+dictionary RTCIdentityValidationResult {
+    required DOMString identity;
+    required DOMString contents;
+};
+
+partial interface RTCPeerConnection {
+    void setIdentityProvider(DOMString provider, optional RTCIdentityProviderOptions options);
+    Promise<DOMString> getIdentityAssertion();
+    readonly        attribute Promise<RTCIdentityAssertion> peerIdentity;
+    readonly        attribute DOMString? idpLoginUrl;
+    readonly        attribute DOMString? idpErrorInfo;
+};
+
+dictionary RTCIdentityProviderOptions {
+    DOMString protocol = "default";
+    DOMString usernameHint;
+    DOMString peerIdentity;
+};
+
+[Constructor(DOMString idp, DOMString name), Exposed=Window]
+interface RTCIdentityAssertion {
+    attribute DOMString idp;
+    attribute DOMString name;
+};
+
+partial dictionary MediaStreamConstraints {
+             DOMString peerIdentity;
+};
+
+partial interface MediaStreamTrack {
+    readonly        attribute boolean isolated;
+                    attribute EventHandler onisolationchange;
+};

--- a/webrtc-identity/idlharness.https.window.js
+++ b/webrtc-identity/idlharness.https.window.js
@@ -1,0 +1,24 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+'use strict';
+
+idl_test(
+  ['webrtc-identity'],
+  ['webrtc', 'mediacapture-streams', 'html', 'dom'],
+  async idlArray => {
+    idlArray.add_objects({
+      RTCPeerConnection: [`new RTCPeerConnection()`],
+      RTCIdentityAssertion: [`new RTCIdentityAssertion('idp', 'name')`],
+      MediaStreamTrack: ['track'],
+      // TODO: RTCIdentityProviderGlobalScope
+      // TODO: RTCIdentityProviderRegistrar
+    });
+
+    try {
+      self.track = await navigator.mediaDevices
+          .getUserMedia({audio: true})
+          .then(m => m.getTracks()[0]);
+    } catch (e) {}
+  }
+);


### PR DESCRIPTION
Supersedes https://github.com/web-platform-tests/wpt/pull/19292

Note that in Chrome stable, the media track code blocks on user input. I don't think that's the case when  we run wpt/chrome with the right flags though (code was taken from mediacapture-streams, which [doesn't time out](https://wpt.fyi/results/mediacapture-streams/idlharness.https.window.html?label=experimental&label=master&aligned)