### PR TITLE
[testharness.js] Implement `promise_setup`

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -430,18 +430,39 @@ not possible to make the test reliable in some other way.
 
 ## Setup ##
 
-Sometimes tests require non-trivial setup that may fail. For this purpose
-there is a `setup()` function, that may be called with one or two arguments.
-The two argument version is:
+Sometimes tests require non-trivial setup that may fail. testharness.js
+provides two global functions for this purpose, `setup` and `promise_setup`.
+
+`setup()` may be called with one or two arguments. The two argument version is:
 
 ```js
 setup(func, properties)
 ```
 
-The one argument versions may omit either argument.
-func is a function to be run synchronously. `setup()` becomes a no-op once
-any tests have returned results. Properties are global properties of the test
-harness. Currently recognised properties are:
+The one argument versions may omit either argument. `func` is a function to be
+run synchronously. `setup()` becomes a no-op once any tests have returned
+results. `properties` is an object which specifies global properties of the
+test harness (enumerated in the following section).
+
+`promise_setup()` allows authors to pause testing until some asynchronous
+operation has completed. It has the following signature:
+
+```js
+promise_setup(func, properties)
+```
+
+Here, the `func` argument is required. The harness will defer execution of this
+function until any subtests have completed. The function must return an object
+with a `then` method (e.g. an ECMAScript Promise instance); the harness will
+wait for the fulfillment of this value before executing any additional tests
+defined with the `promise_test` function. If the value is rejected, the harness
+will report an error and cancel the remaining tests. `properties` may
+optionally be provided as an object which specifies global properties of the
+test harness (enumerated in the following section).
+
+### Setup properties ##
+
+Both setup functions recognize the following properties:
 
 `explicit_done` - Wait for an explicit call to done() before declaring all
 tests complete (see below; implicitly true for single page tests)

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -439,7 +439,7 @@ provides two global functions for this purpose, `setup` and `promise_setup`.
 setup(func, properties)
 ```
 
-The one argument versions may omit either argument. `func` is a function to be
+The one argument version may omit either argument. `func` is a function to be
 run synchronously. `setup()` becomes a no-op once any tests have returned
 results. `properties` is an object which specifies global properties of the
 test harness (enumerated in the following section).
@@ -451,14 +451,13 @@ operation has completed. It has the following signature:
 promise_setup(func, properties)
 ```
 
-Here, the `func` argument is required. The harness will defer execution of this
-function until any subtests have completed. The function must return an object
-with a `then` method (e.g. an ECMAScript Promise instance); the harness will
-wait for the fulfillment of this value before executing any additional tests
-defined with the `promise_test` function. If the value is rejected, the harness
-will report an error and cancel the remaining tests. `properties` may
-optionally be provided as an object which specifies global properties of the
-test harness (enumerated in the following section).
+Here, the `func` argument is required. This argument must be a function which
+returns an object with a `then` method (e.g. an ECMAScript Promise instance);
+the harness will wait for the fulfillment of this value before executing any
+additional subtests defined with the `promise_test` function. If the value is
+rejected, the harness will report an error and cancel the remaining tests.
+`properties` may optionally be provided as an object which specifies global
+properties of the test harness (enumerated in the following section).
 
 ### Setup properties ##
 

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -314,6 +314,7 @@ SET TIMEOUT: resources/test/tests/functional/worker.js
 SET TIMEOUT: resources/test/tests/functional/worker-uncaught-allow.js
 SET TIMEOUT: resources/test/tests/unit/exceptional-cases.html
 SET TIMEOUT: resources/test/tests/unit/exceptional-cases-timeouts.html
+SET TIMEOUT: resources/test/tests/unit/promise_setup.html
 SET TIMEOUT: resources/testharness.js
 
 # setTimeout use in reftests

--- a/resources/test/tests/unit/promise_setup-timeout.html
+++ b/resources/test/tests/unit/promise_setup-timeout.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="timeout" content="long">
+  <script src="/resources/testharness.js"></script>
+  <script src="../../nested-testharness.js"></script>
+  <title>promise_setup - timeout</title>
+</head>
+<body>
+<script>
+'use strict';
+promise_test(() => {
+  return makeTest(
+      () => {
+        test(() => {}, 'before');
+        promise_setup(() => new Promise(() => {}));
+        promise_test(() => Promise.resolve(), 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'TIMEOUT');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'NOTRUN');
+    });
+}, 'timeout when returned promise does not settle');
+</script>
+</body>
+</html>

--- a/resources/test/tests/unit/promise_setup.html
+++ b/resources/test/tests/unit/promise_setup.html
@@ -1,0 +1,333 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <script src="../../nested-testharness.js"></script>
+  <title>promise_setup</title>
+</head>
+<body>
+<script>
+'use strict';
+promise_test(() => {
+  return makeTest(
+      () => {
+        // Ensure that the harness error is the result of explicit error
+        // handling
+        setup({ allow_uncaught_exception: true });
+
+        test(() => {}, 'before');
+        promise_setup({});
+        promise_test(() => Promise.resolve(), 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, undefined);
+    });
+}, 'Error when no function provided');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        test(() => {}, 'before');
+        promise_setup(() => Promise.resolve(), {});
+        promise_test(() => Promise.resolve(), 'after');
+        throw new Error('this error is expected');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'Does not apply unspecified configuration properties');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        var properties = {
+          allow_uncaught_exception: true
+        };
+        test(() => {}, 'before');
+        promise_setup(() => Promise.resolve(), properties);
+        promise_test(() => Promise.resolve(), 'after');
+        throw new Error('this error is expected');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'Ignores configuration properties when some tests have already run');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        var properties = {
+          allow_uncaught_exception: true
+        };
+        promise_setup(() => Promise.resolve(), properties);
+        promise_test(() => {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              resolve();
+              throw new Error('this error is expected');
+            });
+          });
+        }, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'OK');
+      assert_equals(tests.after, 'PASS');
+    });
+}, 'Honors configuration properties');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        // Ensure that the harness error is the result of explicit error
+        // handling
+        setup({ allow_uncaught_exception: true });
+
+        test(() => {}, 'before');
+        promise_setup(() => { throw new Error('this error is expected'); });
+        promise_test(() => Promise.resolve(), 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'NOTRUN');
+    });
+}, 'Error for synchronous exceptions');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        // Ensure that the harness error is the result of explicit error
+        // handling
+        setup({ allow_uncaught_exception: true });
+
+        test(() => {}, 'before');
+        promise_setup(() => undefined);
+        promise_test(() => Promise.resolve(), 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'NOTRUN');
+    });
+}, 'Error for missing return value');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        // Ensure that the harness error is the result of explicit error
+        // handling
+        setup({ allow_uncaught_exception: true });
+
+        test(() => {}, 'before');
+        var noThen = Promise.resolve();
+        noThen.then = undefined;
+        promise_setup(() => noThen);
+        promise_test(() => Promise.resolve(), 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'NOTRUN');
+    });
+}, 'Error for non-thenable return value');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        // Ensure that the harness error is the result of explicit error
+        // handling
+        setup({ allow_uncaught_exception: true });
+
+        test(() => {}, 'before');
+        var poisonedThen = {
+          get then() {
+            throw new Error('this error is expected');
+          }
+        };
+        promise_setup(() => poisonedThen);
+        promise_test(() => Promise.resolve(), 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'NOTRUN');
+    });
+}, 'Error for "poisoned" `then` property');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        // Ensure that the harness error is the result of explicit error
+        // handling
+        setup({ allow_uncaught_exception: true });
+
+        test(() => {}, 'before');
+        var badThen = {
+          then() {
+            throw new Error('this error is expected');
+          }
+        };
+        promise_setup(() => badThen);
+        promise_test(() => Promise.resolve(), 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'NOTRUN');
+    });
+}, 'Error for synchronous error from `then` method');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        // Ensure that the harness error is the result of explicit error
+        // handling
+        setup({ allow_uncaught_exception: true });
+
+        test(() => {}, 'before');
+        promise_setup(() => Promise.resolve());
+        test(() => {}, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, undefined);
+    });
+}, 'Error for subsequent invocation of `test`');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        // Ensure that the harness error is the result of explicit error
+        // handling
+        setup({ allow_uncaught_exception: true });
+
+        test(() => {}, 'before');
+        promise_setup(() => Promise.resolve());
+        async_test((t) => t.done(), 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, undefined);
+    });
+}, 'Error for subsequent invocation of `async_test`');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        // Ensure that the harness error is the result of explicit error
+        // handling
+        setup({ allow_uncaught_exception: true });
+
+        test(() => {}, 'before');
+        promise_setup(() => Promise.reject());
+        promise_test(() => Promise.resolve(), 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'NOTRUN');
+    });
+}, 'Error for rejected promise');
+
+promise_test(() => {
+  var expected_sequence = [
+    'test body',
+    'promise_setup begin',
+    'promise_setup end',
+    'promise_test body'
+  ];
+  var actual_sequence = window.actual_sequence = [];
+
+  return makeTest(
+      () => {
+        test(() => { parent.actual_sequence.push('test body'); }, 'before');
+        promise_setup(() => {
+          parent.actual_sequence.push('promise_setup begin');
+
+          return Promise.resolve()
+            .then(() => new Promise((resolve) => setTimeout(resolve, 300)))
+            .then(() => parent.actual_sequence.push('promise_setup end'));
+        });
+        promise_test(() => {
+          parent.actual_sequence.push('promise_test body');
+          return Promise.resolve();
+        }, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'OK');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'PASS');
+      assert_array_equals(actual_sequence, expected_sequence);
+    });
+}, 'Waits for promise to settle');
+
+promise_test(() => {
+  var expected_sequence = [
+    'promise_test 1 begin',
+    'promise_test 1 end',
+    'promise_setup begin',
+    'promise_setup end',
+    'promise_test 2 body'
+  ];
+  var actual_sequence = window.actual_sequence = [];
+
+  return makeTest(
+      () => {
+        promise_test((t) => {
+          parent.actual_sequence.push('promise_test 1 begin');
+
+          return Promise.resolve()
+            .then(() => new Promise((resolve) => t.step_timeout(resolve, 300)))
+            .then(() => parent.actual_sequence.push('promise_test 1 end'));
+        }, 'before');
+        promise_setup(() => {
+          parent.actual_sequence.push('promise_setup begin');
+
+          return Promise.resolve()
+            .then(() => new Promise((resolve) => setTimeout(resolve, 300)))
+            .then(() => parent.actual_sequence.push('promise_setup end'));
+        });
+        promise_test(() => {
+          parent.actual_sequence.push('promise_test 2 body');
+          return Promise.resolve();
+        }, 'after');
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'OK');
+      assert_equals(tests.before, 'PASS');
+      assert_equals(tests.after, 'PASS');
+      assert_array_equals(actual_sequence, expected_sequence);
+    });
+}, 'Waits for existing promise_test to complete');
+
+promise_test(() => {
+  return makeTest(
+      () => {
+        var properties = { allow_uncaught_exception: true };
+        promise_test(() => {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              resolve();
+              throw new Error('this error is expected');
+            });
+          });
+        }, 'before');
+        promise_setup(() => Promise.resolve(), properties);
+      }
+    ).then(({harness, tests}) => {
+      assert_equals(harness, 'ERROR');
+      assert_equals(tests.before, 'PASS');
+    });
+}, 'Defers application of setup properties');
+</script>
+</body>
+</html>


### PR DESCRIPTION
This enacts the change specified by WPT RFC 32

https://github.com/web-platform-tests/rfcs/blob/master/rfcs/asynchronous_setup.md

---

This implementation differs from the algorithm in [WPT RFC 32](https://github.com/web-platform-tests/rfcs/blob/master/rfcs/asynchronous_setup.md) in one regard: the operations are deferred until the completion of any subtests which were previously defined using `promise_test`. Take the following test for example:

```js
promise_test(async () => {}), 'a');
promise_setup(async () => {});
promise_test(async () => {}), 'b');
```

As written in the RFC, the subtest named "a" and the setup code would run in parallel. The subtest named "b" would run following the completion of both.

In the implementation proposed here, the setup code does not run until *after* the subtest named "a" has completed. The subtest named "b" runs after the setup code has completed. The application of any optional setup properties is likewise deferred, so in keeping with the existing behavior of `setup`, they are ignored.

My cursory search through recent test results didn't turn up any occurrences of this pattern (i.e. setup after some tests are defined), but it's hard to make a conclusive inquiry because asynchronous setup is currently accomplished in an ad-hoc way. My motivation for this divergence is more about consistency and predictability than it is about supporting existing tests.

If we agree that this is in-line with the spirit of the RFC, then I can amend the RFC accordingly. If folks feel this is too substantial a change to make in a code review, I can file a new RFC to propose the alteration.