### PR TITLE
[infra] add a cron workflow to update a new epochs/three_hourly branch

### DIFF
--- a/.github/workflows/epochs.yml
+++ b/.github/workflows/epochs.yml
@@ -1,0 +1,16 @@
+name: epochs
+on:
+  schedule:
+    # Trigger 10 minutes past every 3rd hour. 10 minutes is a safety margin
+    # for any manifest workflow to finish, see tools/wpt/revlist.py.
+    - cron: 10 */3 * * *
+jobs:
+  update:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Run epochs_update.sh
+      run: ./tools/ci/epochs_update.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/ci/epochs_update.sh
+++ b/tools/ci/epochs_update.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -ex
+
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+WPT_ROOT=$SCRIPT_DIR/../..
+cd $WPT_ROOT
+
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN must be set as an environment variable"
+    exit 1
+fi
+
+REMOTE=https://x-access-token:$GITHUB_TOKEN@github.com/web-platform-tests/wpt.git
+
+git branch epochs/three_hourly $(./wpt rev-list --epoch 3h)
+# This is safe because `git push` will by default fail for a non-fast-forward
+# push, for example if the remote branch is ahead of the local branch.
+git push $REMOTE epochs/three_hourly


### PR DESCRIPTION
The epochs/three_hourly branch doesn't exist yet and nothing will be
triggered by it initially, which makes it a good candidate for
verifying that `./wpt rev-list` combined with GitHub Actions will be a
robust way to maintain the epochs branches.

The immediate motivation for this is to increase the frequency of Edge
and Safari runs on Azure Pipelines from every 6 to every 3 hours:
https://github.com/web-platform-tests/wpt/issues/18669#issuecomment-546062584

Part of https://github.com/web-platform-tests/wpt/issues/19322.