### PR TITLE
[GitHub Actions] run website_build.sh directly on Ubuntu 18.04

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,9 +21,6 @@ jobs:
       with:
         fetch-depth: 50
     - name: Run website_build.sh
-      uses: ./tools/docker/documentation
+      run: ./tools/ci/website_build.sh
       env:
         DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
-      with:
-        entrypoint: /bin/bash
-        args: tools/ci/website_build.sh

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,6 +20,10 @@ jobs:
       uses: actions/checkout@v1
       with:
         fetch-depth: 50
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 2.7
     - name: Run website_build.sh
       run: ./tools/ci/website_build.sh
       env:

--- a/tools/docker/documentation/Dockerfile
+++ b/tools/docker/documentation/Dockerfile
@@ -1,3 +1,0 @@
-FROM python:2-stretch
-
-RUN apt-get update && apt-get install --yes git


### PR DESCRIPTION
This is like https://github.com/web-platform-tests/wpt/pull/19580,
but the dependencies of this job are even more modest and are already
fulfilled by the base ubuntu-18.04 image.