### PR TITLE
[css-lists] Opt-in to single-page test feature

### DIFF
--- a/css/css-lists/nested-list-with-list-style-type-none.html
+++ b/css/css-lists/nested-list-with-list-style-type-none.html
@@ -20,6 +20,10 @@ li {
   </ul>
   <script type="text/javascript">
     setup({ single_test: true });
+    // TODO(jugglinmike): If accepted, WPT RFC #33 will introduce a new test
+    // type intended to simplify tests like this one. Refactor this test to the
+    // new test type following its acceptance.
+    // https://github.com/web-platform-tests/rfcs/pull/33
     done();
   </script>
 </body>

--- a/css/css-lists/nested-list-with-list-style-type-none.html
+++ b/css/css-lists/nested-list-with-list-style-type-none.html
@@ -19,6 +19,7 @@ li {
     </li>
   </ul>
   <script type="text/javascript">
+    setup({ single_test: true });
     done();
   </script>
 </body>


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md