### PR TITLE
[ci] Change name of environment variable

### DIFF
--- a/.github/workflows/detect_pull_request_preview.yml
+++ b/.github/workflows/detect_pull_request_preview.yml
@@ -21,4 +21,4 @@ jobs:
           --target https://wptpr.live
           --timeout 600
       env:
-        GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+        DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/pull_request_previews.yml
+++ b/.github/workflows/pull_request_previews.yml
@@ -26,4 +26,4 @@ jobs:
         # "DEPLOY_TOKEN" in this GitHub project.
         #
         # [1] https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows
-        GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+        DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -44,7 +44,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def gh_request(method_name, url, body=None, media_type=None):
-    github_token = os.environ.get('GITHUB_TOKEN')
+    github_token = os.environ['DEPLOY_TOKEN']
 
     kwargs = {
         'headers': {
@@ -200,7 +200,7 @@ class Remote(object):
         # The repository in the GitHub Actions environment is configured with
         # a remote whose URL uses unauthenticated HTTPS, making it unsuitable
         # for pushing changes.
-        self._token = os.environ.get('GITHUB_TOKEN')
+        self._token = os.environ['DEPLOY_TOKEN']
 
     def get_revision(self, refspec):
         output = subprocess.check_output([

--- a/tools/ci/tests/test_pr_preview.py
+++ b/tools/ci/tests/test_pr_preview.py
@@ -191,7 +191,7 @@ def temp_repo():
 
 def synchronize(expected_traffic, refs={}):
     env = {
-        'GITHUB_TOKEN': 'c0ffee'
+        'DEPLOY_TOKEN': 'c0ffee'
     }
     env.update(os.environ)
     server = MockServer((test_host, 0), expected_traffic)
@@ -250,7 +250,7 @@ def synchronize(expected_traffic, refs={}):
 
 def detect(event, expected_github_traffic, expected_preview_traffic):
     env = {
-        'GITHUB_TOKEN': 'c0ffee'
+        'DEPLOY_TOKEN': 'c0ffee'
     }
     env.update(os.environ)
     github_server = MockServer((test_host, 0), expected_github_traffic)


### PR DESCRIPTION
The GitHub Workflow documentation warns against environment variable
names that begin with the sequence `GITHUB_`:

> **Note:** GitHub reserves the `GITHUB_` environment variable prefix
> for internal use by GitHub. Setting an environment variable or secret
> with the `GITHUB_` prefix will result in an error.

Source: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#naming-conventions-for-environment-variables

Although early experiments have shown that it was recently possible to
override the `GITHUB_TOKEN` environment variable, the latest behavior of
the modified GitHub Workflows suggests that the overridden value is
being silently rejected. (Additionally, the disparity between GitHub
Secret name and environment variable name is somewhat confusing.)

Update the configuration to define an environment variable with an
allowed name--one that matches the name of the corresponding GitHub
Secret. Update the relevant scripts to reference this new variable.
Change the access pattern to a mechanism which will trigger a runtime
exception when the variable is not defined.