### PR TITLE
[testharness.js] introduce `assert_precondition`

### DIFF
--- a/infrastructure/expected-fail/precondition-in-promise.html
+++ b/infrastructure/expected-fail/precondition-in-promise.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Precondition in promise</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+new Promise(() => {
+  assert_precondition(false);
+});
+</script>

--- a/infrastructure/expected-fail/precondition-in-setup.html
+++ b/infrastructure/expected-fail/precondition-in-setup.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Precondition in setup</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup(() => {
+  assert_precondition(false);
+});
+</script>

--- a/infrastructure/expected-fail/precondition-without-setup.html
+++ b/infrastructure/expected-fail/precondition-without-setup.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Precondition without wrapping setup</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+assert_precondition(false);
+</script>

--- a/infrastructure/expected-fail/precondition.html
+++ b/infrastructure/expected-fail/precondition.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Preconditions in tests</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_precondition(false, 'precondition 1');
+}, 'test');
+
+async_test((t) => {
+  assert_precondition(false, 'precondition 2');
+  t.done();
+}, 'async_test immediate');
+
+async_test((t) => {
+  t.step_timeout(() => {
+      assert_precondition(false, 'precondition 3');
+      t.done();
+  }, 100);
+}, 'async_test after timeout');
+
+promise_test(async () => {
+  assert_precondition(false, 'precondition 4');
+}, 'promise_test immediate');
+
+promise_test(async () => {
+  await Promise.resolve();
+  assert_precondition(false, 'precondition 5');
+}, 'promise_test after await');
+</script>

--- a/infrastructure/metadata/infrastructure/expected-fail/precondition-in-promise.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/precondition-in-promise.html.ini
@@ -1,0 +1,2 @@
+[precondition-in-promise.html]
+  expected: PRECONDITION_FAILED

--- a/infrastructure/metadata/infrastructure/expected-fail/precondition-in-setup.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/precondition-in-setup.html.ini
@@ -1,0 +1,2 @@
+[precondition-in-setup.html]
+  expected: PRECONDITION_FAILED

--- a/infrastructure/metadata/infrastructure/expected-fail/precondition-without-setup.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/precondition-without-setup.html.ini
@@ -1,0 +1,2 @@
+[precondition-without-setup.html]
+  expected: PRECONDITION_FAILED

--- a/infrastructure/metadata/infrastructure/expected-fail/precondition.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/precondition.html.ini
@@ -1,0 +1,15 @@
+[precondition.html]
+  [test]
+    expected: PRECONDITION_FAILED
+
+  [async_test immediate]
+    expected: PRECONDITION_FAILED
+
+  [async_test after timeout]
+    expected: PRECONDITION_FAILED
+
+  [promise_test immediate]
+    expected: PRECONDITION_FAILED
+
+  [promise_test after await]
+    expected: PRECONDITION_FAILED

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -58,12 +58,14 @@ def strip_server(url):
 class TestharnessResultConverter(object):
     harness_codes = {0: "OK",
                      1: "ERROR",
-                     2: "TIMEOUT"}
+                     2: "TIMEOUT",
+                     3: "PRECONDITION_FAILED"}
 
     test_codes = {0: "PASS",
                   1: "FAIL",
                   2: "TIMEOUT",
-                  3: "NOTRUN"}
+                  3: "NOTRUN",
+                  4: "PRECONDITION_FAILED"}
 
     def __call__(self, test, result, extra=None):
         """Convert a JSON result into a (TestResult, [SubtestResult]) tuple"""

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -47,12 +47,12 @@ class SubtestResult(object):
 
 class TestharnessResult(Result):
     default_expected = "OK"
-    statuses = {"OK", "ERROR", "INTERNAL-ERROR", "TIMEOUT", "EXTERNAL-TIMEOUT", "CRASH"}
+    statuses = {"OK", "ERROR", "INTERNAL-ERROR", "TIMEOUT", "EXTERNAL-TIMEOUT", "CRASH", "PRECONDITION_FAILED"}
 
 
 class TestharnessSubtestResult(SubtestResult):
     default_expected = "PASS"
-    statuses = {"PASS", "FAIL", "TIMEOUT", "NOTRUN"}
+    statuses = {"PASS", "FAIL", "TIMEOUT", "NOTRUN", "PRECONDITION_FAILED"}
 
 
 class ReftestResult(Result):

--- a/vibration/invalid-values.html
+++ b/vibration/invalid-values.html
@@ -8,6 +8,7 @@
 <div id='log'></div>
 <script>
   test(function() {
+    assert_precondition(navigator.vibrate, 'navigator.vibrate exists');
     assert_throws(new TypeError(), function() {
       navigator.vibrate();
     }, 'Argument is required, so was expecting a TypeError.');


### PR DESCRIPTION
This depends on mozlog 5.0 for the new PRECONDITION_FAILED status:
https://bugzilla.mozilla.org/show_bug.cgi?id=1589056

Implements https://github.com/web-platform-tests/rfcs/pull/16.

Includes parts of https://github.com/web-platform-tests/wpt/pull/16689.

Fixes https://github.com/web-platform-tests/wpt/issues/19844.