### PR TITLE
Tweaked, improved sizing-orthog-htb-in-vrl-013-ref.xht

### DIFF
--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-013-ref.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-013-ref.xht
@@ -9,13 +9,14 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
 
   <meta name="DC.date.created" content="2016-12-22T09:54:03+11:00" scheme="W3CDTF" />
-  <meta name="DC.date.modified" content="2019-10-16T09:54:03+11:00" scheme="W3CDTF" />
+  <meta name="DC.date.modified" content="2019-12-18T09:54:03+11:00" scheme="W3CDTF" />
 
   <meta content="" name="flags" />
 
   <style type="text/css"><![CDATA[
   html
     {
+      direction: rtl;
       width: calc(52px + 100vw + 52px);
     }
 
@@ -29,6 +30,7 @@
   table
     {
       border-spacing: 0px;
+      direction: ltr;
       position: absolute;
       width: calc(52px + 100% + 52px);
     }
@@ -56,17 +58,9 @@
     }
   ]]></style>
 
-
-  <script type="text/javascript">
-  function init()
-  {
-  document.documentElement.scrollLeft = 105;
-  }
-  </script>
-
  </head>
 
- <body onload="init();">
+ <body>
 
   <table>
 

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-013-ref.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-013-ref.xht
@@ -9,7 +9,7 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
 
   <meta name="DC.date.created" content="2016-12-22T09:54:03+11:00" scheme="W3CDTF" />
-  <meta name="DC.date.modified" content="2016-12-30T09:54:03+11:00" scheme="W3CDTF" />
+  <meta name="DC.date.modified" content="2019-10-16T09:54:03+11:00" scheme="W3CDTF" />
 
   <meta content="" name="flags" />
 
@@ -55,9 +55,18 @@
       display: block;
     }
   ]]></style>
+
+
+  <script type="text/javascript">
+  function init()
+  {
+  document.documentElement.scrollLeft = 105;
+  }
+  </script>
+
  </head>
 
- <body>
+ <body onload="init();">
 
   <table>
 


### PR DESCRIPTION
Right now, the test
sizing-orthog-htb-in-vrl-013.xht
is reported as FAILED by the 4 browsers (Chrome 78, Edge 79, Firefox 71, Safari 82 Preview):

https://wpt.fyi/results/css/css-writing-modes/sizing-orthog-htb-in-vrl-013.xht?label=master

but, in all fairness, the test is passed by Chromium 76 and Firefox 71. The only problem that needed to be fixed was to **make the viewport of the reference file scrolled horizontally before comparing it with the test**. The code modification in this Pull Request does exactly that: 
`document.documentElement.scrollLeft = 105;`