### PR TITLE
[css-shapes] Refactor tests

### DIFF
--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-radial-gradient-001.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-radial-gradient-001.html
@@ -55,12 +55,17 @@
     </div>
     <div id="log"></div>
     <script>
+    test(function() {
+      assert_true(
         verifyTextPoints({
                 roundedRect: {x: 0, y: 10, width: 100, height: 100, rx: 50, ry: 50},
                 containerWidth: 200,
                 containerHeight: 200,
                 lineHeight: 10
-        }, 10, 1.5);
+        }, 10, 1.5),
+        "Lines positioned properly around the shape."
+      );
+    });
      </script>
 </body>
 </html>

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-radial-gradient-002.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-radial-gradient-002.html
@@ -58,12 +58,17 @@
     </div>
     <div id="log"></div>
     <script>
+    test(function() {
+      assert_true(
         verifyTextPoints({
                 roundedRect: {x: 0, y: 10, width: 100, height: 100, rx: 50, ry: 50},
                 containerWidth: 200,
                 containerHeight: 200,
                 lineHeight: 10
-        }, 10, 1);
+        }, 10, 1),
+        "Lines positioned properly around the shape."
+      );
+    });
      </script>
 </body>
 </html>

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-radial-gradient-003.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-radial-gradient-003.html
@@ -60,12 +60,17 @@
     </div>
     <div id="log"></div>
     <script>
+    test(function() {
+      assert_true(
         verifyTextPoints({
                 roundedRect: {x: 0, y: 10, width: 100, height: 100, rx: 50, ry: 50},
                 containerWidth: 200,
                 containerHeight: 200,
                 lineHeight: 10
-        }, 10, 1.5);
+        }, 10, 1.5),
+        "Lines positioned properly around the shape."
+      );
+    });
      </script>
 </body>
 </html>

--- a/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-radial-gradient-004.html
+++ b/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-radial-gradient-004.html
@@ -59,12 +59,17 @@
     </div>
     <div id="log"></div>
     <script>
+    test(function() {
+      assert_true(
         verifyTextPoints({
                 roundedRect: {x: 100, y: 10, width: 100, height: 100, rx: 50, ry: 50},
                 containerWidth: 200,
                 containerHeight: 200,
                 lineHeight: 10
-        }, 10, 1, "right");
+        }, 10, 1, "right"),
+        "Lines positioned properly around the shape."
+      );
+    });
      </script>
 </body>
 </html>

--- a/css/css-shapes/shape-outside/supported-shapes/support/test-utils.js
+++ b/css/css-shapes/shape-outside/supported-shapes/support/test-utils.js
@@ -1,5 +1,5 @@
 function verifyTextPoints(shape, numLines, tolerance, side) {
-    var failed = false;
+    var passed = true;
     if (tolerance === undefined)
         tolerance = 0.5;
     if (side === undefined)
@@ -19,11 +19,9 @@ function verifyTextPoints(shape, numLines, tolerance, side) {
         if( Math.abs( (actual - expected[i])) > tolerance ){
             line.style.setProperty('color', 'red');
             console.log('diff: ' + Math.abs(actual - expected[i]));
-            failed = true;
+            passed = false;
         }
     }
-    if (window.done) {
-        assert_false(failed, "Lines positioned properly around the shape.");
-        done();
-    }
+
+    return passed;
 }

--- a/css/css-shapes/spec-examples/shape-outside-010.html
+++ b/css/css-shapes/spec-examples/shape-outside-010.html
@@ -32,8 +32,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({ single_test: true });
     function checkFloats() {
       approxShapeTest('test', 'line-', 2, [182, 199, 201, 199, 182, 0]);
+      done();
     }
     </script>
 </head>

--- a/css/css-shapes/spec-examples/shape-outside-011.html
+++ b/css/css-shapes/spec-examples/shape-outside-011.html
@@ -32,8 +32,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({ single_test: true });
     function checkFloats() {
       approxShapeTest('test', 'line-', 2, [218, 236, 238, 236, 218, 160]);
+      done();
     }
     </script>
 </head>

--- a/css/css-shapes/spec-examples/shape-outside-012.html
+++ b/css/css-shapes/spec-examples/shape-outside-012.html
@@ -34,8 +34,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({ single_test: true });
     function checkFloats() {
       approxShapeTest('test', 'line-', 2, [181, 199, 201, 199, 181, 0]);
+      done();
     }
     </script>
 </head>

--- a/css/css-shapes/spec-examples/shape-outside-013.html
+++ b/css/css-shapes/spec-examples/shape-outside-013.html
@@ -42,8 +42,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({ single_test: true });
     function checkFloats() {
       approxShapeTest('test', 'line-', 2, [200, 214, 216, 214, 200, 158, 0]);
+      done();
     }
     </script>
 </head>

--- a/css/css-shapes/spec-examples/shape-outside-014.html
+++ b/css/css-shapes/spec-examples/shape-outside-014.html
@@ -46,8 +46,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({ single_test: true });
     function checkFloats() {
       approxShapeTest('test', 'line-', 3, [182, 198, 200, 198, 182, 0]);
+      done();
     }
     </script>
 </head>

--- a/css/css-shapes/spec-examples/shape-outside-015.html
+++ b/css/css-shapes/spec-examples/shape-outside-015.html
@@ -34,8 +34,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({ single_test: true });
     function checkFloats() {
       approxShapeTest('test', 'line-', 2, [185, 199, 200, 199, 185, 0]);
+      done();
     }
     </script>
 </head>

--- a/css/css-shapes/spec-examples/shape-outside-016.html
+++ b/css/css-shapes/spec-examples/shape-outside-016.html
@@ -34,8 +34,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({ single_test: true });
     function checkFloats() {
       approxShapeTest('test', 'line-', 2, [185, 199, 200, 199, 185, 0]);
+      done();
     }
     </script>
 </head>

--- a/css/css-shapes/spec-examples/shape-outside-017.html
+++ b/css/css-shapes/spec-examples/shape-outside-017.html
@@ -33,8 +33,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({ single_test: true });
     function checkFloats() {
       approxShapeTest('test', 'line-', 2, [185, 199, 200, 199, 185, 0]);
+      done();
     }
     </script>
 </head>

--- a/css/css-shapes/spec-examples/shape-outside-018.html
+++ b/css/css-shapes/spec-examples/shape-outside-018.html
@@ -39,7 +39,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
     document.fonts.ready.then(()=> {
       approxShapeTest('test', 'line-', 2, [48, 88, 128, 168, 180, 0]);
       done();

--- a/css/css-shapes/spec-examples/shape-outside-019.html
+++ b/css/css-shapes/spec-examples/shape-outside-019.html
@@ -41,8 +41,10 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="support/spec-example-utils.js"></script>
     <script>
+    setup({ single_test: true });
     function checkFloats() {
       approxShapeTest('test', 'line-', 2, [242, 256, 258, 256, 242, 204, 0]);
+      done();
     }
     </script>
 </head>

--- a/css/css-shapes/spec-examples/support/spec-example-utils.js
+++ b/css/css-shapes/spec-examples/support/spec-example-utils.js
@@ -11,7 +11,6 @@ function approxShapeTest(testId, linePrefix, epsilon, lineOffsets) {
             var line = document.getElementById(linePrefix + i);
             assert_approx_equals(line.offsetLeft, lineOffsets[i] + testOffset, epsilon, 'Line ' + i + ' is positioned properly');
         }
-        done();
     }
     runTest();
 }


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update some tests which previously opted in implicitly to use the new
API. Update others to instead declare a single subtest (so that they are
no longer single-page tests).

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md