### PR TITLE
[taskcluster] Disable Chrome sandboxing in Docker

### DIFF
--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -14,6 +14,7 @@ commands = pytest {posargs}
 passenv =
   HYPOTHESIS_PROFILE
   PY_COLORS
+  TASKCLUSTER_ROOT_URL
 
 [testenv:py27-flake8]
 deps = -rrequirements_flake8.txt

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -347,6 +347,10 @@ class Chrome(BrowserSetup):
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
             # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
             kwargs["webdriver_args"].append("--disable-build-check")
+        if os.getenv("TASKCLUSTER_ROOT_URL"):
+            # We are on Taskcluster, where our Docker container does not have
+            # enough capabilities to run Chrome with sandboxing. (gh-20133)
+            kwargs["binary_args"].append("--no-sandbox")
 
 
 class ChromeAndroid(BrowserSetup):

--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -14,3 +14,6 @@ deps =
 
 commands =
   pytest {posargs}
+
+passenv =
+  TASKCLUSTER_ROOT_URL

--- a/tools/wptrunner/tox.ini
+++ b/tools/wptrunner/tox.ini
@@ -24,3 +24,6 @@ deps =
 commands = pytest {posargs}
 
 setenv = CURRENT_TOX_ENV = {envname}
+
+passenv =
+  TASKCLUSTER_ROOT_URL


### PR DESCRIPTION
Whenever we see `TASKCLUSTER_ROOT_URL` in the entry point (`runl.py`), we
disable Chrome sandboxing with --no-sandbox.

tox.ini needs to be modified to allow passing of `TASKCLUSTER_ROOT_URL`.

Fix #20133

(Alternative to #20136 )