### PR TITLE
taskcluster: ensure data.metadata.owner is a valid e-mail on push event (v2)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -73,10 +73,7 @@ tasks:
                   A subset of WPT's "${chunk[0]}" tests (chunk number ${chunk[1]}
                   of ${chunk[2]}), run in the ${browser.channel} release of
                   ${browser.name}.
-                owner:
-                  $if: '"@" in event.pusher.email'
-                  then: ${event.pusher.email}
-                  else: ${event.pusher.name}@users.noreply.github.com
+                owner: ${event.sender.login}@users.noreply.github.com
                 source: ${event.repository.url}
               payload:
                 image:


### PR DESCRIPTION
taskcluster: ensure data.metadata.owner is a valid e-mail on push event (v2)

* When the push event comes from a github action, event.pusher.email
seems to be invalid, which causes a fatal error on taskcluster.

* Previous attempt to fix this (0317a96431) has not worked because
event.pusher.email is not defined for github actions and its unknown
if event.pusher.name is.

* Try to fix it this time by defaulting the mail in all cases to
${event.sender.login}@users.noreply.github.com which according to
the GitHub API documentation examples should be always defined
(hopefully that will be also true for github actions).

Related issue: #20106
