### PR TITLE
[taskcluster] Use priviledged mode on Community-TC

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -17,6 +17,13 @@ tasks:
         else:
           github-worker
       else: ci
+    scopes:
+      $if: 'taskcluster_root_url == "https://taskcluster.net"'
+      then: []
+      else:
+        - 'docker-worker:capability:privileged'
+    capabilities:
+      privileged: {$eval: 'taskcluster_root_url != "https://taskcluster.net"'}
   in:
     $flattenDeep:
       - $if: tasks_for == "github-push"
@@ -67,6 +74,7 @@ tasks:
               deadline: {$fromNow: '24 hours'}
               provisionerId: ${provisionerId}
               workerType: ${workerType}
+              scopes: {$eval: scopes}
               metadata:
                 name: wpt-${browser.name}-${browser.channel}-${chunk[0]}-${chunk[1]}
                 description: >-
@@ -78,6 +86,7 @@ tasks:
               payload:
                 image:
                     harjgam/web-platform-tests:0.33
+                capabilities: {$eval: capabilities}
                 maxRunTime: 7200
                 artifacts:
                   public/results:
@@ -165,6 +174,7 @@ tasks:
                 deadline: {$fromNow: '24 hours'}
                 provisionerId: ${provisionerId}
                 workerType: ${workerType}
+                scopes: {$eval: scopes}
                 metadata:
                   name: ${operation.name}
                   description: ${operation.description}
@@ -172,6 +182,7 @@ tasks:
                   source: ${event.repository.url}
                 payload:
                   image: harjgam/web-platform-tests:0.33
+                  capabilities: {$eval: capabilities}
                   maxRunTime: 7200
                   artifacts:
                     public/results:
@@ -326,6 +337,7 @@ tasks:
                 deadline: {$fromNow: '24 hours'}
                 provisionerId: ${provisionerId}
                 workerType: ${workerType}
+                scopes: {$eval: scopes}
                 metadata:
                   name: ${operation.name}
                   description: ${operation.description}
@@ -333,6 +345,7 @@ tasks:
                   source: ${event.repository.url}
                 payload:
                   image: harjgam/web-platform-tests:0.33
+                  capabilities: {$eval: capabilities}
                   maxRunTime: 7200
                   artifacts:
                     public/results:

--- a/infrastructure/expected-fail/failing-test.html
+++ b/infrastructure/expected-fail/failing-test.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- DO NOT MERGE -->
 <meta charset=utf-8>
 <title>Failing test</title>
 <script src="/resources/testharness.js"></script>

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -56,7 +56,8 @@ def main(product, commit_range, wpt_args):
         logger.info("Running all tests")
 
     wpt_args += [
-        "--log-mach-level=info",
+        "--webdriver-arg=--verbose",
+        "--log-mach-level=debug",
         "--log-mach=-",
         "-y",
         "--no-pause",


### PR DESCRIPTION
This is a proven workaround for #20133 .

WARNING: this would effectively give *anyone* **root** access to the *host*. If we were to do this, we would at least want to create two different worker types for pushes and PRs to avoid cross contamination.