### PR TITLE
[wptrunner] Explicitly ignore certificate errors for Chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -39,6 +39,7 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     executor_kwargs["supports_eager_pageload"] = False
 
     capabilities = {
+        "acceptInsecureCerts": True,
         "goog:chromeOptions": {
             "prefs": {
                 "profile": {


### PR DESCRIPTION
ChromeDriver will no longer pass --ignore-certificate-error by default
and users need to explicitly request the acceptInsecureCerts capability.

https://crbug.com/chromedriver/3148