### PR TITLE
Fix shadow-dom/focus/focus-selector-delegatesFocus.html for slotted elements

### DIFF
--- a/shadow-dom/focus/focus-selector-delegatesFocus.html
+++ b/shadow-dom/focus/focus-selector-delegatesFocus.html
@@ -51,8 +51,8 @@ for (const delegatesFocus of delegatesFocusValues) {
 
     slotted.focus();
     assert_true(slotted.matches(":focus"), "slotted element matches :focus");
-    assert_true(host.matches(":focus"), "host matches :focus");
-  }, `:focus applies to host with delegatesFocus=${delegatesFocus} when slotted element has focus`);
+    assert_false(host.matches(":focus"), "host matches :focus");
+  }, `:focus does not apply to host with delegatesFocus=${delegatesFocus} when slotted element has focus`);
 
   for (const nestedDelegatesFocus of delegatesFocusValues) {
     test(() => {


### PR DESCRIPTION
As specified in https://html.spec.whatwg.org/multipage/semantics-other.html#element-has-the-focus, an element has focus when itself is in the focus chain or its shadow root contains the focused element.

Since the shadow tree does not contain a slotted element, its shadow host should not match :focus pseudo class. Otherwise, the shadow host's tree would end up containing more than one element which match :focus, for example, the shadow host and its direct child which is actually focused.