### PR TITLE
[infra] Remove unused configuration file

### DIFF
--- a/check_stability.ini
+++ b/check_stability.ini
@@ -1,8 +1,0 @@
-[file detection]
-# The vast majority of tests rely on files located within the `resources`
-# directory. Because of this, modifications to that directory's contents have
-# the potential to introduce instability in a large number of tests.
-# Exhaustively validating such changes is highly resource intensive
-# (particularly in terms of execution time), making it impractical in most
-# cases.
-ignore_changes: resources/**


### PR DESCRIPTION
This file was used by the sub-command of the `wpt` command-line utility
named `check-stabililty`. That sub-command was removed via [1], so the
file is no longer necessary.

[1] 12527c2a641a1f439a86762c60a47293b6c05272