### PR TITLE
wake lock: Expand IDL harness tests

### DIFF
--- a/wake-lock/idlharness.https.any.js
+++ b/wake-lock/idlharness.https.any.js
@@ -8,9 +8,20 @@
 idl_test(
   ['wake-lock'],
   ['dom', 'html', 'permissions'],
-  idl_array => {
+  async idl_array => {
+    if (self.GLOBAL.isWorker()) {
+      idl_array.add_objects({ WorkerNavigator: ['navigator'] });
+    } else {
+      idl_array.add_objects({ Navigator: ['navigator'] });
+    }
     idl_array.add_objects({
       WakeLock: ['navigator.wakeLock'],
+      WakeLockSentinel: ['sentinel'],
     });
+
+    // For now, this assumes the request will be granted and the promise will
+    // be fulfilled with a WakeLockSentinel object.
+    self.sentinel = await navigator.wakeLock.request('screen');
+    self.sentinel.release();
   }
 );


### PR DESCRIPTION
As mentioned in #19738, the IDL tests need more content, especially now that
interfaces/wake-lock.idl has been updated to match the latest version of the
spec.

* Add Navigator/WorkerNavigator to the objects we test.
* Add WakeLockSentinel to the objects we test by actually requesting and
  then releasing a lock.