### PR TITLE
Added task to cleanup Edge regkeys and folders

### DIFF
--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -72,7 +72,7 @@ steps:
   ignoreLASTEXITCODE: true
 
 - powershell: |
-    $channels = @('Edge', 'Edge Beta', 'Edge Dev', 'Edge Canary')
+    $channels = @('Edge', 'Edge Beta', 'Edge Dev', 'Edge SxS')
     foreach ($channel in $channels) {
       Write-Host "Deleting regkeys for $channel folder"
       Remove-Item -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft $channel" -Recurse -Force -ErrorAction SilentlyContinue

--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -4,6 +4,7 @@
 steps:
 - powershell: |
     function UninstallEdge($edgePath, $uninstallArgs) {
+      $exitCode = 0
       try {
         cmd /c taskkill /f /im msedge* `> nul 2`> nul
         cmd /c taskkill /f /im setup.exe `> nul 2`> nul
@@ -11,8 +12,11 @@ steps:
           $installerPath = Get-ChildItem -PATH $edgePath -Filter "setup.exe" -Recurse | Select -First 1 FullName
           if(-not($installerPath -eq $nul) -and (Test-Path $installerPath.FullName)) {
             Write-Host "Uninstall: $($installerPath.FullName) $uninstallArgs"
-            Start-Process "$($installerPath.FullName)" -ArgumentList $uninstallArgs -Wait
-            Remove-Item -Path $edgePath -Recurse -Force -ErrorAction SilentlyContinue
+            $setup = Start-Process "$($installerPath.FullName)" -ArgumentList $uninstallArgs -PassThru -Wait
+            $exitCode = $setup.ExitCode
+            if ($exitCode -ne $exitCodeSuccess) {
+              Write-Host "Uninstall failed with ExitCode=$exitCode"
+            }
           } else {
             Write-Host "Failed to find setup.exe under $edgePath"
           }
@@ -20,24 +24,27 @@ steps:
       } catch [Exception] {
         Write-Host "Failed to uninstall Edge from $edgePath. ERROR= $($_.Exception.Message)" -ForegroundColor Red
       }
+      return $exitCode
     }
 
     function IsEdgeRunning() {
       return (Get-Process | Where-Object { $_.Name -eq "msedge" }).Length -gt 0
     }
 
+    # Uninstall exit code success for Edge
+    $exitCodeSuccess = 19
     # restore hosts file
     $hostFile = "$env:systemroot\System32\drivers\etc\hosts"
     Copy-Item -Path "$hostFile.back" -Destination $hostFile -Force
 
     # uninstall Edge
-    UninstallEdge "$env:localappdata\Microsoft\Edge\Application" "--uninstall --force-uninstall"
+    $stableExitCode = UninstallEdge "$env:localappdata\Microsoft\Edge" "--uninstall --force-uninstall --verbose-logging"
     # uninstall Edge Canary channel
-    UninstallEdge "$env:localappdata\Microsoft\Edge SxS\Application" "--uninstall --msedge-sxs --system-level --force-uninstall"
+    $canaryExitCode = UninstallEdge "$env:localappdata\Microsoft\Edge SxS" "--uninstall --msedge-sxs --force-uninstall --verbose-logging"
     # uninstall Edge Dev channel
-    UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev\Application" "--uninstall --msedge-dev --system-level --force-uninstall"
+    $devExitCode = UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev" "--uninstall --msedge-dev --force-uninstall --verbose-logging"
     # uninstall Edge Beta channel
-    UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Beta\Application" "--uninstall --msedge-beta --system-level --force-uninstall"
+    $betaExitCode = UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Beta" "--uninstall --msedge-beta --force-uninstall --verbose-logging"
 
     # Check if Edge is still running and try to close it.
     # If we fail to close it, then reboot the system
@@ -50,7 +57,41 @@ steps:
         Restart-Computer -Force
       }
     }
+    if (($stableExitCode -ne $exitCodeSuccess) -and
+        ($canaryExitCode -ne $exitCodeSuccess) -and
+        ($devExitCode -ne $exitCodeSuccess) -and
+        ($betaExitCode -ne $exitCodeSuccess)) {
+      Copy-Item -Path "$env:temp\*edge*.log" -Destination $(Build.ArtifactStagingDirectory) -Force
+      Throw "Failed to uninstall Edge."
+    } else {
+      Write-Host "Successfully uninstalled all Edge channels"
+    }
   displayName: 'Restore hosts file and cleanup test machine'
+  condition: always()
+  errorActionPreference: silentlyContinue
+  ignoreLASTEXITCODE: true
+
+- powershell: |
+    $channelFolders = @('Edge', 'Edge SxS', 'Edge Dev', 'Edge Beta')
+    foreach ($folder in $channelFolders) {
+      Write-Host "Deleting regkeys for $folder folder"
+      Remove-Item -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft $folder" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft $folder" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKLM:SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKLM:SOFTWARE\WOW6432Node\Microsoft\$folder" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKLM:SOFTWARE\Microsoft\EdgeUpdate" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKLM:SOFTWARE\Microsoft\$folder" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKCU:SOFTWARE\Microsoft\EdgeUpdate" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKCU:SOFTWARE\Microsoft\$folder" -Recurse -Force -ErrorAction SilentlyContinue
+
+      Write-Host "Deleting all remaining Edge folders"
+      Remove-Item -Path "$env:localappdata\Microsoft\EdgeUpdate" -Recurse -Force -ErrorAction SilentlyContinue
+      $edgePath = "$env:localappdata\Microsoft\$folder"
+      Remove-Item -Path $edgePath -Recurse -Force -ErrorAction SilentlyContinue
+      $edgePath = "$env:systemdrive\Program Files (x86)\Microsoft\$folder"
+      Remove-Item -Path $edgePath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  displayName: 'Cleanup Edge registry'
   condition: always()
   errorActionPreference: silentlyContinue
   ignoreLASTEXITCODE: true

--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -39,12 +39,12 @@ steps:
 
     # uninstall Edge
     $stableExitCode = UninstallEdge "$env:localappdata\Microsoft\Edge" "--uninstall --force-uninstall --verbose-logging"
-    # uninstall Edge Canary channel
-    $canaryExitCode = UninstallEdge "$env:localappdata\Microsoft\Edge SxS" "--uninstall --msedge-sxs --force-uninstall --verbose-logging"
-    # uninstall Edge Dev channel
-    $devExitCode = UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev" "--uninstall --msedge-dev --force-uninstall --verbose-logging"
     # uninstall Edge Beta channel
     $betaExitCode = UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Beta" "--uninstall --msedge-beta --force-uninstall --verbose-logging"
+    # uninstall Edge Dev channel
+    $devExitCode = UninstallEdge "$env:systemdrive\Program Files (x86)\Microsoft\Edge Dev" "--uninstall --msedge-dev --force-uninstall --verbose-logging"
+    # uninstall Edge Canary channel
+    $canaryExitCode = UninstallEdge "$env:localappdata\Microsoft\Edge SxS" "--uninstall --msedge-sxs --force-uninstall --verbose-logging"
 
     # Check if Edge is still running and try to close it.
     # If we fail to close it, then reboot the system
@@ -58,9 +58,9 @@ steps:
       }
     }
     if (($stableExitCode -ne $exitCodeSuccess) -and
-        ($canaryExitCode -ne $exitCodeSuccess) -and
+        ($betaExitCode -ne $exitCodeSuccess) -and
         ($devExitCode -ne $exitCodeSuccess) -and
-        ($betaExitCode -ne $exitCodeSuccess)) {
+        ($canaryExitCode -ne $exitCodeSuccess)) {
       Copy-Item -Path "$env:temp\*edge*.log" -Destination $(Build.ArtifactStagingDirectory) -Force
       Throw "Failed to uninstall Edge."
     } else {
@@ -72,23 +72,23 @@ steps:
   ignoreLASTEXITCODE: true
 
 - powershell: |
-    $channelFolders = @('Edge', 'Edge SxS', 'Edge Dev', 'Edge Beta')
-    foreach ($folder in $channelFolders) {
-      Write-Host "Deleting regkeys for $folder folder"
-      Remove-Item -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft $folder" -Recurse -Force -ErrorAction SilentlyContinue
-      Remove-Item -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft $folder" -Recurse -Force -ErrorAction SilentlyContinue
+    $channels = @('Edge', 'Edge Beta', 'Edge Dev', 'Edge Canary')
+    foreach ($channel in $channels) {
+      Write-Host "Deleting regkeys for $channel folder"
+      Remove-Item -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft $channel" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft $channel" -Recurse -Force -ErrorAction SilentlyContinue
       Remove-Item -Path "HKLM:SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate" -Recurse -Force -ErrorAction SilentlyContinue
-      Remove-Item -Path "HKLM:SOFTWARE\WOW6432Node\Microsoft\$folder" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKLM:SOFTWARE\WOW6432Node\Microsoft\$channel" -Recurse -Force -ErrorAction SilentlyContinue
       Remove-Item -Path "HKLM:SOFTWARE\Microsoft\EdgeUpdate" -Recurse -Force -ErrorAction SilentlyContinue
-      Remove-Item -Path "HKLM:SOFTWARE\Microsoft\$folder" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKLM:SOFTWARE\Microsoft\$channel" -Recurse -Force -ErrorAction SilentlyContinue
       Remove-Item -Path "HKCU:SOFTWARE\Microsoft\EdgeUpdate" -Recurse -Force -ErrorAction SilentlyContinue
-      Remove-Item -Path "HKCU:SOFTWARE\Microsoft\$folder" -Recurse -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "HKCU:SOFTWARE\Microsoft\$channel" -Recurse -Force -ErrorAction SilentlyContinue
 
       Write-Host "Deleting all remaining Edge folders"
       Remove-Item -Path "$env:localappdata\Microsoft\EdgeUpdate" -Recurse -Force -ErrorAction SilentlyContinue
-      $edgePath = "$env:localappdata\Microsoft\$folder"
+      $edgePath = "$env:localappdata\Microsoft\$channel"
       Remove-Item -Path $edgePath -Recurse -Force -ErrorAction SilentlyContinue
-      $edgePath = "$env:systemdrive\Program Files (x86)\Microsoft\$folder"
+      $edgePath = "$env:systemdrive\Program Files (x86)\Microsoft\$channel"
       Remove-Item -Path $edgePath -Recurse -Force -ErrorAction SilentlyContinue
     }
   displayName: 'Cleanup Edge registry'


### PR DESCRIPTION
This change fixes issue tracked in #19878 The fix is to cleanup Edge registry and files that can get left behind if uninstall fails. As part of this change we also copy setup log file to help analyze failure and hopefully prevent it from happening in the future.

The change is in cleanup code, requires two runs to confirm it:

Run1 (expect failures): https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=35216
Run2 (expect it to pass): https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=35218

Dev channel run: https://dev.azure.com/web-platform-tests/wpt/_build/results?buildId=35226