### PR TITLE
Verify piping disturbs stream synchronously

### DIFF
--- a/fetch/api/response/response-stream-disturbed-by-pipe.any.js
+++ b/fetch/api/response/response-stream-disturbed-by-pipe.any.js
@@ -1,0 +1,15 @@
+test(() => {
+  const r = new Response(new ReadableStream());
+  // highWaterMark: 0 means that nothing will actually be read from the body.
+  r.body.pipeTo(new WritableStream({}, {highWaterMark: 0}));
+  assert_true(r.bodyUsed, 'bodyUsed should be true');
+}, 'using pipeTo on Response body should disturb it synchronously');
+
+test(() => {
+  const r = new Response(new ReadableStream());
+  r.body.pipeThrough({
+    writable: new WritableStream({}, {highWaterMark: 0}),
+    readable: new ReadableStream()
+  });
+  assert_true(r.bodyUsed, 'bodyUsed should be true');
+}, 'using pipeThrough on Response body should disturb it synchronously');


### PR DESCRIPTION
https://github.com/whatwg/streams/pull/1022 changes pipeTo and
pipeThrough to always set the [[disturbed]] slot of the Response's body
to true synchronously.

This test verifies that behaviour.