### PR TITLE
[mediacapture-image] Correct failure reporting

### DIFF
--- a/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
+++ b/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
@@ -47,19 +47,17 @@ var makeAsyncTest = function(c) {
     videoTrack.applyConstraints(constraintsIn)
         .then(() => { /* ignore */ })
         .catch((e) => { /* ignore */ })
-        .then(() => {
+        .then(t.step_func(() => {
           const constraintsOut = videoTrack.getConstraints();
           assert_object_equals(constraintsOut, constraintsIn, "constraints");
-          t.done();
-        });
-
-    // Clear constraints by sending an empty constraint set.
-    videoTrack.applyConstraints({})
-        .then(() => {
+          // Clear constraints by sending an empty constraint set.
+          return videoTrack.applyConstraints({})
+        }))
+        .then(t.step_func(() => {
           const constraintsOut = videoTrack.getConstraints();
           assert_object_equals(constraintsOut, {}, "constraints");
           t.done();
-        });
+        }));
   });
 };
 


### PR DESCRIPTION
Prior to this commit, the test
`MediaStreamTrack-getConstraints-fast.html` triggered asynchronous
operations in parallel. This represented a race condition because for
each subtest, two operations could trigger completion.

Additionally, the test made assertions asynchronously. Because these
assertions were not "wrapped" in the harness's "step" functions,
assertion failures would not be reported as test failures. Failures
would instead be reported inaccurately as harness errors (though if the
browser under test does not implement the `unhandledrejection` event,
the failed assertion would not be reported at all).

Schedule each pair of asynchronous operations to happen in series, and
ensure that all failed assertions are accurately reported as test
failures.