### PR TITLE
Use virtualenv as a Python module

### DIFF
--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -4,36 +4,73 @@ The tests are designed to be run from your local computer.
 
 ## System Setup
 
-The test environment requires [Python 2.7+](http://www.python.org/downloads)
-(but not Python 3.x).
+Running the tests requires `python`, `pip` and `virtualenv`, as well as updating
+the system `hosts` file.
 
-On Windows, be sure to add the Python directory (`c:\python2x`, by default) to
-your `%Path%` [Environment Variable](http://www.computerhope.com/issues/ch000549.htm),
-and read the [Windows Notes](#windows-notes) section below.
+Note that Python 2.7 is required. Using Python 3 is not supported.
 
-<!--
-  There does not appear to be a cross-platform means of installing `pip`.
-  https://github.com/web-platform-tests/wpt/pull/16670
--->
+The required setup is different depending on your operating system.
 
-Install `pip`. On many systems, this can be achieved with the command `python
--m ensurepip`. If this is not possible, use your system's package manager to
-install the `python-pip` package.
+### Linux Setup
 
-Next, install `virtualenv` using the following command:
+If not already present, use the system package manager to install `python`,
+`pip` and `virtualenv`.
+
+On Debian or Ubuntu:
+
+```bash
+sudo apt-get install python python-pip virtualenv
+```
+
+On Fedora or Red Hat:
+
+```bash
+sudo dnf install python2 python2-pip python2-virtualenv
+```
+
+### macOS Setup
+
+The system-provided Python can be used, while `pip` and `virtualenv` can be
+installed for the user only:
+
+```bash
+python -m ensurepip --user
+export PATH="$PATH:$HOME/Library/Python/2.7/bin"
+pip install --user virtualenv
+```
+
+To make the `PATH` change persistent, add it to your `~/.profile` file.
+
+See also [additional setup required to run Safari](safari).
+
+### Windows Setup
+
+Download and install [Python 2.7](https://www.python.org/downloads). The
+installer includes `pip` by default.
+
+Add `C:\Python27` and `C:\Python27\Scripts` to your `%Path%`
+[environment variable](http://www.computerhope.com/issues/ch000549.htm).
+
+Finally, install `virtualenv`:
 
 ```bash
 pip install virtualenv
 ```
 
+The standard Windows shell requires that all `wpt` commands are prefixed
+by the Python binary i.e. assuming `python` is on your path the server is
+started using:
+
+```bash
+python wpt serve
+```
+
+### `hosts` File Setup
+
 To get the tests running, you need to set up the test domains in your
 [`hosts` file](http://en.wikipedia.org/wiki/Hosts_%28file%29%23Location_in_the_file_system).
 
-The necessary content can be generated with `./wpt make-hosts-file`; on
-Windows, you will need to preceed the prior command with `python` or
-the path to the Python binary (`python wpt make-hosts-file`).
-
-For example, on most UNIX-like systems, you can setup the hosts file with:
+On Linux, macOS or other UNIX-like system:
 
 ```bash
 ./wpt make-hosts-file | sudo tee -a /etc/hosts
@@ -47,17 +84,6 @@ python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -E
 
 If you are behind a proxy, you also need to make sure the domains above are
 excluded from your proxy lookups.
-
-### Windows Notes
-
-Generally Windows Subsystem for Linux will provide the smoothest user
-experience for running web-platform-tests on Windows.
-
-The standard Windows shell requires that all `wpt` commands are prefixed
-by the Python binary i.e. assuming `python` is on your path the server is
-started using:
-
-`python wpt serve`
 
 ## Via the browser
 

--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -19,7 +19,7 @@ If not already present, use the system package manager to install `python`,
 On Debian or Ubuntu:
 
 ```bash
-sudo apt-get install python python-pip virtualenv
+sudo apt-get install python python-pip python-virtualenv
 ```
 
 On Fedora or Red Hat:
@@ -35,11 +35,8 @@ installed for the user only:
 
 ```bash
 python -m ensurepip --user
-export PATH="$PATH:$HOME/Library/Python/2.7/bin"
-pip install --user virtualenv
+python -m pip install --user virtualenv
 ```
-
-To make the `PATH` change persistent, add it to your `~/.profile` file.
 
 See also [additional setup required to run Safari](safari).
 
@@ -48,13 +45,12 @@ See also [additional setup required to run Safari](safari).
 Download and install [Python 2.7](https://www.python.org/downloads). The
 installer includes `pip` by default.
 
-Add `C:\Python27` and `C:\Python27\Scripts` to your `%Path%`
-[environment variable](http://www.computerhope.com/issues/ch000549.htm).
+Add `C:\Python27` to your `%Path%` [environment variable](http://www.computerhope.com/issues/ch000549.htm).
 
 Finally, install `virtualenv`:
 
 ```bash
-pip install virtualenv
+python -m pip install virtualenv
 ```
 
 The standard Windows shell requires that all `wpt` commands are prefixed

--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import
+
 import os
 import shutil
 import sys
 import logging
+import virtualenv
 from distutils.spawn import find_executable
 
 # The `pkg_resources` module is provided by `setuptools`, which is itself a
@@ -24,11 +27,7 @@ class Virtualenv(object):
     def __init__(self, path, skip_virtualenv_setup):
         self.path = path
         self.skip_virtualenv_setup = skip_virtualenv_setup
-        if not skip_virtualenv_setup:
-            self.virtualenv = find_executable("virtualenv")
-            if not self.virtualenv:
-                raise ValueError("virtualenv must be installed and on the PATH")
-            self._working_set = None
+        self._working_set = None
 
     @property
     def exists(self):
@@ -40,10 +39,8 @@ class Virtualenv(object):
         return os.path.lexists(python_link) and not os.path.exists(python_link)
 
     def create(self):
-        if os.path.exists(self.path):
-            shutil.rmtree(self.path)
-            self._working_set = None
-        call(self.virtualenv, self.path, "-p", sys.executable)
+        virtualenv.create_environment(self.path, clear=True)
+        self._working_set = None
 
     @property
     def bin_path(self):


### PR DESCRIPTION
This simplifies the installation requirements by not having to update
PATH at all on macOS, and not needing to put `C:\Python27\Scripts`
on the path for Windows.

The macOS instructions would actually also work for Linux.