### PR TITLE
Add a tool for getting test paths from ids

### DIFF
--- a/tools/manifest/commands.json
+++ b/tools/manifest/commands.json
@@ -1,5 +1,23 @@
-{"manifest":
- {"path": "update.py", "script": "run", "parser": "create_parser", "help": "Update the MANIFEST.json file",
-  "virtualenv": false},
- "manifest-download":
- {"path": "download.py", "script": "run", "parser": "create_parser", "help": "Download recent pregenerated MANIFEST.json file", "virtualenv": false}}
+{
+  "manifest": {
+    "path": "update.py",
+    "script": "run",
+    "parser": "create_parser",
+    "help": "Update the MANIFEST.json file",
+    "virtualenv": false
+  },
+  "manifest-download": {
+    "path": "download.py",
+    "script": "run",
+    "parser": "create_parser",
+    "help": "Download recent pregenerated MANIFEST.json file",
+    "virtualenv": false
+  },
+  "test-paths": {
+    "path": "testpaths.py",
+    "script": "run",
+    "parser": "create_parser",
+    "help": "Print test paths given a set of test ids",
+    "virtualenv": false
+  }
+}

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -51,7 +51,7 @@ class ManifestItem(with_metaclass(ManifestItemMeta)):
 
     @abstractproperty
     def id(self):
-        # type: () -> Hashable
+        # type: () -> Text
         """The test's id (usually its url)"""
         pass
 

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -251,18 +251,18 @@ class Manifest(object):
         self.url_base = url_base  # type: Text
 
     def __iter__(self):
-        # type: () -> Iterable[Tuple[str, Text, Set[ManifestItem]]]
+        # type: () -> Iterator[Tuple[str, Text, Set[ManifestItem]]]
         return self.itertypes()
 
     def itertypes(self, *types):
-        # type: (*str) -> Iterable[Tuple[str, Text, Set[ManifestItem]]]
+        # type: (*str) -> Iterator[Tuple[str, Text, Set[ManifestItem]]]
         for item_type in (types or sorted(self._data.keys())):
             for path in sorted(self._data[item_type]):
                 tests = self._data[item_type][path]
                 yield item_type, path, tests
 
     def iterpath(self, path):
-        # type: (Text) -> Iterable[ManifestItem]
+        # type: (Text) -> Iterator[ManifestItem]
         for type_tests in self._data.values():
             i = type_tests.get(path, set())
             assert i is not None
@@ -270,7 +270,7 @@ class Manifest(object):
                 yield test
 
     def iterdir(self, dir_name):
-        # type: (Text) -> Iterable[ManifestItem]
+        # type: (Text) -> Iterator[ManifestItem]
         if not dir_name.endswith(os.path.sep):
             dir_name = dir_name + os.path.sep
         for type_tests in self._data.values():

--- a/tools/manifest/testpaths.py
+++ b/tools/manifest/testpaths.py
@@ -1,0 +1,92 @@
+import argparse
+import json
+import os
+from collections import defaultdict
+
+from six import iteritems
+
+from .manifest import load_and_update, Manifest
+from .log import get_logger
+
+MYPY = False
+if MYPY:
+    # MYPY is set to True when run under Mypy.
+    from typing import Any
+    from typing import Dict
+    from typing import Iterable
+    from typing import List
+    from typing import Text
+
+wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+
+logger = get_logger()
+
+
+def abs_path(path):
+    # type: (str) -> str
+    return os.path.abspath(os.path.expanduser(path))
+
+
+def create_parser():
+    # type: () -> argparse.ArgumentParser
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-p", "--path", type=abs_path, help="Path to manifest file.")
+    parser.add_argument(
+        "--tests-root", type=abs_path, default=wpt_root, help="Path to root of tests.")
+    parser.add_argument(
+        "--no-update", dest="update", action="store_false", default=True,
+        help="Don't update manifest before continuing")
+    parser.add_argument(
+        "-r", "--rebuild", action="store_true", default=False,
+        help="Force a full rebuild of the manifest.")
+    parser.add_argument(
+        "--url-base", action="store", default="/",
+        help="Base url to use as the mount point for tests in this manifest.")
+    parser.add_argument(
+        "--cache-root", action="store", default=os.path.join(wpt_root, ".wptcache"),
+        help="Path in which to store any caches (default <tests_root>/.wptcache/)")
+    parser.add_argument(
+        "--json", action="store_true", default=False,
+        help="Output as JSON")
+    parser.add_argument(
+        "test_ids", action="store", nargs="+",
+        help="Test ids for which to get paths")
+    return parser
+
+
+def get_path_id_map(manifest_file, test_ids):
+    # type: (Manifest, Iterable[Text]) -> Dict[Text, List[Text]]
+    test_ids = set(test_ids)
+    path_id_map = defaultdict(list)  # type: Dict[Text, List[Text]]
+
+    for item_type, path, tests in manifest_file:
+        for test in tests:
+            if test.id in test_ids:
+                path_id_map[path].append(test.id)
+    return path_id_map
+
+
+def run(**kwargs):
+    # type: (**Any) -> None
+    tests_root = kwargs["tests_root"]
+    assert tests_root is not None
+    path = kwargs["path"]
+    if path is None:
+        path = os.path.join(kwargs["tests_root"], "MANIFEST.json")
+
+    manifest_file = load_and_update(tests_root,
+                                    path,
+                                    kwargs["url_base"],
+                                    update=kwargs["update"],
+                                    rebuild=kwargs["rebuild"],
+                                    cache_root=kwargs["cache_root"])
+
+    path_id_map = get_path_id_map(manifest_file, kwargs["test_ids"])
+    if kwargs["json"]:
+        print(json.dumps(path_id_map))
+    else:
+        for path, test_ids in sorted(iteritems(path_id_map)):
+            print(path)
+            for test_id in sorted(test_ids):
+                print("  " + test_id)


### PR DESCRIPTION
Sometimes one has a list of test ids (e.g. from a test run) and wants
to know which files correspond to those tests (e.g. because one has
data stored on a per-file basis). This adds a small command line tool
to get the files corresponding to a test out of the manifest.