### PR TITLE
Add tests for document scrollingElement property

### DIFF
--- a/css/cssom-view/document-scrollingElement-quirks.html
+++ b/css/cssom-view/document-scrollingElement-quirks.html
@@ -1,0 +1,38 @@
+<!-- Quirks Mode -->
+<meta charset=utf-8>
+<title>Document.scrollingElement in Quirks Mode</title>
+<link rel=help href="https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  assert_equals(document.scrollingElement, null);
+  assert_readonly(document, "scrollingElement");
+}, "scrollingElement should be equal to null without body Element for Quirks Mode");
+
+test(function() {
+  let body = document.createElement("body");
+  document.documentElement.appendChild(body);
+
+  assert_true(document.scrollingElement instanceof HTMLBodyElement, "scrollingElement is a reference to HTMLBodyElement");
+  assert_equals(document.scrollingElement, body);
+  assert_readonly(document, "scrollingElement");
+
+  // clean up
+  body.parentNode.removeChild(body);
+}, "scrollingElement should be equal to body Element for Quirks Mode");
+
+test(function() {
+  let body = document.createElement("body");
+  document.documentElement.appendChild(body);
+
+  // make body potentially scrollable: https://drafts.csswg.org/cssom-view/#potentially-scrollable
+  body.style.overflow = "scroll";
+  document.documentElement.style.overflow = "scroll";
+
+  assert_equals(document.scrollingElement, null);
+
+  // clean up
+  body.parentNode.removeChild(body);
+}, "scrollingElement should be equal null if body potentially scrollable for Quirks Mode");
+</script>

--- a/css/cssom-view/document-scrollingElement.html
+++ b/css/cssom-view/document-scrollingElement.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Document.scrollingElement in Standards Mode</title>
+<link rel=help href="https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  assert_true(document.scrollingElement instanceof HTMLElement, "scrollingElement is a reference to Element");
+  assert_equals(document.scrollingElement, document.documentElement);
+  assert_readonly(document, "scrollingElement");
+}, "scrollingElement should be equal to documentElement for Standards Mode");
+
+test(function() {
+  let newDoc = new Document();
+  assert_equals(newDoc.scrollingElement, null);
+
+  let htmlElt = newDoc.createElement("html");
+  newDoc.appendChild(htmlElt);
+  assert_equals(newDoc.scrollingElement, htmlElt);
+}, "scrollingElement should be null in document doesn't have html Element");
+</script>


### PR DESCRIPTION
Fixes #5473

There are two files for two modes: Standards and Quirks.
Thanks in advance for your feedback.