### PR TITLE
Removed unused `platform_ini` member in browser.py

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -91,7 +91,6 @@ class Firefox(Browser):
 
     product = "firefox"
     binary = "browsers/firefox/firefox"
-    platform_ini = "browsers/firefox/platform.ini"
     requirements = "requirements_firefox.txt"
 
     platform = {


### PR DESCRIPTION
I believe its last use was removed in a87e3675f288170b8fa1d1fe90b44c8c82377856; can't find any other references to it.