### PR TITLE
taskcluster: Use the mach logger instead of tbpl for stdout logging

### DIFF
--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -16,7 +16,7 @@ test_infrastructure() {
     else
         ARGS=$1
     fi
-    ./wpt run --log-tbpl - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts $ARGS $PRODUCT infrastructure/
+    TERM=dumb ./wpt run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts $ARGS $PRODUCT infrastructure/
 }
 
 main() {

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -56,8 +56,8 @@ def main(product, commit_range, wpt_args):
         logger.info("Running all tests")
 
     wpt_args += [
-        "--log-tbpl-level=info",
-        "--log-tbpl=-",
+        "--log-mach-level=info",
+        "--log-mach=-",
         "-y",
         "--no-pause",
         "--no-restart-on-unexpected",
@@ -70,8 +70,7 @@ def main(product, commit_range, wpt_args):
     command = ["python", "./wpt", "run"] + wpt_args + [product]
 
     logger.info("Executing command: %s" % " ".join(command))
-
-    retcode = subprocess.call(command)
+    retcode = subprocess.call(command, env=dict(os.environ, TERM="dumb"))
     if retcode != 0:
         sys.exit(retcode)
 


### PR DESCRIPTION
It seems that some runs of webkitgtk_minibrowser are [still timing out on taskcluster](https://tools.taskcluster.net/groups/MTcwFpndQ4mO7ukm8WA5Nw)

It will be very useful to me to be able to see the timestamp of the lines printed on taskcluster so that I can see if the issue is caused because the last test ran has hanged or if is another issue.

This PR switches the log handler used for printing results in stdout for taskcluster from `tbpl` to `match`.

The reasons for this:

* With the `mach` logger a timestamp of when a test starts or ends is printed, which is very useful to detect tests hanging·

* On top of that the `mach` logger provides a more useful summary at the end of the suite run because it gives information about how many tests (and not only subtests) failed, also it summarizes the cause of the unexpected results (like error or timeout).

* Also, the logs produces by the `mach` logger are more compact, around half the size in megabytes is needed for storing a log with match (instead of `tbpl`)

* The environment variable `TERM=dumb` is passed to disable colors to be printed on the terminal

