### PR TITLE
[websockets] Correct references

### DIFF
--- a/websockets/unload-a-document/001-1.html
+++ b/websockets/unload-a-document/001-1.html
@@ -6,7 +6,6 @@
 <script>
 var controller = opener || parent;
 var t = controller.t;
-var assert_equals = controller.asset_equals;
 var assert_unreached = controller.assert_unreached;
 var uuid = controller.uuid;
 t.add_cleanup(function() {delete sessionStorage[uuid];});

--- a/websockets/unload-a-document/002-1.html
+++ b/websockets/unload-a-document/002-1.html
@@ -6,9 +6,9 @@
 <script>
 var controller = opener || parent;
 var t = controller.t;
-var assert_equals = controller.asset_equals;
+var assert_equals = controller.assert_equals;
 var assert_unreached = controller.assert_unreached ;
-var uuid = controller.token;
+var uuid = controller.uuid;
 t.add_cleanup(function() {delete sessionStorage[uuid];});
 t.step(function() {
   // this test can fail if the document is unloaded on navigation e.g. due to OOM


### PR DESCRIPTION
The test titled `002.html` relies on a document which references an
undefined property, `asset_equals`. Since that value is later invoked as
a function, the test cannot pass. Correct the reference.

The document also incorrectly references the `token` function instead of
the intended `uuid` string value. Correct the reference.

The test titled `001.html` also includes a misspelled reference, but it
does not rely on the value. Remove the reference.