### PR TITLE
Add more verbose logging to Edge setup/cleanup tasks

### DIFF
--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -9,10 +9,12 @@ steps:
         cmd /c taskkill /f /im setup.exe `> nul 2`> nul
         if (Test-Path $edgePath) {
           $installerPath = Get-ChildItem -PATH $edgePath -Filter "setup.exe" -Recurse | Select -First 1 FullName
-          if (Test-Path $installerPath.FullName) {
+          if(-not($installerPath -eq $nul) -and (Test-Path $installerPath.FullName)) {
             Write-Host "Uninstall: $($installerPath.FullName) $uninstallArgs"
             Start-Process "$($installerPath.FullName)" -ArgumentList $uninstallArgs -Wait
             Remove-Item -Path $edgePath -Recurse -Force -ErrorAction SilentlyContinue
+          } else {
+            Write-Host "Failed to find setup.exe under $edgePath"
           }
         }
       } catch [Exception] {

--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -18,8 +18,12 @@ steps:
           }
         }
       } catch [Exception] {
-        Write-Host "Failed to unstall Edge from $edgePath. ERROR= $($_.Exception.Message)" -ForegroundColor Red
+        Write-Host "Failed to uninstall Edge from $edgePath. ERROR= $($_.Exception.Message)" -ForegroundColor Red
       }
+    }
+
+    function IsEdgeRunning() {
+      return (Get-Process | Where-Object { $_.Name -eq "msedge" }).Length -gt 0
     }
 
     # restore hosts file
@@ -34,6 +38,18 @@ steps:
     UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev\Application" "--uninstall --msedge-dev --system-level --force-uninstall"
     # uninstall Edge Beta channel
     UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Beta\Application" "--uninstall --msedge-beta --system-level --force-uninstall"
+
+    # Check if Edge is still running and try to close it.
+    # If we fail to close it, then reboot the system
+    # as this lingering process can lead to run instability.
+    if (IsEdgeRunning) {
+      Write-Host "Found Edge process running, try to close it."
+      Stop-Process -Name "msedge" -Force
+      if (IsEdgeRunning) {
+        Write-Host "Failed to close running Edge process, reboot the system." -ForegroundColor Red
+        Restart-Computer -Force
+      }
+    }
   displayName: 'Restore hosts file and cleanup test machine'
   condition: always()
   errorActionPreference: silentlyContinue

--- a/tools/ci/azure/install_edge.yml
+++ b/tools/ci/azure/install_edge.yml
@@ -9,12 +9,18 @@ steps:
       $edgeInstallerName = 'MicrosoftEdgeSetup.exe'
       # Link to Canary channel installer
       Start-BitsTransfer -Source 'https://go.microsoft.com/fwlink/?linkid=2084649&Channel=Canary&language=en-us' -Destination MicrosoftEdgeSetup.exe
+      if (-not (Test-Path $edgeInstallerName)) {
+        Throw "Failed to download Edge installer to $edgeInstallerName."
+      }
       cmd /c START /WAIT $edgeInstallerName /silent /install
       $edgePath = "$env:localappdata\Microsoft\Edge SxS\Application"
       if (Test-Path $edgePath) {
         Write-Host "##vso[task.prependpath]$edgePath"
+        Write-Host "Edge Canary installed at $edgePath."
+        (Get-Item -Path "$edgePath\msedge.exe").VersionInfo | Format-List
       } else {
-        Throw "Failed to install Edge at $edgePath"
+        Copy-Item -Path "$env:temp\*edge*.log" -Destination $(Build.ArtifactStagingDirectory)  -Force
+        Throw "Failed to install Edge Canary at $edgePath"
       }
     displayName: 'Install Edge Canary'
 - ${{ if eq(parameters.channel, 'dev') }}:
@@ -26,7 +32,10 @@ steps:
       $edgePath = "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev\Application"
       if (Test-Path $edgePath) {
         Write-Host "##vso[task.prependpath]$edgePath"
+        Write-Host "Edge Canary installed at $edgePath."
+        (Get-Item -Path "$edgePath\msedge.exe").VersionInfo | Format-List
       } else {
-        Throw "Failed to install Edge at $edgePath"
+        Copy-Item -Path "$env:temp\*edge*.log" -Destination $(Build.ArtifactStagingDirectory) -Force
+        Throw "Failed to install Edge Dev at $edgePath"
       }
     displayName: 'Install Edge Dev'


### PR DESCRIPTION
Sometimes Edge can get into a state where an Edge browser process remains running and can't be closed and the only way to recover from this state is to reboot the system. This change adds handling for that case in Edge cleanup script and adds more logging to setup script to help debug future failures.

Validation job: https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=34833 

See #19772 for details.