### PR TITLE
Replace "TaskCluster" with "Taskcluster" where possible

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-"""Wrapper script for running jobs in TaskCluster
+"""Wrapper script for running jobs in Taskcluster
 
-This is intended for running test jobs in TaskCluster. The script
+This is intended for running test jobs in Taskcluster. The script
 takes a two positional arguments which are the name of the test job
 and the script to actually run.
 

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -34,7 +34,7 @@ def gzip_file(filename, delete_original=True):
 
 
 def main(product, commit_range, wpt_args):
-    """Invoke the `wpt run` command according to the needs of the TaskCluster
+    """Invoke the `wpt run` command according to the needs of the Taskcluster
     continuous integration service."""
 
     logger = logging.getLogger("tc-run")

--- a/tools/ci/tcdownload.py
+++ b/tools/ci/tcdownload.py
@@ -19,7 +19,7 @@ def get_parser():
                         help="Log type to fetch")
     parser.add_argument("--repo-name", action="store", default="web-platform-tests/wpt",
                         help="GitHub repo name in the format owner/repo. "
-                        "This must be the repo from which the TaskCluster run was scheduled "
+                        "This must be the repo from which the Taskcluster run was scheduled "
                         "(for PRs this is the repo into which the PR would merge)")
     parser.add_argument("--token-file", action="store",
                         help="File containing GitHub token")
@@ -70,7 +70,7 @@ def run(*args, **kwargs):
         taskgroups.add(taskgroup_id)
 
     if not taskgroups:
-        logger.error("No complete TaskCluster runs found for ref %s" % kwargs["ref"])
+        logger.error("No complete Taskcluster runs found for ref %s" % kwargs["ref"])
         return 1
 
     for taskgroup in taskgroups:


### PR DESCRIPTION
This matches the Taskcluster website and our label:
https://tools.taskcluster.net/
https://github.com/web-platform-tests/wpt/labels/Taskcluster

Command use:
> git grep -l TaskCluster | xargs sed -i 's/TaskCluster/Taskcluster/g'

Occurences in tools/taskcluster/testdata/ were left alone, as they
match real historical commits/PRs with "TaskCluster" in them.