### PR TITLE
[2dcontext] Include required resource

### DIFF
--- a/2dcontext/imagebitmap/createImageBitmap-serializable.html
+++ b/2dcontext/imagebitmap/createImageBitmap-serializable.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/namespaces.js"></script>
+<script src="/common/media.js"></script>
 <script src="common.sub.js"></script>
 <div id=log></div>
 <script>


### PR DESCRIPTION
"common.sub.js" references a function named `getVideoURI` at the top
level. This function is provided by "/common/media.js"; if the latter
file is not included, "common.sub.js" cannot be executed.

Load the required resource prior to "common.sub.js" so that the test may
run to completion.