### PR TITLE
Fix the test descriptions in animation-fill-mode-001/003-manual.html

### DIFF
--- a/css/css-animations/animation-fill-mode-001-manual.html
+++ b/css/css-animations/animation-fill-mode-001-manual.html
@@ -32,8 +32,8 @@
 <body>
   <p>
     Test passes if there is a filled color square with 'Filler Text',
-    whose color gradually changes in the order:
-    YELLOW to GREEN to BLUE.
+    whose color gradually changes in the order: YELLOW to GREEN.
+    After the animation is finished, the color goes back to BLUE.
   </p>
   <div>Filler Text</div>
 </body>

--- a/css/css-animations/animation-fill-mode-003-manual.html
+++ b/css/css-animations/animation-fill-mode-003-manual.html
@@ -37,8 +37,8 @@
 <body>
   <p>
     Test passes if there is a filled color square with 'Filler Text',
-    whose color gradually changes in the order:
-    YELLOW to GREEN to BLUE.
+    whose color gradually changes in the order: YELLOW to GREEN.
+    After the animation is finished, the color goes back to BLUE.
   </p>
   <div>Filler Text</div>
 </body>


### PR DESCRIPTION
The css animation color's gradual changes in the tests
only include the two colors, yellow and green, not blue.
When the gradual color change is finished, the color goes back to blue.
The test descriptions could confuse the tester running this test cases,
this patch changes it.