### PR TITLE
[2dcontext] Add an invalid empty font test

### DIFF
--- a/2dcontext/text-styles/2d.text.font.parse.invalid.html
+++ b/2dcontext/text-styles/2d.text.font.parse.invalid.html
@@ -23,6 +23,10 @@ ctx.font = '20px serif';
 _assertSame(ctx.font, '20px serif', "ctx.font", "'20px serif'");
 
 ctx.font = '20px serif';
+ctx.font = '';
+_assertSame(ctx.font, '20px serif', "ctx.font", "'20px serif'");
+
+ctx.font = '20px serif';
 ctx.font = 'bogus';
 _assertSame(ctx.font, '20px serif', "ctx.font", "'20px serif'");
 

--- a/2dcontext/tools/tests2dtext.yaml
+++ b/2dcontext/tools/tests2dtext.yaml
@@ -79,6 +79,10 @@
     @assert ctx.font === '20px serif';
 
     ctx.font = '20px serif';
+    ctx.font = '';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
     ctx.font = 'bogus';
     @assert ctx.font === '20px serif';
 

--- a/offscreen-canvas/text/2d.text.font.parse.invalid.html
+++ b/offscreen-canvas/text/2d.text.font.parse.invalid.html
@@ -20,6 +20,10 @@ ctx.font = '20px serif';
 _assertSame(ctx.font, '20px serif', "ctx.font", "'20px serif'");
 
 ctx.font = '20px serif';
+ctx.font = '';
+_assertSame(ctx.font, '20px serif', "ctx.font", "'20px serif'");
+
+ctx.font = '20px serif';
 ctx.font = 'bogus';
 _assertSame(ctx.font, '20px serif', "ctx.font", "'20px serif'");
 

--- a/offscreen-canvas/text/2d.text.font.parse.invalid.worker.js
+++ b/offscreen-canvas/text/2d.text.font.parse.invalid.worker.js
@@ -16,6 +16,10 @@ ctx.font = '20px serif';
 _assertSame(ctx.font, '20px serif', "ctx.font", "'20px serif'");
 
 ctx.font = '20px serif';
+ctx.font = '';
+_assertSame(ctx.font, '20px serif', "ctx.font", "'20px serif'");
+
+ctx.font = '20px serif';
 ctx.font = 'bogus';
 _assertSame(ctx.font, '20px serif', "ctx.font", "'20px serif'");
 

--- a/offscreen-canvas/tools/tests2d.yaml
+++ b/offscreen-canvas/tools/tests2d.yaml
@@ -9305,6 +9305,10 @@
     @assert ctx.font === '20px serif';
 
     ctx.font = '20px serif';
+    ctx.font = '';
+    @assert ctx.font === '20px serif';
+
+    ctx.font = '20px serif';
     ctx.font = 'bogus';
     @assert ctx.font === '20px serif';
 


### PR DESCRIPTION
Add a test that exercises `ctx.font = ""`.

The HTML specification says:
"values that cannot be parsed as CSS font values are ignored."