### PR TITLE
Unskip testdriver Actions infra tests

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/__dir__.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/__dir__.ini
@@ -1,2 +1,0 @@
-disabled:
-  if product == "chrome" and os == "mac": https://bugs.chromium.org/p/chromedriver/issues/detail?id=3114


### PR DESCRIPTION
The tests in infrastructure/testdriver/actions were being skipped due to a Chromedriver bug (https://bugs.chromium.org/p/chromedriver/issues/detail?id=3114). This seems unreproducible with the latest version so I'm re-enabling these tests.