### PR TITLE
Add webkitgtk_minibrowser runs to taskcluster daily.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -73,7 +73,7 @@ tasks:
                 image:
                   $if: browser.name == 'webkitgtk_minibrowser'
                   then:
-                    cl0p3z/web-platform-tests:webkitgtk20190901
+                    cl0p3z/web-platform-tests:0.1
                   else:
                     harjgam/web-platform-tests:0.33
                 maxRunTime: 7200

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -12,7 +12,7 @@ tasks:
             $flatten:
               $match: {
                 event.ref == "refs/heads/master": [{name: firefox, channel: nightly}, {name: chrome, channel: dev}],
-                event.ref == "refs/heads/epochs/daily": [{name: firefox, channel: stable}, {name: chrome, channel: stable}],
+                event.ref == "refs/heads/epochs/daily": [{name: firefox, channel: stable}, {name: chrome, channel: stable}, {name: webkitgtk_minibrowser, channel: stable}],
                 event.ref == "refs/heads/epochs/weekly": [{name: firefox, channel: beta}, {name: chrome, channel: beta}],
                 event.ref == "refs/heads/triggers/chrome_stable": [{name: chrome, channel: stable}],
                 event.ref == "refs/heads/triggers/chrome_beta": [{name: chrome, channel: beta}],
@@ -70,7 +70,12 @@ tasks:
                 owner: ${event.pusher.email}
                 source: ${event.repository.url}
               payload:
-                image: harjgam/web-platform-tests:0.33
+                image:
+                  $if: browser.name == 'webkitgtk_minibrowser'
+                  then:
+                    cl0p3z/web-platform-tests:webkitgtk20190901
+                  else:
+                    harjgam/web-platform-tests:0.33
                 maxRunTime: 7200
                 artifacts:
                   public/results:

--- a/docs/running-tests/webkitgtk_minibrowser.md
+++ b/docs/running-tests/webkitgtk_minibrowser.md
@@ -18,15 +18,3 @@ to run it manually you can find it on any of this paths:
     inside:
     `/usr/lib/${TRIPLET}/webkit2gtk-4.0/MiniBrowser`
     where `TRIPLET=$(gcc -dumpmachine)`
-
-
-Known issues:
-
-* On a docker container WebKitWebDriver fails to listen on localhost,
-because the docker container doesn't provide an IPv6 localhost address.
-To workaround this issue, manually tell it to only listen on IPv4 localhost
-by passing this parameter to wpt run: `--webdriver-arg=--host=127.0.0.1`
-Example:
-```bash
-./wpt run --webdriver-arg=--host=127.0.0.1 webkitgtk_minibrowser TESTS
-```

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -145,6 +145,27 @@ def install_chrome(channel):
     run(["sudo", "apt-get", "-qqy", "update"])
     run(["sudo", "gdebi", "-qn", "/tmp/%s" % deb_archive])
 
+def install_webkitgtk_from_apt_repository(channel):
+    # Configure webkitgtk.org/debian repository for $channel and pin it with maximum priority
+    run(["sudo", "apt-key", "adv", "--fetch-keys", "https://webkitgtk.org/debian/apt.key"])
+    with open("/tmp/webkitgtk.list", "w") as f:
+        f.write("deb [arch=amd64] https://webkitgtk.org/debian buster-wpt-webkit-updates %s\n" % channel)
+    run(["sudo", "mv", "/tmp/webkitgtk.list", "/etc/apt/sources.list.d/"])
+    with open("/tmp/99webkitgtk", "w") as f:
+        f.write("Package: *\nPin: origin webkitgtk.org\nPin-Priority: 1999\n")
+    run(["sudo", "mv", "/tmp/99webkitgtk", "/etc/apt/preferences.d/"])
+    # Install webkit2gtk from the webkitgtk.org/debian repository for $channel
+    run(["sudo", "apt-get", "-qqy", "update"])
+    run(["sudo", "apt-get", "-qqy", "-t", "buster-wpt-webkit-updates", "install", "webkit2gtk-driver"])
+
+
+def install_webkitgtk(channel):
+    if channel in ("experimental", "dev", "nightly"):
+        raise NotImplementedError("Still can't install from release channel: %s" % channel)
+    elif channel in ("beta", "stable"):
+        install_webkitgtk_from_apt_repository(channel)
+    else:
+        raise ValueError("Unrecognized release channel: %s" % channel)
 
 def start_xvfb():
     start(["sudo", "Xvfb", os.environ["DISPLAY"], "-screen", "0",
@@ -217,6 +238,9 @@ def setup_environment(args):
     if "chrome" in args.browser:
         assert args.channel is not None
         install_chrome(args.channel)
+    elif "webkitgtk_minibrowser" in args.browser:
+        assert args.channel is not None
+        install_webkitgtk(args.channel)
 
     if args.xvfb:
         start_xvfb()

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -156,6 +156,7 @@ def install_webkitgtk_from_apt_repository(channel):
     run(["sudo", "mv", "/tmp/99webkitgtk", "/etc/apt/preferences.d/"])
     # Install webkit2gtk from the webkitgtk.org/debian repository for $channel
     run(["sudo", "apt-get", "-qqy", "update"])
+    run(["sudo", "apt-get", "-qqy", "upgrade"])
     run(["sudo", "apt-get", "-qqy", "-t", "buster-wpt-webkit-updates", "install", "webkit2gtk-driver"])
 
 

--- a/tools/docker/Dockerfile.webkitgtk
+++ b/tools/docker/Dockerfile.webkitgtk
@@ -7,9 +7,13 @@ FROM debian:10
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
 
-# Install general requirements not in the base image
+
+# Update and upgrade.
 RUN apt-get -qqy update \
-  && apt-get -qqy install \
+  && apt-get -qqy upgrade
+
+# Install general requirements not in the base image
+RUN apt-get -qqy install \
     bzip2 \
     ca-certificates \
     dbus-x11 \
@@ -29,19 +33,11 @@ RUN apt-get -qqy update \
     xvfb \
     git-core
 
-# Configure buster-wpt-webkit-updates repository
-RUN apt-key adv --fetch-keys https://webkitgtk.org/debian/apt.key
-RUN printf 'deb [arch=amd64] https://webkitgtk.org/debian buster-wpt-webkit-updates main' \
-    > /etc/apt/sources.list.d/webkitgtk.list
-RUN printf 'Package: *\nPin: origin webkitgtk.org\nPin-Priority: 1999' \
-    > /etc/apt/preferences.d/99webkitgtk
 
-# Update and upgrade
-RUN apt-get update \
-  && apt-get -y upgrade
-
-# Install webkit packages from https://webkitgtk.org/debian
-RUN apt-get install -y -t buster-wpt-webkit-updates webkit2gtk-driver
+# To speed up testers, install in the image most of WebKitGTK dependencies
+# but don't install WebKitGTK itself (that will be done at test time)
+RUN apt-get install -qqy webkit2gtk-driver \
+  && apt-get remove -qqy libjavascriptcore* libwebkit* webkit*
 
 # Set the timezone
 ENV TZ "UTC"

--- a/tools/docker/Dockerfile.webkitgtk
+++ b/tools/docker/Dockerfile.webkitgtk
@@ -34,10 +34,9 @@ RUN apt-get -qqy install \
     git-core
 
 
-# To speed up testers, install in the image most of WebKitGTK dependencies
-# but don't install WebKitGTK itself (that will be done at test time)
-RUN apt-get install -qqy webkit2gtk-driver \
-  && apt-get remove -qqy libjavascriptcore* libwebkit* webkit*
+# To speed up testers, cache in the image most of WebKitGTK dependencies
+# but don't install them (that will be done at test time)
+RUN apt-get install -qqy --download-only webkit2gtk-driver
 
 # Set the timezone
 ENV TZ "UTC"

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -15,5 +15,3 @@ To update the image used for WebKitGTK:
 docker build -f Dockerfile.webkitgtk -t <tag> .
 docker push <tag>
 ```
-
-(This image is not yet used in .taskcluster.yml.)

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -36,6 +36,20 @@ def cmd_arg(name, value=None):
     return rv
 
 
+def maybe_add_args(required_args, current_args):
+    for required_arg in required_args:
+        # If the arg is in the form of "variable=value", only add it if
+        # no arg with another value for "variable" is already there.
+        if "=" in required_arg:
+            required_arg_prefix = "%s=" % required_arg.split("=")[0]
+            if not any(item.startswith(required_arg_prefix) for item in current_args):
+                current_args.append(required_arg)
+        else:
+            if required_arg not in current_args:
+                current_args.append(required_arg)
+    return current_args
+
+
 def get_free_port():
     """Get a random unbound port"""
     while True:

--- a/tools/wptrunner/wptrunner/browsers/epiphany.py
+++ b/tools/wptrunner/wptrunner/browsers/epiphany.py
@@ -26,7 +26,7 @@ def check_args(**kwargs):
 def browser_kwargs(test_type, run_info_data, config, **kwargs):
     webdriver_args = kwargs.get("webdriver_args")
     # Workaround for https://gitlab.gnome.org/GNOME/libsoup/issues/172
-    if not any('--host=' in item for item in webdriver_args):
+    if not any(item.startswith('--host=') for item in webdriver_args):
         webdriver_args.append('--host=127.0.0.1')
 
     return {"binary": kwargs["binary"],

--- a/tools/wptrunner/wptrunner/browsers/epiphany.py
+++ b/tools/wptrunner/wptrunner/browsers/epiphany.py
@@ -24,9 +24,14 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(test_type, run_info_data, config, **kwargs):
+    webdriver_args = kwargs.get("webdriver_args")
+    # Workaround for https://gitlab.gnome.org/GNOME/libsoup/issues/172
+    if not any('--host=' in item for item in webdriver_args):
+        webdriver_args.append('--host=127.0.0.1')
+
     return {"binary": kwargs["binary"],
             "webdriver_binary": kwargs["webdriver_binary"],
-            "webdriver_args": kwargs.get("webdriver_args")}
+            "webdriver_args": webdriver_args}
 
 
 def capabilities(server_config, **kwargs):

--- a/tools/wptrunner/wptrunner/browsers/epiphany.py
+++ b/tools/wptrunner/wptrunner/browsers/epiphany.py
@@ -1,4 +1,4 @@
-from .base import get_timeout_multiplier   # noqa: F401
+from .base import get_timeout_multiplier, maybe_add_args   # noqa: F401
 from .webkit import WebKitBrowser
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
@@ -24,11 +24,9 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(test_type, run_info_data, config, **kwargs):
-    webdriver_args = kwargs.get("webdriver_args")
     # Workaround for https://gitlab.gnome.org/GNOME/libsoup/issues/172
-    if not any(item.startswith('--host=') for item in webdriver_args):
-        webdriver_args.append('--host=127.0.0.1')
-
+    webdriver_required_args = ["--host=127.0.0.1"]
+    webdriver_args = maybe_add_args(webdriver_required_args, kwargs.get("webdriver_args"))
     return {"binary": kwargs["binary"],
             "webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": webdriver_args}

--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -1,4 +1,4 @@
-from .base import get_timeout_multiplier   # noqa: F401
+from .base import get_timeout_multiplier, maybe_add_args   # noqa: F401
 from .webkit import WebKitBrowser
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
@@ -22,19 +22,6 @@ __wptrunner__ = {"product": "webkitgtk_minibrowser",
 def check_args(**kwargs):
     pass
 
-
-def maybe_add_args(required_args, current_args):
-    for required_arg in required_args:
-        # If the arg is in the form of "variable=value", only add it if
-        # no arg with another value for "variable" is already there.
-        if "=" in required_arg:
-            required_arg_prefix = "%s=" % required_arg.split("=")[0]
-            if not any(item.startswith(required_arg_prefix) for item in current_args):
-                current_args.append(required_arg)
-        else:
-            if required_arg not in current_args:
-                current_args.append(required_arg)
-    return current_args
 
 def browser_kwargs(test_type, run_info_data, config, **kwargs):
     # Workaround for https://gitlab.gnome.org/GNOME/libsoup/issues/172

--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -28,8 +28,8 @@ def maybe_add_args(required_args, current_args):
         # If the arg is in the form of "variable=value", only add it if
         # no arg with another value for "variable" is already there.
         if "=" in required_arg:
-            required_arg_variable = "%s=" % required_arg.split("=")[0]
-            if not any(required_arg_variable in item for item in current_args):
+            required_arg_prefix = "%s=" % required_arg.split("=")[0]
+            if not any(item.startswith(required_arg_prefix) for item in current_args):
                 current_args.append(required_arg)
         else:
             if required_arg not in current_args:


### PR DESCRIPTION
 * This is testing with the stable channel for now, beta or nightly channels may be integrated later.

 * It uses a different docker image on taskcluster that is currently configured with the last stable version of WebKitGTK with experimental features enabled.

* Enable at run-time on webkitgtk_minibrowser some features that are disabled by default.

* Ensure also that the required --host=127.0.0.1 argument when running in docker is automatically passed to the webdriver by the wpt runner.

// cc @foolip