### PR TITLE
Fix a dead link in docs

### DIFF
--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -36,7 +36,7 @@ pip install --user virtualenv
 To make the `PATH` change persistent, add it to your `~/.bash_profile` file or
 wherever you currently set your PATH.
 
-See also [additional setup required to run Safari](safari).
+See also [additional setup required to run Safari](safari.md).
 
 ### Windows Setup
 **Note:** In general, Windows Subsystem for Linux will provide the smoothest


### PR DESCRIPTION
Although the link without the file extension works on Sphinx, it does not work
on GitHub. Adding the ".md" extension makes it work in both places.