### PR TITLE
[taskcluster] Disable Chrome sandboxing in Docker

### DIFF
--- a/infrastructure/expected-fail/failing-test.html
+++ b/infrastructure/expected-fail/failing-test.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- DO NOT MERGE -->
 <meta charset=utf-8>
 <title>Failing test</title>
 <script src="/resources/testharness.js"></script>

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -276,6 +276,8 @@ def setup_environment(args):
     if "chrome" in args.browser:
         assert args.channel is not None
         install_chrome(args.channel)
+        # Taskcluster Docker doesn't have enough permissions to enable sandbox.
+        args.script_args.append("--binary-arg=--no-sandbox")
     elif "webkitgtk_minibrowser" in args.browser:
         assert args.channel is not None
         install_webkitgtk(args.channel)

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -56,7 +56,8 @@ def main(product, commit_range, wpt_args):
         logger.info("Running all tests")
 
     wpt_args += [
-        "--log-mach-level=info",
+        "--webdriver-arg=--verbose",
+        "--log-mach-level=debug",
         "--log-mach=-",
         "-y",
         "--no-pause",


### PR DESCRIPTION
According to the [theory](https://github.com/web-platform-tests/wpt/issues/20133#issuecomment-550521698), we used to be able to run Chrome without privileged mode because user namespace was not supported in the old github-worker. Let's try disabling it and see if it works on the new worker. If it does, we are not really losing any security compared with before.