### PR TITLE
[IndexedDB] Avoid race condition

### DIFF
--- a/IndexedDB/keypath-exceptions-array-key-prototype.htm
+++ b/IndexedDB/keypath-exceptions-array-key-prototype.htm
@@ -1,0 +1,43 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: Exceptions in extracting keys from Array values</title>
+<meta name="help" href="https://w3c.github.io/IndexedDB/#extract-key-from-value">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+indexeddb_test(
+  (t, db) => {
+    const store = db.createObjectStore('store');
+    store.createIndex('index', 'index0');
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+
+    const array = [];
+    array[99] = 1;
+
+    let getter_called = 0;
+    const prop = '50';
+    Object.defineProperty(Object.prototype, prop, {
+      enumerable: true, configurable: true,
+      get: () => {
+        ++getter_called;
+        return 'foo';
+      },
+    });
+    t.add_cleanup(() => {
+      delete Object.prototype[prop];
+    });
+
+    const request = tx.objectStore('store').put({index0: array}, 'key');
+    request.onerror = t.unreached_func('put should not fail');
+    request.onsuccess = t.step_func(function() {
+      assert_equals(getter_called, 0, 'Prototype getter should not be called');
+      t.done();
+    });
+  },
+  'Array key conversion should not invoke prototype getters'
+);
+</script>

--- a/IndexedDB/keypath-exceptions.htm
+++ b/IndexedDB/keypath-exceptions.htm
@@ -236,37 +236,4 @@ indexeddb_test(
   },
   'Key path evaluation: Exceptions from enumerable getters on prototype'
 );
-
-indexeddb_test(
-  (t, db) => {
-    const store = db.createObjectStore('store');
-    store.createIndex('index', 'index0');
-  },
-  (t, db) => {
-    const tx = db.transaction('store', 'readwrite');
-
-    const array = [];
-    array[99] = 1;
-
-    let getter_called = 0;
-    const prop = '50';
-    Object.defineProperty(Object.prototype, prop, {
-      enumerable: true, configurable: true,
-      get: () => {
-        ++getter_called;
-        return 'foo';
-      },
-    });
-
-    const request = tx.objectStore('store').put({index0: array}, 'key');
-    request.onerror = t.unreached_func('put should not fail');
-    request.onsuccess = t.step_func(function() {
-      assert_equals(getter_called, 0, 'Prototype getter should not be called');
-      delete Object.prototype[prop];
-      t.done();
-    });
-  },
-  'Array key conversion should not invoke prototype getters'
-);
-
 </script>


### PR DESCRIPTION
The `indexeddb_test` helper function uses `async_test` internally, and
subtests defined with `async_test` execute in parallel. If such tests
observe interactions with a globally-defined API (such as the Object
prototype), they may receive unreliable results.

Define the subtest which observes a global API in order to eliminate the
risk of unintended subtest interactions.