### PR TITLE
Allow using CORS filtered image responses as WebGL textures

### DIFF
--- a/2dcontext/drawing-images-to-the-canvas/drawimage_crossorigin.sub.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_crossorigin.sub.html
@@ -1,0 +1,61 @@
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  function draw_and_read_image(img, should_throw) {
+      let c = document.createElement('canvas');
+      document.body.appendChild(c);
+      let ctx = c.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+
+      function get_image_data() {
+          ctx.getImageData(0, 0, 4, 4);
+      }
+
+      if (should_throw) {
+          assert_throws_dom('SecurityError', get_image_data);
+      } else {
+          get_image_data();
+      }
+
+      document.body.removeChild(c);
+  }
+
+  async_test(t => {
+      let img = new Image();
+      img.src = "/images/green.png";
+      img.crossOrigin = "anonymous";
+      img.onload = t.step_func_done(() => {
+          draw_and_read_image(img, false);
+      });
+      img.onerror = t.unreached_func();
+  }, "Can get pixels of canvas with same origin image drawn");
+
+  async_test(t => {
+      let img = new Image();
+      img.src = "http://{{hosts[][www]}}:{{ports[http][0]}}/images/green.png?pipe=header(Access-Control-Allow-Origin,*)";
+      img.crossOrigin = "anonymous";
+      img.onload = t.step_func_done(() => {
+          draw_and_read_image(img, false);
+      });
+      img.onerror = t.unreached_func();
+  }, "Can get pixels of canvas with CORS enabled cross origin image drawn");
+
+  async_test(t => {
+      let img = new Image();
+      img.src = "http://{{hosts[][www]}}:{{ports[http][0]}}/images/green.png?pipe=header(Access-Control-Allow-Origin,*)";
+      img.onload = t.step_func_done(() => {
+          draw_and_read_image(img, true);
+      });
+      img.onerror = t.unreached_func();
+  }, "Can't get pixels of canvas with CORS enabled cross origin image drawn from non-CORS element");
+
+  async_test(t => {
+      let img = new Image();
+      img.src = "http://{{hosts[][www]}}:{{ports[http][0]}}/images/green.png";
+
+      img.onload = t.step_func_done(() => {
+          draw_and_read_image(img, true);
+      });
+      img.onerror = t.unreached_func();
+  }, "Can't get pixels of canvas with non-CORS enabled cross origin image drawn");
+</script>


### PR DESCRIPTION
Reviewed in https://github.com/servo/servo/pull/24340.