### PR TITLE
Add --ignore-glob flag to wpt lint.

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -844,6 +844,7 @@ def create_parser():
                         help="Output markdown")
     parser.add_argument("--repo-root", help="The WPT directory. Use this"
                         "option if the lint script exists outside the repository")
+    parser.add_argument("--ignore-glob", help="Additional file glob to ignore.")
     parser.add_argument("--all", action="store_true", help="If no paths are passed, try to lint the whole "
                         "working directory, not just files that changed")
     return parser
@@ -867,16 +868,21 @@ def main(**kwargs):
 
     paths = lint_paths(kwargs, repo_root)
 
-    return lint(repo_root, paths, output_format)
+    ignore_glob = kwargs.get("ignore_glob")
+
+    return lint(repo_root, paths, output_format, ignore_glob)
 
 
-def lint(repo_root, paths, output_format):
-    # type: (str, List[str], str) -> int
+def lint(repo_root, paths, output_format, ignore_glob):
+    # type: (str, List[str], str, str) -> int
     error_count = defaultdict(int)  # type: Dict[Text, int]
     last = None
 
     with open(os.path.join(repo_root, "lint.whitelist")) as f:
         whitelist, ignored_files = parse_whitelist(f)
+
+    if ignore_glob:
+        ignored_files.add(ignore_glob)
 
     output_errors = {"json": output_errors_json,
                      "markdown": output_errors_markdown,

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -868,12 +868,12 @@ def main(**kwargs):
 
     paths = lint_paths(kwargs, repo_root)
 
-    ignore_glob = kwargs.get("ignore_glob")
+    ignore_glob = kwargs.get(str("ignore_glob")) or str()
 
-    return lint(repo_root, paths, output_format, ignore_glob)
+    return lint(repo_root, paths, output_format, str(ignore_glob))
 
 
-def lint(repo_root, paths, output_format, ignore_glob=""):
+def lint(repo_root, paths, output_format, ignore_glob=str()):
     # type: (str, List[str], str, str) -> int
     error_count = defaultdict(int)  # type: Dict[Text, int]
     last = None

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -873,7 +873,7 @@ def main(**kwargs):
     return lint(repo_root, paths, output_format, ignore_glob)
 
 
-def lint(repo_root, paths, output_format, ignore_glob=None):
+def lint(repo_root, paths, output_format, ignore_glob=""):
     # type: (str, List[str], str, str) -> int
     error_count = defaultdict(int)  # type: Dict[Text, int]
     last = None

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -873,7 +873,7 @@ def main(**kwargs):
     return lint(repo_root, paths, output_format, ignore_glob)
 
 
-def lint(repo_root, paths, output_format, ignore_glob):
+def lint(repo_root, paths, output_format, ignore_glob=None):
     # type: (str, List[str], str, str) -> int
     error_count = defaultdict(int)  # type: Dict[Text, int]
     last = None

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -443,7 +443,8 @@ def test_main_with_args():
                 m.assert_called_once_with(repo_root,
                                           [os.path.relpath(os.path.join(os.getcwd(), x), repo_root)
                                            for x in ['a', 'b', 'c']],
-                                          "normal")
+                                          "normal",
+                                          None)
     finally:
         sys.argv = orig_argv
 
@@ -455,7 +456,7 @@ def test_main_no_args():
         with _mock_lint('lint', return_value=True) as m:
             with _mock_lint('changed_files', return_value=['foo', 'bar']):
                 lint_mod.main(**vars(create_parser().parse_args()))
-                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal")
+                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", None)
     finally:
         sys.argv = orig_argv
 
@@ -467,6 +468,6 @@ def test_main_all():
         with _mock_lint('lint', return_value=True) as m:
             with _mock_lint('all_filesystem_paths', return_value=['foo', 'bar']):
                 lint_mod.main(**vars(create_parser().parse_args()))
-                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal")
+                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", None)
     finally:
         sys.argv = orig_argv

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -444,7 +444,7 @@ def test_main_with_args():
                                           [os.path.relpath(os.path.join(os.getcwd(), x), repo_root)
                                            for x in ['a', 'b', 'c']],
                                           "normal",
-                                          None)
+                                          str())
     finally:
         sys.argv = orig_argv
 
@@ -456,7 +456,7 @@ def test_main_no_args():
         with _mock_lint('lint', return_value=True) as m:
             with _mock_lint('changed_files', return_value=['foo', 'bar']):
                 lint_mod.main(**vars(create_parser().parse_args()))
-                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", None)
+                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", str())
     finally:
         sys.argv = orig_argv
 
@@ -468,6 +468,6 @@ def test_main_all():
         with _mock_lint('lint', return_value=True) as m:
             with _mock_lint('all_filesystem_paths', return_value=['foo', 'bar']):
                 lint_mod.main(**vars(create_parser().parse_args()))
-                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", None)
+                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", str())
     finally:
         sys.argv = orig_argv


### PR DESCRIPTION
This allows specifying file patterns to ignore via the commandline.

This feature is used inside Chromium CI to skip linting some
auto-generated files that aren't part of WPT. The motivation to make
this change upstream is because we sometimes get conflicts between the
local Chromium copy and the update upstream copy.