### PR TITLE
[mediacapture-streams] Refactor test

### DIFF
--- a/mediacapture-streams/MediaDevices-SecureContext.html
+++ b/mediacapture-streams/MediaDevices-SecureContext.html
@@ -7,14 +7,13 @@
 </head>
 <body>
 <script>
-
-assert_false(window.isSecureContext, "This test must be run in a non secure context");
-assert_false('MediaDevices' in window, "MediaDevices is not exposed");
-assert_false('MediaDeviceInfo' in window, "MediaDeviceInfo is not exposed");
-assert_false('getUserMedia' in navigator, "getUserMedia is not exposed");
-assert_false('mediaDevices' in navigator, "mediaDevices is not exposed");
-
-done();
+test(function() {
+  assert_false(window.isSecureContext, "This test must be run in a non secure context");
+  assert_false('MediaDevices' in window, "MediaDevices is not exposed");
+  assert_false('MediaDeviceInfo' in window, "MediaDeviceInfo is not exposed");
+  assert_false('getUserMedia' in navigator, "getUserMedia is not exposed");
+  assert_false('mediaDevices' in navigator, "mediaDevices is not exposed");
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to instead declare
a single subtest (so that it is no longer a single-page test).

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md