### PR TITLE
Fix #19275: Remove lastModifiedDate

### DIFF
--- a/IndexedDB/structured-clone.any.js
+++ b/IndexedDB/structured-clone.any.js
@@ -288,8 +288,6 @@ cloneObjectTest(
     assert_equals(orig.type, clone.type);
     assert_equals(orig.name, clone.name);
     assert_equals(orig.lastModified, clone.lastModified);
-    assert_equals(String(orig.lastModifiedDate),
-                  String(clone.lastModifiedDate));
     assert_equals(await orig.text(), await clone.text());
   });
 


### PR DESCRIPTION
lastModifiedDate is now outdated per w3c/IndexedDB#300

A historical test already exists for the property: https://github.com/web-platform-tests/wpt/blob/master/FileAPI/historical.https.html#L58