### PR TITLE
Replace most instances of "Web Platform Tests"

### DIFF
--- a/common/security-features/resources/common.sub.js
+++ b/common/security-features/resources/common.sub.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Utilities for mixed-content in Web Platform Tests.
+ * @fileoverview Utilities for mixed-content in web-platform-tests.
  * @author burnik@google.com (Kristijan Burnik)
  * Disclaimer: Some methods of other authors are annotated in the corresponding
  *     method's JSDoc.

--- a/css/css-scroll-anchoring/README.md
+++ b/css/css-scroll-anchoring/README.md
@@ -1,4 +1,4 @@
-## Scroll Anchoring Web Platform Tests
+## Scroll Anchoring Test Suite
 
 Scroll anchoring adjusts the scroll position to prevent visible jumps (or
 "reflows") when content changes above the viewport.

--- a/mixed-content/README.md
+++ b/mixed-content/README.md
@@ -1,4 +1,4 @@
-# Mixed-content Web Platform Tests
+# Mixed Content Test Suite
 
 The subdirectory `gen/` is generated using the generator at `common/security-features`.
 See [common/security-features/README.md](../common/security-features/README.md) for how to generate tests.

--- a/mixed-content/generic/test-case.sub.js
+++ b/mixed-content/generic/test-case.sub.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test case for mixed-content in Web Platform Tests.
+ * @fileoverview Test case for mixed-content in web-platform-tests.
  * @author burnik@google.com (Kristijan Burnik)
  */
 

--- a/referrer-policy/README.md
+++ b/referrer-policy/README.md
@@ -1,4 +1,4 @@
-# Referrer-Policy Web Platform Tests
+# Referrer Policy Test Suite
 
 The Referrer-Policy tests are designed for testing browser implementations and conformance to the [W3 Referrer-Policy Specification](http://w3c.github.io/webappsec/specs/referrer-policy/).
 

--- a/sms/README.md
+++ b/sms/README.md
@@ -1,3 +1,3 @@
 # SMS Receiver API
 
-This directory contains Web platform tests of the SMS Receiver API. For more details, refer to [this README file](https://cs.chromium.org/chromium/src/content/browser/sms/README.md).
+This directory contains tests for the SMS Receiver API. For more details, refer to [this README file](https://cs.chromium.org/chromium/src/content/browser/sms/README.md).

--- a/tools/webdriver/README.md
+++ b/tools/webdriver/README.md
@@ -9,7 +9,7 @@ implementation compliance to the specification in mind,
 so that different remote end drivers
 can determine whether they meet the recognised standard.
 The client is used for the WebDriver specification tests
-in the [Web Platform Tests](https://github.com/web-platform-tests/wpt).
+in [web-platform-tests](https://github.com/web-platform-tests/wpt).
 
 ## Installation
 
@@ -24,11 +24,11 @@ which is useful if you want to contribute patches back:
 
     % cd /path/to/wdclient
     % python
-    Python 2.7.12+ (default, Aug  4 2016, 20:04:34) 
+    Python 2.7.12+ (default, Aug  4 2016, 20:04:34)
     [GCC 6.1.1 20160724] on linux2
     Type "help", "copyright", "credits" or "license" for more information.
     >>> import webdriver
-    >>> 
+    >>>
 
 If you are writing WebDriver specification tests for
 [WPT](https://github.com/web-platform-tests/wpt),

--- a/upgrade-insecure-requests/README.md
+++ b/upgrade-insecure-requests/README.md
@@ -1,4 +1,4 @@
-# Upgrade-insecure-requests Web Platform Tests
+# Upgrade Insecure Requests Test Suite
 
 The subdirectory `gen/` is generated using the generator at `common/security-features`.
 See [common/security-features/README.md](../common/security-features/README.md) for how to generate tests.


### PR DESCRIPTION
"web-platform-tests" easily wins a grep battle, even when excluding
URLs.

This leaves only a single occurrence:
https://github.com/web-platform-tests/wpt/blob/bd66eaf4732572de37bbd163842ac060bfe37f84/tools/wptserve/wptserve/sslutils/openssl.py#L199