### PR TITLE
[pointerevents] Stabilize test

### DIFF
--- a/pointerevents/pointerevent_setpointercapture_inactive_button_mouse.html
+++ b/pointerevents/pointerevent_setpointercapture_inactive_button_mouse.html
@@ -27,7 +27,7 @@
 
             var captureGot = false;
 
-            setup({ explicit_done: true });
+            setup({ single_test: true });
             add_completion_callback(showPointerTypes);
 
             function run() {
@@ -49,9 +49,7 @@
                  // When the setPointerCapture method is invoked, if the specified pointer is not in active button state, then the method must have no effect on subsequent pointer events.
                  // TA: 13.2
                 on_event(target0, "pointerout", function (event) {
-                    test(function() {
-                        assert_false(captureGot, "pointer capture is not set while button state is inactive")
-                    }, "pointer capture is not set while button state is inactive");
+                    assert_false(captureGot, "pointer capture is not set while button state is inactive")
                     // Make sure the test finishes after all the input actions are completed.
                     actions_promise.then( () => {
                         done();


### PR DESCRIPTION
Previously, this test conditionally declared a subtest, making it
difficult to compare results between browsers. Depending on the
implementation status, the results could be interpreted in a number of
ways:

- a failing single-page test
- a timed out single-page test
- a completed test with a single failing subtest
- a completed test with a single passing subtest

Refactor to explicitly opt-in to the single-page test feature and to
consistently report unexpected behavior via unhandled Promise rejections
and uncaught exceptions.