### PR TITLE
[tools] Update test

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -346,7 +346,7 @@ def test_tests_affected_idlharness(capsys, manifest_dir):
         wpt.main(argv=["tests-affected", "--metadata", manifest_dir, "%s~..%s" % (commit, commit)])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
-    assert "webrtc-stats/idlharness.window.js\nwebrtc/idlharness.https.window.js\n" == out
+    assert "webrtc-identity/idlharness.https.window.js\nwebrtc-stats/idlharness.window.js\nwebrtc/idlharness.https.window.js\n" == out
 
 
 @pytest.mark.slow  # this updates the manifest


### PR DESCRIPTION
A recent commit introduced a new file which influences the integration
tests for the WPT CLI [1]. Update the test accordingly.

[1] 809afabfac3d41fafa92b20e66f784221ed6129e

The tests for the CLI's functionality should not depend on the state of the
repository, so this patch doesn't solve the real problem. It's a short-term
solution intended to unblock patches which require the test to pass (e.g.
gh-19402).