### PR TITLE
[docs] Describe automatic `done` invocation

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -452,7 +452,9 @@ is called, the two conditions above apply like normal.
 
 Dedicated and shared workers don't have an event that corresponds to the `load`
 event in a document. Therefore these worker tests always behave as if the
-`explicit_done` property is set to true. Service workers depend on the
+`explicit_done` property is set to true (unless they are defined using [the
+"multi-global" pattern](testharness.html#multi-global-tests)). Service workers
+depend on the
 [install](https://w3c.github.io/ServiceWorker/#service-worker-global-scope-install-event)
 event which is fired following the completion of [running the
 worker](https://html.spec.whatwg.org/multipage/workers.html#run-a-worker).

--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -178,6 +178,11 @@ be made available by the framework:
     self.GLOBAL.isWindow()
     self.GLOBAL.isWorker()
 
+Although [the global `done` function must be explicitly invoked for most
+dedicated worker tests and shared worker
+tests](testharness-api.html#determining-when-all-tests-are-complete), it is
+automatically invoked for tests defined using the "multi-global" pattern.
+
 ### Specifying a test title in auto-generated boilerplate tests
 
 Use `// META: title=This is the title of the test` at the beginning of the resource.


### PR DESCRIPTION
The code generated for dedicated and shared workers includes an
immediate invocation of the global `done` function. This behavior
contradicts the testharness.js documentation that describes scheduling
in those specific contexts.

Extend the documentation to include this behavior.