### PR TITLE
[testharness.js] Require single-page test opt-in

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -279,12 +279,6 @@ In order for a test to be interpreted as a single page test, it should set the
 
 The test title for single page tests is always taken from `document.title`.
 
-(Prior to October 2019, this behavior would be enabled implicitly for any test
-that did not call `test()` or `async_test()` anywhere on the page and that
-eventually called the `done()` function. [This behavior was found to be prone
-to errors and is in the process of being
-removed.](https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md))
-
 ## Making assertions ##
 
 Functions for making assertions start `assert_`. The full list of

--- a/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception.html.ini
@@ -1,6 +1,2 @@
 [uncaught-exception.html]
   expected: ERROR
-
-  [Uncaught exception]
-    expected: FAIL
-

--- a/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception.html.ini
@@ -1,4 +1,6 @@
 [uncaught-exception.html]
+  expected: ERROR
+
   [Uncaught exception]
     expected: FAIL
 

--- a/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection.html.ini
@@ -1,4 +1,6 @@
 [unhandled-rejection.html]
+  expected: ERROR
+
   [Unhandled rejection]
     expected: FAIL
 

--- a/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection.html.ini
@@ -1,6 +1,2 @@
 [unhandled-rejection.html]
   expected: ERROR
-
-  [Unhandled rejection]
-    expected: FAIL
-

--- a/infrastructure/metadata/infrastructure/server/context.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/context.any.js.ini
@@ -1,7 +1,6 @@
 [context.any.sharedworker.html]
-  [context]
-    expected:
-      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+  expected:
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR # https://bugs.webkit.org/show_bug.cgi?id=149850
 
 [context.any.serviceworker.html]
   [context]

--- a/infrastructure/metadata/infrastructure/server/order-of-metas.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/order-of-metas.any.js.ini
@@ -1,6 +1,5 @@
 [order-of-metas.any.sharedworker.html]
-  [foo]
-    expected:
-      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+  expected:
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR # https://bugs.webkit.org/show_bug.cgi?id=149850
 
 

--- a/infrastructure/metadata/infrastructure/server/secure-context.https.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/secure-context.https.any.js.ini
@@ -1,7 +1,6 @@
 [secure-context.https.any.sharedworker.html]
-  [secure-context]
-    expected:
-      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+  expected:
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR # https://bugs.webkit.org/show_bug.cgi?id=149850
 
 [secure-context.https.any.serviceworker.html]
   [secure-context]

--- a/infrastructure/metadata/infrastructure/server/title.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/title.any.js.ini
@@ -1,6 +1,5 @@
 [title.any.sharedworker.html]
-  [foobar]
-    expected:
-      if product == "safari" or product == "epiphany" or product == "webkit": FAIL # https://bugs.webkit.org/show_bug.cgi?id=149850
+  expected:
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR # https://bugs.webkit.org/show_bug.cgi?id=149850
 
 

--- a/resources/test/tests/functional/single-page-test-fail.html
+++ b/resources/test/tests/functional/single-page-test-fail.html
@@ -6,6 +6,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({ single_test: true });
 onload = function() {
   assert_true(false);
   done();

--- a/resources/test/tests/functional/single-page-test-no-assertions.html
+++ b/resources/test/tests/functional/single-page-test-no-assertions.html
@@ -6,6 +6,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({ single_test: true });
 done();
 </script>
 <script type="text/json" id="expected">

--- a/resources/test/tests/functional/single-page-test-no-body.html
+++ b/resources/test/tests/functional/single-page-test-no-body.html
@@ -6,6 +6,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({ single_test: true });
 assert_true(true);
 done();
 </script>

--- a/resources/test/tests/functional/single-page-test-pass.html
+++ b/resources/test/tests/functional/single-page-test-pass.html
@@ -6,6 +6,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({ single_test: true });
 onload = function() {
   assert_true(true);
   done();

--- a/resources/test/tests/functional/worker-uncaught-single.js
+++ b/resources/test/tests/functional/worker-uncaught-single.js
@@ -1,6 +1,8 @@
 importScripts("/resources/testharness.js");
 
-// Because this script does not define any sub-tests, it should be interpreted
-// as a single-page test, and the uncaught exception should be reported as a
-// test failure (harness status: OK).
+setup({ single_test: true });
+
+// Because this script enables the `single_test` configuration option, it
+// should be interpreted as a single-page test, and the uncaught exception
+// should be reported as a test failure (harness status: OK).
 throw new Error("This failure is expected.");

--- a/resources/test/tests/unit/exceptional-cases.html
+++ b/resources/test/tests/unit/exceptional-cases.html
@@ -73,7 +73,7 @@ promise_test(() => {
       () => { done(); }
     ).then(({harness, tests}) => {
       assert_equals(harness, 'ERROR');
-      assert_equals(tests['Document title'], 'FAIL');
+      assert_array_equals(Object.keys(tests), []);
     });
 }, 'completion signaled before testing begins');
 
@@ -82,7 +82,7 @@ promise_test(() => {
       () => { assert_true(true); }
     ).then(({harness, tests}) => {
       assert_equals(harness, 'ERROR');
-      assert_equals(tests['Document title'], 'FAIL');
+      assert_array_equals(Object.keys(tests), []);
     });
 }, 'passing assertion before testing begins');
 
@@ -91,7 +91,7 @@ promise_test(() => {
       () => { assert_false(true); }
     ).then(({harness, tests}) => {
       assert_equals(harness, 'ERROR');
-      assert_equals(tests['Document title'], 'FAIL');
+      assert_array_equals(Object.keys(tests), []);
     });
 }, 'failing assertion before testing begins');
 
@@ -100,7 +100,7 @@ promise_test(() => {
       () => { throw new Error('this error is expected'); }
     ).then(({harness, tests}) => {
       assert_equals(harness, 'ERROR');
-      assert_equals(tests['Document title'], 'FAIL');
+      assert_array_equals(Object.keys(tests), []);
     });
 }, 'uncaught exception before testing begins');
 
@@ -193,7 +193,7 @@ if ('onunhandledrejection' in window) {
         () => { Promise.reject(new Error('this error is expected')); }
       ).then(({harness, tests}) => {
         assert_equals(harness, 'ERROR');
-        assert_equals(tests['Document title'], 'FAIL');
+        assert_array_equals(Object.keys(tests), []);
       });
   }, 'unhandled rejection before testing begins');
 

--- a/resources/test/tests/unit/exceptional-cases.html
+++ b/resources/test/tests/unit/exceptional-cases.html
@@ -79,7 +79,7 @@ promise_test(() => {
 
 promise_test(() => {
   return makeTest(
-      () => { assert_true(true); }
+      () => { assert_true(true); done(); }
     ).then(({harness, tests}) => {
       assert_equals(harness, 'ERROR');
       assert_array_equals(Object.keys(tests), []);

--- a/resources/test/tests/unit/exceptional-cases.html
+++ b/resources/test/tests/unit/exceptional-cases.html
@@ -70,12 +70,39 @@ function getEnumProp(object, value) {
 
 promise_test(() => {
   return makeTest(
-      () => { throw new Error('this error is expected'); }
+      () => { done(); }
     ).then(({harness, tests}) => {
-      assert_equals(harness, 'OK');
+      assert_equals(harness, 'ERROR');
       assert_equals(tests['Document title'], 'FAIL');
     });
-}, 'uncaught exception during single-page test');
+}, 'completion signaled before testing begins');
+
+promise_test(() => {
+  return makeTest(
+      () => { assert_true(true); }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests['Document title'], 'FAIL');
+    });
+}, 'passing assertion before testing begins');
+
+promise_test(() => {
+  return makeTest(
+      () => { assert_false(true); }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests['Document title'], 'FAIL');
+    });
+}, 'failing assertion before testing begins');
+
+promise_test(() => {
+  return makeTest(
+      () => { throw new Error('this error is expected'); }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests['Document title'], 'FAIL');
+    });
+}, 'uncaught exception before testing begins');
 
 promise_test(() => {
   return makeTest(
@@ -165,10 +192,10 @@ if ('onunhandledrejection' in window) {
     return makeTest(
         () => { Promise.reject(new Error('this error is expected')); }
       ).then(({harness, tests}) => {
-        assert_equals(harness, 'OK');
+        assert_equals(harness, 'ERROR');
         assert_equals(tests['Document title'], 'FAIL');
       });
-  }, 'unhandled rejection during single-page test');
+  }, 'unhandled rejection before testing begins');
 
   promise_test(() => {
     return makeTest(

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3376,12 +3376,6 @@ policies and contribution forms [3].
      */
     function assert(expected_true, function_name, description, error, substitutions)
     {
-        if (tests.tests.length === 0) {
-            tests.status.status = tests.status.ERROR;
-            tests.status.message = "An assertion was made before testing began.";
-            tests.complete();
-            return;
-        }
         if (expected_true !== true) {
             var msg = make_message(function_name, description,
                                    error, substitutions);
@@ -3672,13 +3666,6 @@ policies and contribution forms [3].
 
     if (global_scope.addEventListener) {
         var error_handler = function(message, stack) {
-            if (tests.tests.length === 0 && !tests.allow_uncaught_exception) {
-                tests.status.status = tests.status.ERROR;
-                tests.status.message = "An error occured before testing began.";
-                tests.complete();
-                return;
-            }
-
             if (tests.file_is_test) {
                 var test = tests.tests[0];
                 if (test.phase >= test.phases.HAS_RESULT) {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -793,6 +793,11 @@ policies and contribution forms [3].
     function done() {
         if (tests.tests.length === 0) {
             tests.set_file_is_test();
+            tests.status.status = tests.status.ERROR;
+            tests.status.message = "The test signaled completion before testing began.";
+            var test = tests.tests[0];
+            test.set_status(test.FAIL, tests.status.message);
+            test.phase = test.phases.HAS_RESULT;
         }
         if (tests.file_is_test) {
             // file is test files never have asynchronous cleanup logic,
@@ -3375,6 +3380,12 @@ policies and contribution forms [3].
     {
         if (tests.tests.length === 0) {
             tests.set_file_is_test();
+            tests.status.status = tests.status.ERROR;
+            tests.status.message = "An assertion was made before testing began.";
+            var test = tests.tests[0];
+            test.set_status(test.FAIL, tests.status.message);
+            test.phase = test.phases.HAS_RESULT;
+            done();
         }
         if (expected_true !== true) {
             var msg = make_message(function_name, description,
@@ -3668,6 +3679,8 @@ policies and contribution forms [3].
         var error_handler = function(message, stack) {
             if (tests.tests.length === 0 && !tests.allow_uncaught_exception) {
                 tests.set_file_is_test();
+                tests.status.status = tests.status.ERROR;
+                tests.status.message = "An error occured before testing began.";
             }
 
             if (tests.file_is_test) {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -793,7 +793,7 @@ policies and contribution forms [3].
     function done() {
         if (tests.tests.length === 0) {
             tests.status.status = tests.status.ERROR;
-            tests.status.message = "The test signaled completion before testing began.";
+            tests.status.message = "done() was called without first defining any tests";
             tests.complete();
             return;
         }

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -792,12 +792,10 @@ policies and contribution forms [3].
 
     function done() {
         if (tests.tests.length === 0) {
-            tests.set_file_is_test();
             tests.status.status = tests.status.ERROR;
             tests.status.message = "The test signaled completion before testing began.";
-            var test = tests.tests[0];
-            test.set_status(test.FAIL, tests.status.message);
-            test.phase = test.phases.HAS_RESULT;
+            tests.complete();
+            return;
         }
         if (tests.file_is_test) {
             // file is test files never have asynchronous cleanup logic,
@@ -3379,13 +3377,10 @@ policies and contribution forms [3].
     function assert(expected_true, function_name, description, error, substitutions)
     {
         if (tests.tests.length === 0) {
-            tests.set_file_is_test();
             tests.status.status = tests.status.ERROR;
             tests.status.message = "An assertion was made before testing began.";
-            var test = tests.tests[0];
-            test.set_status(test.FAIL, tests.status.message);
-            test.phase = test.phases.HAS_RESULT;
-            done();
+            tests.complete();
+            return;
         }
         if (expected_true !== true) {
             var msg = make_message(function_name, description,
@@ -3678,9 +3673,10 @@ policies and contribution forms [3].
     if (global_scope.addEventListener) {
         var error_handler = function(message, stack) {
             if (tests.tests.length === 0 && !tests.allow_uncaught_exception) {
-                tests.set_file_is_test();
                 tests.status.status = tests.status.ERROR;
                 tests.status.message = "An error occured before testing began.";
+                tests.complete();
+                return;
             }
 
             if (tests.file_is_test) {


### PR DESCRIPTION
This enacts the change specified by WPT RFC 28.

https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md

---

Overall, this patch appears to be safe to land, though we may want to wait for gh-19904 and gh-20031 before doing so.

In gh-19578, we aimed to extend all of WPT's single-page tests with [the new implicit opt-in pattern](https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md). Once we completed that, I created this patch and ran it in Chrome Dev and Firefox Nightly.

- [effect of this patch on Chrome Dev results](https://wpt.fyi/results/?diff&filter=ADC&run_id=335020007&run_id=317670008)
- [effect of this patch on Firefox Nightly results](https://wpt.fyi/results/?diff&filter=ADC&run_id=325370007&run_id=321650012)

Most of the discrepancies are due to flaky tests (listed below). The second most common cause comes from references to the API under test outside of a subtest (also listed below). In `master` today, the resulting `ReferenceError` causes the test to be reported as a failing single-page test, even though in most cases, it was authored to define multiple sub-tests. The new result is a harness error, and that's more appropriate for these cases.

There are a handful of tests whose results changed for other reasons:

- these tests are being fixed via https://github.com/web-platform-tests/wpt/pull/19904
  - `WebCryptoAPI/derive_bits_keys/`
- these tests rely on new ECMAScript language features that are not yet supported in Firefox. The harness error is a more appropriate status
  - `IndexedDB/structured-clone.any.html`
  - `IndexedDB/structured-clone.any.worker.html`
- these tests includes an unresolvable reference. The harness error is a more appropriate status
  - `fetch/metadata/sec-fetch-dest/redirect/multiple-redirect-https-downgrade-upgrade.tentative.sub.html`
  - `fetch/metadata/sec-fetch-dest/redirect/redirect-http-upgrade.tentative.sub.html`
- this test includes a syntax error. The harness error is a more appropriate status
  - `fetch/metadata/sec-fetch-dest/redirect/redirect-https-downgrade.tentative.sub.html` -
- this test references an internal API which is not defined. The harness error is a more appropriate status
  - `idle-detection/interceptor.https.html`
- these errors describe the intended effect of the patch
  - `infrastructure/expected-fail/uncaught-exception.html`
  - `infrastructure/expected-fail/unhandled-rejection.html`
- these tests are single-page tests which we failed to identify initially; we're updating them via https://github.com/web-platform-tests/wpt/pull/20031
  - `preload/preload-csp.sub.html`
  - `preload/preload-default-csp.sub.html`

<details>
  <summary>flaky tests</summary>

- detected by Chrome
  - `background-fetch/`
  - `content-security-policy/`
  - `css/` - flaky
  - `html/semantics/links/links-created-by-a-and-area-elements/`
  - `intersection-observer/cross-origin-iframe.sub.html`
  - `longtask-timing/longtask-in-sibling-iframe-crossorigin.html`
  - `offscreen-canvas/`
  - `scroll-to-text-fragment/scroll-to-text-fragment.html`
  - `webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/cors-check.https.html`
  - `webmessaging/broadcastchannel/basics.html`
  - `webmessaging/broadcastchannel/workers.html`
- detected by Firefox
  - `css/css-animations/CSSAnimation-startTime.tentative.html`
  - `css/css-backgrounds/background-334.html`
  - `css/css-multicol/animation/column-rule-color-interpolation.html`
  - `css/css-properties-values-api/property-cascade.html`
  - `css/css-transitions/events-007.html`
  - `css/css-writing-modes/text-combine-upright-parsing-valid-001.html`
  - `html/cross-origin-embedder-policy/require-corp.https.html`
  - `html/semantics/scripting-1/the-script-element/load-error-events-3.html`
  - `html/semantics/scripting-1/the-script-element/script-onerror-insertion-point-1.html`
  - `html/webappapis/dynamic-markup-insertion/opening-the-input-stream/abort-refresh-immediate.window.html`
  - `offscreen-canvas/the-offscreen-canvas/offscreencanvas.commit.w.html`
  - `performance-timeline/case-sensitivity.any.html`
  - `pointerevents/pointerevent_setpointercapture_inactive_button_mouse.html`
  - `referrer-policy/gen/req.attr/same-origin/img-tag/cross-https.swap-origin.http.html`
  - `resource-timing/resource_connection_reuse.html`
  - `resource-timing/resource_timing_buffer_full_eventually.html`
  - `service-workers/service-worker/ready.https.html`
  - `upgrade-insecure-requests/gen/worker-classic-data.meta/upgrade/fetch/cross-http-downgrade.downgrade.https.html`
  - `webaudio/the-audio-api/the-scriptprocessornode-interface/simple-input-output.html`
  - `webdriver/`
  - `webvtt/`

</details>

<details>
  <summary>unsafe API references</summary>

- detected by Chrome
  - `streams/readable-byte-streams/construct-byob-request.any.html`
  - `streams/readable-byte-streams/construct-byob-request.any.serviceworker.html`
  - `streams/readable-byte-streams/construct-byob-request.any.sharedworker.html`
  - `streams/readable-byte-streams/construct-byob-request.any.worker.html`
  - `trusted-types/`
- detected by Firefox
  - `2dcontext/wide-gamut-canvas/imageData-colorManagedBehavior.html`
  - `animation-worklet/worklet-animation-pause.https.html`
  - `animation-worklet/worklet-animation-without-target.https.html`
  - `css/css-properties-values-api/conditional-rules.html`
  - `css/css-properties-values-api/unit-cycles.html`
  - `css/css-properties-values-api/url-resolution.html`
  - `css/css-typed-om/`
  - `custom-elements/form-associated/ElementInternals-accessibility.html`
  - `custom-elements/form-associated/form-associated-callback.html`
  - `encoding/streams/decode-utf8.any.serviceworker.html`
  - `encoding/streams/realms.window.html`
  - `streams/piping/pipe-through.any.serviceworker.html`
  - `streams/readable-byte-streams/construct-byob-request.any.html`
  - `streams/readable-byte-streams/construct-byob-request.any.serviceworker.html`
  - `streams/readable-byte-streams/construct-byob-request.any.worker.html`
  - `streams/transform-streams/brand-checks.any.html`
  - `streams/transform-streams/brand-checks.any.serviceworker.html`
  - `streams/transform-streams/brand-checks.any.worker.html`
  - `streams/transform-streams/properties.any.serviceworker.html`
  - `streams/writable-streams/brand-checks.any.html`
  - `streams/writable-streams/brand-checks.any.serviceworker.html`
  - `streams/writable-streams/brand-checks.any.worker.html`
  - `streams/writable-streams/properties.any.serviceworker.html`
  - `trusted-types/GlobalEventHandlers-onclick.tentative.html`
  - `trusted-types/Node-multiple-arguments.tentative.html`
  - `trusted-types/TrustedTypePolicyFactory-metadata.tentative.html`
  - `trusted-types/WorkerGlobalScope-importScripts.https.html`
  - `trusted-types/block-Node-multiple-arguments.tentative.html`
  - `trusted-types/block-eval.tentative.html`
  - `trusted-types/block-string-assignment-to-Document-write.tentative.html`
  - `trusted-types/block-string-assignment-to-Element-setAttribute.tentative.html`
  - `trusted-types/eval-with-permissive-csp.tentative.html`
  - `trusted-types/trusted-types-eval-reporting-no-unsafe-eval.tentative.https.html`
  - `trusted-types/trusted-types-eval-reporting-report-only.tentative.https.html`
  - `trusted-types/trusted-types-eval-reporting.tentative.https.html`
  - `trusted-types/trusted-types-report-only.tentative.https.html`
  - `trusted-types/trusted-types-reporting-check-report.https.html`
  - `webaudio/the-audio-api/the-audioworklet-interface/audioworklet-messageport.https.html`
  - `webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-sharedarraybuffer.https.html`
  - `webaudio/the-audio-api/the-audioworklet-interface/audioworkletglobalscope-sample-rate.https.html`
  - `webaudio/the-audio-api/the-audioworklet-interface/audioworkletglobalscope-timing-info.https.html`
  - `webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-onerror.https.html`
  - `webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-output-channel-count.https.html`
  - `webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/cors-check.https.html`
  - `webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/no-cors.https.html`

</details>