### PR TITLE
add tests for pinning scripts

### DIFF
--- a/webdriver/tests/execute_async_script/execute_async.py
+++ b/webdriver/tests/execute_async_script/execute_async.py
@@ -5,10 +5,27 @@ from webdriver.transport import Response
 from tests.support.asserts import assert_error, assert_success
 
 
-def execute_async_script(session, script, args=None):
+def pin_script(session, name, script):
+    body = {"script": script}
+
+    return session.transport.send(
+        "POST", "/session/{session_id}/execute/pin/{script_name}".format(
+            session_id=session.session_id,
+            script_name=name),
+        body)
+
+
+def execute_async_script(session, script, name=None, args=None):
     if args is None:
         args = []
     body = {"script": script, "args": args}
+
+    if name is not None:
+        return session.transport.send(
+            "POST", "/session/{session_id}/execute/async/{script_name}".format(
+                session_id=session.session_id,
+                script_name=name),
+            body)
 
     return session.transport.send(
         "POST", "/session/{session_id}/execute/async".format(**vars(session)),
@@ -51,3 +68,26 @@ def test_abort_by_user_prompt_twice(session, dialog_type):
     assert session.alert.text == "Bye"
 
     session.alert.accept()
+
+
+def test_execute_pinned(session):
+    pin_script(session, "One", "return 1;")
+    response = execute_async_script(session, name="One")
+    assert_success(response, 1)
+
+
+def test_name_and_script(session):
+    pin_script(session, "One", "return 1;")
+    response = execute_async_script(session, "return 1;", name="One")
+    assert_error(response, "invalid argument")
+
+
+def test_no_such_pinned_script(session):
+    response = execute_async_script(session, name="One")
+    assert_error(response, "no such script")
+
+
+def test_execute_pinned_with_args(session, http):
+    pin_script(session, "One", "arguments[arguments.length - 1](arguments[0] + arguments[1]);")
+    response = execute_async_script(session, name="One", args=[1, 2])
+    assert_success(response, 3)

--- a/webdriver/tests/execute_async_script/execute_async.py
+++ b/webdriver/tests/execute_async_script/execute_async.py
@@ -5,27 +5,10 @@ from webdriver.transport import Response
 from tests.support.asserts import assert_error, assert_success
 
 
-def pin_script(session, name, script):
-    body = {"script": script}
-
-    return session.transport.send(
-        "POST", "/session/{session_id}/execute/pin/{script_name}".format(
-            session_id=session.session_id,
-            script_name=name),
-        body)
-
-
-def execute_async_script(session, script, name=None, args=None):
+def execute_async_script(session, script, args=None):
     if args is None:
         args = []
     body = {"script": script, "args": args}
-
-    if name is not None:
-        return session.transport.send(
-            "POST", "/session/{session_id}/execute/async/{script_name}".format(
-                session_id=session.session_id,
-                script_name=name),
-            body)
 
     return session.transport.send(
         "POST", "/session/{session_id}/execute/async".format(**vars(session)),
@@ -68,26 +51,3 @@ def test_abort_by_user_prompt_twice(session, dialog_type):
     assert session.alert.text == "Bye"
 
     session.alert.accept()
-
-
-def test_execute_pinned(session):
-    pin_script(session, "One", "return 1;")
-    response = execute_async_script(session, name="One")
-    assert_success(response, 1)
-
-
-def test_name_and_script(session):
-    pin_script(session, "One", "return 1;")
-    response = execute_async_script(session, "return 1;", name="One")
-    assert_error(response, "invalid argument")
-
-
-def test_no_such_pinned_script(session):
-    response = execute_async_script(session, name="One")
-    assert_error(response, "no such script")
-
-
-def test_execute_pinned_with_args(session, http):
-    pin_script(session, "One", "arguments[arguments.length - 1](arguments[0] + arguments[1]);")
-    response = execute_async_script(session, name="One", args=[1, 2])
-    assert_success(response, 3)

--- a/webdriver/tests/execute_async_script/pinning.py
+++ b/webdriver/tests/execute_async_script/pinning.py
@@ -1,0 +1,50 @@
+import pytest
+
+from webdriver.transport import Response
+
+from tests.support.asserts import assert_error, assert_success
+
+
+def pin_script(session, name, script):
+    body = {"script": script}
+
+    return session.transport.send(
+        "POST", "/session/{session_id}/execute/pin/{script_name}".format(
+            session_id=session.session_id,
+            script_name=name),
+        body)
+
+
+def execute_async_script(session, script, name=None, args=None):
+    if args is None:
+        args = []
+    body = {"script": script, "args": args}
+
+    return session.transport.send(
+        "POST", "/session/{session_id}/execute/async/{script_name}".format(
+            session_id=session.session_id,
+            script_name=name),
+        body)
+
+
+def test_execute_pinned(session):
+    pin_script(session, "One", "return 1;")
+    response = execute_async_script(session, name="One")
+    assert_success(response, 1)
+
+
+def test_name_and_script(session):
+    pin_script(session, "One", "return 1;")
+    response = execute_async_script(session, "return 1;", name="One")
+    assert_error(response, "invalid argument")
+
+
+def test_no_such_pinned_script(session):
+    response = execute_async_script(session, name="One")
+    assert_error(response, "no such script")
+
+
+def test_execute_pinned_with_args(session, http):
+    pin_script(session, "One", "arguments[arguments.length - 1](arguments[0] + arguments[1]);")
+    response = execute_async_script(session, name="One", args=[1, 2])
+    assert_success(response, 3)

--- a/webdriver/tests/execute_pin/execute_pin.py
+++ b/webdriver/tests/execute_pin/execute_pin.py
@@ -1,0 +1,48 @@
+import pytest
+
+from webdriver.transport import Response
+
+from tests.support.asserts import assert_error, assert_success
+from tests.support.inline import inline
+
+
+def pin_script(session, name, script):
+    body = {"script": script}
+
+    return session.transport.send(
+        "POST", "/session/{session_id}/execute/pin/{script_name}".format(
+            session_id=session.session_id,
+            script_name=name),
+        body)
+
+
+def test_pinning(session):
+    response = pin_script(session, "One", "return 1;")
+    assert_success(response)
+
+
+def test_null_parameter_value(session, http):
+    path = "/session/{session_id}/execute/sync/one".format(**vars(session))
+    with http.post(path, None) as response:
+        assert_error(Response.from_http(response), "invalid argument")
+
+
+def test_no_browsing_context(session, closed_window):
+    response = pin_script(session, "one", "return 1;")
+    assert_error(response, "no such window")
+
+
+def test_no_name(session):
+    response = pin_script(session, None, "return 1;")
+    assert_error(response, "invalid argument")
+
+
+def test_not_string(session):
+    response = pin_script(session, "One", "return 1;")
+    assert_error(response, "invalid argument")
+
+
+def test_duplicate_no_error(session):
+    pin_script(session, "One", "return 2;")
+    response = pin_script(session, "One", "return 1;")
+    assert_success(response)

--- a/webdriver/tests/execute_script/execute.py
+++ b/webdriver/tests/execute_script/execute.py
@@ -6,10 +6,27 @@ from tests.support.asserts import assert_error, assert_success
 from tests.support.inline import inline
 
 
-def execute_script(session, script, args=None):
+def pin_script(session, name, script):
+    body = {"script": script}
+
+    return session.transport.send(
+        "POST", "/session/{session_id}/execute/pin/{script_name}".format(
+            session_id=session.session_id,
+            script_name=name),
+        body)
+
+
+def execute_script(session, script, name=None, args=None):
     if args is None:
         args = []
     body = {"script": script, "args": args}
+
+    if name is not None:
+        return session.transport.send(
+            "POST", "/session/{session_id}/execute/sync/{script_name}".format(
+                session_id=session.session_id,
+                script_name=name),
+            body)
 
     return session.transport.send(
         "POST", "/session/{session_id}/execute/sync".format(
@@ -70,3 +87,26 @@ def test_abort_by_user_prompt_twice(session, dialog_type):
     assert session.alert.text == "Bye"
 
     session.alert.accept()
+
+
+def test_execute_pinned(session):
+    pin_script(session, "One", "return 1;")
+    response = execute_script(session, name="One")
+    assert_success(response, 1)
+
+
+def test_name_and_script(session):
+    pin_script(session, "One", "return 1;")
+    response = execute_script(session, "return 1;", name="One")
+    assert_error(response, "invalid argument")
+
+
+def test_no_such_pinned_script(session):
+    response = execute_script(session, name="One")
+    assert_error(response, "no such script")
+
+
+def test_execute_pinned_with_args(session, http):
+    pin_script(session, "One", "return arguments[0];")
+    response = execute_script(session, name="One", args=[1])
+    assert_success(response, 1)

--- a/webdriver/tests/execute_script/execute.py
+++ b/webdriver/tests/execute_script/execute.py
@@ -6,27 +6,10 @@ from tests.support.asserts import assert_error, assert_success
 from tests.support.inline import inline
 
 
-def pin_script(session, name, script):
-    body = {"script": script}
-
-    return session.transport.send(
-        "POST", "/session/{session_id}/execute/pin/{script_name}".format(
-            session_id=session.session_id,
-            script_name=name),
-        body)
-
-
-def execute_script(session, script, name=None, args=None):
+def execute_script(session, script, args=None):
     if args is None:
         args = []
     body = {"script": script, "args": args}
-
-    if name is not None:
-        return session.transport.send(
-            "POST", "/session/{session_id}/execute/sync/{script_name}".format(
-                session_id=session.session_id,
-                script_name=name),
-            body)
 
     return session.transport.send(
         "POST", "/session/{session_id}/execute/sync".format(
@@ -87,26 +70,3 @@ def test_abort_by_user_prompt_twice(session, dialog_type):
     assert session.alert.text == "Bye"
 
     session.alert.accept()
-
-
-def test_execute_pinned(session):
-    pin_script(session, "One", "return 1;")
-    response = execute_script(session, name="One")
-    assert_success(response, 1)
-
-
-def test_name_and_script(session):
-    pin_script(session, "One", "return 1;")
-    response = execute_script(session, "return 1;", name="One")
-    assert_error(response, "invalid argument")
-
-
-def test_no_such_pinned_script(session):
-    response = execute_script(session, name="One")
-    assert_error(response, "no such script")
-
-
-def test_execute_pinned_with_args(session, http):
-    pin_script(session, "One", "return arguments[0];")
-    response = execute_script(session, name="One", args=[1])
-    assert_success(response, 1)

--- a/webdriver/tests/execute_script/pinning.py
+++ b/webdriver/tests/execute_script/pinning.py
@@ -27,35 +27,25 @@ def execute_script(session, script, name=None, args=None):
             script_name=name),
         body)
 
-def test_pinning(session):
-    response = pin_script(session, "One", "return 1;")
-    assert_success(response)
 
-
-def test_null_parameter_value(session, http):
-    path = "/session/{session_id}/execute/sync/one".format(**vars(session))
-    with http.post(path, None) as response:
-        assert_error(Response.from_http(response), "invalid argument")
-
-
-def test_no_browsing_context(session, closed_window):
-    response = pin_script(session, "one", "return 1;")
-    assert_error(response, "no such window")
-
-
-def test_no_name(session):
-    response = pin_script(session, None, "return 1;")
-    assert_error(response, "invalid argument")
-
-
-def test_not_string(session):
-    response = pin_script(session, "One", "return 1;")
-    assert_error(response, "invalid argument")
-
-
-def test_duplicate_success(session):
-    pin_script(session, "One", "return 2;")
+def test_execute_pinned(session):
     pin_script(session, "One", "return 1;")
     response = execute_script(session, name="One")
+    assert_success(response, 1)
 
+
+def test_name_and_script(session):
+    pin_script(session, "One", "return 1;")
+    response = execute_script(session, "return 1;", name="One")
+    assert_error(response, "invalid argument")
+
+
+def test_no_such_pinned_script(session):
+    response = execute_script(session, name="One")
+    assert_error(response, "no such script")
+
+
+def test_execute_pinned_with_args(session, http):
+    pin_script(session, "One", "return arguments[0];")
+    response = execute_script(session, name="One", args=[1])
     assert_success(response, 1)


### PR DESCRIPTION
This goes along with this PR: https://github.com/w3c/webdriver/pull/1445

Tests are a little tricky since I have to use the spec to set things in order to use them in execute script. I know I don't want to write `pin_script` method 3 times here, but I'm not sure where to put it so that it is correct.

Also, my Python is rusty. :)