### PR TITLE
Let retry.py flush stdout after each log message

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -56,7 +56,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.36
+            image: webplatformtests/wpt:0.37
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.36
+    image: webplatformtests/wpt:0.37
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/docker/retry.py
+++ b/tools/docker/retry.py
@@ -21,23 +21,28 @@ def iter_range(n):
         i += 1
 
 
+def log(value):
+    print(value)
+    sys.stdout.flush()
+
+
 def main():
     args = get_args().parse_args()
 
     if not args.cmd:
-        print("No command supplied")
+        log("No command supplied")
         sys.exit(1)
 
     retcode = None
 
     for n in iter_range(args.count):
         try:
-            print("Running %s [try %d/%d]" % (" ".join(args.cmd), (n+1), args.count))
+            log("Running %s [try %d/%d]" % (" ".join(args.cmd), (n+1), args.count))
             subprocess.check_call(args.cmd)
         except subprocess.CalledProcessError as e:
             retcode = e.returncode
         else:
-            print("Command succeeded")
+            log("Command succeeded")
             retcode = 0
             break
 
@@ -46,10 +51,10 @@ def main():
         else:
             wait_time = args.factor**n * args.delay
         if n < args.count - 1:
-            print("Command failed, waiting %s seconds to retry" % wait_time)
+            log("Command failed, waiting %s seconds to retry" % wait_time)
             time.sleep(wait_time)
         else:
-            print("Command failed, out of retries")
+            log("Command failed, out of retries")
 
     sys.exit(retcode)
 


### PR DESCRIPTION
This is to avoid the subprocess output appearing before the
"Running %s [try %d/%d]" message.