### PR TITLE
Indexed DB: Verify array proxies are not valid keys

### DIFF
--- a/IndexedDB/key_invalid.htm
+++ b/IndexedDB/key_invalid.htm
@@ -124,6 +124,8 @@
     var recursive3 = [recursive];
     invalid_key('array member contains self', recursive3);
 
+    invalid_key('proxy of an array', new Proxy([1,2,3], {}));
+
 </script>
 
 <div id=log></div>


### PR DESCRIPTION
Arrays of keys are valid keys, but implementations don't allow proxies of arrays to be keys. Add a test, corresponding to pending spec PR:

Bug: https://github.com/w3c/IndexedDB/issues/309
PR:  https://github.com/w3c/IndexedDB/pull/311