### PR TITLE
taskcluster: ensure data.metadata.owner is a valid e-mail on push event (v3)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -27,6 +27,7 @@ tasks:
                 event.ref == "refs/heads/master": [{name: firefox, channel: nightly}, {name: chrome, channel: dev}],
                 event.ref == "refs/heads/epochs/daily": [{name: firefox, channel: stable}, {name: chrome, channel: stable}, {name: webkitgtk_minibrowser, channel: nightly}],
                 event.ref == "refs/heads/epochs/weekly": [{name: firefox, channel: beta}, {name: chrome, channel: beta}, {name: webkitgtk_minibrowser, channel: stable}],
+                event.ref == "refs/heads/epochs/three_hourly": [{name: firefox, channel: stable}, {name: chrome, channel: stable}, {name: webkitgtk_minibrowser, channel: nightly}],
                 event.ref == "refs/heads/triggers/chrome_stable": [{name: chrome, channel: stable}],
                 event.ref == "refs/heads/triggers/chrome_beta": [{name: chrome, channel: beta}],
                 event.ref == "refs/heads/triggers/chrome_dev": [{name: chrome, channel: dev}],
@@ -73,7 +74,10 @@ tasks:
                   A subset of WPT's "${chunk[0]}" tests (chunk number ${chunk[1]}
                   of ${chunk[2]}), run in the ${browser.channel} release of
                   ${browser.name}.
-                owner: ${event.sender.login}@users.noreply.github.com
+                owner:
+                  $if: 'event.sender.login'
+                  then: ${event.sender.login}@users.noreply.github.com
+                  else: web-platform-tests@users.noreply.github.com
                 source: ${event.repository.url}
               payload:
                 image:


### PR DESCRIPTION
Related issue #20106

* When the push event comes from a github action, event.pusher.email
seems to be invalid, which causes a fatal error on taskcluster.
It also seems that event.sender.login is invalid.

* Lets try to use event.sender.login to construct the owner e-mail address
only if its not an empty string. If it is empty then default the login
to "web-platform-tests"

 * According to the [taskcluster/json-e documentation](https://taskcluster.github.io/json-e/#Language/truthiness), `"" (empty string)` is `false` but `"any-non-empty-string"` is `true`

Add also temporally taskcluster tests to the branch epochs/three_hourly to speed up testing. This will be reverted once taskcluster works back again on the daily branch.
