### PR TITLE
[testharness.js] Ignore errors after completion

### DIFF
--- a/infrastructure/expected-fail/unhandled-rejection-following-subtest.html
+++ b/infrastructure/expected-fail/unhandled-rejection-following-subtest.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Unhandled rejection following subtest</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {});
+Promise.reject(new Error("error outside any setup or test"));
+</script>

--- a/infrastructure/expected-fail/unhandled-rejection-following-subtest.html
+++ b/infrastructure/expected-fail/unhandled-rejection-following-subtest.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<meta charset=utf-8>
-<title>Unhandled rejection following subtest</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script>
-test(function() {});
-Promise.reject(new Error("error outside any setup or test"));
-</script>

--- a/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection-following-subtest.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection-following-subtest.html.ini
@@ -1,6 +1,0 @@
-[unhandled-rejection-following-subtest.html]
-  expected: ERROR
-
-  [Unhandled rejection following subtest]
-    expected: PASS
-

--- a/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection-following-subtest.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/unhandled-rejection-following-subtest.html.ini
@@ -1,0 +1,8 @@
+[unhandled-rejection-following-subtest.html]
+  expected:
+    if product == "chrome": OK # https://github.com/web-platform-tests/wpt/pull/20329
+    ERROR
+
+  [Unhandled rejection following subtest]
+    expected: PASS
+

--- a/infrastructure/testharness.js/uncaught-error-after-completion.html
+++ b/infrastructure/testharness.js/uncaught-error-after-completion.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Uncaught error immediately following completion</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<p>Uncaught errors following completion should not influence harness status.</p>
+<script>
+setup({explicit_done: true});
+onload = function() {
+  test(() => {}, 'empty test');
+  done();
+  throw new Error('this is an uncaught error');
+};
+</script>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3698,6 +3698,14 @@ policies and contribution forms [3].
     if (global_scope.addEventListener) {
         var error_handler = function(error, message, stack) {
             var precondition_failed = error instanceof PreconditionFailedError;
+
+            // Modifying the harness status following completion could
+            // interfere with the value reported by some implementations
+            // (depending on the synchronicity of the reporting mechanism).
+            if (tests.phase === tests.phases.COMPLETE) {
+                return;
+            }
+
             if (tests.file_is_test) {
                 var test = tests.tests[0];
                 if (test.phase >= test.phases.HAS_RESULT) {


### PR DESCRIPTION
Although uncaught exceptions are often an indication of errors in test design, the harness status cannot be safely modified following completion, so these exceptions must be ignored.

---

Here are some comparisons between test results collected from `master` and test results collected with this patch applied:

- Chrome: https://wpt.fyi/results/?diff&filter=ADC&run_id=348750003&run_id=345290003
- Firefox: https://wpt.fyi/results/?diff&filter=ADC&run_id=352460003&run_id=348770002

As usual, flaky tests make interpreting these comparisons a little tricky. Firefox's results don't seem to be influenced by this change, but Chrome's results have some differences.

I found 5 tests which report `ERROR` consistently in `master` and `OK` consistently with the patch applied.

- [`content-security-policy/script-src/script-src-strict_dynamic_hashes.html`](https://wpt.fyi/results/content-security-policy/script-src/script-src-strict_dynamic_hashes.html?diff&filter=ADC&run_id=348750003&run_id=345290003) - this test has a bug which [I've reported with this issue](https://github.com/web-platform-tests/wpt/issues/20226)
- [`html/syntax/parsing/html5lib_innerHTML_adoption01.html`](https://wpt.fyi/results/html/syntax/parsing/html5lib_innerHTML_adoption01.html?diff&filter=ADC&run_id=348750003&run_id=345290003) - this test has a bug which [I've tried to fix with this patch](https://github.com/web-platform-tests/wpt/pull/20223)
- [`infrastructure/expected-fail/unhandled-rejection-following-subtest.html`](https://wpt.fyi/results/infrastructure/expected-fail/unhandled-rejection-following-subtest.html?diff&filter=ADC&run_id=348750003&run_id=345290003) - this is a test for the behavior under consideration. I've added a "fixup!" commit to this branch to remove it
- [`mediacapture-image/MediaStreamTrack-getConstraints-fast.html`](https://wpt.fyi/results/mediacapture-image/MediaStreamTrack-getConstraints-fast.html?diff&filter=ADC&run_id=348750003&run_id=345290003) - this test has a bug which [I've tried to fix with this patch](https://github.com/web-platform-tests/wpt/pull/20234)
- [`trusted-types/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.tentative.html`](https://wpt.fyi/results/trusted-types/block-string-assignment-to-DOMWindowTimers-setTimeout-setInterval.tentative.html?diff&filter=ADC&run_id=348750003&run_id=345290003) - this test intentionally triggers an uncaught exception, so it seems to expect the behavior proposed here. As a "tentative" test, it may be that the authors aren't yet scrutinizing the results on wpt.fyi

I found 5 tests which are flaky in `master` and consistent with the patch applied:

- [`content-security-policy/script-src/script-src-strict_dynamic_in_img-src.html`](https://wpt.fyi/results/content-security-policy/script-src/script-src-strict_dynamic_in_img-src.html?diff&filter=ADC&run_id=348750003&run_id=345290003)
- [`html/webappapis/microtask-queuing/queue-microtask-exceptions.any.worker.html`](https://wpt.fyi/results/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.worker.html?diff&filter=ADC&run_id=348750003&run_id=345290003)
- [`offscreen-canvas/*`](https://wpt.fyi/results/offscreen-canvas?diff&filter=ADC&run_id=348750003&run_id=345290003) ([coincidentally, we just recently recognized that these tests are invalid](https://github.com/web-platform-tests/wpt/issues/20180))
- [`workers/baseurl/alpha/sharedworker-in-worker.html`](https://wpt.fyi/results/workers/baseurl/alpha/sharedworker-in-worker.html?diff&filter=ADC&run_id=348750003&run_id=345290003)
- [`workers/interfaces/WorkerGlobalScope/onerror/exception-in-onerror.html`](https://wpt.fyi/results/workers/interfaces/WorkerGlobalScope/onerror/exception-in-onerror.html?diff&filter=ADC&run_id=348750003&run_id=345290003)

If the effect of this change seems agreeable, I'd be happy to discuss alternative implementations. For instance, we could freeze the status object at the moment of completion, or we could call [`structured_clone`](https://github.com/web-platform-tests/wpt/blob/3ee67ef03aeee31247ee1b5aca3e91ddef4fdfd8/resources/testharness.js#L2417-L2429) (which would have a similar effect due to memoization).