### PR TITLE
Fix ChromeDriver acceptInsecureCerts capability tests

### DIFF
--- a/webdriver/tests/new_session/conftest.py
+++ b/webdriver/tests/new_session/conftest.py
@@ -25,6 +25,19 @@ def fixture_add_browser_capabilities(configuration):
     return add_browser_capabilities
 
 
+@pytest.fixture(name="configuration")
+def fixture_configuration(configuration):
+  """Remove "acceptInsecureCerts" from capabilities if it exists.
+
+  Some browser configurations add acceptInsecureCerts capability by default.
+  Remote it during new_session tests to avoid interference.
+  """
+
+  if "acceptInsecureCerts" in configuration["capabilities"]:
+    configuration = dict(configuration)
+    del configuration["capabilities"]["acceptInsecureCerts"]
+  return configuration
+
 @pytest.fixture(name="new_session")
 def fixture_new_session(request, configuration, current_session):
     """Start a new session for tests which themselves test creating new sessions.

--- a/webdriver/tests/new_session/conftest.py
+++ b/webdriver/tests/new_session/conftest.py
@@ -30,7 +30,7 @@ def fixture_configuration(configuration):
   """Remove "acceptInsecureCerts" from capabilities if it exists.
 
   Some browser configurations add acceptInsecureCerts capability by default.
-  Remote it during new_session tests to avoid interference.
+  Remove it during new_session tests to avoid interference.
   """
 
   if "acceptInsecureCerts" in configuration["capabilities"]:


### PR DESCRIPTION
PR #19402 added acceptInsecureCerts capability to Chrome configuration
by default. This causes failures in tests that explicitly check this
capability. Fixing by removing the default acceptInsecureCerts
capability during new_session tests.