### PR TITLE
[workers] Correct variable name

### DIFF
--- a/workers/semantics/interface-objects/003.any.js
+++ b/workers/semantics/interface-objects/003.any.js
@@ -76,8 +76,8 @@ var expected = [
   "IDBTransaction",
 ];
 
-for (var i = 0; i < unexpected.length; ++i) {
+for (var i = 0; i < expected.length; ++i) {
   test(function() {
-    assert_true(unexpected[i] in self);
-  }, "The " + unexpected[i] + " interface object should not be exposed");
+    assert_true(expected[i] in self);
+  }, "The " + expected[i] + " interface object should be exposed");
 }


### PR DESCRIPTION
This test generates subtests based on the value of a binding named
`unexpected`. Prior to this commit, no such binding was declared by the
test, so it failed to declare any subtests and instead produced a
ReferenceError. Currently, testharness.js interprets this result as a
failing "single-page test," although it will soon be more accurately
reported as a harness error [1].

Update the test to declare a binding named `unexpected`.

[1] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md

---

This change makes the test run to completion, but it seems like there is a more
fundamental problem with the semantics. The subtest titles state that the
relevant object should *not* be exposed, but the assertion verifies that the
corresponding property is present in the global object.

Should the assertion be changed from `assert_true` to `assert_false`?

(This is in service of https://github.com/web-platform-tests/rfcs/pull/28)