### PR TITLE
taskcluster: ensure data.metadata.owner is a valid e-mail on push event

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -73,7 +73,10 @@ tasks:
                   A subset of WPT's "${chunk[0]}" tests (chunk number ${chunk[1]}
                   of ${chunk[2]}), run in the ${browser.channel} release of
                   ${browser.name}.
-                owner: ${event.pusher.email}
+                owner:
+                  $if: '"@" in event.pusher.email'
+                  then: ${event.pusher.email}
+                  else: ${event.pusher.name}@users.noreply.github.com
                 source: ${event.repository.url}
               payload:
                 image:


### PR DESCRIPTION
* When the push event comes from a github action, event.pusher.email
seems to be invalid, which causes a fatal error on taskcluster.
Fix this by appending @users.noreply.github.com to user id of the
push event.

Related issue: #20106