### PR TITLE
[compat] Refactor test

### DIFF
--- a/compat/webkit-box-removing-triggering-anonymous-merge.html
+++ b/compat/webkit-box-removing-triggering-anonymous-merge.html
@@ -7,8 +7,9 @@
   text
 </div>
 <script>
-// Force a layout before removing.
-document.body.offsetTop;
-document.getElementById('target').remove();
-done();
+test(function() {
+  // Force a layout before removing.
+  document.body.offsetTop;
+  document.getElementById('target').remove();
+}, '-webkit-box: removal of child');
 </script>


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to instead declare
a single subtest (so that it is no longer a single-page test).

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md