### PR TITLE
[encoding] Defer API reference

### DIFF
--- a/encoding/streams/backpressure.any.js
+++ b/encoding/streams/backpressure.any.js
@@ -4,11 +4,11 @@
 
 const classes = [
   {
-    constructor: TextDecoderStream,
+    name: 'TextDecoderStream',
     input: new Uint8Array([65])
   },
   {
-    constructor: TextEncoderStream,
+    name: 'TextEncoderStream',
     input: 'A'
   }
 ];
@@ -17,7 +17,7 @@ const microtasksRun = () => new Promise(resolve => step_timeout(resolve, 0));
 
 for (const streamClass of classes) {
   promise_test(async () => {
-    const stream = new streamClass.constructor();
+    const stream = new self[streamClass.name]();
     const writer = stream.writable.getWriter();
     const reader = stream.readable.getReader();
     const events = [];
@@ -32,10 +32,10 @@ for (const streamClass of classes) {
     assert_array_equals(events, ['paused', 'read', 'write'],
                         'write should happen after read');
   }, 'write() should not complete until read relieves backpressure for ' +
-     `${streamClass.constructor.name}`);
+     `${streamClass.name}`);
 
   promise_test(async () => {
-    const stream = new streamClass.constructor();
+    const stream = new self[streamClass.name]();
     const writer = stream.writable.getWriter();
     const reader = stream.readable.getReader();
     const events = [];
@@ -56,5 +56,5 @@ for (const streamClass of classes) {
                                  'write2'],
                         'writes should not happen before read2');
   }, 'additional writes should wait for backpressure to be relieved for ' +
-     `class ${streamClass.constructor.name}`);
+     `class ${streamClass.name}`);
 }


### PR DESCRIPTION
This test references the API under test outside the context of a
subtest. This produces an uncaught exception in non-conforming
implementations. Currently, testharness.js interprets this result as a
failing "single-page test," although it will soon be more accurately
reported as a harness error [1].

Update the test to only reference the API from within the body of a
subtest.

[1] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md

This is in service of https://github.com/web-platform-tests/rfcs/pull/28