### PR TITLE
Update psutil to 5.6.5

### DIFF
--- a/tools/wptrunner/requirements_firefox.txt
+++ b/tools/wptrunner/requirements_firefox.txt
@@ -8,4 +8,4 @@ mozprocess==1.0.0
 mozprofile==2.4.0
 mozrunner==7.7.0
 mozversion==2.2.0
-psutil==5.6.4
+psutil==5.6.5


### PR DESCRIPTION
5.6.4 breaks Servo's automatic sync; 5.6.5 has a fix that avoids this.