### PR TITLE
Load Ahem as a web font in css-shapes tests.

### DIFF
--- a/css/css-shapes/shape-outside/values/shape-margin-001.html
+++ b/css/css-shapes/shape-outside/values/shape-margin-001.html
@@ -10,25 +10,101 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />-->
     </head>
     <body>
         <div id="log"></div>
         <script type="text/javascript">
-        var shape_margin_valid_unit_tests = [];
-        ParsingUtils.validUnits.forEach(function(unit) {
-            test = "10"+unit;
-            testCase = new Object();
-            // actual & expected_inline should be the same
-            // expected_computed will get converted to the px value in the test framework
-            testCase["actual"] = test;
-            testCase["expected_inline"] = test;
-            testCase["expected_computed"] = test;
-            shape_margin_valid_unit_tests.push(testCase);
+        // actual & expected should be the same for inline
+        // expected for computed are converted to the px value in the test framework
+
+        setup({explicit_done: true});
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10cm", "10cm");
+            }, '10cm - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10mm", "10mm");
+            }, '10mm - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10in", "10in");
+            }, '10in - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10pt", "10pt");
+            }, '10pt - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10pc", "10pc");
+            }, '10pc - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10em", "10em");
+            }, '10em - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10ex", "10ex");
+            }, '10ex - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10ch", "10ch");
+            }, '10ch - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10rem", "10rem");
+            }, '10rem - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10vw", "10vw");
+            }, '10vw - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10vh", "10vh");
+            }, '10vh - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10vmin", "10vmin");
+            }, '10vmin - inline');
+            test(function() {
+                ParsingUtils.testShapeMarginInlineStyle("10vmax", "10vmax");
+            }, '10vmax - inline');
+
+        ParsingUtils.setupFonts();
+        document.fonts.ready.then(()=> {
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10cm", ParsingUtils.convertToPx("10cm"));
+            }, '10cm - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10mm", ParsingUtils.convertToPx("10mm"));
+            }, '10mm - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10in", ParsingUtils.convertToPx("10in"));
+            }, '10in - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10pt", ParsingUtils.convertToPx("10pt"));
+            }, '10pt - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10pc", ParsingUtils.convertToPx("10pc"));
+            }, '10pc - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10em", ParsingUtils.convertToPx("10em"));
+            }, '10em - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10ex", ParsingUtils.convertToPx("10ex"));
+            }, '10ex - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10ch", ParsingUtils.convertToPx("10ch"));
+            }, '10ch - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10rem", ParsingUtils.convertToPx("10rem"));
+            }, '10rem - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10vw", ParsingUtils.convertToPx("10vw"));
+            }, '10vw - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10vh", ParsingUtils.convertToPx("10vh"));
+            }, '10vh - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10vmin", ParsingUtils.convertToPx("10vmin"));
+            }, '10vmin - computed');
+            test(function() {
+                ParsingUtils.testShapeMarginComputedStyle("10vmax", ParsingUtils.convertToPx("10vmax"));
+            }, '10vmax - computed');
+
+            ParsingUtils.restoreFonts();
+            done();
         });
-        generate_tests( ParsingUtils.testShapeMarginInlineStyle,
-                        ParsingUtils.buildTestCases(shape_margin_valid_unit_tests, "inline"), true);
-        generate_tests( ParsingUtils.testShapeMarginComputedStyle,
-                        ParsingUtils.buildTestCases(shape_margin_valid_unit_tests, "computed"), true);
+
         </script>
     </body>
 </html>

--- a/css/css-shapes/shape-outside/values/shape-margin-001.html
+++ b/css/css-shapes/shape-outside/values/shape-margin-001.html
@@ -15,96 +15,28 @@
     <body>
         <div id="log"></div>
         <script type="text/javascript">
-        // actual & expected should be the same for inline
-        // expected for computed are converted to the px value in the test framework
-
         setup({explicit_done: true});
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10cm", "10cm");
-            }, '10cm - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10mm", "10mm");
-            }, '10mm - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10in", "10in");
-            }, '10in - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10pt", "10pt");
-            }, '10pt - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10pc", "10pc");
-            }, '10pc - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10em", "10em");
-            }, '10em - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10ex", "10ex");
-            }, '10ex - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10ch", "10ch");
-            }, '10ch - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10rem", "10rem");
-            }, '10rem - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10vw", "10vw");
-            }, '10vw - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10vh", "10vh");
-            }, '10vh - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10vmin", "10vmin");
-            }, '10vmin - inline');
-            test(function() {
-                ParsingUtils.testShapeMarginInlineStyle("10vmax", "10vmax");
-            }, '10vmax - inline');
+        var shape_margin_valid_unit_tests = [];
+        ParsingUtils.validUnits.forEach(function(unit) {
+            test = "10"+unit;
+            testCase = new Object();
+            // actual & expected_inline should be the same
+            // expected_computed will get converted to the px value in the test framework
+            testCase["actual"] = test;
+            testCase["expected_inline"] = test;
+            testCase["expected_computed"] = test;
+            shape_margin_valid_unit_tests.push(testCase);
+        });
 
+        generate_tests( ParsingUtils.testShapeMarginInlineStyle,
+                        ParsingUtils.buildTestCases(shape_margin_valid_unit_tests, "inline"), true);
         ParsingUtils.setupFonts();
         document.fonts.ready.then(()=> {
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10cm", ParsingUtils.convertToPx("10cm"));
-            }, '10cm - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10mm", ParsingUtils.convertToPx("10mm"));
-            }, '10mm - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10in", ParsingUtils.convertToPx("10in"));
-            }, '10in - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10pt", ParsingUtils.convertToPx("10pt"));
-            }, '10pt - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10pc", ParsingUtils.convertToPx("10pc"));
-            }, '10pc - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10em", ParsingUtils.convertToPx("10em"));
-            }, '10em - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10ex", ParsingUtils.convertToPx("10ex"));
-            }, '10ex - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10ch", ParsingUtils.convertToPx("10ch"));
-            }, '10ch - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10rem", ParsingUtils.convertToPx("10rem"));
-            }, '10rem - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10vw", ParsingUtils.convertToPx("10vw"));
-            }, '10vw - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10vh", ParsingUtils.convertToPx("10vh"));
-            }, '10vh - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10vmin", ParsingUtils.convertToPx("10vmin"));
-            }, '10vmin - computed');
-            test(function() {
-                ParsingUtils.testShapeMarginComputedStyle("10vmax", ParsingUtils.convertToPx("10vmax"));
-            }, '10vmax - computed');
-
+            generate_tests( ParsingUtils.testShapeMarginComputedStyle,
+                            ParsingUtils.buildTestCases(shape_margin_valid_unit_tests, "computed"), true);
             ParsingUtils.restoreFonts();
             done();
         });
-
         </script>
     </body>
 </html>

--- a/css/css-shapes/shape-outside/values/shape-margin-001.html
+++ b/css/css-shapes/shape-outside/values/shape-margin-001.html
@@ -10,7 +10,7 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>
-        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />-->
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     </head>
     <body>
         <div id="log"></div>

--- a/css/css-shapes/shape-outside/values/shape-outside-circle-004.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-circle-004.html
@@ -13,14 +13,21 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     </head>
     <body>
         <div id="log"></div>
         <script type="text/javascript">
+            setup({explicit_done: true});
             generate_tests( ParsingUtils.testInlineStyle,
                             ParsingUtils.buildPositionTests("circle", true, 'lengthUnit + inline', ParsingUtils.validUnits) );
-            generate_tests( ParsingUtils.testComputedStyle,
-                            ParsingUtils.buildPositionTests("circle", true, 'lengthUnit + computed', ParsingUtils.validUnits) );
+            ParsingUtils.setupFonts();
+            document.fonts.ready.then(()=> {
+                generate_tests( ParsingUtils.testComputedStyle,
+                                ParsingUtils.buildPositionTests("circle", true, 'lengthUnit + computed', ParsingUtils.validUnits) );
+                ParsingUtils.restoreFonts();
+                done();
+            });
         </script>
     </body>
 </html>

--- a/css/css-shapes/shape-outside/values/shape-outside-circle-005.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-circle-005.html
@@ -12,12 +12,19 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     </head>
     <body>
         <div id="log"></div>
         <script type="text/javascript">
+            setup({explicit_done: true});
             generate_tests(ParsingUtils.testInlineStyle, ParsingUtils.buildRadiiTests('circle', 'lengthUnit + inline', ParsingUtils.validUnits));
-            generate_tests(ParsingUtils.testComputedStyle, ParsingUtils.buildRadiiTests('circle', 'lengthUnit + computed', ParsingUtils.validUnits));
+            ParsingUtils.setupFonts();
+            document.fonts.ready.then(()=> {
+                generate_tests(ParsingUtils.testComputedStyle, ParsingUtils.buildRadiiTests('circle', 'lengthUnit + computed', ParsingUtils.validUnits));
+                ParsingUtils.restoreFonts();
+                done();
+            });
         </script>
     </body>
 </html>

--- a/css/css-shapes/shape-outside/values/shape-outside-ellipse-004.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-ellipse-004.html
@@ -13,14 +13,21 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     </head>
     <body>
         <div id="log"></div>
         <script type="text/javascript">
+            setup({explicit_done: true});
             generate_tests( ParsingUtils.testInlineStyle,
                             ParsingUtils.buildPositionTests("ellipse", true, 'lengthUnit + inline', ParsingUtils.validUnits) );
-            generate_tests( ParsingUtils.testComputedStyle,
-                            ParsingUtils.buildPositionTests("ellipse", true, 'lengthUnit + computed', ParsingUtils.validUnits) );
+            ParsingUtils.setupFonts();
+            document.fonts.ready.then(()=> {
+                generate_tests( ParsingUtils.testComputedStyle,
+                                ParsingUtils.buildPositionTests("ellipse", true, 'lengthUnit + computed', ParsingUtils.validUnits) );
+                ParsingUtils.restoreFonts();
+                done();
+            });
         </script>
     </body>
 </html>

--- a/css/css-shapes/shape-outside/values/shape-outside-ellipse-005.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-ellipse-005.html
@@ -12,12 +12,20 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     </head>
     <body>
         <div id="log"></div>
         <script type="text/javascript">
+            setup({explicit_done: true});
             generate_tests(ParsingUtils.testInlineStyle, ParsingUtils.buildRadiiTests('ellipse', 'lengthUnit + inline', ParsingUtils.validUnits));
-            generate_tests(ParsingUtils.testComputedStyle, ParsingUtils.buildRadiiTests('ellipse', 'lengthUnit + computed', ParsingUtils.validUnits));
+            ParsingUtils.setupFonts();
+            document.fonts.ready.then(()=> {
+                generate_tests(ParsingUtils.testComputedStyle,
+                                ParsingUtils.buildRadiiTests('ellipse', 'lengthUnit + computed', ParsingUtils.validUnits));
+                ParsingUtils.restoreFonts();
+                done();
+            });
         </script>
     </body>
 </html>

--- a/css/css-shapes/shape-outside/values/shape-outside-inset-003.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-inset-003.html
@@ -13,15 +13,22 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     </head>
     <body>
         <div id="log"></div>
         <script type="text/javascript">
+           setup({explicit_done: true});
            ParsingUtils.validUnits.forEach(function(unit) {
                 generate_tests(ParsingUtils.testInlineStyle, ParsingUtils.generateInsetRoundCases(unit, 'inline'));
            });
-           ParsingUtils.validUnits.forEach(function(unit) {
-                generate_tests(ParsingUtils.testComputedStyle, ParsingUtils.generateInsetRoundCases(unit, 'computed'));
+           ParsingUtils.setupFonts();
+           document.fonts.ready.then(()=> {
+                ParsingUtils.validUnits.forEach(function(unit) {
+                    generate_tests(ParsingUtils.testComputedStyle, ParsingUtils.generateInsetRoundCases(unit, 'computed'));
+                });
+                ParsingUtils.restoreFonts();
+                done();
            });
         </script>
     </body>

--- a/css/css-shapes/shape-outside/values/shape-outside-polygon-004.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-polygon-004.html
@@ -13,10 +13,12 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     </head>
     <body>
         <div id="log"></div>
         <script type="text/javascript">
+            setup({explicit_done: true});
             var arg_length_units_tests = [
                ['%', 'px', 'px'],
                ['px', '%', 'px'],
@@ -31,8 +33,13 @@
             ];
             generate_tests( ParsingUtils.testInlineStyle,
                             ParsingUtils.buildPolygonTests(arg_length_units_tests, 'inline') );
-            generate_tests( ParsingUtils.testComputedStyle,
-                            ParsingUtils.buildPolygonTests(arg_length_units_tests, 'computed') );
+            ParsingUtils.setupFonts();
+            document.fonts.ready.then(()=> {
+                generate_tests( ParsingUtils.testComputedStyle,
+                                ParsingUtils.buildPolygonTests(arg_length_units_tests, 'computed') );
+                ParsingUtils.restoreFonts();
+                done();
+            });
         </script>
     </body>
 </html>

--- a/css/css-shapes/shape-outside/values/shape-outside-shape-arguments-000.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-shape-arguments-000.html
@@ -22,58 +22,46 @@
             // fixed units: cm, mm, in, px, pt, pc
             // percentage unit: %
             // zero length: 0
-
             setup({explicit_done: true});
+            var basic_shape_args_tests = [
+                {
+                  "name": "0-valued",
+                  "actual": "polygon(nonzero, 0 0)",
+                  "expected_inline": "polygon(0px 0px)",
+                  "expected_computed": "polygon(0px 0px)"
+                },
+                {
+                  "name": "Font relative units",
+                  "actual": "polygon(nonzero, 1em 1ex, 1ch 1rem)",
+                  "expected_inline": "polygon(1em 1ex, 1ch 1rem)",
+                  "expected_computed": "polygon(1em 1ex, 1ch 1rem)" // converted to px by the framework
+                },
+                {
+                  "name": "View relative units",
+                  "actual": "polygon(nonzero, 1vw 1vh, 1vmin 1vmax)",
+                  "expected_inline": "polygon(1vw 1vh, 1vmin 1vmax)",
+                  "expected_computed": "polygon(1vw 1vh, 1vmin 1vmax)" // converted to px by the framework
+                },
+                {
+                  "name": "Fixed units",
+                  "actual": "polygon(nonzero, 1cm 1mm, 1in 1px, 1pt 1pc)",
+                  "expected_inline": "polygon(1cm 1mm, 1in 1px, 1pt 1pc)",
+                  "expected_computed": "polygon(1cm 1mm, 1in 1px, 1pt 1pc)" // converted to px by the framework
+                },
+                {
+                  "name": "Percentage units",
+                  "actual": "polygon(nonzero, 1% 2%)",
+                  "expected_inline": "polygon(1% 2%)",
+                  "expected_computed": "polygon(1% 2%)"
+                }
+            ];
 
-            test(function() {
-                ParsingUtils.testInlineStyle(
-                    "polygon(nonzero, 0 0)", "polygon(0px 0px)");
-            }, '0-valued - inline');
-            test(function() {
-                ParsingUtils.testInlineStyle(
-                    "polygon(nonzero, 1em 1ex, 1ch 1rem)", "polygon(1em 1ex, 1ch 1rem)");
-            }, 'Font relative units - inline');
-            test(function() {
-                ParsingUtils.testInlineStyle(
-                    "polygon(nonzero, 1vw 1vh, 1vmin 1vmax)", "polygon(1vw 1vh, 1vmin 1vmax)");
-            }, 'View relative units - inline');
-            test(function() {
-                ParsingUtils.testInlineStyle(
-                    "polygon(nonzero, 1cm 1mm, 1in 1px, 1pt 1pc)",
-                    "polygon(1cm 1mm, 1in 1px, 1pt 1pc)");
-            }, 'Fixed units - inline');
-            test(function() {
-                ParsingUtils.testInlineStyle(
-                    "polygon(nonzero, 1% 2%)", "polygon(1% 2%)");
-            }, 'Percentage units - inline');
-
+            generate_tests( ParsingUtils.testInlineStyle,
+                            ParsingUtils.buildTestCases(basic_shape_args_tests, "inline") );
             ParsingUtils.setupFonts();
             document.fonts.ready.then(()=> {
-                test(function() {
-                    ParsingUtils.testComputedStyle(
-                        "polygon(nonzero, 0 0)", ParsingUtils.convertToPx("polygon(0px 0px)"));
-                }, '0-valued - computed');
-                test(function() {
-                    ParsingUtils.testComputedStyle(
-                        "polygon(nonzero, 1em 1ex, 1ch 1rem)",
-                        ParsingUtils.convertToPx("polygon(1em 1ex, 1ch 1rem)"));
-                }, 'Font relative units - computed');
-                test(function() {
-                    ParsingUtils.testComputedStyle(
-                        "polygon(nonzero, 1vw 1vh, 1vmin 1vmax)",
-                        ParsingUtils.convertToPx("polygon(1vw 1vh, 1vmin 1vmax)"));
-                }, 'View relative units - computed');
-                test(function() {
-                    ParsingUtils.testComputedStyle(
-                        "polygon(nonzero, 1cm 1mm, 1in 1px, 1pt 1pc)",
-                        ParsingUtils.convertToPx("polygon(1cm 1mm, 1in 1px, 1pt 1pc)"));
-                }, 'Fixed units - computed');
-                test(function() {
-                    ParsingUtils.testComputedStyle(
-                        "polygon(nonzero, 1% 2%)",
-                        ParsingUtils.convertToPx("polygon(1% 2%)"));
-                }, 'Percentage units - computed');
-
+                generate_tests( ParsingUtils.testComputedStyle,
+                                ParsingUtils.buildTestCases(basic_shape_args_tests, "computed") );
                 ParsingUtils.restoreFonts();
                 done();
             });

--- a/css/css-shapes/shape-outside/values/shape-outside-shape-arguments-000.html
+++ b/css/css-shapes/shape-outside/values/shape-outside-shape-arguments-000.html
@@ -13,6 +13,7 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>
+        <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     </head>
     <body>
         <div id="log"></div>
@@ -21,42 +22,62 @@
             // fixed units: cm, mm, in, px, pt, pc
             // percentage unit: %
             // zero length: 0
-            var basic_shape_args_tests = [
-                {
-                  "name": "0-valued",
-                  "actual": "polygon(nonzero, 0 0)",
-                  "expected_inline": "polygon(0px 0px)",
-                  "expected_computed": "polygon(0px 0px)"
-                },
-                {
-                  "name": "Font relative units",
-                  "actual": "polygon(nonzero, 1em 1ex, 1ch 1rem)",
-                  "expected_inline": "polygon(1em 1ex, 1ch 1rem)",
-                  "expected_computed": "polygon(1em 1ex, 1ch 1rem)" // converted to px by the framework
-                },
-                {
-                  "name": "View relative units",
-                  "actual": "polygon(nonzero, 1vw 1vh, 1vmin 1vmax)",
-                  "expected_inline": "polygon(1vw 1vh, 1vmin 1vmax)",
-                  "expected_computed": "polygon(1vw 1vh, 1vmin 1vmax)" // converted to px by the framework
-                },
-                {
-                  "name": "Fixed units",
-                  "actual": "polygon(nonzero, 1cm 1mm, 1in 1px, 1pt 1pc)",
-                  "expected_inline": "polygon(1cm 1mm, 1in 1px, 1pt 1pc)",
-                  "expected_computed": "polygon(1cm 1mm, 1in 1px, 1pt 1pc)" // converted to px by the framework
-                },
-                {
-                  "name": "Percentage units",
-                  "actual": "polygon(nonzero, 1% 2%)",
-                  "expected_inline": "polygon(1% 2%)",
-                  "expected_computed": "polygon(1% 2%)"
-                }
-            ];
-            generate_tests( ParsingUtils.testInlineStyle,
-                            ParsingUtils.buildTestCases(basic_shape_args_tests, "inline") );
-            generate_tests( ParsingUtils.testComputedStyle,
-                            ParsingUtils.buildTestCases(basic_shape_args_tests, "computed") );
+
+            setup({explicit_done: true});
+
+            test(function() {
+                ParsingUtils.testInlineStyle(
+                    "polygon(nonzero, 0 0)", "polygon(0px 0px)");
+            }, '0-valued - inline');
+            test(function() {
+                ParsingUtils.testInlineStyle(
+                    "polygon(nonzero, 1em 1ex, 1ch 1rem)", "polygon(1em 1ex, 1ch 1rem)");
+            }, 'Font relative units - inline');
+            test(function() {
+                ParsingUtils.testInlineStyle(
+                    "polygon(nonzero, 1vw 1vh, 1vmin 1vmax)", "polygon(1vw 1vh, 1vmin 1vmax)");
+            }, 'View relative units - inline');
+            test(function() {
+                ParsingUtils.testInlineStyle(
+                    "polygon(nonzero, 1cm 1mm, 1in 1px, 1pt 1pc)",
+                    "polygon(1cm 1mm, 1in 1px, 1pt 1pc)");
+            }, 'Fixed units - inline');
+            test(function() {
+                ParsingUtils.testInlineStyle(
+                    "polygon(nonzero, 1% 2%)", "polygon(1% 2%)");
+            }, 'Percentage units - inline');
+
+            ParsingUtils.setupFonts();
+            document.fonts.ready.then(()=> {
+                test(function() {
+                    ParsingUtils.testComputedStyle(
+                        "polygon(nonzero, 0 0)", ParsingUtils.convertToPx("polygon(0px 0px)"));
+                }, '0-valued - computed');
+                test(function() {
+                    ParsingUtils.testComputedStyle(
+                        "polygon(nonzero, 1em 1ex, 1ch 1rem)",
+                        ParsingUtils.convertToPx("polygon(1em 1ex, 1ch 1rem)"));
+                }, 'Font relative units - computed');
+                test(function() {
+                    ParsingUtils.testComputedStyle(
+                        "polygon(nonzero, 1vw 1vh, 1vmin 1vmax)",
+                        ParsingUtils.convertToPx("polygon(1vw 1vh, 1vmin 1vmax)"));
+                }, 'View relative units - computed');
+                test(function() {
+                    ParsingUtils.testComputedStyle(
+                        "polygon(nonzero, 1cm 1mm, 1in 1px, 1pt 1pc)",
+                        ParsingUtils.convertToPx("polygon(1cm 1mm, 1in 1px, 1pt 1pc)"));
+                }, 'Fixed units - computed');
+                test(function() {
+                    ParsingUtils.testComputedStyle(
+                        "polygon(nonzero, 1% 2%)",
+                        ParsingUtils.convertToPx("polygon(1% 2%)"));
+                }, 'Percentage units - computed');
+
+                ParsingUtils.restoreFonts();
+                done();
+            });
+
         </script>
     </body>
 </html>

--- a/css/css-shapes/shape-outside/values/support/parsing-utils.js
+++ b/css/css-shapes/shape-outside/values/support/parsing-utils.js
@@ -837,6 +837,5 @@ return {
     roundResultStr: roundResultStr,
     setupFonts: setupFonts,
     restoreFonts: restoreFonts,
-    convertToPx: convertToPx
 }
 })();

--- a/css/css-shapes/shape-outside/values/support/parsing-utils.js
+++ b/css/css-shapes/shape-outside/values/support/parsing-utils.js
@@ -446,31 +446,32 @@ function each(object, func) {
     }
 }
 
-function setupFonts(func) {
-    return function () {
-        var fontProperties = {
-            'font-family': 'Ahem',
-            'font-size': '16px',
-            'line-height': '1'
-        };
-        var savedValues = { };
-        each(fontProperties, function (key, value) {
-            savedValues[key] = document.body.style.getPropertyValue(key);
-            document.body.style.setProperty(key, value);
-        });
-        try {
-            func.apply(this, arguments);
-        } finally {
-            each(savedValues, function (key, value) {
-                if (value) {
-                    document.body.style.setProperty(key, value);
-                }
-                else {
-                    document.body.style.removeProperty(key);
-                }
-            });
-        }
+/// For saving and restoring font properties
+var savedFontValues = { };
+
+function setupFonts() {
+    var fontProperties = {
+        'font-family': 'Ahem',
+        'font-size': '16px',
+        'line-height': '1'
     };
+    savedFontValues = { };
+    each(fontProperties, function (key, value) {
+        savedFontValues[key] = document.body.style.getPropertyValue(key);
+        document.body.style.setProperty(key, value);
+    });
+}
+
+function restoreFonts() {
+    each(savedFontValues, function (key, value) {
+        if (value) {
+            document.body.style.setProperty(key, value);
+        }
+        else {
+            document.body.style.removeProperty(key);
+        }
+    });
+    savedFontValues = { };
 }
 
 var validUnits = [
@@ -819,11 +820,11 @@ var calcTestValues = [
 
 return {
     testInlineStyle: testInlineStyle,
-    testComputedStyle: setupFonts(testComputedStyle),
+    testComputedStyle: testComputedStyle,
     testShapeMarginInlineStyle: testShapeMarginInlineStyle,
-    testShapeMarginComputedStyle: setupFonts(testShapeMarginComputedStyle),
+    testShapeMarginComputedStyle: testShapeMarginComputedStyle,
     testShapeThresholdInlineStyle: testShapeThresholdInlineStyle,
-    testShapeThresholdComputedStyle: setupFonts(testShapeThresholdComputedStyle),
+    testShapeThresholdComputedStyle: testShapeThresholdComputedStyle,
     buildTestCases: buildTestCases,
     buildRadiiTests: buildRadiiTests,
     buildPositionTests: buildPositionTests,
@@ -834,6 +835,8 @@ return {
     validUnits: validUnits,
     calcTestValues: calcTestValues,
     roundResultStr: roundResultStr,
-    setupFonts: setupFonts
+    setupFonts: setupFonts,
+    restoreFonts: restoreFonts,
+    convertToPx: convertToPx
 }
 })();


### PR DESCRIPTION
This makes font setup/restoration explicit rather than per-subtest.
This allows us to setup Ahem usage, then wait for fonts to load, and
then run all computed tests as a discrete block.

The previous method (which dynamically inserted Ahem prior to a subtest
and removed it immediately after) didn't allow us to wait for the web
fonts to be loaded because the test page would have no Ahem usage
present at the time we waited for the fonts.ready event.