### PR TITLE
[html] Convert srcdoc_change_hash.html to promise_test

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/srcdoc_change_hash.html
+++ b/html/semantics/embedded-content/the-iframe-element/srcdoc_change_hash.html
@@ -1,12 +1,10 @@
-<!--
-  Test same-document navigation inside an srcdoc iframe using location.hash
--->
+<title>same-document navigation inside an srcdoc iframe using location.hash</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script>
-  async function test() {
+  promise_test(async () => {
     // Wait until 'document' is available.
     await new Promise(resolve => window.addEventListener('load', resolve));
 
@@ -66,8 +64,5 @@
       await hash_changed;
       assert_equals(iframe.contentWindow.location.href, "about:srcdoc#2");
     }
-
-    done();
-  }
-  test();
+  });
 </script>


### PR DESCRIPTION
This is an alternative to adding `setup({ single_test: true })` in
https://github.com/web-platform-tests/wpt/pull/19918.