### PR TITLE
[Azure Pipelines] work around safaridriver issue with plist hack

### DIFF
--- a/tools/ci/azure/com.apple.Safari.plist
+++ b/tools/ci/azure/com.apple.Safari.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AllowRemoteAutomation</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -12,6 +12,9 @@ steps:
     displayName: 'Install Safari Technology Preview'
 - ${{ if eq(parameters.channel, 'stable') }}:
   - script: |
-      sudo safaridriver --enable
+      # Workaround for `sudo safardriver --enable` not working:
+      # https://github.com/web-platform-tests/wpt/issues/19845
+      mkdir -p ~/Library/WebDriver/
+      cp tools/ci/azure/com.apple.Safari.plist ~/Library/WebDriver/
       defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
     displayName: 'Configure Safari'


### PR DESCRIPTION
Adapted from a successful workaround on STP 91:
https://github.com/web-platform-tests/wpt/pull/18925/commits/f31328c4c2fd102f8a39208e90e2f1f88f441284

That workaround stopped working in STP 92:
https://github.com/web-platform-tests/wpt/pull/19142#issuecomment-532827391

There's a non-trivial risk that it will stop working for Safari stable
as well, but right now it works and is better than no results.