### PR TITLE
[content-security-policy] Opt-in to single-page test feature

### DIFF
--- a/content-security-policy/script-src/scripthash-default-src.sub.html
+++ b/content-security-policy/script-src/scripthash-default-src.sub.html
@@ -6,8 +6,9 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script nonce='abc'>
+        setup({ single_test: true });
         window.addEventListener('securitypolicyviolation', function(e) {
-            test(function() { assert_unreached("Should not have fired event")});
+            assert_unreached("Should not have fired event");
         });
     </script>
     

--- a/content-security-policy/style-src/stylehash-default-src.sub.html
+++ b/content-security-policy/style-src/stylehash-default-src.sub.html
@@ -6,8 +6,9 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>
+        setup({ single_test: true });
         window.addEventListener('securitypolicyviolation', function(e) {
-            test(function() { assert_unreached("securitypolicyviolat was fired")});
+            assert_unreached("securitypolicyviolat was fired");
         });
     </script>
     </head>


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md