### PR TITLE
[server-timing] Opt-in to single-page test feature

### DIFF
--- a/server-timing/navigation_timing_idl.https.html
+++ b/server-timing/navigation_timing_idl.https.html
@@ -5,7 +5,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/performance-timeline-utils.js"></script>
     <script>
-      setup({explicit_done: true})
+      setup({single_test: true})
       delayedLoadListener(function(){
         assert_not_equals(typeof performance.getEntriesByType('navigation')[0].serverTiming, 'undefined',
           'An instance of `PerformanceNavigationTiming` should have a `serverTiming` attribute.')

--- a/server-timing/resource_timing_idl.https.html
+++ b/server-timing/resource_timing_idl.https.html
@@ -5,7 +5,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/performance-timeline-utils.js"></script>
     <script>
-      setup({explicit_done: true})
+      setup({single_test: true})
       delayedLoadListener(function(){
         assert_not_equals(typeof performance.getEntriesByType('resource')[0].serverTiming, 'undefined',
           'An instance of `PerformanceResourceTiming` should have a `serverTiming` attribute.')


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md