### PR TITLE
[ci] Correct syntax in git commands

### DIFF
--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -206,7 +206,7 @@ class Remote(object):
         output = subprocess.check_output([
             'git',
             '-c',
-            'credential.username={}"'.format(self._token),
+            'credential.username={}'.format(self._token),
             '-c',
             'core.askPass=true',
             'ls-remote',
@@ -227,7 +227,7 @@ class Remote(object):
         subprocess.check_call([
             'git',
             '-c',
-            'credential.username={}"'.format(self._token),
+            'credential.username={}'.format(self._token),
             '-c',
             'core.askPass=true',
             'push',


### PR DESCRIPTION
@stephenmcgruer It's surprising to me that we saw this script function correctly in the presence of these typos (both during the original validation of the feature and again just today). For what it's worth, I've verified the corrected version of the command by executing it directly in a shell running in a virtual machine.