### PR TITLE
Test for link element firing multiple events

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-multiple-error-events.html
+++ b/html/semantics/document-metadata/the-link-element/link-multiple-error-events.html
@@ -3,19 +3,19 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-link-element">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link id=link rel=stylesheet
-      onload="t.unreached_func('Sheet should fail to load')">
+<link id=style_link rel=stylesheet>
 <script>
-  const t = async_test("Check if the <link>'s error event fires for each style " +
-                     "sheet it fails to load");
+  async_test(t => {
+    const link = document.querySelector('#style_link');
+    link.onload = t.unreached_func('Sheet should fail to load');
+    link.onerror = t.step_func(() => {
+      link.onerror = t.step_func_done(() => {});
+      link.href = 'nonexistent.css?second';
+    });
 
-  link.onerror = t.step_func(() => {
-    link.onerror = t.step_func_done(() => {});
-    link.href = 'nonexistent.css?second';
-  });
+    link.href = 'nonexistent.css?first';
+  }, "Check if the <link>'s error event fires for each stylesheet it fails to load");
 
-  link.href = 'nonexistent.css?first';
-</script>
-
+  </script>
 </head>
 </html>

--- a/html/semantics/document-metadata/the-link-element/link-multiple-error-events.html
+++ b/html/semantics/document-metadata/the-link-element/link-multiple-error-events.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-link-element">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link id=link rel=stylesheet id=style_test
+<link id=link rel=stylesheet
       onload="t.unreached_func('Sheet should fail to load')">
 <script>
   const t = async_test("Check if the <link>'s error event fires for each style " +

--- a/html/semantics/document-metadata/the-link-element/link-multiple-error-events.html
+++ b/html/semantics/document-metadata/the-link-element/link-multiple-error-events.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Dom Farolino" href="mailto:dom@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-link-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link id=link rel=stylesheet id=style_test
+      onload="t.unreached_func('Sheet should fail to load')">
+<script>
+  const t = async_test("Check if the <link>'s error event fires for each style " +
+                     "sheet it fails to load");
+
+  link.onerror = t.step_func(() => {
+    link.onerror = t.step_func_done(() => {});
+    link.href = 'nonexistent.css?second';
+  });
+
+  link.href = 'nonexistent.css?first';
+</script>
+
+</head>
+</html>

--- a/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html
+++ b/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html
@@ -3,19 +3,19 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-link-element">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link id=link rel=stylesheet
-      onerror="t.unreached_func('Sheet should load successfully')">
+<link id=style_link rel=stylesheet>
 <script>
-  const t = async_test("Check if the <link>'s load event fires for each style " +
-                     "sheet it loads");
+  async_test(t => {
+    const link = document.querySelector('#style_link');
+    link.onerror = t.unreached_func('Sheet should load successfully');
+    link.onload = t.step_func(() => {
+      link.onload = t.step_func_done(() => {});
+      link.href = 'style.css?second';
+    });
 
-  link.onload = t.step_func(() => {
-    link.onload = t.step_func_done(() => {});
-    link.href = 'style.css?second';
-  });
+    link.href = 'style.css?first';
 
-  link.href = 'style.css?first';
-</script>
-
+  }, "Check if the <link>'s load event fires for each stylesheet it loads");
+  </script>
 </head>
 </html>

--- a/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html
+++ b/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="author" title="Dom Farolino" href="mailto:dom@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-link-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link id=link rel=stylesheet id=style_test
+      onerror="t.unreached_func('Sheet should load successfully')">
+<script>
+  const t = async_test("Check if the <link>'s load event fires for each style " +
+                     "sheet it loads");
+
+  link.onload = t.step_func(() => {
+    link.onload = t.step_func_done(() => {});
+    link.href = 'style.css?second';
+  });
+
+  link.href = 'style.css?first';
+</script>
+
+</head>
+</html>

--- a/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html
+++ b/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-link-element">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link id=link rel=stylesheet id=style_test
+<link id=link rel=stylesheet
       onerror="t.unreached_func('Sheet should load successfully')">
 <script>
   const t = async_test("Check if the <link>'s load event fires for each style " +


### PR DESCRIPTION
If the same link element loads (successfully or unsuccessfully) multiple resources over time, the `onload` and `onerror` events should fire for each as appropriate. This passes in Firefox, however times out for Chrome + Safari.

Chromium tracking bug: https://crbug.com/922618