### PR TITLE
Sync Mozilla CSS tests as of 2019-11-17

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/reftest.list
@@ -9,6 +9,7 @@
 == will-change-stacking-context-position-1.html green-square-100-by-100-ref.html
 == will-change-stacking-context-transform-1.html green-square-100-by-100-ref.html
 == will-change-stacking-context-translate-1.html green-square-100-by-100-ref.html
+== will-change-stacking-context-offset-path-1.html green-square-100-by-100-ref.html
 == will-change-stacking-context-transform-style-1.html green-square-100-by-100-ref.html
 == will-change-stacking-context-z-index-1.html green-square-100-by-100-ref.html
 == will-change-fixpos-cb-contain-1.html green-square-100-by-100-offset-ref.html
@@ -18,4 +19,5 @@
 == will-change-fixpos-cb-position-1.html green-square-100-by-100-offset-ref.html
 == will-change-fixpos-cb-transform-1.html green-square-100-by-100-offset-ref.html
 == will-change-fixpos-cb-translate-1.html green-square-100-by-100-offset-ref.html
+== will-change-fixpos-cb-offset-path-1.html green-square-100-by-100-offset-ref.html
 == will-change-fixpos-cb-transform-style-1.html green-square-100-by-100-offset-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/will-change-fixpos-cb-offset-path-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/will-change-fixpos-cb-offset-path-1.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS will-change: 'will-change: offset-path' creates a containing block for fixed positioned elements</title>
+<link rel="author" title="Mozilla" href="http://www.mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-will-change-1/#will-change">
+<link rel="help" href="https://drafts.fxtf.org/motion-1/#offset-path-property">
+<link rel="match" href="green-square-100-by-100-offset-ref.html">
+<meta name="assert" content="If any non-initial value of a property would cause the element to generate a containing block for fixed-position elements, specifying that property in will-change must cause the element to generate a containing block for fixed-position elements.">
+<style>
+html, body { margin: 0; padding: 0; }
+div { width: 100px; height: 100px }
+#wc { will-change: offset-path; margin: 100px 0 0 100px; background: red }
+.child { top: 0; left: 0; width: 50px; background: green }
+#fixpos { position: fixed }
+#abspos { position: absolute; left: 50px }
+</style>
+<body>
+  <div id="wc">
+    <div class="child" id="fixpos">
+    </div>
+    <div class="child" id="abspos">
+    </div>
+  </div>
+</body>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/will-change-stacking-context-offset-path-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/will-change/will-change-stacking-context-offset-path-1.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS will-change: 'will-change: offset-path' creates a stacking context</title>
+<link rel="author" title="Mozilla" href="http://www.mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-will-change-1/#will-change">
+<link rel="help" href="https://drafts.fxtf.org/motion-1/#offset-path-property">
+<link rel="match" href="green-square-100-by-100-ref.html">
+<meta name="assert" content="If any non-initial value of a property would create a stacking context on the element, specifying that property in will-change must create a stacking context on the element.">
+<style>
+html, body { margin: 0; padding: 0; }
+div { width: 100px; height: 100px }
+#wc { will-change: offset-path; background: red }
+#child { position: absolute; top: 0; left: 0; z-index: -1; background: green }
+</style>
+<body>
+  <div id="wc">
+    <div id="child">
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/20eeab9d1782c253e1d01fe5ffb978e2db47ef01 .

This contains changes from [bug 1596610](https://bugzilla.mozilla.org/show_bug.cgi?id=1596610) by @BorisChiou, reviewed by @hiikezoe.