### PR TITLE
Retry the download of the webkitgtk nightly built product.

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -42,6 +42,8 @@ import re
 import subprocess
 import sys
 import tempfile
+from socket import error as SocketError  # NOQA: N812
+import errno
 try:
     from urllib2 import urlopen
 except ImportError:
@@ -161,15 +163,41 @@ def install_webkitgtk_from_apt_repository(channel):
     run(["sudo", "apt-get", "-qqy", "-t", "bionic-wpt-webkit-updates", "install", "webkit2gtk-driver"])
 
 
+# Download an URL in chunks and saves it to a file descriptor (truncating it)
+# It doesn't close the descriptor, but flushes it on success.
+# It retries the download in case of ECONNRESET up to max_retries.
+def download_url_to_descriptor(fd, url, max_retries=3):
+    download_succeed = False
+    if max_retries < 0:
+        max_retries = 0
+    for current_retry in range(max_retries+1):
+        try:
+            resp = urlopen(url)
+            # We may come here in a retry, ensure to truncate fd before start writing.
+            fd.seek(0)
+            fd.truncate(0)
+            while True:
+                chunk = resp.read(16*1024)
+                if not chunk:
+                    break  # Download finished
+                fd.write(chunk)
+            fd.flush()
+            download_succeed = True
+            break  # Sucess
+        except SocketError as e:
+            if e.errno != errno.ECONNRESET:
+                raise  # Unknown error
+            if current_retry < max_retries:
+                print("ERROR: Connection reset by peer. Retrying ...")
+                continue  # Retry
+    return download_succeed
+
+
 def install_webkitgtk_from_tarball_bundle(channel):
     with tempfile.NamedTemporaryFile(suffix=".tar.xz") as temp_tarball:
-        resp = urlopen("https://webkitgtk.org/built-products/nightly/webkitgtk-nightly-build-last.tar.xz")
-        while True:
-            chunk = resp.read(16*1024)
-            if not chunk:
-                break
-            temp_tarball.write(chunk)
-        temp_tarball.flush()
+        download_url = "https://webkitgtk.org/built-products/nightly/webkitgtk-nightly-build-last.tar.xz"
+        if not download_url_to_descriptor(temp_tarball, download_url):
+            raise RuntimeError("Can't download %s. Aborting" % download_url)
         run(["sudo", "tar", "xfa", temp_tarball.name, "-C", "/"])
     # Install dependencies
     run(["sudo", "apt-get", "-qqy", "update"])


### PR DESCRIPTION
It has been observed that the download on taskcluster fails sometimes with a "socket.error: [Errno 104] Connection reset by peer" error.

For example in:
https://tools.taskcluster.net/groups/Yvv_o50_Q4u88-oneHpxdA/tasks/CLhV8hAnRUGhgfpfmb0jiQ/runs/0/logs/public%2Flogs%2Flive.log

This moves the download code to a new function that will retry the download in that case. Up to 3 times by default.