### PR TITLE
[wpt] Enable experimental features for Edge Canary

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -476,8 +476,8 @@ class EdgeChromium(BrowserSetup):
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
                 raise WptrunError("Unable to locate or install msedgedriver binary")
-        if browser_channel == "dev":
-            logger.info("Automatically turning on experimental features for Edge Dev")
+        if browser_channel in ("dev", "canary"):
+            logger.info("Automatically turning on experimental features for Edge Dev/Canary")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
 
 


### PR DESCRIPTION
PR #16920 added Edge Dev & Canary to Azure but only enabled experimental
web platform features for Dev.

Relevant to https://github.com/web-platform-tests/wpt.fyi/issues/1635