### PR TITLE
Test some lazyload edge cases

### DIFF
--- a/loading/lazyload/META.yml
+++ b/loading/lazyload/META.yml
@@ -1,0 +1,3 @@
+spec: https://github.com/whatwg/html/pull/3752
+suggested_reviewers:
+  - domfarolino

--- a/loading/lazyload/common.js
+++ b/loading/lazyload/common.js
@@ -12,3 +12,20 @@ class ElementLoadPromise {
     return document.getElementById(this.element_id);
   }
 }
+
+// Returns if the image is complete and fully loaded as a non-placeholder image.
+function is_image_fully_loaded(image) {
+  if (!image.complete) {
+    return false;
+  }
+
+  let canvas = document.createElement('canvas');
+  canvas.width = canvas.height = 1;
+  let canvasContext = canvas.getContext("2d");
+  canvasContext.drawImage(image, 0, 0);
+  let data = canvasContext.getImageData(0, 0, canvas.width, canvas.height).data;
+
+  // Fully loaded image should not be a placeholder which is drawn as a
+  // translucent gray rectangle in placeholder_image.cc
+  return data[0] != 0xd9 || data[1] != 0xd9 || data[2] != 0xd9;
+}

--- a/loading/lazyload/common.js
+++ b/loading/lazyload/common.js
@@ -26,6 +26,6 @@ function is_image_fully_loaded(image) {
   let data = canvasContext.getImageData(0, 0, canvas.width, canvas.height).data;
 
   // Fully loaded image should not be a placeholder which is drawn as a
-  // translucent gray rectangle in placeholder_image.cc
+  // translucent gray rectangle.
   return data[0] != 0xd9 || data[1] != 0xd9 || data[2] != 0xd9;
 }

--- a/loading/lazyload/move-element-and-scroll.tentative.html
+++ b/loading/lazyload/move-element-and-scroll.tentative.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<head>
+  <title>Images with loading='lazy' load being moved to another document and then scrolled to.</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="common.js"></script>
+</head>
+
+<!--
+Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
+-->
+
+<body>
+  <img id="in_viewport" src='resources/image.png'>
+  <div style="height:10000px;"></div>
+  <img id="below_viewport" src='resources/image.png' loading="lazy">
+
+  <script>
+    var in_viewport_element = document.getElementById("in_viewport");
+    var below_viewport_element = document.getElementById("below_viewport");
+
+    async_test(function(t) {
+      var iframe = document.createElement('iframe');
+      iframe.srcdoc = "<body></body>";
+      iframe.onload = function() {
+        var adopted_img = iframe.contentDocument.adoptNode(below_viewport_element);
+        iframe.contentDocument.body.appendChild(adopted_img);
+        window.scrollTo(0, 10000);
+        t.step_timeout(function() { assert_false(is_image_fully_loaded(below_viewport_element)); t.done(); }, 1000);
+      };
+      document.body.insertBefore(iframe, in_viewport_element,);
+    }, "Test that <img> below viewport is not loaded when moved to another document and then scrolled to.");
+</script>
+</body>

--- a/loading/lazyload/move-element-and-scroll.tentative.html
+++ b/loading/lazyload/move-element-and-scroll.tentative.html
@@ -13,11 +13,11 @@ Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
 <body>
   <img id="in_viewport" src='resources/image.png'>
   <div style="height:10000px;"></div>
-  <img id="below_viewport" src='resources/image.png' loading="lazy">
+  <img id="below_viewport" src='resources/image.png?second' loading="lazy">
 
   <script>
-    var in_viewport_element = document.getElementById("in_viewport");
-    var below_viewport_element = document.getElementById("below_viewport");
+    const in_viewport_element = document.getElementById("in_viewport");
+    const below_viewport_element = document.getElementById("below_viewport");
 
     async_test(function(t) {
       var iframe = document.createElement('iframe');
@@ -26,9 +26,9 @@ Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
         var adopted_img = iframe.contentDocument.adoptNode(below_viewport_element);
         iframe.contentDocument.body.appendChild(adopted_img);
         window.scrollTo(0, 10000);
-        t.step_timeout(function() { assert_false(is_image_fully_loaded(below_viewport_element)); t.done(); }, 1000);
+        t.step_timeout(function() { assert_false(is_image_fully_loaded(below_viewport_element)); t.done(); }, 2000);
       };
-      document.body.insertBefore(iframe, in_viewport_element,);
+      document.body.insertBefore(iframe, in_viewport_element);
     }, "Test that <img> below viewport is not loaded when moved to another document and then scrolled to.");
 </script>
 </body>

--- a/loading/lazyload/remove-element-and-scroll.tentative.html
+++ b/loading/lazyload/remove-element-and-scroll.tentative.html
@@ -13,18 +13,18 @@ Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
 <body>
   <img id="in_viewport" src='resources/image.png'>
   <div style="height:10000px;"></div>
-  <img id="below_viewport" src='resources/image.png' loading="lazy">
+  <img id="below_viewport" src='resources/image.png?second' loading="lazy">
 
   <script>
-    var in_viewport_element = document.getElementById("in_viewport");
-    var below_viewport_element = document.getElementById("below_viewport");
+    const in_viewport_element = document.getElementById("in_viewport");
+    const below_viewport_element = document.getElementById("below_viewport");
 
     async_test(function(t) {
       below_viewport_element.remove();
       assert_false(is_image_fully_loaded(below_viewport_element));
       in_viewport_element.addEventListener("load", t.step_func(function() {
         window.scrollTo(0, 10000);
-        t.step_timeout(function() { assert_false(is_image_fully_loaded(below_viewport_element)); t.done(); }, 1000);
+        t.step_timeout(function() { assert_false(is_image_fully_loaded(below_viewport_element)); t.done(); }, 2000);
       }));
     }, "Test that <img> below viewport is not loaded when removed from the document and then scrolled to.");
   </script>

--- a/loading/lazyload/remove-element-and-scroll.tentative.html
+++ b/loading/lazyload/remove-element-and-scroll.tentative.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<head>
+  <title>Images with loading='lazy' load being removed and then scrolled to.</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="common.js"></script>
+</head>
+
+<!--
+Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
+-->
+
+<body>
+  <img id="in_viewport" src='resources/image.png'>
+  <div style="height:10000px;"></div>
+  <img id="below_viewport" src='resources/image.png' loading="lazy">
+
+  <script>
+    var in_viewport_element = document.getElementById("in_viewport");
+    var below_viewport_element = document.getElementById("below_viewport");
+
+    async_test(function(t) {
+      below_viewport_element.remove();
+      assert_false(is_image_fully_loaded(below_viewport_element));
+      in_viewport_element.addEventListener("load", t.step_func(function() {
+        window.scrollTo(0, 10000);
+        t.step_timeout(function() { assert_false(is_image_fully_loaded(below_viewport_element)); t.done(); }, 1000);
+      }));
+    }, "Test that <img> below viewport is not loaded when removed from the document and then scrolled to.");
+  </script>
+</body>


### PR DESCRIPTION
Add tests for lazy loading edge cases, removing a lazy loaded image before
scrolling to it and same but with the image moved to another document.