### PR TITLE
[webaudio] Opt-in to single-page test feature

### DIFF
--- a/webaudio/the-audio-api/the-analysernode-interface/test-analyser-minimum.html
+++ b/webaudio/the-audio-api/the-analysernode-interface/test-analyser-minimum.html
@@ -7,7 +7,7 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script>
-
+    setup({ single_test: true });
     var ac = new AudioContext();
     var analyser = ac.createAnalyser();
     var constant = ac.createConstantSource();

--- a/webaudio/the-audio-api/the-analysernode-interface/test-analyser-output.html
+++ b/webaudio/the-audio-api/the-analysernode-interface/test-analyser-output.html
@@ -8,6 +8,8 @@
   <script src="/resources/testharnessreport.js"></script>
   <script src="/webaudio/js/helpers.js"></script>
   <script>
+setup({ single_test: true });
+
 var gTest = {
   length: 2048,
   numberOfChannels: 1,

--- a/webaudio/the-audio-api/the-analysernode-interface/test-analyser-scale.html
+++ b/webaudio/the-audio-api/the-analysernode-interface/test-analyser-scale.html
@@ -6,6 +6,8 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script>
+    setup({ single_test: true });
+
     var context = new AudioContext();
 
     var gain = context.createGain();


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md