### PR TITLE
[navigation-timing] Opt-in to single-page test feature

### DIFF
--- a/navigation-timing/nav2_test_document_open.html
+++ b/navigation-timing/nav2_test_document_open.html
@@ -8,6 +8,8 @@
           <script src="/resources/testharness.js"></script>
           <script src="/resources/testharnessreport.js"></script>
           <script>
+              setup({ single_test: true });
+
               var navTiming2Attributes = [
                   'connectEnd',
                   'connectStart',

--- a/navigation-timing/nav2_test_document_replaced.html
+++ b/navigation-timing/nav2_test_document_replaced.html
@@ -8,6 +8,8 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script>
+            setup({ single_test: true });
+
             var navigation_frame;
             var pnt1;
             var step = 1;

--- a/navigation-timing/nav2_test_navigate_within_document.html
+++ b/navigation-timing/nav2_test_navigate_within_document.html
@@ -13,6 +13,8 @@
         <p>This test validates that all of the window.performance.getEntriesByType("navigation") attributes remain unchanged after an in document navigation (URL fragment change).</p>
 
         <script>
+            setup({ single_test: true });
+
             var navTiming2Attributes = [
                 'connectEnd',
                 'connectStart',

--- a/navigation-timing/nav2_test_navigation_type_backforward.html
+++ b/navigation-timing/nav2_test_navigation_type_backforward.html
@@ -8,6 +8,7 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script>
+            setup({ single_test: true });
 
             function onload_test()
             {

--- a/navigation-timing/nav2_test_navigation_type_reload.html
+++ b/navigation-timing/nav2_test_navigation_type_reload.html
@@ -8,6 +8,7 @@
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script>
+            setup({ single_test: true });
 
             var reload_frame;
 

--- a/navigation-timing/nav2_test_redirect_chain_xserver_partial_opt_in.html
+++ b/navigation-timing/nav2_test_redirect_chain_xserver_partial_opt_in.html
@@ -9,6 +9,7 @@
         <script src="/resources/testharnessreport.js"></script>
         <script src="/common/utils.js"></script>
         <script>
+            setup({ single_test: true });
 
             function verifyTimingEventOrder(eventOrder, timingEntry) {
                 for (let i = 0; i < eventOrder.length - 1; i++) {

--- a/navigation-timing/nav2_test_redirect_server.html
+++ b/navigation-timing/nav2_test_redirect_server.html
@@ -9,6 +9,7 @@
         <script src="/resources/testharnessreport.js"></script>
 
         <script>
+            setup({ single_test: true });
 
             function verifyTimingEventOrder(eventOrder, timingEntry) {
                 for (let i = 0; i < eventOrder.length - 1; i++) {

--- a/navigation-timing/nav2_test_redirect_xserver.html
+++ b/navigation-timing/nav2_test_redirect_xserver.html
@@ -9,6 +9,7 @@
         <script src="/resources/testharnessreport.js"></script>
         <script src="/common/utils.js"></script>
         <script>
+            setup({ single_test: true });
 
             function onload_test()
             {


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md