### PR TITLE
Reattach the node in resetScroll

### DIFF
--- a/css/cssom-view/scroll-behavior-element.html
+++ b/css/cssom-view/scroll-behavior-element.html
@@ -186,4 +186,20 @@
       assert_equals(scrollingElement.scrollTop, 0, "Final value of scrollTop");
     });
   }, "Aborting an ongoing smooth scrolling on an element with an instant scrolling");
+
+  promise_test(() => {
+    scrollNode(scrollingElement, "scroll", "smooth", elementToRevealLeft, elementToRevealTop);
+    return waitForScrollEnd(scrollingElement).then(() => {
+      assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Final value of scrollLeft after first smooth scroll");
+      assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop after first smooth scroll");
+      scrollNode(scrollingElement, "scroll", "instant", 0, 0);
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      scrollNode(scrollingElement, "scroll", "smooth", elementToRevealLeft, elementToRevealTop);
+      return waitForScrollEnd(scrollingElement).then(() => {
+        assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Final value of scrollLeft");
+        assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
+      });
+    });
+  }, "Test a combination of instant and smooth scroll");
 </script>

--- a/css/cssom-view/scroll-behavior-smooth-positions.html
+++ b/css/cssom-view/scroll-behavior-smooth-positions.html
@@ -67,6 +67,7 @@
     [0, initialPosition].forEach((initial) => {
       promise_test(() => {
         return new Promise(function(resolve, reject) {
+          resetScroll(overflowNode);
           scrollNode(overflowNode, "scroll", "instant", initial, initial);
           var oldValue = overflowNode[scrollTest.scrollAttribute];
           assert_equals(oldValue, initial, `${scrollTest.scrollAttribute} should be at initial position`);

--- a/css/cssom-view/support/scroll-behavior.js
+++ b/css/cssom-view/support/scroll-behavior.js
@@ -41,6 +41,10 @@ function waitForScrollEnd(elements) {
 }
 
 function resetScroll(scrollingElement) {
+  // Reattach the node, make sure it won't be affected by last scrolling.
+  var parentElement = scrollingElement.parentNode;
+  parentElement.removeChild(scrollingElement);
+  parentElement.appendChild(scrollingElement);
   // Try various methods to ensure the element position is reset immediately.
   scrollingElement.scrollLeft = 0;
   scrollingElement.scrollTop = 0;


### PR DESCRIPTION
Hi Fred,
This patch reattached the scrolling node in resetScroll(), make sure it won't be affected by last scrolling.
And add test with a combination of instant and smooth sroll.

PTAL, thanks:)