### PR TITLE
reftests: if images hashes don't match, try to compare pixels

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -304,6 +304,11 @@ class RefTestImplementation(object):
         assert relation in ("==", "!=")
         if not fuzzy or fuzzy == ((0,0), (0,0)):
             equal = hashes[0] == hashes[1]
+            # sometimes images can have different hashes, but pixels can be identical.
+            if not equal:
+                self.logger.info("Image hashes didn't match, checking pixel differences")
+                max_per_channel, pixels_different = self.get_differences(screenshots)
+                equal = pixels_different == 0 and max_per_channel == 0
         else:
             max_per_channel, pixels_different = self.get_differences(screenshots)
             allowed_per_channel, allowed_different = fuzzy


### PR DESCRIPTION
* When comparing the result of a reftest, checking if the hash of
the expected result matches the hash of the test is not enough.
An image can have different hash, but still be the very same
image (same pixels).

* This patch implements checks for pixel equality between the two
images when the hashes are different.

* It has been observed that in WebKit based browsers (Safari, WebKitGTK)
this happens and many tests are beeing flagged incorrectly as failing.