### PR TITLE
Add test cases for changing scroll position with scroll behavior

### DIFF
--- a/css/cssom-view/scroll-behavior-element.html
+++ b/css/cssom-view/scroll-behavior-element.html
@@ -135,6 +135,32 @@
    }, `Element with smooth scroll-behavior ; ${scrollFunction}() with smooth behavior`);
   });
 
+  [{scrollAttribute: "scrollLeft", scrollValue: elementToRevealLeft}, {scrollAttribute: "scrollTop", scrollValue: elementToRevealTop}].forEach((attributeTest) => {
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "autoBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      var expectedValue = Number(attributeTest.scrollValue);
+      setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+      assert_equals( scrollingElement[attributeTest.scrollAttribute], expectedValue, "Should set scroll attribute immediately");
+      return new Promise((resolve) => { resolve(); });
+    }, `Set ${attributeTest.scrollAttribute} to element with auto scroll-behavior`);
+
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      var expectedValue = Number(attributeTest.scrollValue);
+      setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+      assert_less_than(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Shouldn't set scroll attribute immediately");
+      return waitForScrollEnd(scrollingElement).then(() => {
+        assert_equals(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Final value of scroll attribute");
+      });
+    }, `Set ${attributeTest.scrollAttribute} to element with smooth scroll-behavior`);
+  });
+
   promise_test(() => {
     resetScroll(scrollingElement);
     setScrollBehavior(styledElement, "smoothBehavior");

--- a/css/cssom-view/scroll-behavior-element.html
+++ b/css/cssom-view/scroll-behavior-element.html
@@ -142,7 +142,7 @@
       assert_equals(scrollingElement.scrollLeft, 0);
       assert_equals(scrollingElement.scrollTop, 0);
       var expectedValue = Number(attributeTest.scrollValue);
-      setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+      scrollingElement[attributeTest.scrollAttribute] = expectedValue;
       assert_equals( scrollingElement[attributeTest.scrollAttribute], expectedValue, "Should set scroll attribute immediately");
       return new Promise((resolve) => { resolve(); });
     }, `Set ${attributeTest.scrollAttribute} to element with auto scroll-behavior`);
@@ -153,7 +153,7 @@
       assert_equals(scrollingElement.scrollLeft, 0);
       assert_equals(scrollingElement.scrollTop, 0);
       var expectedValue = Number(attributeTest.scrollValue);
-      setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+      scrollingElement[attributeTest.scrollAttribute] = expectedValue;
       assert_less_than(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Shouldn't set scroll attribute immediately");
       return waitForScrollEnd(scrollingElement).then(() => {
         assert_equals(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Final value of scroll attribute");

--- a/css/cssom-view/scroll-behavior-main-frame-root.html
+++ b/css/cssom-view/scroll-behavior-main-frame-root.html
@@ -147,7 +147,7 @@
         assert_equals(scrollingElement.scrollLeft, 0);
         assert_equals(scrollingElement.scrollTop, 0);
         var expectedValue = Number(attributeTest.scrollValue);
-        setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+        scrollingElement[attributeTest.scrollAttribute] = expectedValue;
         assert_equals( scrollingElement[attributeTest.scrollAttribute], expectedValue, "Should set scroll attribute immediately");
         return new Promise((resolve) => { resolve(); });
       }, `Set ${attributeTest.scrollAttribute} to frame with auto scroll-behavior`);
@@ -158,7 +158,7 @@
         assert_equals(scrollingElement.scrollLeft, 0);
         assert_equals(scrollingElement.scrollTop, 0);
         var expectedValue = Number(attributeTest.scrollValue);
-        setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+        scrollingElement[attributeTest.scrollAttribute] = expectedValue;
         assert_less_than(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Shouldn't set scroll attribute immediately");
         return waitForScrollEnd(scrollingElement).then(() => {
           assert_equals(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Final value of scroll attribute");

--- a/css/cssom-view/scroll-behavior-main-frame-root.html
+++ b/css/cssom-view/scroll-behavior-main-frame-root.html
@@ -140,6 +140,32 @@
      }, `Main frame with smooth scroll-behavior ; ${scrollFunction}() with smooth behavior`);
     });
 
+    [{scrollAttribute: "scrollLeft", scrollValue: elementToRevealLeft}, {scrollAttribute: "scrollTop", scrollValue: elementToRevealTop}].forEach((attributeTest) => {
+      promise_test(() => {
+        resetScroll(scrollingElement);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingElement.scrollLeft, 0);
+        assert_equals(scrollingElement.scrollTop, 0);
+        var expectedValue = Number(attributeTest.scrollValue);
+        setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+        assert_equals( scrollingElement[attributeTest.scrollAttribute], expectedValue, "Should set scroll attribute immediately");
+        return new Promise((resolve) => { resolve(); });
+      }, `Set ${attributeTest.scrollAttribute} to frame with auto scroll-behavior`);
+
+      promise_test(() => {
+        resetScroll(scrollingElement);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingElement.scrollLeft, 0);
+        assert_equals(scrollingElement.scrollTop, 0);
+        var expectedValue = Number(attributeTest.scrollValue);
+        setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+        assert_less_than(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Shouldn't set scroll attribute immediately");
+        return waitForScrollEnd(scrollingElement).then(() => {
+          assert_equals(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Final value of scroll attribute");
+        });
+      }, `Set ${attributeTest.scrollAttribute} to frame with smooth scroll-behavior`);
+    });
+
     promise_test(() => {
       resetScroll(scrollingElement);
       setScrollBehavior(styledElement, "smoothBehavior");

--- a/css/cssom-view/scroll-behavior-smooth-positions.html
+++ b/css/cssom-view/scroll-behavior-smooth-positions.html
@@ -71,7 +71,7 @@
           var oldValue = overflowNode[scrollTest.scrollAttribute];
           assert_equals(oldValue, initial, `${scrollTest.scrollAttribute} should be at initial position`);
           var expectedValue = Number(scrollTest.scrollValue);
-          setScrollAttribute(overflowNode, scrollTest.scrollAttribute, expectedValue);
+          overflowNode[scrollTest.scrollAttribute] = expectedValue;
           observeScrolling(overflowNode, function(done) {
             try {
               var newValue = overflowNode[scrollTest.scrollAttribute];

--- a/css/cssom-view/scroll-behavior-smooth-positions.html
+++ b/css/cssom-view/scroll-behavior-smooth-positions.html
@@ -62,6 +62,34 @@
     });
   });
 
+  [{scrollAttribute: "scrollLeft", scrollValue: 500}, {scrollAttribute: "scrollTop", scrollValue: 250}].forEach(function(scrollTest) {
+    var initialPosition = Number(scrollTest.scrollValue) * 2;
+    [0, initialPosition].forEach((initial) => {
+      promise_test(() => {
+        return new Promise(function(resolve, reject) {
+          scrollNode(overflowNode, "scroll", "instant", initial, initial);
+          var oldValue = overflowNode[scrollTest.scrollAttribute];
+          assert_equals(oldValue, initial, `${scrollTest.scrollAttribute} should be at initial position`);
+          var expectedValue = Number(scrollTest.scrollValue);
+          setScrollAttribute(overflowNode, scrollTest.scrollAttribute, expectedValue);
+          observeScrolling(overflowNode, function(done) {
+            try {
+              var newValue = overflowNode[scrollTest.scrollAttribute];
+              assert_less_than_equal(Math.abs(expectedValue - newValue), Math.abs(expectedValue - oldValue), "Scroll position should move towards the final position");
+              if (done)
+                assert_equals(newValue, expectedValue, `${scrollTest.scrollAttribute} should reach final position`);
+              oldValue = newValue;
+            } catch(e) {
+              reject(e);
+            }
+            if (done)
+              resolve();
+          });
+        });
+      }, `Scroll positions when performing smooth scrolling from ${initial} to ${scrollTest.scrollValue} by setting ${scrollTest.scrollAttribute} `);
+    });
+  });
+
   promise_test(() => {
     return new Promise(function(resolve, reject) {
       resetScroll(overflowNode);

--- a/css/cssom-view/scroll-behavior-subframe-root.html
+++ b/css/cssom-view/scroll-behavior-subframe-root.html
@@ -148,7 +148,7 @@
         assert_equals(scrollingElement.scrollLeft, 0);
         assert_equals(scrollingElement.scrollTop, 0);
         var expectedValue = Number(attributeTest.scrollValue);
-        setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+        scrollingElement[attributeTest.scrollAttribute] = expectedValue;
         assert_equals(scrollingElement[attributeTest.scrollAttribute], expectedValue, `Should set ${attributeTest.scrollAttribute} immediately`);
         return new Promise((resolve) => { resolve(); });
       }, `Subframe setting ${attributeTest.scrollAttribute} with auto scroll-behavior`);
@@ -159,7 +159,7 @@
         assert_equals(scrollingElement.scrollLeft, 0);
         assert_equals(scrollingElement.scrollTop, 0);
         var expectedValue = Number(attributeTest.scrollValue);
-        setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+        scrollingElement[attributeTest.scrollAttribute] = expectedValue;
         assert_less_than(scrollingElement[attributeTest.scrollAttribute], expectedValue, `Should not set ${attributeTest.scrollAttribute} immediately`);
         return waitForScrollEnd(scrollingElement).then(() => {
           assert_equals(scrollingElement[attributeTest.scrollAttribute], expectedValue, `Final value of ${attributeTest.scrollAttribute}`);

--- a/css/cssom-view/scroll-behavior-subframe-root.html
+++ b/css/cssom-view/scroll-behavior-subframe-root.html
@@ -141,6 +141,32 @@
      }, `Subframe with smooth scroll-behavior ; ${scrollFunction}() with smooth behavior`);
     });
 
+    [{scrollAttribute: "scrollLeft", scrollValue: elementToRevealLeft}, {scrollAttribute: "scrollTop", scrollValue: elementToRevealTop}].forEach((attributeTest) => {
+      promise_test(() => {
+        resetScroll(scrollingElement);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingElement.scrollLeft, 0);
+        assert_equals(scrollingElement.scrollTop, 0);
+        var expectedValue = Number(attributeTest.scrollValue);
+        setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+        assert_equals(scrollingElement[attributeTest.scrollAttribute], expectedValue, `Should set ${attributeTest.scrollAttribute} immediately`);
+        return new Promise((resolve) => { resolve(); });
+      }, `Subframe setting ${attributeTest.scrollAttribute} with auto scroll-behavior`);
+
+      promise_test(() => {
+        resetScroll(scrollingElement);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingElement.scrollLeft, 0);
+        assert_equals(scrollingElement.scrollTop, 0);
+        var expectedValue = Number(attributeTest.scrollValue);
+        setScrollAttribute(scrollingElement, attributeTest.scrollAttribute, expectedValue);
+        assert_less_than(scrollingElement[attributeTest.scrollAttribute], expectedValue, `Should not set ${attributeTest.scrollAttribute} immediately`);
+        return waitForScrollEnd(scrollingElement).then(() => {
+          assert_equals(scrollingElement[attributeTest.scrollAttribute], expectedValue, `Final value of ${attributeTest.scrollAttribute}`);
+        });
+     }, `Subframe setting ${attributeTest.scrollAttribute} with smooth scroll-behavior`);
+    });
+
     promise_test(() => {
       resetScroll(scrollingElement);
       setScrollBehavior(styledElement, "smoothBehavior");
@@ -164,7 +190,7 @@
       return waitForScrollEnd(scrollingElement).then(() => {
         assert_equals(scrollingElement.scrollLeft, 0, "Final value of scrollLeft");
         assert_equals(scrollingElement.scrollTop, 0, "Final value of scrollTop");
-    });
-  }, "Aborting an ongoing smooth scrolling on a subframe with an instant scrolling");
+      });
+    }, "Aborting an ongoing smooth scrolling on a subframe with an instant scrolling");
   }));
 </script>

--- a/css/cssom-view/support/scroll-behavior.js
+++ b/css/cssom-view/support/scroll-behavior.js
@@ -85,3 +85,7 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
   args.top = elementToRevealTop;
   scrollingWindow[scrollFunction](args);
 }
+
+function setScrollAttribute(scrollingElement, scrollAttribute, scrollValue) {
+  scrollingElement[scrollAttribute] = scrollValue;
+}

--- a/css/cssom-view/support/scroll-behavior.js
+++ b/css/cssom-view/support/scroll-behavior.js
@@ -85,7 +85,3 @@ function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToReveal
   args.top = elementToRevealTop;
   scrollingWindow[scrollFunction](args);
 }
-
-function setScrollAttribute(scrollingElement, scrollAttribute, scrollValue) {
-  scrollingElement[scrollAttribute] = scrollValue;
-}


### PR DESCRIPTION
Hi Fred,

This patch added test case for changing scroll attributes of element, frame and subframe.
The test in scroll-behavior-main-frame-window.html isn't needed, because the scroll attributes of window are readonly. https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface

PTAL, thanks:)