### PR TITLE
[web-locks] Improve test determinism

### DIFF
--- a/web-locks/signal.tentative.https.any.js
+++ b/web-locks/signal.tentative.https.any.js
@@ -38,8 +38,8 @@ promise_test(async t => {
 promise_test(async t => {
   const res = uniqueName(t);
 
-  // Grab a lock and hold it forever.
-  const never_settled = new Promise(resolve => { /* never */ });
+  // Grab a lock and hold it until this subtest completes.
+  const never_settled = new Promise(resolve => t.add_cleanup(resolve));
   navigator.locks.request(res, lock => never_settled);
 
   const controller = new AbortController();
@@ -67,8 +67,8 @@ promise_test(async t => {
 promise_test(async t => {
   const res = uniqueName(t);
 
-  // Grab a lock and hold it forever.
-  const never_settled = new Promise(resolve => { /* never */ });
+  // Grab a lock and hold it until this subtest completes.
+  const never_settled = new Promise(resolve => t.add_cleanup(resolve));
   navigator.locks.request(res, lock => never_settled);
 
   const controller = new AbortController();


### PR DESCRIPTION
Two subtests rely on locks which must not be released while the subtest
is running. By providing a Promise that never settles, these tests are
susceptible to interference from locks which have been created in
previous test executions. This is most pronounced when the stability of
the tests is being verified (e.g. during automated patch validation).

Configure the test harness to release locks following subtest
completion.

---

@inexorabletash @pwnall The behavior that this patch guards against may be faulty. [The spec currently dictates that an operation to release all locks should be queued "when an agent terminates."](https://wicg.github.io/web-locks/#agent-integration) It doesn't explain what "terminate" means, but if it includes navigation, then the flakiness which Chromium is exhibiting is evidence of a violation.

In that case, one might argue that this patch is superfluous. I'd still recommend merging it, though, because the current failure is inconsistent (so it blocks work like gh-12267) and difficult to interpret. A new test which is explicitly designed around navigation would be better.