### PR TITLE
Make css/css-lists/content-property/marker-text-matches-armenian.html not depend on fallback font metrics inside list markers

### DIFF
--- a/css/css-lists/content-property/marker-text-matches-armenian-ref.html
+++ b/css/css-lists/content-property/marker-text-matches-armenian-ref.html
@@ -7,4 +7,4 @@
     padding: 0;
 }
 </style>
-<p>Ա. Filler Text
+<p>Ա. Filler Text<span style="display: inline-block; width: 1px; height: 50px;"></span>

--- a/css/css-lists/content-property/marker-text-matches-armenian.html
+++ b/css/css-lists/content-property/marker-text-matches-armenian.html
@@ -14,5 +14,5 @@ ol {
 </style>
 
 <ol>
-  <li>Filler Text</li>
+  <li>Filler Text<span style="display: inline-block; width: 1px; height: 50px;"></span></li>
 </ol>


### PR DESCRIPTION
The test fails in Safari and Firefox because line height calculations don’t consider fallback fonts in list markers. It also fails in Chrome with LayoutNG disabled for the same reason. It passes in Chrome with LayoutNG enabled, though Koji (cc’ed) tells me this behavior change in LayoutNG was unintentional.

It doesn't appear to be specified anywhere whether fallback fonts in list markers affect line height, so we shouldn't be testing it in a WPT test.