### PR TITLE
[mediacapture-image] Execute subtests in series

### DIFF
--- a/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
+++ b/mediacapture-image/MediaStreamTrack-getConstraints-fast.html
@@ -35,8 +35,8 @@ context.fillRect(0, 0, 10, 10);
 
 // These tests verify that MediaStreamTrack.getConstraints() exists and that,
 // returns the constraints passed beforehand with applyConstraints.
-var makeAsyncTest = function(c) {
-  async_test(function(t) {
+var makePromiseTest = function(c) {
+  promise_test(function(t) {
     var stream = canvas.captureStream();
     var videoTrack = stream.getVideoTracks()[0];
 
@@ -44,7 +44,7 @@ var makeAsyncTest = function(c) {
 
     // Method applyConstraints() will fail since there is no Image Capture
     // service in this Layout Test, but |constraintsIn| should be cached.
-    videoTrack.applyConstraints(constraintsIn)
+    return videoTrack.applyConstraints(constraintsIn)
         .then(() => { /* ignore */ })
         .catch((e) => { /* ignore */ })
         .then(t.step_func(() => {
@@ -66,11 +66,11 @@ for (key in constraints) {
   var one_constraint = {};
   one_constraint[key] = constraints[key];
   generate_tests(
-      makeAsyncTest,
+      makePromiseTest,
       [[ 'MediaStreamTrack.getConstraints(), key: ' + key, one_constraint ]]);
 }
 
-generate_tests(makeAsyncTest, [[
+generate_tests(makePromiseTest, [[
                  'MediaStreamTrack.getConstraints(), complete ', constraints
                ]]);
 


### PR DESCRIPTION
Subtests created with `async_test` execute in parallel. Because each
subtest in the modified file use the same `canvas` element, parallel
execution make them susceptible to undesired interactions.

Declare the subtests using `promise_test` so that the harness executes
them in series.

---

@reillyeon requested this change in gh-20234, where they wrote

> Since the generated async tests are reusing the same `<canvas>` element
> should they be converted to promise tests so that they run sequentially
> rather than attempting to apply a bunch of different constraints in parallel?
> That seems to depend on whether or not `captureStream()` is guaranteed to
> return fully independent `MediaStream` instances.

These tests do not pass on my system (neither from `master` nor from this branch), so I can't verify the validity of this change.