### PR TITLE
[preload] Opt-in to single-page test feature

### DIFF
--- a/preload/preload-csp.sub.html
+++ b/preload/preload-csp.sub.html
@@ -15,7 +15,7 @@
 <link rel=preload href="resources/dummy.xml">
 <body>
 <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
 

--- a/preload/preload-default-csp.sub.html
+++ b/preload/preload-default-csp.sub.html
@@ -15,7 +15,7 @@
 <link rel=preload href="resources/dummy.xml">
 <body>
 <script>
-    setup({explicit_done: true});
+    setup({single_test: true});
 
     var iterations = 0;
 


### PR DESCRIPTION
testharness.js was recently extended with an API to explicitly opt-in to
the "single page test" feature [1]. As per WPT RFC 28 [2], tests which
do not use this API and which do not declare any subtests will soon be
reported as a harness error.

Update the tests which previously opted in implicitly to use the new
API.

[1] https://github.com/web-platform-tests/wpt/pull/19449
[2] https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md

---

These changes should have been included in gh-19913. Sorry for the omission!