### PR TITLE
Miscellaneous improvements to MathML DOM tests

### DIFF
--- a/mathml/relations/html5-tree/clipboard-event-handlers.tentative.html
+++ b/mathml/relations/html5-tree/clipboard-event-handlers.tentative.html
@@ -29,19 +29,15 @@
         "http://www.w3.org/1998/Math/MathML",
         "math"
     );
-    async_test(test => {
-      test.step(function() {
-        assert_true(MathMLElement.prototype.hasOwnProperty(`on${name}`));
-      });
-      mathEl[`on${name}`] = test.step_func_done(e => {
-        assert_equals(e.currentTarget, mathEl,
-                      "The event must be fired at the <math> element");
-      });
+    test(() => {
+      let target = undefined;
+      mathEl[`on${name}`] = (e) => { target = e.currentTarget; }
       const event = new ClipboardEvent(name, {
         bubbles: true,
         cancellable: true
       });
       mathEl.dispatchEvent(event);
+      assert_equals(target, mathEl, "The event must be fired at the <math> element");
     }, `${name}: dispatching an Event at a <math> element must trigger element.on${name}`);
   }
 

--- a/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
+++ b/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
@@ -124,23 +124,15 @@
           assert_equals(el[name], null, `The ${name} property must be null (remove attribute)`);
         }, `${name}: dynamic changes on the attribute`);
 
-        async_test(t => {
-          t.step(function() {
-            assert_true(MathMLElement.prototype.hasOwnProperty(name));
-          });
+        test(() => {
           const element = document.createElementNS(
             "http://www.w3.org/1998/Math/MathML",
             "math"
           );
-          element[name] = t.step_func_done(e => {
-            assert_equals(
-              e.currentTarget,
-              element,
-              "The event must be fired at the <math> element"
-            );
-          });
-
+          let target = undefined;
+          element[name] = (e) => { target = e.currentTarget; }
           element.dispatchEvent(new Event(withoutOn));
+          assert_equals(target, element, "The event must be fired at the <math> element");
         }, `${name}: dispatching an Event at a <math> element must trigger element.${name}`);
       }
 

--- a/mathml/relations/html5-tree/tabindex-002.html
+++ b/mathml/relations/html5-tree/tabindex-002.html
@@ -10,6 +10,7 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <div id="log"></div>
+<a tabindex="1" href="#link">tabindex(1)-html</a>
 <math>
   <mtext id="text1">tabindex(omitted)</mtext>
   <mtext id="text2" tabindex="">tabindex(empty)</mtext>
@@ -26,13 +27,20 @@
 <script>
 
 var i = 0,
-    expectation = ["text11", "text8", "text9", "text10", "text7", "text5", "text6"],
+    expectation = ["text11", "text8", "text9", "text10", "text7", "text5"],
     results = [],
     t = async_test("Elements with different tabindex must be focused sequentially when pressing 'Tab' keys");
 
 setup(function () {
   document.body.focus();
 });
+
+document.querySelector("a").addEventListener("focus", function (evt) {
+    // Links are tab-navigable on that platform.
+    expectation.push("text6");
+    // TAB = '\ue004'
+    test_driver.send_keys(document.body, "\ue004");
+}, true);
 
 document.querySelector("math").addEventListener("focus", function (evt) {
   results.push(evt.target.id);

--- a/mathml/relations/html5-tree/tabindex-002.html
+++ b/mathml/relations/html5-tree/tabindex-002.html
@@ -10,7 +10,7 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <div id="log"></div>
-<a tabindex="1" href="#link">tabindex(1)-html</a>
+<a href="#link">tabindex(html,href)</a>
 <math>
   <mtext id="text1">tabindex(omitted)</mtext>
   <mtext id="text2" tabindex="">tabindex(empty)</mtext>


### PR DESCRIPTION
- Don't use asynchronous test to check MathMLElement onevent attributes.
  closes #19500
- Only test tab-navigation of MathML links when HTML links are tab-navigable.
  https://github.com/mathml-refresh/mathml/issues/152
  https://github.com/Igalia/chromium-dev/issues/50
  https://bugzilla.mozilla.org/show_bug.cgi?id=1571487#c30