### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=203236

### DIFF
--- a/service-workers/service-worker/postMessage-fetch-order-worker.js
+++ b/service-workers/service-worker/postMessage-fetch-order-worker.js
@@ -1,0 +1,24 @@
+var postMessageFetchEventsOrder = [];
+async function doTest(event)
+{
+    if (event.data === "postMessageBeforeFetch") {
+        postMessageFetchEventsOrder.push("postMessageBeforeFetch");
+        return;
+    }
+    if (event.data === "postMessageAfterFetch") {
+        postMessageFetchEventsOrder.push("postMessageAfterFetch");
+        event.source.postMessage(postMessageFetchEventsOrder);
+        postMessageFetchEventsOrder = [];
+    }
+}
+
+self.addEventListener("message", doTest);
+
+async function doFetch(event)
+{
+    if (event.request.url.includes("betweenPostMessages"))
+        postMessageFetchEventsOrder.push("fetch");
+    event.respondWith(new Response("Intercepted"));
+}
+
+self.addEventListener("fetch", doFetch);

--- a/service-workers/service-worker/postMessage-fetch-order.https.html
+++ b/service-workers/service-worker/postMessage-fetch-order.https.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+<title>message and fetch events order</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/test-helpers.sub.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (test) => {
+    const scope = "resources";
+
+    const registration = await navigator.serviceWorker.register("postMessage-fetch-order-worker.js", { scope : scope });
+    test.add_cleanup(() => { registration.unregister(); });
+
+    activeWorker = registration.active;
+    if (!activeWorker) {
+       activeWorker = registration.installing;
+        await new Promise(resolve => {
+            activeWorker.addEventListener('statechange', () => {
+                if (activeWorker.state === "activated")
+                    resolve();
+            });
+        });
+    }
+
+    const iframe = await with_iframe(scope);
+    test.add_cleanup(() => { iframe.remove(); });
+
+    var promise = new Promise((resolve, reject) => {
+        navigator.serviceWorker.addEventListener("message", (event) => {
+            resolve(event.data);
+        });
+        test.step_timeout(() => reject("No response message from service worker"), 5000);
+    });
+
+    activeWorker.postMessage("postMessageBeforeFetch");
+    iframe.contentWindow.fetch("betweenPostMessages");
+    activeWorker.postMessage("postMessageAfterFetch");
+
+    var result = await promise;
+    assert_array_equals(result, ["postMessageBeforeFetch", "fetch", "postMessageAfterFetch"]);
+}, " Make sure order of postMessage/fetch event is respected");
+</script>
+</body>
+</html>


### PR DESCRIPTION
WebKit export from bug: [Order of postMessage and fetch events should be preserved when going from client to service worker](https://bugs.webkit.org/show_bug.cgi?id=203236)