### PR TITLE
[Azure Pipelines] trigger CI builds only on certain branches

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -17,6 +17,10 @@
 #    Documention for the setup of these agents:
 #    https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-windows
 
+trigger:
+- epochs/*
+- triggers/*
+
 jobs:
 # The affected tests jobs are unconditional for speed, as most PRs have one or
 # more affected tests: https://github.com/web-platform-tests/wpt/issues/13936.


### PR DESCRIPTION
The CI builds do nothing for most branches and create a lot of no-op
builds in the Azure DevOps UI, making it harder to find the real ones.

PR builds are not affected by this.