### PR TITLE
taskcluster: ensure data.metadata.owner is a valid e-mail on push event (v5)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -75,9 +75,15 @@ tasks:
                   of ${chunk[2]}), run in the ${browser.channel} release of
                   ${browser.name}.
                 owner:
-                  $if: '"epochs/" in event.ref'
-                  then: web-platform-tests@users.noreply.github.com
-                  else: ${event.pusher.email}
+                  # event.pusher.email is null when it comes from a GitHub action, so it has to be null-checked,
+                  # and using the "in" operator causes an evaluation error when the right variable is null, if its
+                  # done on the same "if" statement than the null-check (with &&), therefore we use a nested "if" here.
+                  $if: 'event.pusher.email'
+                  then:
+                    $if: '"@" in event.pusher.email'
+                    then: ${event.pusher.email}
+                    else: web-platform-tests@users.noreply.github.com
+                  else: web-platform-tests@users.noreply.github.com
                 source: ${event.repository.url}
               payload:
                 image:


### PR DESCRIPTION

* The previous attempt (v4) worked and now we known the data that github is
sending to taskcluster in the push event.

* event.pusher.email is null, so it has to be null-checked before trying to
test it to see if it contains an "@" inside.

* this patch set as owner the event event.pusher.email if that seems to be
a valid e-mail address, otherwise it sets web-platform-tests@users.noreply.github.com

Related issue: #20106