### PR TITLE
taskcluster: ensure data.metadata.owner is a valid e-mail on push event (v4)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -75,7 +75,7 @@ tasks:
                   of ${chunk[2]}), run in the ${browser.channel} release of
                   ${browser.name}.
                 owner:
-                  $if: '"epochs" in event.ref'
+                  $if: '"epochs/" in event.ref'
                   then: web-platform-tests@users.noreply.github.com
                   else: ${event.pusher.email}
                 source: ${event.repository.url}

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -75,9 +75,9 @@ tasks:
                   of ${chunk[2]}), run in the ${browser.channel} release of
                   ${browser.name}.
                 owner:
-                  $if: 'event.sender.login'
-                  then: ${event.sender.login}@users.noreply.github.com
-                  else: web-platform-tests@users.noreply.github.com
+                  $if: '"epochs" in event.ref'
+                  then: web-platform-tests@users.noreply.github.com
+                  else: ${event.pusher.email}
                 source: ${event.repository.url}
               payload:
                 image:


### PR DESCRIPTION

* Previous attempts of resolving this issue have failed.

* At this point its not clear at all what exactly contains the json that
taskcluster receives from the GitHub action in the push event.
Let's try to simply hardcode a valid e-mail address.

* Hardcode it only for when the push event happens on a epochs branch,
which are the ones automatically updated by GitHub actions

* For the non-epoch branches use `${event.pusher.email}` as e-mail address,
as it was set previously to this issue.

Related issue: #20106