### PR TITLE
[FileAPI] Opt-in to single-page test feature

### DIFF
--- a/FileAPI/url/multi-global-origin-serialization.sub.html
+++ b/FileAPI/url/multi-global-origin-serialization.sub.html
@@ -13,6 +13,7 @@
 
 <script>
 "use strict";
+setup({ single_test: true });
 document.domain = "{{host}}";
 
 window.onload = () => {


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md