### PR TITLE
[html] Refactor tests

### DIFF
--- a/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function-parent.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function-parent.html
@@ -6,6 +6,7 @@
 <div id=log></div>
 <iframe></iframe>
 <script>
+  setup({ single_test: true });
   onload = function() {
     var fr = document.querySelector("iframe")
     fr.contentWindow.location = "support/dummy.html"

--- a/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-src-about-blank.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-src-about-blank.html
@@ -6,6 +6,7 @@
 <div id=log></div>
 <iframe></iframe>
 <script>
+  setup({ single_test: true });
   onload = function() {
     var fr = document.querySelector("iframe")
     fr.src = "about:blank"

--- a/html/interaction/focus/the-autofocus-attribute/not-on-first-task.html
+++ b/html/interaction/focus/the-autofocus-attribute/not-on-first-task.html
@@ -13,10 +13,10 @@
 <script>
 "use strict";
 
-const input = document.querySelector("input");
+test(() => {
+  const input = document.querySelector("input");
 
-assert_equals(document.activeElement, document.body);
-assert_not_equals(document.activeElement, input);
-
-done();
+  assert_equals(document.activeElement, document.body);
+  assert_not_equals(document.activeElement, input);
+});
 </script>

--- a/html/rendering/non-replaced-elements/flow-content-0/dialog-display.html
+++ b/html/rendering/non-replaced-elements/flow-content-0/dialog-display.html
@@ -7,6 +7,7 @@
 </style>
 <dialog open id=dialog></dialog>
 <script>
-assert_equals(getComputedStyle(document.getElementById('dialog')).display, 'block');
-done();
+test(function() {
+  assert_equals(getComputedStyle(document.getElementById('dialog')).display, 'block');
+});
 </script>

--- a/html/rendering/non-replaced-elements/margin-collapsing-quirks/compare-computed-style.js
+++ b/html/rendering/non-replaced-elements/margin-collapsing-quirks/compare-computed-style.js
@@ -1,6 +1,7 @@
-var testStyle = getComputedStyle(document.getElementById('test'));
-var refStyle = getComputedStyle(document.getElementById('ref'));
-for (var prop in testStyle) {
-  assert_equals(testStyle[prop], refStyle[prop], prop);
-}
-done();
+test(function() {
+  var testStyle = getComputedStyle(document.getElementById('test'));
+  var refStyle = getComputedStyle(document.getElementById('ref'));
+  for (var prop in testStyle) {
+    assert_equals(testStyle[prop], refStyle[prop], prop);
+  }
+});

--- a/html/rendering/non-replaced-elements/tables/table-vspace-hspace-s.html
+++ b/html/rendering/non-replaced-elements/tables/table-vspace-hspace-s.html
@@ -7,9 +7,10 @@
 <table vspace=25 hspace=25><tr><td>x</table>
 <div>x</div>
 <script>
-var style = getComputedStyle(document.querySelector('table'));
-['marginTop', 'marginRight', 'marginBottom', 'marginLeft'].forEach(function(m) {
-  assert_equals(style[m], '0px', m);
+test(function() {
+  var style = getComputedStyle(document.querySelector('table'));
+  ['marginTop', 'marginRight', 'marginBottom', 'marginLeft'].forEach(function(m) {
+    assert_equals(style[m], '0px', m);
+  });
 });
-done();
 </script>

--- a/html/rendering/non-replaced-elements/tables/table-vspace-hspace.html
+++ b/html/rendering/non-replaced-elements/tables/table-vspace-hspace.html
@@ -7,9 +7,10 @@
 <table vspace=25 hspace=25><tr><td>x</table>
 <div>x</div> <!-- prevent margin collapsing quirks -->
 <script>
-var style = getComputedStyle(document.querySelector('table'));
-['marginTop', 'marginRight', 'marginBottom', 'marginLeft'].forEach(function(m) {
-  assert_equals(style[m], '0px', m);
+test(function() {
+  var style = getComputedStyle(document.querySelector('table'));
+  ['marginTop', 'marginRight', 'marginBottom', 'marginLeft'].forEach(function(m) {
+    assert_equals(style[m], '0px', m);
+  });
 });
-done();
 </script>

--- a/html/rendering/non-replaced-elements/the-page/iframe-marginwidth-marginheight.html
+++ b/html/rendering/non-replaced-elements/the-page/iframe-marginwidth-marginheight.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <iframe src="/common/blank.html" marginwidth=0 marginheight=0></iframe>
 <script>
+setup({ single_test: true });
 onload = () => {
   assert_equals(window[0].document.body.attributes.length, 0, "Number of attributes on the child document's body");
   done();

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/allow-scripts-flag-changing-1.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/allow-scripts-flag-changing-1.html
@@ -9,6 +9,7 @@
 
 <script>
 "use strict";
+setup({ single_test: true });
 
 const sourceIFrame = document.createElement("iframe");
 sourceIFrame.setAttribute("sandbox", "allow-same-origin");

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/allow-scripts-flag-changing-2.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/allow-scripts-flag-changing-2.html
@@ -9,6 +9,7 @@
 
 <script>
 "use strict";
+setup({ single_test: true });
 
 const sourceIFrame = document.createElement("iframe");
 

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/dynamic-append.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/dynamic-append.html
@@ -9,6 +9,7 @@
 
 <script>
 "use strict";
+setup({ single_test: true });
 
 const iframe = document.createElement("iframe");
 let loadCount = 0;

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/not-in-shadow-tree.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/not-in-shadow-tree.html
@@ -9,6 +9,7 @@
 <div id="log"></div>
 <script>
 "use strict";
+setup({ single_test: true });
 
 const iframe = document.createElement("iframe");
 iframe.src = "support/ufoo";

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/remove-from-document.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/remove-from-document.html
@@ -9,6 +9,7 @@
 
 <script>
 "use strict";
+setup({ single_test: true });
 
 const sourceIFrame = document.createElement("iframe");
 let sourceLoadCount = 0;

--- a/html/semantics/embedded-content/media-elements/ready-states/autoplay-with-slow-text-tracks.html
+++ b/html/semantics/embedded-content/media-elements/ready-states/autoplay-with-slow-text-tracks.html
@@ -5,6 +5,7 @@
 <script src="/common/media.js"></script>
 <div id="log"></div>
 <script>
+setup({ single_test: true });
 // https://html.spec.whatwg.org/#ready-states says:
 //
 // HAVE_FUTURE_DATA: "the text tracks are ready".

--- a/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_01.html
+++ b/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_01.html
@@ -6,6 +6,7 @@
 <iframe src="about:blank"></iframe>
 <div id="target"></div>
 <script>
+setup({ single_test: true });
 onload = function() {
   var ifr = document.getElementsByTagName('iframe')[0];
   ifr.contentDocument.body.appendChild(ifr.contentDocument.createElement('p')).textContent = 'Modified document';

--- a/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_02.html
+++ b/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_02.html
@@ -6,6 +6,7 @@
 <iframe src="about:blank"></iframe>
 <div id="target"></div>
 <script>
+setup({ single_test: true });
 onload = function() {
   var ifr = document.getElementsByTagName('iframe')[0];
   ifr.contentDocument.open();

--- a/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_03.html
+++ b/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_03.html
@@ -6,6 +6,7 @@
 <iframe src="support/blank.htm"></iframe>
 <div id="target"></div>
 <script>
+setup({ single_test: true });
 onload = function() {
   var ifr = document.getElementsByTagName('iframe')[0];
   ifr.contentDocument.body.appendChild(ifr.contentDocument.createElement('p')).textContent = 'Modified document';

--- a/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_04.html
+++ b/html/semantics/embedded-content/the-iframe-element/move_iframe_in_dom_04.html
@@ -6,6 +6,7 @@
 <iframe src="support/blank.htm"></iframe>
 <div id="target"></div>
 <script>
+setup({ single_test: true });
 onload = function(){
   var ifr = document.getElementsByTagName('iframe')[0];
   ifr.contentDocument.open();

--- a/html/semantics/embedded-content/the-img-element/data-url.html
+++ b/html/semantics/embedded-content/the-img-element/data-url.html
@@ -5,6 +5,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
+setup({ single_test: true });
+
 var c = document.createElement("canvas"),
     con = c.getContext("2d"),
     img = document.createElement("img")

--- a/html/semantics/embedded-content/the-img-element/srcset/avoid-reload-on-resize.html
+++ b/html/semantics/embedded-content/the-img-element/srcset/avoid-reload-on-resize.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-setup({explicit_done:true});
+setup({single_test:true});
 const image_was_loaded = () => {
   const iframe = document.getElementById("iframe");
   // Resize the iframe

--- a/html/semantics/embedded-content/the-img-element/update-src-complete.html
+++ b/html/semantics/embedded-content/the-img-element/update-src-complete.html
@@ -5,6 +5,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <p id="display"><img src="image.png"></p>
 <script>
+    setup({ single_test: true });
+
     function check() {
         var img = document.querySelector("img");
         assert_true(img.complete, "By onload, image should have loaded");

--- a/html/webappapis/timers/negative-setinterval.html
+++ b/html/webappapis/timers/negative-setinterval.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({ single_test: true });
 var i = 0;
 var interval;
 function next() {

--- a/html/webappapis/timers/negative-settimeout.html
+++ b/html/webappapis/timers/negative-settimeout.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+ setup({ single_test: true });
  setTimeout(done, -100);
  setTimeout(assert_unreached, 10);
 </script>

--- a/html/webappapis/timers/type-long-setinterval.html
+++ b/html/webappapis/timers/type-long-setinterval.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({ single_test: true });
 var interval;
 function next() {
   clearInterval(interval);

--- a/html/webappapis/timers/type-long-settimeout.html
+++ b/html/webappapis/timers/type-long-settimeout.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({ single_test: true });
 setTimeout(done, Math.pow(2, 32));
 setTimeout(assert_unreached, 100);
 </script>


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update some tests which previously opted in implicitly to use the new
API. Update others to instead declare a single subtest (so that they are
no longer single-page tests).

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md