### PR TITLE
[infra] update the epochs_update cronjob command (#19322)

### DIFF
--- a/tools/ci/epochs_update.sh
+++ b/tools/ci/epochs_update.sh
@@ -3,6 +3,37 @@ set -ex
 
 SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
 WPT_ROOT=$SCRIPT_DIR/../..
+
+EPOCHS=(
+epochs/three_hourly::3h
+epochs/six_hourly::6h
+epochs/twelve_hourly::12h
+epochs/daily::1d
+epochs/weekly::1w
+)
+
+function get_epoch_branch_name () {
+    echo ${1} | awk -F '::' '{print $1}'
+}
+
+function get_epoch_timeval () {
+    echo ${1} | awk -F '::' '{print $2}'
+}
+
+main () {
+    ALL_BRANCHES_NAMES=""
+    for e in "${EPOCHS[@]}";
+    do
+        EPOCH=$(get_epoch_timeval ${e})
+        EPOCH_BRANCH_NAME=$(get_epoch_branch_name ${e})
+        git branch ${EPOCH_BRANCH_NAME} $(./wpt rev-list --epoch ${EPOCH})
+        ALL_BRANCHES_NAMES="${ALL_BRANCHES_NAMES} ${EPOCH_BRANCH_NAME}"
+    done
+    # This is safe because `git push` will by default fail for a non-fast-forward
+    # push, for example if the remote branch is ahead of the local branch.
+    git push ${REMOTE} ${ALL_BRANCHES_NAMES}
+}
+
 cd $WPT_ROOT
 
 if [ -z "$GITHUB_TOKEN" ]; then
@@ -12,7 +43,4 @@ fi
 
 REMOTE=https://x-access-token:$GITHUB_TOKEN@github.com/web-platform-tests/wpt.git
 
-git branch epochs/three_hourly $(./wpt rev-list --epoch 3h)
-# This is safe because `git push` will by default fail for a non-fast-forward
-# push, for example if the remote branch is ahead of the local branch.
-git push $REMOTE epochs/three_hourly
+main


### PR DESCRIPTION
This patch complements the work initiated in the PR #19873 adding the still missing epochs branches to the cronjob executed by the Github Actions.

Related to issue #19322 and PR  #19536 #19873