### PR TITLE
webdriver: perform_actions/validity.py::test_pause_invalid_types

### DIFF
--- a/webdriver/tests/perform_actions/validity.py
+++ b/webdriver/tests/perform_actions/validity.py
@@ -12,7 +12,7 @@ def perform_actions(session, actions):
 
 @pytest.mark.parametrize("action_type", ["none", "key", "pointer"])
 def test_pause_positive_integer(session, action_type):
-    for valid_duration in [0, 1]:
+    for valid_duration in [0.0, 1]:
         actions = [{
             "type": action_type,
             "id": "foobar",
@@ -38,7 +38,7 @@ def test_pause_positive_integer(session, action_type):
 
 @pytest.mark.parametrize("action_type", ["none", "key", "pointer"])
 def test_pause_invalid_types(session, action_type):
-    for invalid_type in [0.0, None, "foo", True, [], {}]:
+    for invalid_type in [0.1, None, "foo", True, [], {}]:
         actions = [{
             "type": action_type,
             "id": "foobar",


### PR DESCRIPTION
0.0 is considered an invalid type, but it's valid according to the spec.
Use 0.1 instead, which should be invalid value. Also modify test_pause_positive_integer
to use 0.0 to check it's valid value.