### PR TITLE
Add support for the mutable argument to addImportedGlobal.

### DIFF
--- a/wasm/jsapi/wasm-module-builder.js
+++ b/wasm/jsapi/wasm-module-builder.js
@@ -553,9 +553,9 @@ class WasmModuleBuilder {
     return this.num_imported_funcs++;
   }
 
-  addImportedGlobal(module, name, type) {
+  addImportedGlobal(module, name, type, mutable = false) {
     let o = {module: module, name: name, kind: kExternalGlobal, type: type,
-             mutable: false}
+             mutable: mutable};
     this.imports.push(o);
     return this.num_imported_globals++;
   }


### PR DESCRIPTION
This also exists in the V8 version at <https://cs.chromium.org/chromium/src/v8/test/mjsunit/wasm/wasm-module-builder.js>.

I didn't do a complete sync to avoid having to review all the changes.