### PR TITLE
Convert tabs to spaces in directories with few lint errors

### DIFF
--- a/content-security-policy/connect-src/connect-src-beacon-allowed.sub.html
+++ b/content-security-policy/connect-src/connect-src-beacon-allowed.sub.html
@@ -19,19 +19,19 @@ connect-src 'self' http://{{host}}:{{ports[http][0]}}; script-src 'self' 'unsafe
         window.addEventListener('securitypolicyviolation', function(e) {
             log("FAIL");
         });
-    
- 	      if (typeof navigator.sendBeacon != 'function') {
+
+        if (typeof navigator.sendBeacon != 'function') {
             t_log.set_status(t_log.NOTRUN, "No navigator.sendBeacon, cannot run test.");
             t_log.phase = t_log.phases.HAS_RESULT;
             t_log.done();
         } else {
-	          try {
-       	       var es = navigator.sendBeacon("http://{{host}}:{{ports[http][0]}}/cors/resources/status.py");
-       	       log("Pass");
-       	    } catch (e) {
-       	       log("Fail");
-       	    }
-	      }
+            try {
+                var es = navigator.sendBeacon("http://{{host}}:{{ports[http][0]}}/cors/resources/status.py");
+                log("Pass");
+            } catch (e) {
+                log("Fail");
+            }
+        }
     </script>
     <div id="log"></div>
 </body>

--- a/content-security-policy/connect-src/connect-src-beacon-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-beacon-blocked.sub.html
@@ -3,7 +3,7 @@
 
 <head>
     <!-- Programmatically converted from a WebKit Reftest, please forgive resulting idiosyncracies.-->
-    <meta http-equiv="Content-Security-Policy" content="connect-src 'self'; script-src 'self' 'unsafe-inline';"> 
+    <meta http-equiv="Content-Security-Policy" content="connect-src 'self'; script-src 'self' 'unsafe-inline';">
     <title>connect-src-beacon-blocked</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
@@ -16,22 +16,22 @@ connect-src 'self' http://{{host}}:{{ports[http][0]}}; script-src 'self' 'unsafe
 
 <body>
     <script>
-       window.addEventListener('securitypolicyviolation', function(e) {
+        window.addEventListener('securitypolicyviolation', function(e) {
             log("violated-directive=" + e.violatedDirective);
-       });
-       
-       if (typeof navigator.sendBeacon != 'function') {
+        });
+
+        if (typeof navigator.sendBeacon != 'function') {
             t_log.set_status(t_log.NOTRUN, "No navigator.sendBeacon, cannot run test.");
             t_log.phase = t_log.phases.HAS_RESULT;
             t_log.done();
-       } else {
-	         try {
-	             var es = navigator.sendBeacon("http://www1.{{host}}:{{ports[http][0]}}/security/contentSecurityPolicy/echo-report.php");
-       	       log("Pass");
-           } catch (e) {
-               log("Fail");
-           }
-	     }
+        } else {
+            try {
+                var es = navigator.sendBeacon("http://www1.{{host}}:{{ports[http][0]}}/security/contentSecurityPolicy/echo-report.php");
+                log("Pass");
+            } catch (e) {
+                log("Fail");
+            }
+        }
     </script>
     <div id="log"></div>
 </body>

--- a/content-security-policy/connect-src/connect-src-beacon-redirect-to-blocked.sub.html
+++ b/content-security-policy/connect-src/connect-src-beacon-redirect-to-blocked.sub.html
@@ -16,12 +16,12 @@
     <p>The beacon should not follow the redirect to http://www1.{{host}}:{{ports[http][0]}}/content-security-policy/support/fail.png and send a CSP violation report.</p>
     <p>Verify that a CSP connect-src directive blocks redirects.</p>
     <script>
-       window.addEventListener('securitypolicyviolation', function(e) {
+        window.addEventListener('securitypolicyviolation', function(e) {
             log("violated-directive=" + e.violatedDirective);
-       });
-       
-	     if (typeof navigator.sendBeacon != 'function') {
-	          t_log.set_status(t_log.NOTRUN, "No navigator.sendBeacon, cannot run test.");
+        });
+
+        if (typeof navigator.sendBeacon != 'function') {
+            t_log.set_status(t_log.NOTRUN, "No navigator.sendBeacon, cannot run test.");
             t_log.phase = t_log.phases.HAS_RESULT;
             t_log.done();
         } else {

--- a/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-sandboxed-cross-url-block.html
+++ b/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-sandboxed-cross-url-block.html
@@ -8,9 +8,9 @@
 <body>
     <script>
         test = async_test("A 'frame-ancestors' CSP directive with a URL value should compare against each frame's origin rather than URL, " +
-		    "so a nested frame with a sandboxed parent frame should be blocked due to the parent having a unique origin.");
+                          "so a nested frame with a sandboxed parent frame should be blocked due to the parent having a unique origin.");
 
-	testNestedSandboxedIFrame(SAMEORIGIN_ORIGIN + " " + CROSSORIGIN_ORIGIN, CROSS_ORIGIN, CROSS_ORIGIN, EXPECT_BLOCK);
+        testNestedSandboxedIFrame(SAMEORIGIN_ORIGIN + " " + CROSSORIGIN_ORIGIN, CROSS_ORIGIN, CROSS_ORIGIN, EXPECT_BLOCK);
     </script>
 </body>
 </html>

--- a/content-security-policy/media-src/media-src-7_3_2.sub.html
+++ b/content-security-policy/media-src/media-src-7_3_2.sub.html
@@ -15,14 +15,14 @@
         async_test("Disallowed track element onerror handler fires.");
 
     var trackURL = location.protocol + "//{{domains[www]}}:{{ports[http][0]}}/media/foo.vtt";
-    
+
     var t_spv = async_test("Test that securitypolicyviolation events are fired");
     var test_count = 1;
     window.addEventListener("securitypolicyviolation", t_spv.step_func(function(e) {
           assert_equals(e.violatedDirective, "media-src");
           assert_equals(e.blockedURI, trackURL);
           if (--test_count <= 0) {
-              t_spv.done(); 
+              t_spv.done();
           }
       }));
 
@@ -62,9 +62,9 @@
 
         setTimeout(function() {
           if(source_test.phase != source_test.phases.COMPLETE) {
-		source_test.step( function () { assert_unreached("Onerror event never fired for track element."); });
-		source_test.done();
-	   }
+            source_test.step( function () { assert_unreached("Onerror event never fired for track element."); });
+            source_test.done();
+          }
         }, 2 * 1000);
     </script>
 

--- a/content-security-policy/reporting/report-cross-origin-no-cookies.sub.html
+++ b/content-security-policy/reporting/report-cross-origin-no-cookies.sub.html
@@ -12,7 +12,7 @@
 <body>
 <script>
   promise_test(function(test) {
-	const path = encodeURIComponent("{{domains[www1]}}:{{ports[http][0]}}/");
+    const path = encodeURIComponent("{{domains[www1]}}:{{ports[http][0]}}/");
     return fetch(
       "/cookies/resources/set-cookie.py?name=cspViolationReportCookie1&path=" + path,
       {mode: 'no-cors', credentials: 'include'})

--- a/content-security-policy/script-src/scripthash-unicode-normalization.sub.html
+++ b/content-security-policy/script-src/scripthash-unicode-normalization.sub.html
@@ -49,9 +49,9 @@
             script1.test.done();
           });
         } else {
-	  script1.test.step(function() {
+          script1.test.step(function() {
             assert_unreached("nonMatchingContent script ran");
-	  });
+          });
         }
       }
 

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -7,13 +7,7 @@
 
 ## Whitespace rules that we can't enforce yet ##
 
-INDENT TABS: .gitmodules
 INDENT TABS: conformance-checkers/*
-INDENT TABS: content-security-policy/*
-INDENT TABS: pointerlock/*
-INDENT TABS: shadow-dom/*
-INDENT TABS: webaudio/*
-INDENT TABS: webvtt/*
 INDENT TABS: encoding/legacy*/*
 
 TRAILING WHITESPACE: 2dcontext/tools/current-work-canvas.xhtml
@@ -76,8 +70,8 @@ SET TIMEOUT: docs/*
 WEB-PLATFORM.TEST:README.md
 WEB-PLATFORM.TEST:*/README.md
 WEB-PLATFORM.TEST:docs/*
-INDENT TABS:docs/*
-CR AT EOL:docs/*
+CR AT EOL, INDENT TABS:docs/make.bat
+INDENT TABS:docs/Makefile
 
 ## Helper scripts ##
 
@@ -106,6 +100,8 @@ CR AT EOL: webvtt/parsing/file-parsing/tests/support/newlines.vtt
 
 # Intentional use of tabs
 INDENT TABS: html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html
+INDENT TABS: webvtt/parsing/file-parsing/tests/support/header-tab.vtt
+INDENT TABS: webvtt/parsing/file-parsing/tests/support/whitespace-chars.vtt
 
 # Intentional use of print statements
 PRINT STATEMENT: dom/nodes/Document-createElement-namespace-tests/generate.py

--- a/pointerlock/movementX_Y_no-jumps-manual.html
+++ b/pointerlock/movementX_Y_no-jumps-manual.html
@@ -33,14 +33,14 @@
 
     <div id="status-log">Waiting... Click to start loging.</div>
     <div class="data-log">
-	    <table>
-	    	<tr><td></td><td>X</td><td>Y</td></tr>
-	    	<tr><td>client_init:</td><td id="clientX_init-log">X</td><td id="clientY_init-log">Y</td></tr>
-	    	<tr><td>client_last:</td><td id="clientX_last-log">X</td><td id="clientY_last-log">Y</td></tr>
-	    	<tr><td>client_delta:</td><td id="clientX_delta-log">X</td><td id="clientY_delta-log">Y</td></tr>
-	    	<tr><td>movement_sum:</td><td id="movementX_sum-log">X</td><td id="movementY_sum-log">Y</td></tr>
-	    	<tr><td>movement:</td><td id="movementX-log">X</td><td id="movementY-log">Y</td></tr>
-	    </table>
+        <table>
+            <tr><td></td><td>X</td><td>Y</td></tr>
+            <tr><td>client_init:</td><td id="clientX_init-log">X</td><td id="clientY_init-log">Y</td></tr>
+            <tr><td>client_last:</td><td id="clientX_last-log">X</td><td id="clientY_last-log">Y</td></tr>
+            <tr><td>client_delta:</td><td id="clientX_delta-log">X</td><td id="clientY_delta-log">Y</td></tr>
+            <tr><td>movement_sum:</td><td id="movementX_sum-log">X</td><td id="movementY_sum-log">Y</td></tr>
+            <tr><td>movement:</td><td id="movementX-log">X</td><td id="movementY-log">Y</td></tr>
+        </table>
     </div>
     <hr/>
 
@@ -98,10 +98,10 @@
                     movementY_sum = movementY;
                 }
 
-	            movementX_Y_outside_window_Test.step(function() {
-	            	assert_less_than(Math.abs(movementX), 50, "movementX should not have large jumps in value.");
-	            	assert_less_than(Math.abs(movementY), 50, "movementY should not have large jumps in value.");
-	            });
+                movementX_Y_outside_window_Test.step(function() {
+                    assert_less_than(Math.abs(movementX), 50, "movementX should not have large jumps in value.");
+                    assert_less_than(Math.abs(movementY), 50, "movementY should not have large jumps in value.");
+                });
 
                 movementX_sum += movementX;
                 movementY_sum += movementY;
@@ -117,10 +117,10 @@
 
         document.addEventListener("mouseenter", function (e) {
             if(click_counter === 1) {
-	            movementX_Y_outside_window_Test.step(function() {
+                movementX_Y_outside_window_Test.step(function() {
                     assert_greater_than(Math.abs(e.clientX-clientX_last) + Math.abs(e.clientY-clientY_last), 100, "Test requires mouse to be moved at least 100 pixels outside of window.");
-	            });
-	        }
+                });
+            }
         });
 
         function updateData() {

--- a/shadow-dom/leaktests/html-collection.html
+++ b/shadow-dom/leaktests/html-collection.html
@@ -29,10 +29,10 @@ function fillTemplate(root, prefix) {
     var tmpl = document.getElementById('collection-template');
     root.appendChild(document.importNode(tmpl.content, true));
     for (var i = 0; i < root.childNodes.length; ++i) {
-	var el = root.childNodes[i];
-	if (el.nodeType != 1)
-	    continue;
-	el.id = prefix + el.tagName.toLowerCase();
+        var el = root.childNodes[i];
+        if (el.nodeType != 1)
+            continue;
+        el.id = prefix + el.tagName.toLowerCase();
     }
 }
 

--- a/webaudio/the-audio-api/the-waveshapernode-interface/curve-tests.html
+++ b/webaudio/the-audio-api/the-waveshapernode-interface/curve-tests.html
@@ -1,184 +1,184 @@
 <!doctype html>
 <html>
 <head>
-	<title>WaveShaperNode interface - Curve tests | WebAudio</title>
+    <title>WaveShaperNode interface - Curve tests | WebAudio</title>
 
-	<script type="text/javascript" src="/resources/testharness.js"></script>
-	<script type="text/javascript" src="/resources/testharnessreport.js"></script>
+    <script type="text/javascript" src="/resources/testharness.js"></script>
+    <script type="text/javascript" src="/resources/testharnessreport.js"></script>
 </head>
 <body>
-	<div id="log">
-	</div>
+    <div id="log">
+    </div>
 
-	<script type="text/javascript">
-		var sampleRate=44100.0;
-		var tolerance=0.01;
+    <script type="text/javascript">
+        var sampleRate=44100.0;
+        var tolerance=0.01;
 
-		/*
-		Testing that -1, 0 and +1 map correctly to curve (with 1:1 correlation)
-		=======================================================================
-		From the specification:
-			The input signal is nominally within the range -1 -> +1.
-			Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
-				to the center value of the curve array.
-		*/
-		(function() {
-			var threeElementCurve=[2.0, -3.0, 4.0];
-			var inputData=[-1.0, 0, 1.0];
-			var expectedData=[2.0, -3.0, 4.0];
-			executeTest(threeElementCurve, inputData, expectedData, "Testing that -1, 0 and +1 map correctly to curve (with 1:1 correlation)");
-		})();
+        /*
+        Testing that -1, 0 and +1 map correctly to curve (with 1:1 correlation)
+        =======================================================================
+        From the specification:
+            The input signal is nominally within the range -1 -> +1.
+            Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
+                to the center value of the curve array.
+        */
+        (function() {
+            var threeElementCurve=[2.0, -3.0, 4.0];
+            var inputData=[-1.0, 0, 1.0];
+            var expectedData=[2.0, -3.0, 4.0];
+            executeTest(threeElementCurve, inputData, expectedData, "Testing that -1, 0 and +1 map correctly to curve (with 1:1 correlation)");
+        })();
 
-		/*
-		Testing interpolation (where inputs don't correlate directly to curve elements)
-		===============================================================================
-		From the specification:
-			The implementation must perform linear interpolation between adjacent points in the curve.
-		*/
-		(function() {
-			var threeElementCurve=[2.0, -3.0, 4.0];
-			var inputData=[-0.5, +0.5, +0.75];
-			var expectedData=[-0.5, +0.5, +2.25];
-			executeTest(threeElementCurve, inputData, expectedData, "Testing interpolation (where inputs don't correlate directly to curve elements)");
-		})();
+        /*
+        Testing interpolation (where inputs don't correlate directly to curve elements)
+        ===============================================================================
+        From the specification:
+            The implementation must perform linear interpolation between adjacent points in the curve.
+        */
+        (function() {
+            var threeElementCurve=[2.0, -3.0, 4.0];
+            var inputData=[-0.5, +0.5, +0.75];
+            var expectedData=[-0.5, +0.5, +2.25];
+            executeTest(threeElementCurve, inputData, expectedData, "Testing interpolation (where inputs don't correlate directly to curve elements)");
+        })();
 
-		/*
-		Testing out-of-range inputs (should be mapped to the first/last elements of the curve)
-		======================================================================================
-		From the specification:
-			Any sample value less than -1 will correspond to the first value in the curve array.
-			Any sample value greater than +1 will correspond to the last value in the curve array.
-		*/
-		(function() {
-			var threeElementCurve=[2.0, -3.0, 4.0];
-			var inputData=[-1.5, +1.5];
-			var expectedData=[2.0, 4.0];
-			executeTest(threeElementCurve, inputData, expectedData, "Testing out-of-range inputs (should be mapped to the first/last elements of the curve)");
-		})();
+        /*
+        Testing out-of-range inputs (should be mapped to the first/last elements of the curve)
+        ======================================================================================
+        From the specification:
+            Any sample value less than -1 will correspond to the first value in the curve array.
+            Any sample value greater than +1 will correspond to the last value in the curve array.
+        */
+        (function() {
+            var threeElementCurve=[2.0, -3.0, 4.0];
+            var inputData=[-1.5, +1.5];
+            var expectedData=[2.0, 4.0];
+            executeTest(threeElementCurve, inputData, expectedData, "Testing out-of-range inputs (should be mapped to the first/last elements of the curve)");
+        })();
 
-		/*
-		Testing a 2-element curve (does not have a middle element)
-		==========================================================
-		From the specification:
-			Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
-				to the center value of the curve array.
-			The implementation must perform linear interpolation between adjacent points in the curve.
-		*/
-		(function() {
-			var twoElementCurve=[2.0, -2.0];
-			var inputData=[-1.0, 0, 1.0];
-			var expectedData=[2.0, 0.0, -2.0];
-			executeTest(twoElementCurve, inputData, expectedData, "Testing a 2-element curve (does not have a middle element)");
-		})();
+        /*
+        Testing a 2-element curve (does not have a middle element)
+        ==========================================================
+        From the specification:
+            Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
+                to the center value of the curve array.
+            The implementation must perform linear interpolation between adjacent points in the curve.
+        */
+        (function() {
+            var twoElementCurve=[2.0, -2.0];
+            var inputData=[-1.0, 0, 1.0];
+            var expectedData=[2.0, 0.0, -2.0];
+            executeTest(twoElementCurve, inputData, expectedData, "Testing a 2-element curve (does not have a middle element)");
+        })();
 
-		/*
-		Testing a 4-element curve (does not have a middle element)
-		==========================================================
-		From the specification:
-			Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
-				to the center value of the curve array.
-			The implementation must perform linear interpolation between adjacent points in the curve.
-		*/
-		(function() {
-			var fourElementCurve=[1.0, 2.0, 4.0, 7.0];
-			var inputData=[-1.0, 0, 1.0];
-			var expectedData=[1.0, 3.0, 7.0];
-			executeTest(fourElementCurve, inputData, expectedData, "Testing a 4-element curve (does not have a middle element)");
-		})();
+        /*
+        Testing a 4-element curve (does not have a middle element)
+        ==========================================================
+        From the specification:
+            Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
+                to the center value of the curve array.
+            The implementation must perform linear interpolation between adjacent points in the curve.
+        */
+        (function() {
+            var fourElementCurve=[1.0, 2.0, 4.0, 7.0];
+            var inputData=[-1.0, 0, 1.0];
+            var expectedData=[1.0, 3.0, 7.0];
+            executeTest(fourElementCurve, inputData, expectedData, "Testing a 4-element curve (does not have a middle element)");
+        })();
 
-		/*
-		Testing a huge curve
-		====================
-		From the specification:
-			Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
-				to the center value of the curve array.
-		*/
-		(function() {
-			var bigCurve=[];
-			for(var i=0;i<=60000;i++) { bigCurve.push(i/3.5435); }
-			var inputData=[-1.0, 0, 1.0];
-			var expectedData=[bigCurve[0], bigCurve[30000], bigCurve[60000]];
-			executeTest(bigCurve, inputData, expectedData, "Testing a huge curve");
-		})();
+        /*
+        Testing a huge curve
+        ====================
+        From the specification:
+            Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
+                to the center value of the curve array.
+        */
+        (function() {
+            var bigCurve=[];
+            for(var i=0;i<=60000;i++) { bigCurve.push(i/3.5435); }
+            var inputData=[-1.0, 0, 1.0];
+            var expectedData=[bigCurve[0], bigCurve[30000], bigCurve[60000]];
+            executeTest(bigCurve, inputData, expectedData, "Testing a huge curve");
+        })();
 
-		/*
-		Testing single-element curve (boundary condition)
-		=================================================
-		From the specification:
-			Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
-				to the center value of the curve array.
-			Any sample value less than -1 will correspond to the first value in the curve array.
-			Any sample value greater than +1 will correspond to the last value in the curve array.
-			The implementation must perform linear interpolation between adjacent points in the curve.
-		*/
+        /*
+        Testing single-element curve (boundary condition)
+        =================================================
+        From the specification:
+            Each input sample within this range will index into the shaping curve with a signal level of zero corresponding
+                to the center value of the curve array.
+            Any sample value less than -1 will correspond to the first value in the curve array.
+            Any sample value greater than +1 will correspond to the last value in the curve array.
+            The implementation must perform linear interpolation between adjacent points in the curve.
+        */
 
-		/*
-		Testing null curve (should return input values)
-		===============================================
-		From the specification:
-			Initially the curve attribute is null, which means that the WaveShaperNode will pass its input to its output
-				without modification.
-		*/
-		(function() {
-			var inputData=[-1.0, 0, 1.0, 2.0];
-			var expectedData=[-1.0, 0.0, 1.0, 2.0];
-			executeTest(null, inputData, expectedData, "Testing null curve (should return input values)");
-		})();
+        /*
+        Testing null curve (should return input values)
+        ===============================================
+        From the specification:
+            Initially the curve attribute is null, which means that the WaveShaperNode will pass its input to its output
+                without modification.
+        */
+        (function() {
+            var inputData=[-1.0, 0, 1.0, 2.0];
+            var expectedData=[-1.0, 0.0, 1.0, 2.0];
+            executeTest(null, inputData, expectedData, "Testing null curve (should return input values)");
+        })();
 
-		/**
-		* Function that does the actual testing (using an asynchronous test).
-		* @param {?Array.<number>} curveData - Array containing values for the WaveShaper curve.
-		* @param {!Array.<number>} inputData - Array containing values for the input stream.
-		* @param {!Array.<number>} expectedData - Array containing expected results for each of the corresponding inputs.
-		* @param {!string} testName - Name of the test case.
-		*/
-		function executeTest(curveData, inputData, expectedData, testName) {
-			var stTest=async_test("WaveShaperNode - "+testName);
-			stTest.step(function() {
+        /**
+        * Function that does the actual testing (using an asynchronous test).
+        * @param {?Array.<number>} curveData - Array containing values for the WaveShaper curve.
+        * @param {!Array.<number>} inputData - Array containing values for the input stream.
+        * @param {!Array.<number>} expectedData - Array containing expected results for each of the corresponding inputs.
+        * @param {!string} testName - Name of the test case.
+        */
+        function executeTest(curveData, inputData, expectedData, testName) {
+            var stTest=async_test("WaveShaperNode - "+testName);
+            stTest.step(function() {
 
-				// Create offline audio context.
-				var ac=new OfflineAudioContext(1, inputData.length, sampleRate);
+                // Create offline audio context.
+                var ac=new OfflineAudioContext(1, inputData.length, sampleRate);
 
-				// Create the WaveShaper and its curve.
-				var waveShaper=ac.createWaveShaper();
-				if(curveData!=null) {
-					var curve=new Float32Array(curveData.length);
-					for(var i=0;i<curveData.length;i++) { curve[i]=curveData[i]; }
-					waveShaper.curve=curve;
-				}
-				waveShaper.connect(ac.destination);
+                // Create the WaveShaper and its curve.
+                var waveShaper=ac.createWaveShaper();
+                if(curveData!=null) {
+                    var curve=new Float32Array(curveData.length);
+                    for(var i=0;i<curveData.length;i++) { curve[i]=curveData[i]; }
+                    waveShaper.curve=curve;
+                }
+                waveShaper.connect(ac.destination);
 
-				// Create buffer containing the input values.
-				var inputBuffer=ac.createBuffer(1, Math.max(inputData.length, 2), sampleRate);
-				var d=inputBuffer.getChannelData(0);
-				for(var i=0;i<inputData.length;i++) { d[i]=inputData[i]; }
+                // Create buffer containing the input values.
+                var inputBuffer=ac.createBuffer(1, Math.max(inputData.length, 2), sampleRate);
+                var d=inputBuffer.getChannelData(0);
+                for(var i=0;i<inputData.length;i++) { d[i]=inputData[i]; }
 
-				// Play the input buffer through the WaveShaper.
-				var src=ac.createBufferSource();
-				src.buffer=inputBuffer;
-				src.connect(waveShaper);
-				src.start();
+                // Play the input buffer through the WaveShaper.
+                var src=ac.createBufferSource();
+                src.buffer=inputBuffer;
+                src.connect(waveShaper);
+                src.start();
 
-				// Test the outputs match the expected values.
-				ac.oncomplete=stTest.step_func_done(function(ev) {
-					var d=ev.renderedBuffer.getChannelData(0);
+                // Test the outputs match the expected values.
+                ac.oncomplete=stTest.step_func_done(function(ev) {
+                    var d=ev.renderedBuffer.getChannelData(0);
 
-					for(var i=0;i<expectedData.length;i++) {
-						var curveText="null";
-						if(curve!=null) {
-							if(curveData.length<20) {
-								curveText=curveData.join(",");
-							} else {
-								curveText="TooBigToDisplay ("+(curveData.length-1)+" elements)";
-							}
-						}
-						var comment="Input="+inputData[i]+", Curve=["+curveText+"] >>> ";
-						assert_approx_equals(d[i], expectedData[i], tolerance, comment);
-					}
-				});
-				ac.startRendering();
-			});
-		}
-	</script>
+                    for(var i=0;i<expectedData.length;i++) {
+                        var curveText="null";
+                        if(curve!=null) {
+                            if(curveData.length<20) {
+                                curveText=curveData.join(",");
+                            } else {
+                                curveText="TooBigToDisplay ("+(curveData.length-1)+" elements)";
+                            }
+                        }
+                        var comment="Input="+inputData[i]+", Curve=["+curveText+"] >>> ";
+                        assert_approx_equals(d[i], expectedData[i], tolerance, comment);
+                    }
+                });
+                ac.startRendering();
+            });
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
To find the candidates for this change, the "INDENT TABS" exceptions
in lint.whitelist were removed and ./wpt lint` run.

The output was piped through `grep '^ERROR:lint:' | cut -d: -f3 | sort
| uniq | cut -d/ -f1 | uniq -c | sort -n`, giving the following list:

```
      1 pointerlock
      1 shadow-dom
      1 webaudio
      2 docs
      2 webvtt
      7 content-security-policy
      9 encoding
    203 conformance-checkers
   5011 css
```

Based on that, conformance-checkers, css and encoding were left alone.