### PR TITLE
[GitHub Actions] dry run the manifest workflow on pull requests

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    paths:
+      - 'tools/**'
 name: manifest
 jobs:
   build-and-tag:

--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -172,7 +172,7 @@ def should_dry_run():
 
 def main():
     dry_run = should_dry_run()
-    
+
     manifest_path = os.path.expanduser(os.path.join("~", "meta", "MANIFEST.json"))
 
     os.makedirs(os.path.dirname(manifest_path))

--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -188,11 +188,10 @@ def main():
     summary = git("show", "--no-patch", '--format="%s"', "HEAD")
     body = git("show", "--no-patch", '--format="%b"', "HEAD")
 
-    pr = get_pr(owner, repo, head_rev)
-
     if dry_run:
         return Status.SUCCESS
 
+    pr = get_pr(owner, repo, head_rev)
     if pr is None:
         return Status.FAIL
     tag_name = "merge_pr_%s" % pr


### PR DESCRIPTION
To avoid mishaps like https://github.com/web-platform-tests/wpt/pull/19568#issuecomment-539546267.