### PR TITLE
Sync Mozilla CSS tests as of 2019-10-01

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-align-self-baseline-horiz-008-ref.xhtml
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-align-self-baseline-horiz-008-ref.xhtml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<!-- Reference case for behavior of 'baseline' and 'last baseline' values
+     for align-items and align-self for sideways writing modes.
+-->
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Brad Werth" href="mailto:bwerth@mozilla.com"/>
+    <style>
+      .container {
+        float: left;
+        display: flex;
+        writing-mode: sideways-rl;
+        border: 1px dashed blue;
+        font: 14px sans-serif;
+        width: 80px;
+      }
+
+      .reverse { flex-flow: row wrap-reverse; }
+
+      .start  { align-self: start; }
+      .end    { align-self: end; }
+
+      .offset { margin-right: 10px;
+                margin-left: 3px; }
+
+      .lime   { background: lime;   }
+      .yellow { background: yellow; }
+      .orange { background: orange; }
+      .pink   { background: pink;   }
+
+      .ib     { display: inline-block; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="lime offset start">one line (first)</div
+      ><div class="yellow offset end">one line (last)</div
+      ><div class="orange offset end">two<br/>lines and offset (last)</div
+      ><div class="pink offset start">offset (first)</div>
+    </div>
+    <div class="container reverse">
+      <div class="lime offset end">one line (first)</div
+      ><div class="offset start"><div class="yellow ib">one line (last)</div
+      ><div class="orange ib">two<br/>lines and offset (last)</div></div
+      ><div class="pink offset end">offset (first)</div>
+    </div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-align-self-baseline-horiz-008.xhtml
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-align-self-baseline-horiz-008.xhtml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<!-- Testcase for behavior of 'baseline' and 'last baseline' values
+     for align-items (and align-self, implicitly) for sideways
+     writing modes. This test confirms non-interference between the
+     'baseline' and 'last baseline' items.
+-->
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>CSS Test: Baseline alignment of block flex items with 'baseline' and 'last-baseline' values for 'align-self' against each other.</title>
+    <link rel="author" title="Brad Werth" href="mailto:bwerth@mozilla.com"/>
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#baseline-participation"/>
+    <link rel="match" href="flexbox-align-self-baseline-horiz-008-ref.xhtml"/>
+    <style>
+      .container {
+        float: left;
+        display: flex;
+        writing-mode: sideways-rl;
+        border: 1px dashed blue;
+        font: 14px sans-serif;
+        width: 80px;
+      }
+
+      .reverse { flex-flow: row wrap-reverse; }
+
+      .base     { align-self: baseline; }
+      .lastbase { align-self: last baseline; }
+
+      .offset { margin-right: 10px;
+                margin-left: 3px; }
+
+      .lime   { background: lime;   }
+      .yellow { background: yellow; }
+      .orange { background: orange; }
+      .pink   { background: pink;   }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="lime base">one line (first)</div>
+      <div class="yellow lastbase">one line (last)</div>
+      <div class="orange offset lastbase">two<br/>lines and offset (last)</div>
+      <div class="pink offset base">offset (first)</div>
+    </div>
+    <div class="container reverse">
+      <div class="lime base">one line (first)</div>
+      <div class="yellow lastbase">one line (last)</div>
+      <div class="orange offset lastbase">two<br/>lines and offset (last)</div>
+      <div class="pink offset base">offset (first)</div>
+    </div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
@@ -24,6 +24,7 @@
 == flexbox-align-self-baseline-horiz-005.xhtml flexbox-align-self-baseline-horiz-005-ref.xhtml
 == flexbox-align-self-baseline-horiz-006.xhtml flexbox-align-self-baseline-horiz-006-ref.xhtml
 == flexbox-align-self-baseline-horiz-007.xhtml flexbox-align-self-baseline-horiz-007-ref.xhtml
+== flexbox-align-self-baseline-horiz-008.xhtml flexbox-align-self-baseline-horiz-008-ref.xhtml
 
 == flexbox-align-self-stretch-vert-001.html flexbox-align-self-stretch-vert-001-ref.html
 == flexbox-align-self-stretch-vert-002.html flexbox-align-self-stretch-vert-002-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/reftest.list
@@ -8,6 +8,7 @@
 == will-change-stacking-context-perspective-1.html green-square-100-by-100-ref.html
 == will-change-stacking-context-position-1.html green-square-100-by-100-ref.html
 == will-change-stacking-context-transform-1.html green-square-100-by-100-ref.html
+== will-change-stacking-context-translate-1.html green-square-100-by-100-ref.html
 == will-change-stacking-context-transform-style-1.html green-square-100-by-100-ref.html
 == will-change-stacking-context-z-index-1.html green-square-100-by-100-ref.html
 == will-change-fixpos-cb-contain-1.html green-square-100-by-100-offset-ref.html
@@ -16,4 +17,5 @@
 == will-change-fixpos-cb-perspective-1.html green-square-100-by-100-offset-ref.html
 == will-change-fixpos-cb-position-1.html green-square-100-by-100-offset-ref.html
 == will-change-fixpos-cb-transform-1.html green-square-100-by-100-offset-ref.html
+== will-change-fixpos-cb-translate-1.html green-square-100-by-100-offset-ref.html
 == will-change-fixpos-cb-transform-style-1.html green-square-100-by-100-offset-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/will-change-fixpos-cb-translate-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/will-change-fixpos-cb-translate-1.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS will-change: 'will-change: translate' creates a containing block for fixed positioned elements</title>
+<link rel="author" title="Mozilla" href="http://www.mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-will-change-1/#will-change">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">
+<link rel="match" href="green-square-100-by-100-offset-ref.html">
+<meta name="assert" content="If any non-initial value of a property would cause the element to generate a containing block for fixed-position elements, specifying that property in will-change must cause the element to generate a containing block for fixed-position elements.">
+<style>
+html, body { margin: 0; padding: 0; }
+div { width: 100px; height: 100px }
+#wc { will-change: translate; margin: 100px 0 0 100px; background: red }
+.child { top: 0; left: 0; width: 50px; background: green }
+#fixpos { position: fixed }
+#abspos { position: absolute; left: 50px }
+</style>
+<body>
+  <div id="wc">
+    <div class="child" id="fixpos">
+    </div>
+    <div class="child" id="abspos">
+    </div>
+  </div>
+</body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/will-change-stacking-context-translate-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/will-change-stacking-context-translate-1.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS will-change: 'will-change: translate' creates a stacking context</title>
+<link rel="author" title="Mozilla" href="http://www.mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-will-change-1/#will-change">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">
+<link rel="match" href="green-square-100-by-100-ref.html">
+<meta name="assert" content="If any non-initial value of a property would create a stacking context on the element, specifying that property in will-change must create a stacking context on the element.">
+<style>
+html, body { margin: 0; padding: 0; }
+div { width: 100px; height: 100px }
+#wc { will-change: translate; background: red }
+#child { position: absolute; top: 0; left: 0; z-index: -1; background: green }
+</style>
+<body>
+  <div id="wc">
+    <div id="child">
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/9a4d6aacc48080f019024c02ac7da1fd576b39fe .

This contains changes from:
* [bug 1384266](https://bugzilla.mozilla.org/show_bug.cgi?id=1384266) by @bradwerth, reviewed by @dholbert
* [bug 1510486](https://bugzilla.mozilla.org/show_bug.cgi?id=1510486) by @BorisChiou, reviewed by @hiikezoe