### PR TITLE
Make interpolation-testcommon.js produce consistent subtest names

### DIFF
--- a/css/support/interpolation-testcommon.js
+++ b/css/support/interpolation-testcommon.js
@@ -284,7 +284,7 @@
           comparisonFunction(
               getComputedStyle(target).getPropertyValue(property),
               expectedValue);
-        }, `${testText} at (${expectation.at}) should be [${sanitizeUrls(expectedValue)}]`);
+        }, `${testText} at (${expectation.at}) should be [${sanitizeUrls(expectation.expect)}]`);
       };
       return target;
     });


### PR DESCRIPTION
Passing expectations.expect through computed style may mutate it in an
implementation-dependent way. Those are interop bugs when that happens,
but we shouldn't surface it in the subtest name as that causes it to
fluctuate between browsers and releases.