### PR TITLE
Cleanup Edge driver files after every run

### DIFF
--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -98,19 +98,20 @@ steps:
 
 - powershell: |
     ($webdriverFiles = Get-ChildItem -PATH "$env:systemdrive\*msedgedriver.exe" -Recurse) >$null 2>$null
-    if ($webdriverFiles.Count -gt 0) {
-      Write-Host "Found $($webdriverFiles.Count) msedgedriver binaries"
-      foreach ($file in $webdriverFiles) {
-        Write-Host "Deleting $file"
-        Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
-      }
-      $driverNotesFolder = Join-Path $webdriverFiles.Directory 'Driver_Notes'
-      if (Test-Path $driverNotesFolder) {
-        Write-Host "Delete $driverNotesFolder folder"
-        Remove-Item -Path $driverNotesFolder -Recurse -Force -ErrorAction SilentlyContinue
-      }
-      Write-Host "Delete downloaded zip file"
-      Remove-Item -Path $webdriverFiles.Directory -Filter "edgedriver*" -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Host "Found $($webdriverFiles.Count) msedgedriver binaries"
+    foreach ($file in $webdriverFiles) {
+      Write-Host "Deleting $file"
+      Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
+    }
+    ($driverNotesFolder = Get-ChildItem -PATH "$env:systemdrive\*Driver_Notes" -Recurse) >$null 2>$null
+    foreach ($file in $driverNotesFolder) {
+      Write-Host "Deleting $file folder"
+      Remove-Item -Path $file.FullName -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    ($zipFile = Get-ChildItem -PATH "$env:systemdrive\*edgedriver_*.zip" -Recurse) >$null 2>$null
+    foreach ($file in $zipFile) {
+      Write-Host "Deleting $file file"
+      Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
     }
   displayName: 'Cleanup Edge driver binaries'
   condition: always()

--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -98,10 +98,19 @@ steps:
 
 - powershell: |
     ($webdriverFiles = Get-ChildItem -PATH "$env:systemdrive\*msedgedriver.exe" -Recurse) >$null 2>$null
-    Write-Host "Found $($webdriverFiles.Count) msedgedriver binaries"
-    foreach ($file in $webdriverFiles) {
-      Write-Host "Deleting $file"
-      Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
+    if ($webdriverFiles.Count -gt 0) {
+      Write-Host "Found $($webdriverFiles.Count) msedgedriver binaries"
+      foreach ($file in $webdriverFiles) {
+        Write-Host "Deleting $file"
+        Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
+      }
+      $driverNotesFolder = Join-Path $webdriverFiles.Directory 'Driver_Notes'
+      if (Test-Path $driverNotesFolder) {
+        Write-Host "Delete $driverNotesFolder folder"
+        Remove-Item -Path $driverNotesFolder -Recurse -Force -ErrorAction SilentlyContinue
+      }
+      Write-Host "Delete downloaded zip file"
+      Remove-Item -Path $webdriverFiles.Directory -Filter "edgedriver*" -Recurse -Force -ErrorAction SilentlyContinue
     }
   displayName: 'Cleanup Edge driver binaries'
   condition: always()

--- a/tools/ci/azure/cleanup_win10.yml
+++ b/tools/ci/azure/cleanup_win10.yml
@@ -95,3 +95,15 @@ steps:
   condition: always()
   errorActionPreference: silentlyContinue
   ignoreLASTEXITCODE: true
+
+- powershell: |
+    ($webdriverFiles = Get-ChildItem -PATH "$env:systemdrive\*msedgedriver.exe" -Recurse) >$null 2>$null
+    Write-Host "Found $($webdriverFiles.Count) msedgedriver binaries"
+    foreach ($file in $webdriverFiles) {
+      Write-Host "Deleting $file"
+      Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
+    }
+  displayName: 'Cleanup Edge driver binaries'
+  condition: always()
+  errorActionPreference: silentlyContinue
+  ignoreLASTEXITCODE: true

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -874,10 +874,12 @@ class EdgeChromium(Browser):
         if os.path.isfile(edgedriver_path):
             # remove read-only attribute
             os.chmod(edgedriver_path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
+            print("Delete %s file" % edgedriver_path)
             os.remove(edgedriver_path)
-            driver_notes_path = os.path.join(dest, "Driver_notes")
-            if os.path.isdir(driver_notes_path):
-                shutil.rmtree(driver_notes_path, ignore_errors=False, onerror=handle_remove_readonly)
+        driver_notes_path = os.path.join(dest, "Driver_notes")
+        if os.path.isdir(driver_notes_path):
+            print("Delete %s folder" % driver_notes_path)
+            shutil.rmtree(driver_notes_path, ignore_errors=False, onerror=handle_remove_readonly)
 
         self.logger.info("Downloading MSEdgeDriver from %s" % url)
         unzip(get(url).raw, dest)


### PR DESCRIPTION
We need to ensure that Edge driver files (all files unzipped during setup stage) are deleted at the end of each run to ensure that Canary and Dev channel runs use matching driver binaries. Whenever our Canary builds change major version (ex from 79 to 80) then we end up with msedgedriver.exe Canary version that blocks running older Edge versions which leads to failures in our Dev channel runs (see #19975 for details). 

The fix is to always delete msedgedriver.exe file, Driver_Notes folder and downloaded zip file at the end of each run in cleanup VM stage.