### PR TITLE
[WebCryptoAPI] Defer harness completion

### DIFF
--- a/WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.js
@@ -1,3 +1,9 @@
 // META: title=WebCryptoAPI: deriveBits() Using ECDH
 // META: script=ecdh_bits.js
-run_test();
+
+// Define subtests from a `promise_test` to ensure the harness does not
+// complete before the subtests are available. `explicit_done` cannot be used
+// for this purpose because the global `done` function is automatically invoked
+// by the WPT infrastructure in dedicated worker tests defined using the
+// "multi-global" pattern.
+promise_test(define_tests, 'setup - define tests');

--- a/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
@@ -1,5 +1,5 @@
 
-function run_test() {
+function define_tests() {
     // May want to test prefixed implementations.
     var subtle = self.crypto.subtle;
 
@@ -27,7 +27,7 @@ function run_test() {
         "P-384": new Uint8Array([224, 189, 107, 206, 10, 239, 140, 164, 136, 56, 166, 226, 252, 197, 126, 103, 185, 197, 232, 134, 12, 95, 11, 233, 218, 190, 197, 62, 69, 78, 24, 160, 161, 116, 196, 136, 136, 162, 100, 136, 17, 91, 45, 201, 241, 223, 165, 45])
     };
 
-    importKeys(pkcs8, spki, sizes)
+    return importKeys(pkcs8, spki, sizes)
     .then(function(results) {
         publicKeys = results.publicKeys;
         privateKeys = results.privateKeys;
@@ -184,7 +184,6 @@ function run_test() {
                 });
             }, namedCurve + " asking for too many bits");
         });
-        done()
     });
 
     function importKeys(pkcs8, spki, sizes) {

--- a/WebCryptoAPI/derive_bits_keys/ecdh_keys.https.any.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_keys.https.any.js
@@ -1,3 +1,9 @@
 // META: title=WebCryptoAPI: deriveKey() Using ECDH
 // META: script=ecdh_keys.js
-run_test();
+
+// Define subtests from a `promise_test` to ensure the harness does not
+// complete before the subtests are available. `explicit_done` cannot be used
+// for this purpose because the global `done` function is automatically invoked
+// by the WPT infrastructure in dedicated worker tests defined using the
+// "multi-global" pattern.
+promise_test(define_tests, 'setup - define tests');

--- a/WebCryptoAPI/derive_bits_keys/ecdh_keys.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_keys.js
@@ -1,5 +1,5 @@
 
-function run_test() {
+function define_tests() {
     // May want to test prefixed implementations.
     var subtle = self.crypto.subtle;
 
@@ -27,7 +27,7 @@ function run_test() {
         "P-384": new Uint8Array([224, 189, 107, 206, 10, 239, 140, 164, 136, 56, 166, 226, 252, 197, 126, 103, 185, 197, 232, 134, 12, 95, 11, 233, 218, 190, 197, 62, 69, 78, 24, 160, 161, 116, 196, 136, 136, 162, 100, 136, 17, 91, 45, 201, 241, 223, 165, 45])
     };
 
-    importKeys(pkcs8, spki, sizes)
+    return importKeys(pkcs8, spki, sizes)
     .then(function(results) {
         publicKeys = results.publicKeys;
         privateKeys = results.privateKeys;
@@ -153,7 +153,6 @@ function run_test() {
                 });
             }, namedCurve + " public property value is a secret key");
         });
-        done();
     });
 
     function importKeys(pkcs8, spki, sizes) {

--- a/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js
+++ b/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js
@@ -6,4 +6,10 @@
 // META: script=/common/subset-tests.js
 // META: script=hkdf_vectors.js
 // META: script=hkdf.js
-run_test();
+
+// Define subtests from a `promise_test` to ensure the harness does not
+// complete before the subtests are available. `explicit_done` cannot be used
+// for this purpose because the global `done` function is automatically invoked
+// by the WPT infrastructure in dedicated worker tests defined using the
+// "multi-global" pattern.
+promise_test(define_tests, 'setup - define tests');

--- a/WebCryptoAPI/derive_bits_keys/hkdf.js
+++ b/WebCryptoAPI/derive_bits_keys/hkdf.js
@@ -1,5 +1,5 @@
 
-function run_test() {
+function define_tests() {
     // May want to test prefixed implementations.
     var subtle = self.crypto.subtle;
 
@@ -14,7 +14,7 @@ function run_test() {
     // What kinds of keys can be created with deriveKey? The following:
     var derivedKeyTypes = testData.derivedKeyTypes;
 
-    setUpBaseKeys(derivedKeys)
+    return setUpBaseKeys(derivedKeys)
     .then(function(allKeys) {
         // We get several kinds of base keys. Normal ones that can be used for
         // derivation operations, ones that lack the deriveBits usage, ones
@@ -232,13 +232,6 @@ function run_test() {
 
             });
         });
-
-        done();
-    }, function(err) {
-        subsetTest(test, function(test) {
-            assert_unreached("setUpBaseKeys failed with error '" + err.message + "'");
-        }, "setUpBaseKeys");
-        done();
     });
 
     // Deriving bits and keys requires starting with a base key, which is created

--- a/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js
+++ b/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js
@@ -12,4 +12,10 @@
 // META: script=/common/subset-tests.js
 // META: script=pbkdf2_vectors.js
 // META: script=pbkdf2.js
-run_test();
+
+// Define subtests from a `promise_test` to ensure the harness does not
+// complete before the subtests are available. `explicit_done` cannot be used
+// for this purpose because the global `done` function is automatically invoked
+// by the WPT infrastructure in dedicated worker tests defined using the
+// "multi-global" pattern.
+promise_test(define_tests, 'setup - define tests');

--- a/WebCryptoAPI/derive_bits_keys/pbkdf2.js
+++ b/WebCryptoAPI/derive_bits_keys/pbkdf2.js
@@ -1,4 +1,4 @@
-function run_test() {
+function define_tests() {
     // May want to test prefixed implementations.
     var subtle = self.crypto.subtle;
 
@@ -12,7 +12,7 @@ function run_test() {
     // What kinds of keys can be created with deriveKey? The following:
     var derivedKeyTypes = testData.derivedKeyTypes;
 
-    setUpBaseKeys(passwords)
+    return setUpBaseKeys(passwords)
     .then(function(allKeys) {
         // We get several kinds of base keys. Normal ones that can be used for
         // derivation operations, ones that lack the deriveBits usage, ones
@@ -229,13 +229,6 @@ function run_test() {
 
             });
         });
-
-        done();
-    }, function(err) {
-        subsetTest(test, function(test) {
-            assert_unreached("setUpBaseKeys failed with error '" + err.message + "'");
-        }, "setUpBaseKeys");
-        done();
     });
 
     // Deriving bits and keys requires starting with a base key, which is created


### PR DESCRIPTION
This change ensures that all subtests are executed when the tests are
evaluated in dedicated worker contexts.