### PR TITLE
[Azure Pipelines] use `python -m ensurepip` instead of `easy_install pip`

### DIFF
--- a/tools/ci/azure/pip_install.yml
+++ b/tools/ci/azure/pip_install.yml
@@ -3,7 +3,7 @@ parameters:
 
 steps:
 - script: |
-    sudo easy_install pip
+    sudo python -m ensurepip
     # `sudo pip install` is not used because some packages (e.g. tox) depend on
     # system packages (e.g. setuptools) which cannot be upgraded due to System
     # Integrity Protection, see https://stackoverflow.com/a/33004920.


### PR DESCRIPTION
Based on investigation in https://github.com/web-platform-tests/wpt/issues/19753#issuecomment-546586311.