### PR TITLE
[docs] Document `on_event` function

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -820,10 +820,11 @@ asserts that one `assert_func(actual, expected_array_N, extra_arg1, ..., extra_a
 
 ## Utility functions ##
 
-### `on_event(object, event, callback)`
+### **DEPRECATED** `on_event(object, event, callback)`
 
 Register a function as a DOM event listener to the given object for the event
-bubbling phase.
+bubbling phase. New tests should not use this function. Instead, they should
+invoke the `addEventListener` method of the `object` value.
 
 ### `format_value(value)`
 

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -818,7 +818,14 @@ asserts that one `assert_func(actual, expected_array_N, extra_arg1, ..., extra_a
   allows multiple behaviours. Test authors should not use this method simply to hide
   UA bugs.
 
-## Formatting ##
+## Utility functions ##
+
+### `on_event(object, event, callback)`
+
+Register a function as a DOM event listener to the given object for the event
+bubbling phase.
+
+### `format_value(value)`
 
 When many JavaScript Object values are coerced to a String, the resulting value
 will be `"[object Object]"`. This obscures helpful information, making the

--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -28,6 +28,24 @@
     }
     on_event(window, "load", windowLoad);
 
+    test(function() {
+        var sequence = [];
+        var outer = document.createElement("div");
+        var inner = document.createElement("div");
+        outer.appendChild(inner);
+        document.body.appendChild(outer);
+        inner.addEventListener("click", function() {
+            sequence.push("inner");
+        }, false);
+
+        on_event(outer, "click", function() {
+            sequence.push("outer");
+        });
+        inner.click();
+
+        assert_array_equals(sequence, ["inner", "outer"]);
+    }, "on_event does not use event capture");
+
     // see the body onload below
     var load_test_attr = async_test("body element fires the onload event set from the attribute");
 </script>
@@ -430,6 +448,12 @@
     {
       "status_string": "PASS",
       "name": "window onload event fires when set from the handler",
+      "message": null,
+      "properties": {}
+    },
+    {
+      "status_string": "PASS",
+      "name": "on_event does not use event capture",
       "message": null,
       "properties": {}
     }

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -818,6 +818,8 @@ policies and contribution forms [3].
     /*
      * Register a function as a DOM event listener to the given object for the
      * event bubbling phase.
+     *
+     * This function was deprecated in November of 2019.
      */
     function on_event(object, event, callback)
     {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -815,6 +815,10 @@ policies and contribution forms [3].
                 });
     }
 
+    /*
+     * Register a function as a DOM event listener to the given object for the
+     * event bubbling phase.
+     */
     function on_event(object, event, callback)
     {
         object.addEventListener(event, callback, false);


### PR DESCRIPTION
This function is currently in use by over 150 tests. Document it and add
a test to verify that event capture is not in use.