### PR TITLE
fix(accname): Close tag

### DIFF
--- a/accname/name_test_case_610-manual.html
+++ b/accname/name_test_case_610-manual.html
@@ -62,7 +62,7 @@
   <body>
   <p>This test examines the ARIA properties for Name test case 610.</p>
     <input id="test" type="text" aria-label="bar" aria-labelledby="ID1 test">
-  <div id="ID1">foo</label>
+  <div id="ID1">foo</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>


### PR DESCRIPTION
This was problematic if visiting the site manually which causes the test result table to be part of the accessible name (since the `ID1` includes the test result table).