### PR TITLE
[html] Test unhandled rejection during parse

### DIFF
--- a/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-during-parse.html
+++ b/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-during-parse.html
@@ -19,7 +19,7 @@ transition the state to "complete."
 setup({ allow_uncaught_exception: true });
 
 async_test(function(t) {
-  var events = [];
+  const events = [];
   document.addEventListener('readystatechange', t.step_func(function() {
     events.push('readystatechange:' + document.readyState);
   }));

--- a/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-during-parse.html
+++ b/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-during-parse.html
@@ -8,10 +8,11 @@
 <p>The script in this test is executed immediately while parsing is ongoing, and
 <a
 href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">cleaning
-up after running script</a> involves queueing a task to fire the
-<code>unhandledrejection</code> event. Parsing then completes, immediately
-transitioning the document's readiness state to "interactive," and queuing
-another task to transition the state to "complete."
+up after running script</a> involves queueing a task on the DOM manipulation
+task source to fire the <code>unhandledrejection</code> event. Parsing then
+completes, immediately transitioning the document's readiness state to
+"interactive," and queuing another task on the DOM manipulation task source to
+transition the state to "complete."
 </p>
 <script>
 'use strict';
@@ -20,7 +21,7 @@ setup({ allow_uncaught_exception: true });
 async_test(function(t) {
   var events = [];
   document.addEventListener('readystatechange', t.step_func(function() {
-    events.push('readystatechange');
+    events.push('readystatechange:' + document.readyState);
   }));
   addEventListener('unhandledrejection', t.step_func(function() {
     events.push('unhandledrejection');
@@ -31,7 +32,11 @@ async_test(function(t) {
   addEventListener('load', t.step_func(function() {
     assert_array_equals(
       events,
-      ['readystatechange', 'unhandledrejection', 'readystatechange']
+      [
+        'readystatechange:interactive',
+        'unhandledrejection',
+        'readystatechange:complete'
+      ]
     );
     t.done();
   }));

--- a/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-during-parse.html
+++ b/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-during-parse.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Promise rejection during initial parsing of document</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/#unhandled-promise-rejections">
+<body>
+<p>The script in this test is executed immediately while parsing is ongoing, and
+<a
+href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">cleaning
+up after running script</a> involves queueing a task to fire the
+<code>unhandledrejection</code> event. Parsing then completes, immediately
+transitioning the document's readiness state to "interactive," and queuing
+another task to transition the state to "complete."
+</p>
+<script>
+'use strict';
+setup({ allow_uncaught_exception: true });
+
+async_test(function(t) {
+  var events = [];
+  document.addEventListener('readystatechange', t.step_func(function() {
+    events.push('readystatechange');
+  }));
+  addEventListener('unhandledrejection', t.step_func(function() {
+    events.push('unhandledrejection');
+  }));
+
+  Promise.reject(new Error('this error is intentional'));
+
+  addEventListener('load', t.step_func(function() {
+    assert_array_equals(
+      events,
+      ['readystatechange', 'unhandledrejection', 'readystatechange']
+    );
+    t.done();
+  }));
+});
+</script>


### PR DESCRIPTION
Chrome and Safari both fail this test:

browser    | event sequence
-----------|---------------
Chrome 80  | `readystatechange`, `readystatechange`, `load`, `unhandledrejection`
Firefox 70 | `readystatechange`, `unhandledrejection`, `readystatechange`, `load`
Safari 13  | `readystatechange`, `readystatechange`, `load`, `unhandledrejection`