### PR TITLE
[ci] Emit changes to built website in logs

### DIFF
--- a/tools/ci/website_build.sh
+++ b/tools/ci/website_build.sh
@@ -52,6 +52,10 @@ touch .nojekyll
 # Publish the website by pushing the built contents to the `gh-pages` branch
 git add .
 
+echo This submission alters the compiled files as follows
+
+git diff --staged
+
 if is_pull_request ; then
   echo Submission comes from a pull request. Exiting without publishing.
 


### PR DESCRIPTION
In gh-19928, we recognized that reviewing changes to the website build process (particularly to the tooling) can be labor-intensive:

> @jugglinmike if an update like this would break the docs, would we know
> without doing a lot of manual work?

> Whether or not the resulting website is still acceptable is harder to say,
> but maybe not by that much. By building locally, one could compare the
> contents of the `_build/html` directory for both versions of recommonmark.

> That is pretty much what I suspected, a lot of manual work could reveal
> problems. Building regression testing is tricky if the output often change in
> ways that don't matter to users.
>
> So... I guess we just merge and hope.

This patch exposes that information in the continuous integration logs.