### PR TITLE
[css-grid] Correct ID in grid-inline-support-grid-template-areas-001.html

### DIFF
--- a/css/css-grid/grid-definition/grid-inline-support-grid-template-areas-001.html
+++ b/css/css-grid/grid-definition/grid-inline-support-grid-template-areas-001.html
@@ -9,7 +9,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/testing-utils.js"></script>
 <style>
-  #grid {
+  #inline-grid {
     display: inline-grid;
   }
 </style>


### PR DESCRIPTION
An ID used in [grid-inline-support-grid-template-areas-001.html](https://github.com/web-platform-tests/wpt/blob/master/css/css-grid/grid-definition/grid-inline-support-grid-template-areas-001.html) seems to be incorrect and should be 'inline-grid' instead of 'grid'.