### PR TITLE
[testharness.js] extract the stack for unhandled rejection

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3706,15 +3706,17 @@ policies and contribution forms [3].
         }, false);
 
         addEventListener("unhandledrejection", function(e) {
-            var reason;
-            if (e.reason) {
-                reason  = e.reason.message ? e.reason.message : e.reason;
+            var message;
+            if (e.reason && e.reason.message) {
+                message = "Unhandled rejection: " + e.reason.message;
             } else {
-                reason = e;
+                message = "Unhandled rejection";
             }
-            var message = "Unhandled rejection: " + reason;
-            // There's no stack for unhandled rejections.
-            error_handler(message);
+            var stack;
+            if (e.reason && e.reason.stack) {
+                stack = e.reason.stack;
+            }
+            error_handler(message, stack);
         }, false);
     }
 


### PR DESCRIPTION
Contrary to the earlier comment, a stack may exist if the rejection
value was an error object with a stack...