### PR TITLE
[testharness.js] Don't complete after allowed exc.

### DIFF
--- a/resources/test/tests/functional/worker-uncaught-allow.js
+++ b/resources/test/tests/functional/worker-uncaught-allow.js
@@ -15,3 +15,5 @@ async_test(function(t) {
     throw new Error("This error is expected.");
   }, 0);
 }, 'onerror event is triggered');
+
+done();

--- a/resources/test/tests/unit/exceptional-cases.html
+++ b/resources/test/tests/unit/exceptional-cases.html
@@ -80,6 +80,23 @@ promise_test(() => {
 promise_test(() => {
   return makeTest(
       () => {
+        setup({ allow_uncaught_exception: true });
+        throw new Error('this error is expected');
+      },
+      () => {
+        test(function() {}, 'a');
+        test(function() {}, 'b');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'OK');
+      assert_equals(tests.a, 'PASS');
+      assert_equals(tests.b, 'PASS');
+    });
+}, 'uncaught exception with subsequent subtest');
+
+promise_test(() => {
+  return makeTest(
+      () => {
         async_test((t) => {
           setTimeout(() => {
             setTimeout(() => t.done(), 0);

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3682,7 +3682,14 @@ policies and contribution forms [3].
                 tests.status.message = message;
                 tests.status.stack = stack;
             }
-            done();
+
+            // Do not transition to the "complete" phase if the test has been
+            // configured to allow uncaught exceptions. This gives the test an
+            // opportunity to define subtests based on the exception reporting
+            // behavior.
+            if (!tests.allow_uncaught_exception) {
+                done();
+            }
         };
 
         addEventListener("error", function(e) {


### PR DESCRIPTION
The following tests intentionally produce an uncaught exception and then define
subtests:

- html/semantics/scripting-1/the-script-element/module/error-and-slow-dependency.html
- html/webappapis/scripting/processing-model-2/window-onerror-parse-error.html
- html/webappapis/scripting/processing-model-2/window-onerror-runtime-error.html
- html/webappapis/scripting/processing-model-2/window-onerror-runtime-error-throw.html

testharness.js immediately transitions to "complete" and ignores the
subsequent subtests.

---

Today, the tests referenced in the commit message  are reported as passing single-page tests. Once we've completed the implementation of [WPT RFC 28](https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md), they will instead be reported as test harness errors.

As an alternative to this patch, we could modify each of the tests. If a subtest is defined *before* the exception is thrown, then all the subtests are reported as expected. (We could, for example, declare the existing synchronous subtests as asynchronous subtests instead.)

Changing the harness is definitely riskier, but it also seems more correct to me.

This change could interfere with single-page tests that use `allow_uncaught_exceptions`. My experiments don't indicate that any such tests exist, but it's difficult to demonstrate or summarize that research here. A more blunt heuristic might do. Only three tests use `allow_uncaught_exception` without invoking functions named `test`, `promise_test`, or `async_test`:

    $ git grep -l allow_uncaught_exception | xargs grep -LE '\b(test|promise_test|async_test)\s*\('
    IndexedDB/fire-error-event-exception.html
    IndexedDB/fire-success-event-exception.html
    custom-elements/upgrading/upgrading-enqueue-reactions.html

All three define subtests indirectly through helper functions.