### PR TITLE
taskcluster: remove trigger on branch epochs/three_hourly

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -27,7 +27,6 @@ tasks:
                 event.ref == "refs/heads/master": [{name: firefox, channel: nightly}, {name: chrome, channel: dev}],
                 event.ref == "refs/heads/epochs/daily": [{name: firefox, channel: stable}, {name: chrome, channel: stable}, {name: webkitgtk_minibrowser, channel: nightly}],
                 event.ref == "refs/heads/epochs/weekly": [{name: firefox, channel: beta}, {name: chrome, channel: beta}, {name: webkitgtk_minibrowser, channel: stable}],
-                event.ref == "refs/heads/epochs/three_hourly": [{name: firefox, channel: stable}, {name: chrome, channel: stable}, {name: webkitgtk_minibrowser, channel: nightly}],
                 event.ref == "refs/heads/triggers/chrome_stable": [{name: chrome, channel: stable}],
                 event.ref == "refs/heads/triggers/chrome_beta": [{name: chrome, channel: beta}],
                 event.ref == "refs/heads/triggers/chrome_dev": [{name: chrome, channel: dev}],


### PR DESCRIPTION
This was added on beff32767b9 to speed up the testing related to the
issue #20106. Now that things are working as expected its time to
remove it.