### PR TITLE
Use a new temporary directory for manifest generation in CI

### DIFF
--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -3,6 +3,7 @@ import logging
 import os
 import subprocess
 import sys
+import tempfile
 
 import requests
 
@@ -164,9 +165,7 @@ def should_dry_run():
 def main():
     dry_run = should_dry_run()
 
-    manifest_path = os.path.expanduser(os.path.join("~", "meta", "MANIFEST.json"))
-
-    os.makedirs(os.path.dirname(manifest_path))
+    manifest_path = os.path.join(tempfile.mkdtemp(), "MANIFEST.json")
 
     create_manifest(manifest_path)
 


### PR DESCRIPTION
In https://github.com/web-platform-tests/wpt/pull/19580 retry for
manifest generation was introduced, to make it more robust in case of
network errors or the GitHub search API not indexing the merged PR
fast enough.

However, an accidental commit to master showed that this won't work:
https://github.com/web-platform-tests/wpt/runs/265191690

It first failed with "No PR found for 9e1d0a26f155ccb088d342b0036e535d033423c1"
because there was no PR, just a direct push to master. Retries then
failed with "File exists: '/home/runner/meta'".

Use a new temporary directory every time to deal with this. Don't
attempt to remove the directory when done as this script is run in a
CI system where all state is thrown away on completion.