### PR TITLE
[GitHub Actions] shorten names of workflow files and names

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,15 +7,16 @@ on:
       - 'docs/**'
       - 'resources/**'
       - 'tools/**'
-name: Build & Publish Documentation Website
+name: documentation
 jobs:
-  website-build-and-publish:
+  build-and-publish:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v1
       with:
         fetch-depth: 50
-    - name: website-build-and-publish
+    - name: Run website_build.sh
       uses: ./tools/docker/documentation
       env:
         DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -2,15 +2,16 @@ on:
   push:
     branches:
       - master
-name: Build & Release Manifest
+name: manifest
 jobs:
-  manifest-build-and-tag:
+  build-and-tag:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v1
       with:
         fetch-depth: 50
-    - name: manifest-build-and-tag
+    - name: Run manifest_build.py
       uses: ./tools/docker/github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With this, instead of checks named like this:
 - "Build & Release Manifest / manifest-build-and-tag"
 - "Build & Publish Documentation Website / website-build-and-publish"

The checks will installed be named like this:
 - "manifest / build-and-tag"
 - "documentation / build-and-publish"