### PR TITLE
[css-writing-modes] Fix bug in wm-propagation-001

### DIFF
--- a/css/css-writing-modes/wm-propagation-001.html
+++ b/css/css-writing-modes/wm-propagation-001.html
@@ -13,18 +13,17 @@ body {
   writing-mode: vertical-rl;
   width: 0; height: 0;
 }
-html::before {
-  content: "This text must be vertical.";
-  /* This is inline content of the root,
-     and should therefore be vertical,
-     as the root's used value is vertical */
-}
 html::after {
   content: "This text must be horizontal.";
   display: block;
-  /* This is a block level element,
-     with it's own writing mode inherited from the root,
-     horizontal since the root's computed value should be horizontal*/
+  /* The writing mode inherited from the root must be horizontal
+  since the root's computed value should be horizontal */
+
 }
 </style>
-<body></body>
+<script>
+  document.documentElement.append("This text must be vertical");
+  /* This is direct content of the root,
+     and should therefore be vertical,
+     as the root's used value is vertical */
+</script>


### PR DESCRIPTION
Text content must be directly inline in the html element to observe its
writing mode's used value. If placed in a descendant pseudo, it will
inherit from the computed value instead.