### PR TITLE
[workers] Opt-in to single-page test feature

### DIFF
--- a/workers/constructors/SharedWorker/URLMismatchError.htm
+++ b/workers/constructors/SharedWorker/URLMismatchError.htm
@@ -6,6 +6,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
+setup({ single_test: true });
+
 var counter = 0
 function maybeDone() {
   if(counter) {

--- a/workers/interfaces/WorkerGlobalScope/close/incoming-message.html
+++ b/workers/interfaces/WorkerGlobalScope/close/incoming-message.html
@@ -4,6 +4,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
+setup({ single_test: true });
+
 var worker = new Worker('incoming-message.js');
 worker.onmessage = function(e) {
   assert_unreached("Got message");

--- a/workers/interfaces/WorkerGlobalScope/close/setInterval.html
+++ b/workers/interfaces/WorkerGlobalScope/close/setInterval.html
@@ -4,6 +4,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
+setup({ single_test: true });
+
 var worker = new Worker('setInterval.js');
 worker.onmessage = function(e) {
   assert_unreached("Got message");

--- a/workers/interfaces/WorkerGlobalScope/close/setTimeout.html
+++ b/workers/interfaces/WorkerGlobalScope/close/setTimeout.html
@@ -4,6 +4,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
+setup({ single_test: true });
+
 var worker = new Worker('setTimeout.js');
 worker.onmessage = function(e) {
   assert_unreached("Got message");

--- a/workers/semantics/multiple-workers/004.html
+++ b/workers/semantics/multiple-workers/004.html
@@ -5,6 +5,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
+setup({ single_test: true });
+
 var i = 0;
 var load_count = 0;
 

--- a/workers/semantics/navigation/001.html
+++ b/workers/semantics/navigation/001.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
+setup({ single_test: true });
 var date;
 var newDate;
 </script>

--- a/workers/shared-worker-name-via-options.html
+++ b/workers/shared-worker-name-via-options.html
@@ -10,6 +10,7 @@
 
 <script>
 "use strict";
+setup({ single_test: true });
 
 const name = "my name";
 


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md