### PR TITLE
Fix URL setter tests for gopher no longer being special

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -122,7 +122,7 @@
             "href": "gopher://example.net:1234",
             "new_value": "file",
             "expected": {
-                "href": "gopher://example.net:1234/",
+                "href": "gopher://example.net:1234",
                 "protocol": "gopher:"
             }
         },
@@ -212,7 +212,7 @@
         },
         {
             "href": "ssh://me@example.net",
-            "new_value": "gopher",
+            "new_value": "https",
             "expected": {
                 "href": "ssh://me@example.net",
                 "protocol": "ssh:"


### PR DESCRIPTION
Part of https://github.com/whatwg/url/issues/455.

/cc @achristensen07