### PR TITLE
[fetch] Opt-in to single-page test feature

### DIFF
--- a/fetch/content-length/content-length.html
+++ b/fetch/content-length/content-length.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({ single_test: true });
 onload = function() {
   assert_equals(document.body.textContent, "PASS");
   done();

--- a/fetch/content-length/content-length.html.headers
+++ b/fetch/content-length/content-length.html.headers
@@ -1,1 +1,1 @@
-Content-Length: 373
+Content-Length: 403

--- a/fetch/corb/script-js-mislabeled-as-html-nosniff.sub.html
+++ b/fetch/corb/script-js-mislabeled-as-html-nosniff.sub.html
@@ -16,6 +16,7 @@
 <div id=log></div>
 
 <script>
+setup({ single_test: true });
 window.has_executed_script = false;
 </script>
 

--- a/fetch/corb/script-js-mislabeled-as-html.sub.html
+++ b/fetch/corb/script-js-mislabeled-as-html.sub.html
@@ -8,6 +8,7 @@
 <div id=log></div>
 
 <script>
+setup({ single_test: true });
 window.has_executed_script = false;
 </script>
 

--- a/fetch/corb/script-resource-with-nonsniffable-types.tentative.sub.html
+++ b/fetch/corb/script-resource-with-nonsniffable-types.tentative.sub.html
@@ -14,7 +14,7 @@
 <script src="/common/utils.js"></script>
 <div id=log></div>
 <script>
-setup({allow_uncaught_exception : true});
+setup({allow_uncaught_exception : true, single_test : true});
 
 function test(mime_type, is_blocking_expected) {
   var action = is_blocking_expected ? "blocks" : "does not block";

--- a/fetch/corb/style-css-mislabeled-as-html-nosniff.sub.html
+++ b/fetch/corb/style-css-mislabeled-as-html-nosniff.sub.html
@@ -9,6 +9,7 @@
   - fetch/nosniff/stylesheet.html
 -->
 <meta charset="utf-8">
+<title>CSS is not applied (because of nosniff + non-text/css headers)</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 
@@ -31,11 +32,11 @@ h1 { color: green; }
 </body>
 
 <script>
-// Verify that CSS is not applied (because of nosniff + non-text/css headers).
-let style = getComputedStyle(document.getElementById('header'));
-const external_color = 'rgb(255, 0, 0)';  // red
-const default_color = 'rgb(0, 128, 0)';  // green
-assert_equals(style.getPropertyValue('color'), default_color);
-assert_not_equals(style.getPropertyValue('color'), external_color);
-done();
+test(() => {
+  let style = getComputedStyle(document.getElementById('header'));
+  const external_color = 'rgb(255, 0, 0)';  // red
+  const default_color = 'rgb(0, 128, 0)';  // green
+  assert_equals(style.getPropertyValue('color'), default_color);
+  assert_not_equals(style.getPropertyValue('color'), external_color);
+});
 </script>

--- a/fetch/corb/style-css-mislabeled-as-html.sub.html
+++ b/fetch/corb/style-css-mislabeled-as-html.sub.html
@@ -3,6 +3,7 @@
   as text/html (because even without CORB mislabeled CSS will be rejected).
 -->
 <meta charset="utf-8">
+<title>CSS is not applied (because of strict content-type enforcement for cross-origin stylesheets)</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 
@@ -25,12 +26,11 @@ h1 { color: green; }
 </body>
 
 <script>
-// Verify that CSS is not applied (because of strict content-type enforcement
-// for cross-origin stylesheets).
-let style = getComputedStyle(document.getElementById('header'));
-const external_color = 'rgb(255, 0, 0)';  // red
-const default_color = 'rgb(0, 128, 0)';  // green
-assert_equals(style.getPropertyValue('color'), default_color);
-assert_not_equals(style.getPropertyValue('color'), external_color);
-done();
+test(() => {
+  let style = getComputedStyle(document.getElementById('header'));
+  const external_color = 'rgb(255, 0, 0)';  // red
+  const default_color = 'rgb(0, 128, 0)';  // green
+  assert_equals(style.getPropertyValue('color'), default_color);
+  assert_not_equals(style.getPropertyValue('color'), external_color);
+});
 </script>

--- a/fetch/corb/style-css-with-json-parser-breaker.sub.html
+++ b/fetch/corb/style-css-with-json-parser-breaker.sub.html
@@ -4,6 +4,7 @@
      2) starts with a JSON parser breaker (like )]}')
 -->
 <meta charset="utf-8">
+<title>CORB doesn't block a stylesheet that has a proper Content-Type and begins with a JSON parser breaker</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 
@@ -26,11 +27,12 @@ h1 { color: green; }
 </body>
 
 <script>
-// Verify that CSS got applied / did not get blocked by CORB.
-let style = getComputedStyle(document.getElementById('header'));
-const external_color = 'rgb(255, 0, 0)';  // red
-const default_color = 'rgb(0, 128, 0)';  // green
-assert_equals(style.getPropertyValue('color'), external_color);
-assert_not_equals(style.getPropertyValue('color'), default_color);
-done();
+test(() => {
+  // Verify that CSS got applied / did not get blocked by CORB.
+  let style = getComputedStyle(document.getElementById('header'));
+  const external_color = 'rgb(255, 0, 0)';  // red
+  const default_color = 'rgb(0, 128, 0)';  // green
+  assert_equals(style.getPropertyValue('color'), external_color);
+  assert_not_equals(style.getPropertyValue('color'), default_color);
+});
 </script>

--- a/fetch/corb/style-html-correctly-labeled.sub.html
+++ b/fetch/corb/style-html-correctly-labeled.sub.html
@@ -11,6 +11,7 @@
     CORB-blocked response as a stylesheet.
 -->
 <meta charset="utf-8">
+<title>CSS is not applied (because of mismatched Content-Type header)</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 
@@ -32,9 +33,9 @@ h1 { color: green; }
 </body>
 
 <script>
-// Verify that CSS is not applied (because of mismatched Content-Type header).
-var style = getComputedStyle(document.getElementById('header'));
-const default_color = 'rgb(0, 128, 0)';  // green
-assert_equals(style.getPropertyValue('color'), default_color);
-done();
+test(() => {
+  var style = getComputedStyle(document.getElementById('header'));
+  const default_color = 'rgb(0, 128, 0)';  // green
+  assert_equals(style.getPropertyValue('color'), default_color);
+});
 </script>

--- a/fetch/images/canvas-remote-read-remote-image-redirect.html
+++ b/fetch/images/canvas-remote-read-remote-image-redirect.html
@@ -5,6 +5,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <script>
+setup({ single_test: true });
 var image = new Image();
 image.onload = function() {
     const canvas = document.createElement("canvas");


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md