### PR TITLE
Prevent potential timeout results in 2 MathML tests:

### DIFF
--- a/mathml/relations/html5-tree/css-inline-style-dynamic.tentative.html
+++ b/mathml/relations/html5-tree/css-inline-style-dynamic.tentative.html
@@ -5,6 +5,7 @@
     <title>MathML 'ElementCSSInlineStyle` Dynamic Tests</title>
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#dom-and-javascript"/>
     <link rel="match" href="css-inline-style-dynamic.tentative-ref.html"/>
+    <script src="/mathml/support/feature-detection.js"></script>
     <style>
       #hidden  {
         visibility: hidden;
@@ -21,9 +22,17 @@
     <script type="text/javascript">
       function test()
       {
+        MathMLFeatureDetection.ensure_for_match_reftest("has_mspace");
         document.body.offsetTop; // Update layout
-        document.getElementById("hidden").style.visibility = "visible";
-        document.getElementById("red").style.backgroundColor = "green";
+
+        var mspace = document.getElementById("hidden");
+        if (mspace.style)
+          mspace.style.visibility = "visible";
+
+        mspace = document.getElementById("red");
+        if (mspace.style)
+          mspace.style.backgroundColor = "green";
+
         document.documentElement.className = "";
       }
     </script>

--- a/mathml/relations/html5-tree/href-click-3.html
+++ b/mathml/relations/html5-tree/href-click-3.html
@@ -19,10 +19,20 @@
       <mspace width="50px" height="10px" style="background: gray"></mspace>
     </math>
   </p>
+  <a id="badTarget" href="javascript:badHandler()">DON'T CLICK ME</a>
   <script>
     var t = async_test("Click element with href");
     function handler() { t.done(); }
-    test_driver.click(document.getElementById("target"));
+    function badHandler() {
+      t.step(() => { assert_unreached("Bad handler executed"); });
+      t.done();
+    }
+    test_driver.click(document.getElementById("target")).then(() => {
+      return test_driver.click(document.getElementById("badTarget"));
+    }).catch(() => {
+      t.step(() => { assert_unreached("Click failed"); });
+      t.done();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
cc @rwlbuis 

- css-inline-style-dynamic.tentative.html:
  Verify that MathMLElement.style is defined before using it. Add a
  feature detection for mspace to avoid false positive.

- href-click-3.html: Handle test_driver's click failure and perform a
  second click with a 'bad' HTML target. If href is supported, the test
  would have completed before the 'bad' handler is called. Otherwise,
  the test will complete in that 'bad' handler.

closes https://github.com/mathml-refresh/mathml/issues/167