### PR TITLE
[css-values] Add tests for basic min() / max() support

### DIFF
--- a/css/css-values/attr-in-max.html
+++ b/css/css-values/attr-in-max.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>
+		CSS Values and Units Test:
+		attr() in max()
+	</title>
+	<meta name="assert" content="
+	    The attr() function notation is allowed inside a max() notation.
+	" />
+
+	<link
+		rel="author"
+		title="Fuqiao Xue"
+		href="mailto:xfq@w3.org"
+	/>
+
+	<link rel="help" href="https://drafts.csswg.org/css-values/#attr-notation"/>
+
+    <link rel="help" href="https://drafts.csswg.org/css-values/#calc-notation"/>
+
+	<link
+		rel="match"
+		href="reference/200-200-green.html"
+	/>
+
+	<style>
+
+			html, body { margin: 0px; padding: 0px; }
+
+			html { background: white; overflow: hidden; }
+			#outer { position: relative; background: green; }
+
+			#outer { width: max(attr(data-test length)); height: 200px; }
+
+	</style>
+
+</head>
+<body>
+
+	<div id="outer" data-test="200px"></div>
+
+</body>
+</html>

--- a/css/css-values/attr-in-max.html
+++ b/css/css-values/attr-in-max.html
@@ -2,38 +2,22 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<title>
-		CSS Values and Units Test:
-		attr() in max()
-	</title>
-	<meta name="assert" content="
-	    The attr() function notation is allowed inside a max() notation.
-	" />
+	<title>CSS Values and Units Test: attr() in max()</title>
 
-	<link
-		rel="author"
-		title="Fuqiao Xue"
-		href="mailto:xfq@w3.org"
-	/>
-
-	<link rel="help" href="https://drafts.csswg.org/css-values/#attr-notation"/>
-
-    <link rel="help" href="https://drafts.csswg.org/css-values/#calc-notation"/>
-
-	<link
-		rel="match"
-		href="reference/200-200-green.html"
-	/>
+	<meta name="assert" content="The attr() function notation is allowed inside a max() notation.">
+	<link rel="author" title="Fuqiao Xue" href="mailto:xfq@w3.org">
+	<link rel="help" href="https://drafts.csswg.org/css-values/#attr-notation">
+	<link rel="help" href="https://drafts.csswg.org/css-values/#calc-notation">
+	
+	<link rel="match" href="reference/200-200-green.html">
 
 	<style>
-
 			html, body { margin: 0px; padding: 0px; }
 
 			html { background: white; overflow: hidden; }
 			#outer { position: relative; background: green; }
 
 			#outer { width: max(attr(data-test length)); height: 200px; }
-
 	</style>
 
 </head>

--- a/css/css-values/attr-in-max.html
+++ b/css/css-values/attr-in-max.html
@@ -8,7 +8,6 @@
 	<link rel="author" title="Fuqiao Xue" href="mailto:xfq@w3.org">
 	<link rel="help" href="https://drafts.csswg.org/css-values/#attr-notation">
 	<link rel="help" href="https://drafts.csswg.org/css-values/#calc-notation">
-	
 	<link rel="match" href="reference/200-200-green.html">
 
 	<style>

--- a/css/css-values/calc-in-max.html
+++ b/css/css-values/calc-in-max.html
@@ -29,8 +29,8 @@
 
 			html { background: red; overflow: hidden; }
 			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
-			
-            #outer { height: max(calc(100%)); }
+
+			#outer { height: max(calc(100%)); }
 
 	</style>
 

--- a/css/css-values/calc-in-max.html
+++ b/css/css-values/calc-in-max.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>
+		CSS Values and Units Test:
+		calc() in max()
+	</title>
+	<meta name="assert" content="
+		The calc() function notation is allowed inside a max() notation.
+	" />
+
+	<link
+		rel="author"
+		title="Fuqiao Xue"
+		href="mailto:xfq@w3.org"
+	/>
+
+	<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-syntax"/>
+
+	<link
+		rel="match"
+		href="reference/all-green.html"
+	/>
+
+	<style>
+
+			html, body { margin: 0px; padding: 0px; }
+
+			html { background: red; overflow: hidden; }
+			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
+			
+            #outer { height: max(calc(100%)); }
+
+	</style>
+
+</head>
+<body>
+
+	<div id="outer"></div>
+
+</body>
+</html>

--- a/css/css-values/calc-in-max.html
+++ b/css/css-values/calc-in-max.html
@@ -1,43 +1,27 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8">
-	<title>
-		CSS Values and Units Test:
-		calc() in max()
-	</title>
-	<meta name="assert" content="
-		The calc() function notation is allowed inside a max() notation.
-	" />
+  <meta charset="utf-8">
+  <title>CSS Values and Units Test: calc() in max()</title>
 
-	<link
-		rel="author"
-		title="Fuqiao Xue"
-		href="mailto:xfq@w3.org"
-	/>
+  <meta name="assert" content="The calc() function notation is allowed inside a max() notation.">
+  <link rel="author" title="Fuqiao Xue" href="mailto:xfq@w3.org">
+  <link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-syntax">
+  <link rel="match" href="reference/all-green.html">
 
-	<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-syntax"/>
+  <style>
+      html, body { margin: 0px; padding: 0px; }
 
-	<link
-		rel="match"
-		href="reference/all-green.html"
-	/>
+      html { background: red; overflow: hidden; }
+      #outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
 
-	<style>
-
-			html, body { margin: 0px; padding: 0px; }
-
-			html { background: red; overflow: hidden; }
-			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
-
-			#outer { height: max(calc(100%)); }
-
-	</style>
+      #outer { height: max(calc(100%)); }
+  </style>
 
 </head>
 <body>
 
-	<div id="outer"></div>
+  <div id="outer"></div>
 
 </body>
 </html>

--- a/css/css-values/max-20-arguments.html
+++ b/css/css-values/max-20-arguments.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>
+		CSS Values and Units Test:
+		max() with 20 arguments
+	</title>
+	<meta name="assert" content="
+	    UAs must support math function expressions of at least 20 terms.
+	" />
+
+	<link
+		rel="author"
+		title="Fuqiao Xue"
+		href="mailto:xfq@w3.org"
+	/>
+
+	<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-syntax"/>
+
+	<link
+		rel="match"
+		href="reference/all-green.html"
+	/>
+
+	<style>
+
+			html, body { margin: 0px; padding: 0px; }
+
+			html { background: red; overflow: hidden; }
+			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
+			
+            #outer { height: max(5%, 10%, 15%, 20%, 25%, 30%, 35%, 40%, 45%, 50%, 55%, 60%, 65%, 70%, 75%, 80%, 85%, 90%, 95%, 100%); }
+
+	</style>
+
+</head>
+<body>
+
+	<div id="outer"></div>
+
+</body>
+</html>

--- a/css/css-values/max-20-arguments.html
+++ b/css/css-values/max-20-arguments.html
@@ -29,8 +29,8 @@
 
 			html { background: red; overflow: hidden; }
 			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
-			
-            #outer { height: max(5%, 10%, 15%, 20%, 25%, 30%, 35%, 40%, 45%, 50%, 55%, 60%, 65%, 70%, 75%, 80%, 85%, 90%, 95%, 100%); }
+
+			#outer { height: max(5%, 10%, 15%, 20%, 25%, 30%, 35%, 40%, 45%, 50%, 55%, 60%, 65%, 70%, 75%, 80%, 85%, 90%, 95%, 100%); }
 
 	</style>
 

--- a/css/css-values/max-20-arguments.html
+++ b/css/css-values/max-20-arguments.html
@@ -2,36 +2,20 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<title>
-		CSS Values and Units Test:
-		max() with 20 arguments
-	</title>
-	<meta name="assert" content="
-	    UAs must support math function expressions of at least 20 terms.
-	" />
+	<title>CSS Values and Units Test: max() with 20 arguments</title>
 
-	<link
-		rel="author"
-		title="Fuqiao Xue"
-		href="mailto:xfq@w3.org"
-	/>
-
-	<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-syntax"/>
-
-	<link
-		rel="match"
-		href="reference/all-green.html"
-	/>
+	<meta name="assert" content="UAs must support math function expressions of at least 20 terms.">
+	<link rel="author" title="Fuqiao Xue" href="mailto:xfq@w3.org">
+	<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-syntax">
+	<link rel="match" href="reference/all-green.html">
 
 	<style>
-
 			html, body { margin: 0px; padding: 0px; }
 
 			html { background: red; overflow: hidden; }
 			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
 
 			#outer { height: max(5%, 10%, 15%, 20%, 25%, 30%, 35%, 40%, 45%, 50%, 55%, 60%, 65%, 70%, 75%, 80%, 85%, 90%, 95%, 100%); }
-
 	</style>
 
 </head>

--- a/css/css-values/max-unitless-zero-invalid.html
+++ b/css/css-values/max-unitless-zero-invalid.html
@@ -30,12 +30,12 @@
 			html { background: red; overflow: hidden; }
 			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
 
-            #outer {
+			#outer {
 				/* Assert that min() is supported */
 				height: min(100%);
-    
+
 	 			/* The min() expression (thus the declaration) should be invalid */
-    			height: min(0, 100%);
+				height: min(0, 100%);
 			}
 
 	</style>

--- a/css/css-values/max-unitless-zero-invalid.html
+++ b/css/css-values/max-unitless-zero-invalid.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>
+		CSS Values and Units Test:
+		min() with unitless 0
+	</title>
+	<meta name="assert" content="
+	    Unitless 0 isn't supported in math functions.
+	" />
+
+	<link
+		rel="author"
+		title="Fuqiao Xue"
+		href="mailto:xfq@w3.org"
+	/>
+
+	<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking"/>
+
+	<link
+		rel="match"
+		href="reference/all-green.html"
+	/>
+
+	<style>
+
+			html, body { margin: 0px; padding: 0px; }
+
+			html { background: red; overflow: hidden; }
+			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
+
+            #outer {
+				/* Assert that min() is supported */
+				height: min(100%);
+    
+	 			/* The min() expression (thus the declaration) should be invalid */
+    			height: min(0, 100%);
+			}
+
+	</style>
+
+</head>
+<body>
+
+	<div id="outer"></div>
+
+</body>
+</html>

--- a/css/css-values/max-unitless-zero-invalid.html
+++ b/css/css-values/max-unitless-zero-invalid.html
@@ -2,29 +2,14 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<title>
-		CSS Values and Units Test:
-		min() with unitless 0
-	</title>
-	<meta name="assert" content="
-	    Unitless 0 isn't supported in math functions.
-	" />
+	<title>CSS Values and Units Test: min() with unitless 0</title>
 
-	<link
-		rel="author"
-		title="Fuqiao Xue"
-		href="mailto:xfq@w3.org"
-	/>
-
-	<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking"/>
-
-	<link
-		rel="match"
-		href="reference/all-green.html"
-	/>
+	<meta name="assert" content="Unitless 0 isn't supported in math functions.">
+	<link rel="author" title="Fuqiao Xue" href="mailto:xfq@w3.org">
+	<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking">
+	<link rel="match" href="reference/all-green.html">
 
 	<style>
-
 			html, body { margin: 0px; padding: 0px; }
 
 			html { background: red; overflow: hidden; }
@@ -37,7 +22,6 @@
 	 			/* The min() expression (thus the declaration) should be invalid */
 				height: min(0, 100%);
 			}
-
 	</style>
 
 </head>


### PR DESCRIPTION
Resubmitted from https://github.com/web-platform-tests/wpt/pull/19801. Original description:

> https://drafts.csswg.org/css-values-4/#functional-notations
> 
> Tests cover the following:
> 
> - `attr()` in `max()`
> - `calc()` in `max()`
> - `max()` with 20 arguments
> - `min()` with unitless 0
> 
> This is my first wpt test. Comments are very welcome. Thanks!