### PR TITLE
[IndexedDB] Avoid race condition redux

### DIFF
--- a/IndexedDB/keypath-exceptions.htm
+++ b/IndexedDB/keypath-exceptions.htm
@@ -248,21 +248,31 @@ indexeddb_test(
     const array = [];
     array[99] = 1;
 
+    // Implemented as function wrapper to clean up
+    // immediately after use, otherwise it may
+    // interfere with the test harness.
     let getter_called = 0;
-    const prop = '50';
-    Object.defineProperty(Object.prototype, prop, {
-      enumerable: true, configurable: true,
-      get: () => {
-        ++getter_called;
-        return 'foo';
-      },
-    });
+    function with_proto_getter(f) {
+      const prop = '50';
+      Object.defineProperty(Object.prototype, prop, {
+        enumerable: true, configurable: true,
+        get: () => {
+          ++getter_called;
+          return 'foo';
+        }
+      });
+      try {
+        return f();
+      } finally {
+        delete Object.prototype[prop];
+      }
+    }
 
-    const request = tx.objectStore('store').put({index0: array}, 'key');
+    const request = with_proto_getter(
+      () => tx.objectStore('store').put({index0: array}, 'key'));
     request.onerror = t.unreached_func('put should not fail');
     request.onsuccess = t.step_func(function() {
       assert_equals(getter_called, 0, 'Prototype getter should not be called');
-      delete Object.prototype[prop];
       t.done();
     });
   },


### PR DESCRIPTION
One of the async subtests leaves a getter on Object.prototype across turns of the event loop, which can lead to flaky behavior. Scope the lifetime of the getter to a synchronous call following a pattern used elsewhere in the test file.

Pulling the test case into a separate file is insufficient as the getter can interfere with both the test harness and the webdriver implementation (specifically, chromedriver). 