### PR TITLE
[Azure Pipelines] upgrade to Ubuntu 18.04 (from 16.04)

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
   displayName: './wpt test-jobs'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
   - template: tools/ci/azure/checkout.yml
   - script: |

--- a/tools/ci/azure/fyi_hook.yml
+++ b/tools/ci/azure/fyi_hook.yml
@@ -10,7 +10,7 @@ jobs:
   displayName: 'wpt.fyi hook: ${{ parameters.artifactName }}'
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
   - checkout: none
   - script: curl -f -s -S -d "artifact=${{ parameters.artifactName }}" -X POST https://wpt.fyi/api/checks/azure/$(Build.BuildId)


### PR DESCRIPTION
These jobs only run `./wpt test-jobs` and `curl`, but it's just as
well to upgrade them well before Ubuntu 16.04 is no longer supported.