### PR TITLE
[docs] update wpt.live address

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The most important sources of information and activity are:
 - [web-platform-tests.org](https://web-platform-tests.org): the documentation
   website; details how to set up the project, how to write tests, how to give
   and receive peer review, how to serve as an administrator, and more
-- [web-platform-tests.live](http://web-platform-tests.live): a public
-  deployment of the test suite, allowing anyone to run the tests by visiting
-  from an Internet-enabled browser of their choice
+- [wpt.live](http://wpt.live): a public deployment of the test suite,
+  allowing anyone to run the tests by visiting from an
+  Internet-enabled browser of their choice
 - [wpt.fyi](https://wpt.fyi): an archive of test results collected from an
   array of web browsers on a regular basis
 - [Real-time chat room](http://irc.w3.org/?channels=testing): the

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,9 @@ The most important sources of information and activity are:
 - [web-platform-tests.org](https://web-platform-tests.org): the documentation
   website; details how to set up the project, how to write tests, how to give
   and receive peer review, how to serve as an administrator, and more
-- [web-platform-tests.live](http://web-platform-tests.live): a public
-  deployment of the test suite, allowing anyone to run the tests by visiting
-  from an Internet-enabled browser of their choice
+- [wpt.live](http://wpt.live): a public deployment of the test suite,
+  allowing anyone to run the tests by visiting from an
+  Internet-enabled browser of their choice
 - [wpt.fyi](https://wpt.fyi): an archive of test results collected from an
   array of web browsers on a regular basis
 - [Real-time chat room](http://irc.w3.org/?channels=testing): the


### PR DESCRIPTION
Update the old http://web-platform-tests.live address to the new
address at http://wpt.live in the top-level README.md and
docs/index.md. The old address no longer functions.

There is still a reference to web-platform-tests.live in `docs/intro-video-transcript.md`. Not sure how to address that.