### PR TITLE
[preload] Opt-in to single-page test feature

### DIFF
--- a/preload/download-resources.html
+++ b/preload/download-resources.html
@@ -15,7 +15,7 @@
 <link rel=preload href="resources/dummy.xml" as="fetch">
 <body>
 <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
 

--- a/preload/link-header-on-subresource.html
+++ b/preload/link-header-on-subresource.html
@@ -5,7 +5,7 @@
 <script src="/preload/resources/preload_helper.js"></script>
 <link rel=stylesheet href="resources/dummy-preloads-subresource.css?link-header-on-subresource">
 <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
 

--- a/preload/link-header-preload-imagesrcset.html
+++ b/preload/link-header-preload-imagesrcset.html
@@ -6,7 +6,7 @@
 <script src="/preload/resources/preload_helper.js"></script>
 <body>
 <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
     var expectation = new Array(10).fill(0);

--- a/preload/link-header-preload-nonce.html
+++ b/preload/link-header-preload-nonce.html
@@ -5,7 +5,7 @@
 <script nonce="abc" src="/preload/resources/preload_helper.js"></script>
 <body>
 <script nonce="abc">
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
 

--- a/preload/link-header-preload.html
+++ b/preload/link-header-preload.html
@@ -5,7 +5,7 @@
 <script src="/preload/resources/preload_helper.js"></script>
 <body>
 <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
 

--- a/preload/onerror-event.html
+++ b/preload/onerror-event.html
@@ -28,7 +28,7 @@
 <link rel=preload href="non-existent/dummy.xml?empty" onerror="emptyFailed = true;">
 <body>
 <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
 

--- a/preload/onload-event.html
+++ b/preload/onload-event.html
@@ -28,7 +28,7 @@
 <link rel=preload href="resources/dummy.xml" onload="noTypeLoaded = true;">
 <body>
 <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
 

--- a/preload/preload-with-type.html
+++ b/preload/preload-with-type.html
@@ -48,7 +48,7 @@
 <link rel=preload href="resources/foo.vtt" as=track type="text/foobar" onload="gibberishLoaded++;">
 <body>
 <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
 

--- a/preload/single-download-late-used-preload.html
+++ b/preload/single-download-late-used-preload.html
@@ -5,6 +5,7 @@
 <script src="/preload/resources/preload_helper.js"></script>
 <link rel=preload href="resources/square.png?pipe=trickle(d1)" as=image>
 <script>
+    setup({ single_test: true });
     var link = document.getElementsByTagName("link")[0]
     assert_equals(link.as, "image");
     link.addEventListener("load", () => {


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md