### PR TITLE
[testharness.js] Preserve harness error message

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -792,8 +792,14 @@ policies and contribution forms [3].
 
     function done() {
         if (tests.tests.length === 0) {
-            tests.status.status = tests.status.ERROR;
-            tests.status.message = "done() was called without first defining any tests";
+            // `done` is invoked after handling uncaught exceptions, so if the
+            // harness status is already set, the corresponding message is more
+            // descriptive than the generic message defined here.
+            if (tests.status.status === null) {
+                tests.status.status = tests.status.ERROR;
+                tests.status.message = "done() was called without first defining any tests";
+            }
+
             tests.complete();
             return;
         }


### PR DESCRIPTION
This change does not modify tests because it only effects the harness status string, and we do not validate that.

I checked the "raw" wpt.fyi results for gh-20036. There were 10 occurrences of the generic harness error message in Chrome's data:

    $ grep 'called without first defining' report-master-chrome-pretty.json -C 3 | grep 'test":'
    "test": "/idle-detection/interceptor.https.html",
    "test": "/fetch/metadata/sec-fetch-dest/redirect/multiple-redirect-https-downgrade-upgrade.tentative.sub.html",
    "test": "/fetch/metadata/sec-fetch-dest/redirect/redirect-http-upgrade.tentative.sub.html",
    "test": "/fetch/metadata/sec-fetch-dest/redirect/redirect-https-downgrade.tentative.sub.html",
    "test": "/streams/readable-byte-streams/construct-byob-request.any.sharedworker.html",
    "test": "/streams/readable-byte-streams/construct-byob-request.any.serviceworker.html",
    "test": "/streams/readable-byte-streams/construct-byob-request.any.html",
    "test": "/streams/readable-byte-streams/construct-byob-request.any.worker.html",
    "test": "/infrastructure/expected-fail/uncaught-exception.html",
    "test": "/infrastructure/expected-fail/unhandled-rejection.html",

Firefox had a significantly greater number:

    $ grep 'called without first defining' report-master-firefox-pretty.json | wc -l
    346

Following the application of this patch, both browsers report just one test--a legitimate and previously-unreported testing error:

    $ grep 'called without first defining' report-patched-chrome-pretty.json -C 3 | grep 'test":'
    "test": "/css/css-lists/list-inside-contain.html",
    $ grep 'called without first defining' report-patched-firefox-pretty.json -C 3 | grep 'test":'
    "test": "/css/css-lists/list-inside-contain.html",

That test was merged after gh-20036, so we shouldn't lose sleep about any lack of care. It was most likely submitted from a branch that didn't include the `single_test` enforcement. In any event, I've opened gh-20167 to correct it.

Reviewing this patch's effect on results more generally, it doesn't appear to have any unintended side effects:

- Chrome: https://wpt.fyi/results/?diff&filter=ADC&run_id=354170001&run_id=335520002
- Firefox: https://wpt.fyi/results/?diff&filter=ADC&run_id=356180001&run_id=346920014

Although many of the discrepancies are due to pre-existing instabilities, I haven't yet reviewed all of them. I'm opening this pull request now because this problem is blocking gh-19993, so others can verify in my place if they want to move forward before I return tomorrow (EST).