### PR TITLE
Remove @lukebjerring as interfaces/ reviewer 🙁

### DIFF
--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -48,7 +48,6 @@ explicitly-managed secret.
 - [Google Domains](https://domains.google/): https://wpt.fyi
   - foolip@google.com
   - jeffcarp@google.com
-  - lukebjerring@google.com
   - mike@bocoup.com
 - [GitHub](https://github.com/): web-platform-tests
   - [@foolip](https://github.com/foolip)
@@ -66,8 +65,6 @@ explicitly-managed secret.
   - foolip@google.com
   - geoffers@gmail.com
   - jeffcarp@google.com
-  - kereliuk@google.com
-  - lukebjerring@google.com
   - markdittmer@google.com
   - mike@bocoup.com
   - rick@bocoup.com

--- a/interfaces/META.yml
+++ b/interfaces/META.yml
@@ -1,3 +1,2 @@
 suggested_reviewers:
   - foolip
-  - lukebjerring

--- a/interfaces/README.md
+++ b/interfaces/README.md
@@ -2,4 +2,4 @@ This directory contains [Web IDL](https://heycam.github.io/webidl/) interface de
 
 The `.idl` files are extracted from specs by [Reffy](https://github.com/tidoust/reffy) into [reffy-reports](https://github.com/tidoust/reffy-reports), and a [sync script](https://github.com/tidoust/reffy-reports/blob/master/wpt-sync/sync.js) sends [automatic PRs](https://github.com/web-platform-tests/wpt/pulls/autofoolip). The PRs require manual review but can be approved/merged by anyone with write access.
 
-If some IDL in this directory is not up to date with the spec, first look for an [open PR](https://github.com/web-platform-tests/wpt/pulls/autofoolip) and if there is none [file an issue on reffy-reports](https://github.com/tidoust/reffy-reports/issues) and notify @foolip and @lukebjerring.
+If some IDL in this directory is not up to date with the spec, first look for an [open PR](https://github.com/web-platform-tests/wpt/pulls/autofoolip) and if there is none [file an issue on reffy-reports](https://github.com/tidoust/reffy-reports/issues) and notify @foolip.


### PR DESCRIPTION
This way, all @autofoolip PRs in interfaces/ go to @foolip.

Drive-by: clean up admin docs. kereliuk@google.com also bounces.