### PR TITLE
[Azure Pipelines] remove `pip` installation step on macOS

### DIFF
--- a/tools/ci/azure/pip_install.yml
+++ b/tools/ci/azure/pip_install.yml
@@ -3,7 +3,6 @@ parameters:
 
 steps:
 - script: |
-    sudo easy_install pip
     # `sudo pip install` is not used because some packages (e.g. tox) depend on
     # system packages (e.g. setuptools) which cannot be upgraded due to System
     # Integrity Protection, see https://stackoverflow.com/a/33004920.


### PR DESCRIPTION
`pip` is now available out of the box on Azure Pipelines.