### PR TITLE
[html] Include omitted script

### DIFF
--- a/html/syntax/parsing/html5lib_innerHTML_adoption01.html
+++ b/html/syntax/parsing/html5lib_innerHTML_adoption01.html
@@ -9,8 +9,8 @@
     <h1>html5lib Parser Test</h1>
     <div id="log"></div>
     <script src="common.js"></script>
-    <script src="template.js"></script>
     <script src="test.js"></script>
+    <script src="template.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>

--- a/html/syntax/parsing/html5lib_innerHTML_adoption01.html
+++ b/html/syntax/parsing/html5lib_innerHTML_adoption01.html
@@ -9,6 +9,7 @@
     <h1>html5lib Parser Test</h1>
     <div id="log"></div>
     <script src="common.js"></script>
+    <script src="template.js"></script>
     <script src="test.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/html/syntax/parsing/html5lib_innerHTML_foreign-fragment.html
+++ b/html/syntax/parsing/html5lib_innerHTML_foreign-fragment.html
@@ -10,6 +10,7 @@
     <div id="log"></div>
     <script src="common.js"></script>
     <script src="test.js"></script>
+    <script src="template.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>

--- a/html/syntax/parsing/html5lib_innerHTML_math.html
+++ b/html/syntax/parsing/html5lib_innerHTML_math.html
@@ -10,6 +10,7 @@
     <div id="log"></div>
     <script src="common.js"></script>
     <script src="test.js"></script>
+    <script src="template.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>

--- a/html/syntax/parsing/html5lib_innerHTML_tests4.html
+++ b/html/syntax/parsing/html5lib_innerHTML_tests4.html
@@ -10,6 +10,7 @@
     <div id="log"></div>
     <script src="common.js"></script>
     <script src="test.js"></script>
+    <script src="template.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>

--- a/html/syntax/parsing/html5lib_innerHTML_tests6.html
+++ b/html/syntax/parsing/html5lib_innerHTML_tests6.html
@@ -10,6 +10,7 @@
     <div id="log"></div>
     <script src="common.js"></script>
     <script src="test.js"></script>
+    <script src="template.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>

--- a/html/syntax/parsing/html5lib_innerHTML_tests7.html
+++ b/html/syntax/parsing/html5lib_innerHTML_tests7.html
@@ -10,6 +10,7 @@
     <div id="log"></div>
     <script src="common.js"></script>
     <script src="test.js"></script>
+    <script src="template.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>

--- a/html/syntax/parsing/html5lib_innerHTML_tests_innerHTML_1.html
+++ b/html/syntax/parsing/html5lib_innerHTML_tests_innerHTML_1.html
@@ -10,6 +10,7 @@
     <div id="log"></div>
     <script src="common.js"></script>
     <script src="test.js"></script>
+    <script src="template.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>

--- a/html/syntax/parsing/html5lib_innerHTML_webkit02.html
+++ b/html/syntax/parsing/html5lib_innerHTML_webkit02.html
@@ -10,6 +10,7 @@
     <div id="log"></div>
     <script src="common.js"></script>
     <script src="test.js"></script>
+    <script src="template.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>

--- a/html/tools/html5lib_test_fragment.xml
+++ b/html/tools/html5lib_test_fragment.xml
@@ -9,6 +9,7 @@
     <div id="log"></div>
     <script src="common.js"></script>
     <script src="test.js"></script>
+    <script src="template.js"></script>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script>


### PR DESCRIPTION
The ReferenceError that's thrown due to the absence of this script can cause some browsers to report unstable results. I'm going to discuss addressing that at the harness level, but this fix is straightforward enough that I thought we should apply it regardless.

There are a handful of other tests that include `test.js` without `template.js`, but none of them actually depend on that script.

    $ git grep -l test.js html/syntax/parsing | xargs grep -L template.js
    html/syntax/parsing/html5lib_innerHTML_foreign-fragment.html
    html/syntax/parsing/html5lib_innerHTML_math.html
    html/syntax/parsing/html5lib_innerHTML_tests4.html
    html/syntax/parsing/html5lib_innerHTML_tests6.html
    html/syntax/parsing/html5lib_innerHTML_tests7.html
    html/syntax/parsing/html5lib_innerHTML_tests_innerHTML_1.html
    html/syntax/parsing/html5lib_innerHTML_webkit02.html