### PR TITLE
docs: update the readme link for running https tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To use the web-based runner point your browser to:
 http://web-platform.test:8000/tools/runner/index.html <br>
 https://web-platform.test:8443/tools/runner/index.html *
 
-\**See [Trusting Root CA](#trusting-root-ca)*
+\**See [Trusting Root CA](./tools/certs/README.md)*
 
 Running Tests Automatically
 ---------------------------


### PR DESCRIPTION
### The issue
The link doesn't do anything at the moment.

### The solution
After some digging around, I found that there is actually a useful readme to get https working locally. I updated the link to point to this readme file instead.