### PR TITLE
 [wptrunner/Chrome] Switch to --ignore-certificate-error

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -61,7 +61,9 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
         chrome_options["binary"] = kwargs["binary"]
 
     # Here we set a few Chrome flags that are always passed.
-    chrome_options["args"] = []
+    # ChromeDriver's "acceptInsecureCerts" capability only controls the current
+    # browsing context, whereas the CLI flag works for workers, too.
+    chrome_options["args"] = ["--ignore-certificate-errors"]
     # Allow audio autoplay without a user gesture.
     chrome_options["args"].append("--autoplay-policy=no-user-gesture-required")
     # Allow WebRTC tests to call getUserMedia.

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -39,7 +39,6 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     executor_kwargs["supports_eager_pageload"] = False
 
     capabilities = {
-        "acceptInsecureCerts": True,
         "goog:chromeOptions": {
             "prefs": {
                 "profile": {


### PR DESCRIPTION
This PR reverts #19402 and switches to a different approach because of https://github.com/web-platform-tests/wpt/pull/19999#issuecomment-548115986. See individual commits.

Please rebase-merge.