### PR TITLE
[docs] Use supported syntax highlight name

### DIFF
--- a/docs/writing-tests/test-templates.md
+++ b/docs/writing-tests/test-templates.md
@@ -54,7 +54,7 @@ Filename: `{description}.html` or `{test-topic}-###-ref.html`
 
 ### SVG test
 
-``` svg
+``` xml
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>${1:Test title}</title>
   <metadata>
@@ -69,7 +69,7 @@ Filename: `{test-topic}-###.svg`
 
 ### SVG reference
 
-``` svg
+``` xml
 <svg xmlns="http://www.w3.org/2000/svg">
   <title>${1:Reference title}</title>
   ${2:Reference content}
@@ -97,7 +97,7 @@ Filename: `{test-topic}-###.html`
 
 ### SVG
 
-``` svg
+``` xml
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>${1:Test title}</title>
   <metadata>
@@ -133,7 +133,7 @@ Filename: `{test-topic}-###-manual.html`
 
 #### SVG
 
-``` svg
+``` xml
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
   <title>${1:Test title}</title>
   <metadata>


### PR DESCRIPTION
A recent addition to the project documentation specifies "svg" as the
desired syntax for a number of examples [1]. However, the package used
to provide syntax highlighting ("pygments" from Python) does not
recognize SVG, so the new examples introduced the following error:

    Warning, treated as error:
    docs/writing-tests/test-templates.md:55:Pygments lexer name u'svg' is not known

Update the examples to instead request generic XML highlighting.

@heycam @sideshowbarker This failure should have been apparent in gh-19150, but [the relevant GitHub Action](https://github.com/web-platform-tests/wpt/blob/563a1ecea1478f6ef34c50259c3ff66bb5ea4fc3/.github/workflows/push-build-publish-documentation-website.yml) never ran. I don't know why, but I do know GitHub Actions is still in beta, and we've experienced flakiness before.