### PR TITLE
WebKitWebDriver: pass list of domains where WPT certificate is valid (#19233)

### DIFF
--- a/tools/wptrunner/tox.ini
+++ b/tools/wptrunner/tox.ini
@@ -2,7 +2,7 @@
 xfail_strict=true
 
 [tox]
-envlist = py27-{base,chrome,edge,firefox,ie,opera,safari,sauce,servo},py36-base
+envlist = py27-{base,chrome,edge,firefox,ie,opera,safari,sauce,servo,webkit,webkitgtk_minibrowser,epiphany},py36-base
 skip_missing_interpreters = true
 
 [testenv]
@@ -20,6 +20,9 @@ deps =
      safari: -r{toxinidir}/requirements_safari.txt
      sauce: -r{toxinidir}/requirements_sauce.txt
      servo: -r{toxinidir}/requirements_servo.txt
+     webkit: -r{toxinidir}/requirements_webkit.txt
+     webkitgtk_minibrowser: -r{toxinidir}/requirements_webkit.txt
+     epiphany: -r{toxinidir}/requirements_epiphany.txt
 
 commands = pytest {posargs}
 

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -50,6 +50,14 @@ def maybe_add_args(required_args, current_args):
     return current_args
 
 
+def certificate_domain_list(list_of_domains, certificate_file):
+    """Build a list of domains where certificate_file should be used"""
+    cert_list = []
+    for domain in list_of_domains:
+        cert_list.append({"host": domain, "certificateFile": certificate_file})
+    return cert_list
+
+
 def get_free_port():
     """Get a random unbound port"""
     while True:

--- a/tools/wptrunner/wptrunner/browsers/epiphany.py
+++ b/tools/wptrunner/wptrunner/browsers/epiphany.py
@@ -1,4 +1,4 @@
-from .base import get_timeout_multiplier, maybe_add_args   # noqa: F401
+from .base import get_timeout_multiplier, maybe_add_args, certificate_domain_list  # noqa: F401
 from .webkit import WebKitBrowser
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
@@ -44,9 +44,7 @@ def capabilities(server_config, **kwargs):
         "webkitgtk:browserOptions": {
             "binary": kwargs["binary"],
             "args": args,
-            "certificates": [
-                {"host": server_config["browser_host"],
-                 "certificateFile": kwargs["host_cert_path"]}]}}
+            "certificates": certificate_domain_list(server_config.domains_set, kwargs["host_cert_path"])}}
 
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data,

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -1,5 +1,5 @@
 from .base import Browser, ExecutorBrowser, require_arg
-from .base import get_timeout_multiplier   # noqa: F401
+from .base import get_timeout_multiplier, certificate_domain_list  # noqa: F401
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
                                            WebDriverRefTestExecutor)  # noqa: F401
@@ -47,9 +47,7 @@ def capabilities_for_port(server_config, **kwargs):
             browser_options_key: {
                 "binary": kwargs["binary"],
                 "args": kwargs.get("binary_args", []),
-                "certificates": [
-                    {"host": server_config["browser_host"],
-                     "certificateFile": kwargs["host_cert_path"]}]}}
+                "certificates": certificate_domain_list(server_config.domains_set, kwargs["host_cert_path"])}}
 
     return {}
 

--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -1,4 +1,4 @@
-from .base import get_timeout_multiplier, maybe_add_args   # noqa: F401
+from .base import get_timeout_multiplier, maybe_add_args, certificate_domain_list  # noqa: F401
 from .webkit import WebKitBrowser
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
@@ -48,9 +48,7 @@ def capabilities(server_config, **kwargs):
         "webkitgtk:browserOptions": {
             "binary": kwargs["binary"],
             "args": args,
-            "certificates": [
-                {"host": server_config["browser_host"],
-                 "certificateFile": kwargs["host_cert_path"]}]}}
+            "certificates": certificate_domain_list(server_config.domains_set, kwargs["host_cert_path"])}}
 
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data,

--- a/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
@@ -3,14 +3,15 @@ from os.path import join, dirname
 import pytest
 
 from wptserve.config import ConfigBuilder
+from ..base import active_products
 from wptrunner import environment, products
 
 test_paths = {"/": {"tests_path": join(dirname(__file__), "..", "..", "..", "..", "..")}}  # repo root
 environment.do_delayed_imports(None, test_paths)
 
 
-@pytest.mark.parametrize("browser_product", ["epiphany", "webkit", "webkitgtk_minibrowser"])
-def test_webkitgtk_certificate_domain_list(browser_product):
+@active_products("product")
+def test_webkitgtk_certificate_domain_list(product):
 
     def domain_is_inside_certificate_list_cert(domain_to_find, webkitgtk_certificate_list, cert_file):
         for domain in webkitgtk_certificate_list:
@@ -18,10 +19,13 @@ def test_webkitgtk_certificate_domain_list(browser_product):
                 return True
         return False
 
+    if product not in ["epiphany", "webkit", "webkitgtk_minibrowser"]:
+        pytest.skip("%s doesn't support certificate_domain_list" % product)
+
     (check_args,
      target_browser_cls, get_browser_kwargs,
      executor_classes, get_executor_kwargs,
-     env_options, get_env_extras, run_info_extras) = products.load_product({}, browser_product)
+     env_options, get_env_extras, run_info_extras) = products.load_product({}, product)
 
     cert_file = "/home/user/wpt/tools/certs/cacert.pem"
     valid_domains_test = ["a.example.org", "b.example.org", "example.org",

--- a/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
@@ -1,0 +1,53 @@
+from os.path import join, dirname
+
+import pytest
+
+from wptserve.config import ConfigBuilder
+from wptrunner import environment, products
+
+test_paths = {"/": {"tests_path": join(dirname(__file__), "..", "..", "..", "..", "..")}}  # repo root
+environment.do_delayed_imports(None, test_paths)
+
+
+@pytest.mark.parametrize("browser_product", ["epiphany", "webkit", "webkitgtk_minibrowser"])
+def test_webkitgtk_certificate_domain_list(browser_product):
+
+    def domain_is_inside_certificate_list_cert(domain_to_find, webkitgtk_certificate_list, cert_file):
+        for domain in webkitgtk_certificate_list:
+            if domain["host"] == domain_to_find and domain["certificateFile"] == cert_file:
+                return True
+        return False
+
+    (check_args,
+     target_browser_cls, get_browser_kwargs,
+     executor_classes, get_executor_kwargs,
+     env_options, get_env_extras, run_info_extras) = products.load_product({}, browser_product)
+
+    cert_file = "/home/user/wpt/tools/certs/cacert.pem"
+    valid_domains_test = ["a.example.org", "b.example.org", "example.org",
+                          "a.example.net", "b.example.net", "example.net"]
+    invalid_domains_test = ["x.example.org", "y.example.org", "example.it",
+                            "x.example.net", "y.example.net", "z.example.net"]
+    kwargs = {}
+    kwargs["timeout_multiplier"] = 1
+    kwargs["debug_info"] = None
+    kwargs["host_cert_path"] = cert_file
+    kwargs["webkit_port"] = "gtk"
+    kwargs["binary"] = None
+    kwargs["webdriver_binary"] = None
+    with ConfigBuilder(browser_host="example.net",
+                       alternate_hosts={"alt": "example.org"},
+                       subdomains={"a", "b"},
+                       not_subdomains={"x", "y"}) as env_config:
+
+        executor_args = get_executor_kwargs(None, env_config, None, None, **kwargs)
+        assert('capabilities' in executor_args)
+        assert('webkitgtk:browserOptions' in executor_args['capabilities'])
+        assert('certificates' in executor_args['capabilities']['webkitgtk:browserOptions'])
+        cert_list = executor_args['capabilities']['webkitgtk:browserOptions']['certificates']
+        for valid_domain in valid_domains_test:
+            assert(domain_is_inside_certificate_list_cert(valid_domain, cert_list, cert_file))
+            assert(not domain_is_inside_certificate_list_cert(valid_domain, cert_list, cert_file + ".backup_non_existent"))
+        for invalid_domain in invalid_domains_test:
+            assert(not domain_is_inside_certificate_list_cert(invalid_domain, cert_list, cert_file))
+            assert(not domain_is_inside_certificate_list_cert(invalid_domain, cert_list, cert_file + ".backup_non_existent"))


### PR DESCRIPTION
This PR is for issue #19233

* WebKitWebDriver can be informed of a list of domains where a specific
  certificate should be valid. See https://trac.webkit.org/r233035

* Use that feature to configure the custom certificate for WPT tests in
  all domains and subdomains that will be used for testing.

* Enable it on all the current 3 WebKitWebDriver based product browsers:
  webkit, webkitgtk_minibrowser and epiphany

* Add also an unit test to check that the dictionary gets built as
  expected.