### PR TITLE
Don't depend on execfile in virtualenv.py

### DIFF
--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -90,7 +90,8 @@ class Virtualenv(object):
 
     def activate(self):
         path = os.path.join(self.bin_path, "activate_this.py")
-        execfile(path, {"__file__": path})  # noqa: F821
+        with open(path) as f:
+            exec(f.read(), {"__file__": path})
 
     def start(self):
         if not self.exists or self.broken_link:


### PR DESCRIPTION
This is gone in Python 3 and prevents otherwise Py3-compatible wpt
commands working with `python3 wpt`.