### PR TITLE
[fetch] Correct assertion

### DIFF
--- a/fetch/api/request/request-init-stream.any.js
+++ b/fetch/api/request/request-init-stream.any.js
@@ -2,50 +2,50 @@
 
 "use strict";
 
-async function assert_request(input, init) {
+function assert_request(test, input, init) {
   assert_throws(new TypeError(), () => new Request(input, init), "new Request()");
-  assert_throws(new TypeError(), async () => await fetch(input, init), "fetch()");
+  return promise_rejects_js(test, TypeError, fetch(input, init), "fetch()");
 }
 
-promise_test(async () => {
+promise_test(async (t) => {
   const stream = new ReadableStream();
   stream.getReader();
-  await assert_request("...", { method:"POST", body: stream });
+  await assert_request(t, "...", { method:"POST", body: stream });
 }, "Constructing a Request with a stream on which getReader() is called");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const stream = new ReadableStream();
   stream.getReader().read();
-  await assert_request("...", { method:"POST", body: stream });
+  await assert_request(t, "...", { method:"POST", body: stream });
 }, "Constructing a Request with a stream on which read() is called");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const stream = new ReadableStream({ pull: c => c.enqueue(new Uint8Array()) }),
         reader = stream.getReader();
   await reader.read();
   reader.releaseLock();
-  await assert_request("...", { method:"POST", body: stream });
+  await assert_request(t, "...", { method:"POST", body: stream });
 }, "Constructing a Request with a stream on which read() and releaseLock() are called");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const request = new Request("...", { method: "POST", body: "..." });
   request.body.getReader();
-  await assert_request(request);
+  await assert_request(t, request);
   assert_class_string(new Request(request, { body: "..." }), "Request");
 }, "Constructing a Request with a Request on which body.getReader() is called");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const request = new Request("...", { method: "POST", body: "..." });
   request.body.getReader().read();
-  await assert_request(request);
+  await assert_request(t, request);
   assert_class_string(new Request(request, { body: "..." }), "Request");
 }, "Constructing a Request with a Request on which body.getReader().read() is called");
 
-promise_test(async () => {
+promise_test(async (t) => {
   const request = new Request("...", { method: "POST", body: "..." }),
         reader = request.body.getReader();
   await reader.read();
   reader.releaseLock();
-  await assert_request(request);
+  await assert_request(t, request);
   assert_class_string(new Request(request, { body: "..." }), "Request");
 }, "Constructing a Request with a Request on which read() and releaseLock() are called");

--- a/fetch/api/request/request-init-stream.any.js
+++ b/fetch/api/request/request-init-stream.any.js
@@ -2,9 +2,9 @@
 
 "use strict";
 
-function assert_request(test, input, init) {
+async function assert_request(test, input, init) {
   assert_throws(new TypeError(), () => new Request(input, init), "new Request()");
-  return promise_rejects_js(test, TypeError, fetch(input, init), "fetch()");
+  await promise_rejects_js(test, TypeError, fetch(input, init), "fetch()");
 }
 
 promise_test(async (t) => {


### PR DESCRIPTION
Previously, the `assert_throws` utility function was invoked with a
function which could not throw an error. Update the tests to verify that
the function returns a promise that is rejected.