### PR TITLE
Minor changes to testdriver docs

### DIFF
--- a/docs/writing-tests/index.md
+++ b/docs/writing-tests/index.md
@@ -28,7 +28,7 @@ There's also a load of [general guidelines](general-guidelines) that apply to al
    server-features
    submission-process
    testdriver
-   testdriver-tutorial
+   testdriver-extension-tutorial
    testharness
    testharness-tutorial
    tools

--- a/docs/writing-tests/testdriver-extension-tutorial.md
+++ b/docs/writing-tests/testdriver-extension-tutorial.md
@@ -1,5 +1,4 @@
-# testdriver.js Tutorial
-
+# Testdriver extension tutorial
 Adding new commands to testdriver.js
 
 ## Assumptions

--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -16,16 +16,22 @@ the global scope.
 NB: presently, testdriver.js only works in the top-level test browsing
 context (and not therefore in any frame or window opened from it).
 
-### action_sequence
-Usage: `test_driver.action_sequence(actions)`
- * `actions`: an array of `Action` objects
+### Actions
+Usage: 
+```
+let actions = new test_driver.Actions()
+   .action1()
+   .action2();
+actions.send()
+```
 
-This function causes a sequence of actions to be sent to the browser. It is based on the [WebDriver API](https://w3c.github.io/webdriver/#actions).
+Test authors are encouraged to use the builder API to generate the sequence of actions. The builder
+API can be accessed via the `new test_driver.Actions()` object, and actions are defined in [testdriver-actions.js](https://github.com/web-platform-tests/wpt/blob/master/resources/testdriver-actions.js) 
+
+The `actions.send()` function causes the sequence of actions to be sent to the browser. It is based on the [WebDriver API](https://w3c.github.io/webdriver/#actions).
 The action can be a keyboard action, a pointer action or a pause. It returns a `Promise` that
 resolves after the actions have been sent or rejects if an error was thrown.
 
-Test authors are encouraged to use the builder API to generate the sequence of actions. The builder
-API can be accessed via the `new test_driver.Actions()` object.
 
 Example:
 

--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -17,7 +17,7 @@ NB: presently, testdriver.js only works in the top-level test browsing
 context (and not therefore in any frame or window opened from it).
 
 ### Actions
-Usage: 
+Usage:
 ```
 let actions = new test_driver.Actions()
    .action1()
@@ -26,7 +26,7 @@ actions.send()
 ```
 
 Test authors are encouraged to use the builder API to generate the sequence of actions. The builder
-API can be accessed via the `new test_driver.Actions()` object, and actions are defined in [testdriver-actions.js](https://github.com/web-platform-tests/wpt/blob/master/resources/testdriver-actions.js) 
+API can be accessed via the `new test_driver.Actions()` object, and actions are defined in [testdriver-actions.js](https://github.com/web-platform-tests/wpt/blob/master/resources/testdriver-actions.js)
 
 The `actions.send()` function causes the sequence of actions to be sent to the browser. It is based on the [WebDriver API](https://w3c.github.io/webdriver/#actions).
 The action can be a keyboard action, a pointer action or a pause. It returns a `Promise` that

--- a/docs/writing-tests/testharness.md
+++ b/docs/writing-tests/testharness.md
@@ -6,7 +6,7 @@
 
    idlharness
    testharness-api
-   testdriver-tutorial
+   testdriver-extension-tutorial
    testdriver
 ```
 


### PR DESCRIPTION
1. Rename testdriver-tutorial to testdriver-extension-tutorial, and
clarify that it's about how to extend testdriver.
2. Clarify testdriver Actions docs to focus on Actions builder API
instead of action_sequence

Bug: #19892