### PR TITLE
[dom] Opt-in to single-page test feature

### DIFF
--- a/dom/nodes/Element-getElementsByTagName-change-document-HTMLNess.html
+++ b/dom/nodes/Element-getElementsByTagName-change-document-HTMLNess.html
@@ -5,6 +5,7 @@
 <script src=/resources/testharnessreport.js></script>
 <iframe src="Element-getElementsByTagName-change-document-HTMLNess-iframe.xml"></iframe>
 <script>
+  setup({ single_test: true });
   onload = function() {
     var parent = document.createElement("div");
     var child1 = document.createElementNS("http://www.w3.org/1999/xhtml", "a");


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md