### PR TITLE
[infrastructure] Refactor tests & extend coverage

### DIFF
--- a/infrastructure/browsers/firefox/prefs.html
+++ b/infrastructure/browsers/firefox/prefs.html
@@ -2,7 +2,8 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-assert_equals(getComputedStyle(document.documentElement).color, "rgb(0, 255, 0)")
-done();
+test(function() {
+  assert_equals(getComputedStyle(document.documentElement).color, "rgb(0, 255, 0)")
+});
 </script>
 <p>This should be green</p>

--- a/infrastructure/expected-fail/uncaught-exception-following-subtest.html
+++ b/infrastructure/expected-fail/uncaught-exception-following-subtest.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Uncaught exception following subtest</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {});
+throw new Error("error outside any setup or test");
+</script>

--- a/infrastructure/expected-fail/uncaught-exception-single-test.html
+++ b/infrastructure/expected-fail/uncaught-exception-single-test.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Uncaught exception in single-page test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({ single_test: true });
+throw new Error("error outside any setup or test");
+</script>

--- a/infrastructure/expected-fail/unhandled-rejection-following-subtest.html
+++ b/infrastructure/expected-fail/unhandled-rejection-following-subtest.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Unhandled rejection following subtest</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {});
+Promise.reject(new Error("error outside any setup or test"));
+</script>

--- a/infrastructure/expected-fail/unhandled-rejection-single-test.html
+++ b/infrastructure/expected-fail/unhandled-rejection-single-test.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Unhandled rejection in single-page test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({ single_test: true });
+Promise.reject(new Error("error outside any setup or test"));
+</script>

--- a/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception-following-subtest.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception-following-subtest.html.ini
@@ -1,0 +1,6 @@
+[uncaught-exception-following-subtest.html]
+  expected: ERROR
+
+  [Uncaught exception following subtest]
+    expected: PASS
+

--- a/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception-single-test.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception-single-test.html.ini
@@ -1,0 +1,4 @@
+[uncaught-exception-single-test.html]
+  [Uncaught exception in single-page test]
+    expected: FAIL
+

--- a/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection-following-subtest.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection-following-subtest.html.ini
@@ -1,0 +1,6 @@
+[unhandled-rejection-following-subtest.html]
+  expected: ERROR
+
+  [Unhandled rejection following subtest]
+    expected: PASS
+

--- a/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection-single-test.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection-single-test.html.ini
@@ -1,0 +1,4 @@
+[unhandled-rejection-single-test.html]
+  [Unhandled rejection in single-page test]
+    expected: FAIL
+

--- a/infrastructure/testdriver/file_upload.sub.html
+++ b/infrastructure/testdriver/file_upload.sub.html
@@ -9,18 +9,18 @@
   <input id="file_input" name="file_input" type="file">
 </form>
 <script>
-let form = document.getElementById("form");
-let input = document.getElementById("file_input");
-test_driver
-  .send_keys(input, "{{fs_path(file_upload_data.txt)}}")
-  .then(() =>
-    fetch("file_upload.py",
-      {method: "POST",
-       body: new FormData(form)}))
-   .then(response => response.text())
-   .then(data => {
-     assert_equals(data, "PASS");
-     done();
-   })
-   .catch(() => assert_unreached("File upload failed"));
+promise_test(() => {
+  let form = document.getElementById("form");
+  let input = document.getElementById("file_input");
+  return test_driver
+    .send_keys(input, "{{fs_path(file_upload_data.txt)}}")
+    .then(() =>
+      fetch("file_upload.py",
+        {method: "POST",
+         body: new FormData(form)}))
+     .then(response => response.text())
+     .then(data => {
+       assert_equals(data, "PASS");
+     });
+});
 </script>


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update some tests which previously opted in implicitly to use the new
API. Update others to instead declare a single subtest (so that they are
no longer single-page tests). Add new tests to fully cover the
conditions under which an uncaught exception or unhandled rejection
could occur.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md