### PR TITLE
[docs] Fix markup in Android WebView instructions

### DIFF
--- a/docs/running-tests/android_webview.md
+++ b/docs/running-tests/android_webview.md
@@ -6,11 +6,11 @@ Currently, Android WebView support is experimental.
 
 ## Prerequisites
 
-#### Please check [Chrome for Android](chrome_android.md) for the common instructions for Android support first.
+Please check [Chrome for Android](chrome_android.md) for the common instructions for Android support first.
 
-#### Ensure you have a userdebug or eng Android build installed on the device.
+Ensure you have a userdebug or eng Android build installed on the device.
 
-#### Install an up-to-date version of system webview shell.
+Install an up-to-date version of system webview shell:
 1. Go to [chromium-browser-snapshots](https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Android/)
 2. Find the subdirectory with the highest number and click it, this number can be found
    in the "Commit Position" column of row "LAST_CHANGE" (at bottom of page).
@@ -21,7 +21,7 @@ Currently, Android WebView support is experimental.
    * Run an emulator with
      [writable system partition from command line](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/android_emulator.md/)
 
-#### If you have an issue with ChromeDriver version mismatch, try one of the following.
+If you have an issue with ChromeDriver version mismatch, try one of the following:
   * Try removing `_venv/bin/chromedriver` such that wpt runner can install a matching version
   automatically. Failing that, please check your environment path and make
   sure that no other ChromeDriver is used.
@@ -30,16 +30,16 @@ Currently, Android WebView support is experimental.
     ./wpt run --webdriver-binary <binary path> ...
     ```
 
-#### Configure host remap rules in the [webview commandline file](https://cs.chromium.org/chromium/src/android_webview/docs/commandline-flags.md?l=57).
+Configure host remap rules in the [webview commandline file](https://cs.chromium.org/chromium/src/android_webview/docs/commandline-flags.md?l=57):
 ```
 adb shell "echo '_ --host-resolver-rules=\"MAP nonexistent.*.test ~NOTFOUND, MAP *.test 127.0.0.1\"' > /data/local/tmp/webview-command-line"
 ```
 
-#### Ensure that `adb` can be found on your system's PATH.
+Ensure that `adb` can be found on your system's PATH.
 
 ## Running Tests
 
-#### Example command line:
+Example command line:
 
 ```bash
 ./wpt run --test-type=testharness android_webview <TESTS>


### PR DESCRIPTION
Headings were used far too much.