### PR TITLE
Use long timeout in webdriver/tests/find_element_from_element/find.py

### DIFF
--- a/webdriver/tests/find_element_from_element/find.py
+++ b/webdriver/tests/find_element_from_element/find.py
@@ -1,3 +1,4 @@
+# META: timeout=long
 import pytest
 
 from webdriver.transport import Response


### PR DESCRIPTION
WebKitWebDriver (WebKitGTK) needs at least 55 seconds to run this test.
The default timeout (25+5 seconds) is not enough.
So use a long timeout (180+5) instead for this wdspec test.