### PR TITLE
Allow metadata to expect any subtest statuses for a test.

### DIFF
--- a/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
@@ -157,11 +157,11 @@ def test_subtest_messages(capfd):
     output_json = json.load(output)
 
     t1_log = output_json["tests"]["t1"]["artifacts"]["log"]
-    assert t1_log == "[FAIL] t1_a: t1_a_message\n" \
+    assert t1_log == "[FAIL expected PASS] t1_a: t1_a_message\n" \
                      "[PASS] t1_b: t1_b_message\n"
 
     t2_log = output_json["tests"]["t2"]["artifacts"]["log"]
-    assert t2_log == "[TIMEOUT] t2_message\n"
+    assert t2_log == "[TIMEOUT expected PASS] t2_message\n"
 
 
 def test_subtest_failure(capfd):
@@ -203,11 +203,102 @@ def test_subtest_failure(capfd):
 
     test_obj = output_json["tests"]["t1"]
     t1_log = test_obj["artifacts"]["log"]
+    assert t1_log == "[FAIL expected PASS] t1_a: t1_a_message\n" \
+                     "[PASS] t1_b: t1_b_message\n" \
+                     "[TIMEOUT expected PASS] t1_c: t1_c_message\n"
+    # The status of the test in the output is a failure because subtests failed,
+    # despite the harness reporting that the test passed.
+    assert test_obj["actual"] == "FAIL"
+    # Also ensure that the formatter cleaned up its internal state
+    assert "t1" not in formatter.tests_with_subtest_fails
+
+
+def test_expected_subtest_failure(capfd):
+    # Tests that a expected subtest failure does not cause the test to fail
+
+    # Set up the handler.
+    output = StringIO()
+    logger = structuredlog.StructuredLogger("test_a")
+    formatter = ChromiumFormatter()
+    logger.add_handler(handlers.StreamHandler(output, formatter))
+
+    # Run a test with some expected subtest failures.
+    logger.suite_start(["t1"], run_info={}, time=123)
+    logger.test_start("t1")
+    logger.test_status("t1", status="FAIL", expected="FAIL", subtest="t1_a",
+                       message="t1_a_message")
+    logger.test_status("t1", status="PASS", subtest="t1_b",
+                       message="t1_b_message")
+    logger.test_status("t1", status="TIMEOUT", expected="TIMEOUT", subtest="t1_c",
+                       message="t1_c_message")
+
+    # The subtest failures are all expected so this test should not be added to
+    # the set of tests with subtest failures.
+    assert "t1" not in formatter.tests_with_subtest_fails
+
+    # The test status is reported as a pass here because the harness was able to
+    # run the test to completion.
+    logger.test_end("t1", status="PASS", expected="PASS")
+    logger.suite_end()
+
+    # check nothing got output to stdout/stderr
+    # (note that mozlog outputs exceptions during handling to stderr!)
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    # check the actual output of the formatter
+    output.seek(0)
+    output_json = json.load(output)
+
+    test_obj = output_json["tests"]["t1"]
+    t1_log = test_obj["artifacts"]["log"]
     assert t1_log == "[FAIL] t1_a: t1_a_message\n" \
                      "[PASS] t1_b: t1_b_message\n" \
                      "[TIMEOUT] t1_c: t1_c_message\n"
-    # The status of the test in the output is a failure because subtests failed,
-    # despite the harness reporting that the test passed.
+    # The status of the test in the output is a pass because the subtest
+    # failures were all expected.
+    assert test_obj["actual"] == "PASS"
+
+
+def test_unexpected_subtest_pass(capfd):
+    # A test that unexpectedly passes is considered a failure condition.
+
+    # Set up the handler.
+    output = StringIO()
+    logger = structuredlog.StructuredLogger("test_a")
+    formatter = ChromiumFormatter()
+    logger.add_handler(handlers.StreamHandler(output, formatter))
+
+    # Run a test with a subtest that is expected to fail but passes.
+    logger.suite_start(["t1"], run_info={}, time=123)
+    logger.test_start("t1")
+    logger.test_status("t1", status="PASS", expected="FAIL", subtest="t1_a",
+                       message="t1_a_message")
+
+    # Since the subtest behaviour is unexpected, it's considered a failure, so
+    # the test should be added to the set of tests with subtest failures.
+    assert "t1" in formatter.tests_with_subtest_fails
+
+    # The test status is reported as a pass here because the harness was able to
+    # run the test to completion.
+    logger.test_end("t1", status="PASS", expected="PASS")
+    logger.suite_end()
+
+    # check nothing got output to stdout/stderr
+    # (note that mozlog outputs exceptions during handling to stderr!)
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    # check the actual output of the formatter
+    output.seek(0)
+    output_json = json.load(output)
+
+    test_obj = output_json["tests"]["t1"]
+    t1_log = test_obj["artifacts"]["log"]
+    assert t1_log == "[PASS expected FAIL] t1_a: t1_a_message\n"
+    # Since the subtest status is unexpected, we fail the test.
     assert test_obj["actual"] == "FAIL"
     # Also ensure that the formatter cleaned up its internal state
     assert "t1" not in formatter.tests_with_subtest_fails

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -572,10 +572,16 @@ class TestRunnerManager(threading.Thread):
         # Write the result of each subtest
         file_result, test_results = results
         subtest_unexpected = False
+        expect_any_subtest_status = test.expect_any_subtest_status()
+        if expect_any_subtest_status:
+            self.logger.debug("Ignoring subtest statuses for test %s" % test.id)
         for result in test_results:
             if test.disabled(result.name):
                 continue
-            expected = test.expected(result.name)
+            if expect_any_subtest_status:
+                expected = result.status
+            else:
+                expected = test.expected(result.name)
             known_intermittent = test.known_intermittent(result.name)
             is_unexpected = expected != result.status and result.status not in known_intermittent
 

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -68,6 +68,11 @@ test_6 = """\
   expected: [OK, FAIL]
 """
 
+test_7 = """\
+[7.html]
+  expect_any_subtest_status: yep
+"""
+
 test_fuzzy = """\
 [fuzzy.html]
   fuzzy: fuzzy-ref.html:1;200
@@ -201,6 +206,14 @@ def test_known_intermittent():
     test_obj = make_test_object(test_6, "a/6.html", 6, ("test", "a", 7), None, False)
     assert test_obj.expected() == "OK"
     assert test_obj.known_intermittent() == ["FAIL"]
+
+
+@pytest.mark.xfail(sys.version[0] == "3",
+                   reason="bytes/text confusion in py3")
+def test_expect_any_subtest_status():
+    test_obj = make_test_object(test_7, "a/7.html", 7, ("test", "a", 8), None, False)
+    assert test_obj.expected() == "OK"
+    assert test_obj.expect_any_subtest_status() == True
 
 
 @pytest.mark.xfail(sys.version[0] == "3",

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -70,7 +70,7 @@ test_6 = """\
 
 test_7 = """\
 [7.html]
-  expect_any_subtest_status: yep
+  blink_expect_any_subtest_status: yep
 """
 
 test_fuzzy = """\

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -213,7 +213,7 @@ def test_known_intermittent():
 def test_expect_any_subtest_status():
     test_obj = make_test_object(test_7, "a/7.html", 7, ("test", "a", 8), None, False)
     assert test_obj.expected() == "OK"
-    assert test_obj.expect_any_subtest_status() == True
+    assert test_obj.expect_any_subtest_status() is True
 
 
 @pytest.mark.xfail(sys.version[0] == "3",

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -347,6 +347,16 @@ class Test(object):
         except KeyError:
             return []
 
+    def expect_any_subtest_status(self):
+        metadata = self._get_metadata()
+        if metadata is None:
+            return False
+        try:
+            expect_any_subtest_failure = metadata.get("expect_any_subtest_status")
+            return True
+        except KeyError:
+            return False
+
     def __repr__(self):
         return "<%s.%s %s>" % (self.__module__, self.__class__.__name__, self.id)
 

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -352,7 +352,7 @@ class Test(object):
         if metadata is None:
             return False
         try:
-            expect_any_subtest_failure = metadata.get("expect_any_subtest_status")
+            metadata.get("expect_any_subtest_status")
             return True
         except KeyError:
             return False

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -352,7 +352,8 @@ class Test(object):
         if metadata is None:
             return False
         try:
-            metadata.get("expect_any_subtest_status")
+            # This key is used by the Blink CI to ignore subtest statuses
+            metadata.get("blink_expect_any_subtest_status")
             return True
         except KeyError:
             return False


### PR DESCRIPTION
This introduces a new key into metadata called `expect_any_subtest_status`. This can be set on the top-most test level. When this key is present, all subtest status will be treated as expected without having to enumerate every failing subtest.

This PR also updates the chromium formatter to better handle unexpected results.