### PR TITLE
[tools] Correct filtering logic for building docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,6 +2,10 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'docs/**'
+      - 'resources/**'
+      - 'tools/**'
   pull_request:
     paths:
       - 'docs/**'

--- a/tools/ci/website_build.sh
+++ b/tools/ci/website_build.sh
@@ -25,20 +25,6 @@ function targets_master {
   test $(json_property ${GITHUB_EVENT_PATH} ref) == 'refs/heads/master'
 }
 
-function modifies_relevant_files {
-  base_revision=$(json_property ${GITHUB_EVENT_PATH} before)
-
-  git diff --name-only ${base_revision} | \
-    grep -E --silent '^(docs|tools)/'
-}
-
-if ! modifies_relevant_files ; then
-  echo No files related to the website have been modified. Exiting without
-  echo building.
-
-  exit ${neutral_status}
-fi
-
 git config --global user.email "wpt-pr-bot@users.noreply.github.com"
 git config --global user.name "wpt-pr-bot"
 


### PR DESCRIPTION
The "before" property is only present in the "Push" GitHub Event [1].
Because of this, the script could not correctly detect changes when
running in response to a "Pull Request" GitHub Event [2].

Remove the file filtering logic from the Bash script and instead rely on
the equivalent functionality as provided by GitHub Actions [3].

[1] https://developer.github.com/v3/activity/events/types/#pushevent
[2] https://developer.github.com/v3/pulls/
[3] https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requestpaths