### PR TITLE
Added a speech-api test for speaking an empty utterance

### DIFF
--- a/speech-api/SpeechSynthesis-speak-events.html
+++ b/speech-api/SpeechSynthesis-speak-events.html
@@ -5,14 +5,21 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <body>
 <script>
-async_test(t => {
+function runStartEndTest(t, utterance) {
   test_driver.bless('speechSynthesis.speak', t.step_func(() => {
-    const utter = new SpeechSynthesisUtterance('test');
-    utter.onerror = t.unreached_func('error event');
-    speechSynthesis.speak(utter);
-    utter.onstart = t.step_func(() => {
-      utter.onend = t.step_func_done();
+    utterance.onerror = t.unreached_func('error event');
+    speechSynthesis.speak(utterance);
+    utterance.onstart = t.step_func(() => {
+      utterance.onend = t.step_func_done();
     });
   }));
+}
+async_test(t => {
+  const utterance = new SpeechSynthesisUtterance();
+  runStartEndTest(t, utterance);
+}, 'speechSynthesis.speak() fires start and end events with empty utterance');
+async_test(t => {
+  const utterance = new SpeechSynthesisUtterance('test');
+  runStartEndTest(t, utterance);
 }, 'speechSynthesis.speak() fires start and end events');
 </script>

--- a/speech-api/SpeechSynthesis-speak-events.html
+++ b/speech-api/SpeechSynthesis-speak-events.html
@@ -5,21 +5,18 @@
 <script src="/resources/testdriver-vendor.js"></script>
 <body>
 <script>
-function runStartEndTest(t, utterance) {
-  test_driver.bless('speechSynthesis.speak', t.step_func(() => {
-    utterance.onerror = t.unreached_func('error event');
-    speechSynthesis.speak(utterance);
-    utterance.onstart = t.step_func(() => {
-      utterance.onend = t.step_func_done();
-    });
-  }));
+async function runStartEndTest(t, utterance) {
+  const eventWatcher = new EventWatcher(t, utterance, ['start', 'end', 'error']);
+  await test_driver.bless('speechSynthesis.speak',
+      () => speechSynthesis.speak(utterance));
+  await eventWatcher.wait_for(['start', 'end']);
 }
-async_test(t => {
+promise_test(async (t) => {
   const utterance = new SpeechSynthesisUtterance();
-  runStartEndTest(t, utterance);
+  await runStartEndTest(t, utterance);
 }, 'speechSynthesis.speak() fires start and end events with empty utterance');
-async_test(t => {
+promise_test(async (t) => {
   const utterance = new SpeechSynthesisUtterance('test');
-  runStartEndTest(t, utterance);
+  await runStartEndTest(t, utterance);
 }, 'speechSynthesis.speak() fires start and end events');
 </script>


### PR DESCRIPTION
Added a start and end test that uses an empty utterance. This functionality was recently broken on Chromium based browsers, so probably deserves a test.