### PR TITLE
Use spread syntax in WebIDL/current-realm.html.

### DIFF
--- a/WebIDL/current-realm.html
+++ b/WebIDL/current-realm.html
@@ -35,10 +35,11 @@
     ["createNodeIterator", document.head],
     ["createTreeWalker", document.head]].forEach(function(val) {
      test(function() {
-       var obj = self[0].document[val[0]](val[1], val[2])
+       const method = val.shift();
+       let obj = self[0].document[method](...val);
        assert_global(obj)
 
-       obj = Document.prototype[val[0]].call(self[0].document, val[1], val[2])
+       obj = Document.prototype[method].call(self[0].document, ...val);
        assert_global(obj)
      }, val[0])
    })
@@ -61,10 +62,11 @@
      ["getElementsByTagNameNS", null, "x"],
      ["getElementsByClassName", "x"]].forEach(function(val) {
      test(function() {
-       var obj = self[0].document[val[0]](val[1], val[2])
+       const method = val.shift();
+       const obj = self[0].document[method](...val);
        assert_global(obj)
 
-       var obj2 = Document.prototype[val[0]].call(self[0].document, val[1], val[2])
+       const obj2 = Document.prototype[method].call(self[0].document, ...val);
        assert_global(obj)
 
        assert_equals(obj, obj2) // XXX this might be controversial
@@ -75,10 +77,11 @@
      ["createDocument", null, "", null],
      ["createHTMLDocument", "x"]].forEach(function(val) {
      test(function() {
-       var obj = self[0].document.implementation[val[0]](val[1], val[2], val[3])
+       const method = val.shift();
+       let obj = self[0].document.implementation[method](...val);
        assert_global(obj)
 
-       obj = DOMImplementation.prototype[val[0]].call(self[0].document.implementation, val[1], val[2], val[3])
+       obj = DOMImplementation.prototype[method].call(self[0].document.implementation, ...val);
        assert_global(obj)
      }, val[0])
    })
@@ -87,10 +90,11 @@
      ["getNamedItem", "test"],
      ["getNamedItemNS", null, "test"]].forEach(function(val) {
      test(function() {
-       var obj = self[0].document.body.attributes[val[0]](val[1], val[2])
+       const method = val.shift();
+       const obj = self[0].document.body.attributes[method](...val);
        assert_global(obj)
 
-       var obj2 = NamedNodeMap.prototype[val[0]].call(self[0].document.body.attributes, val[1], val[2])
+       const obj2 = NamedNodeMap.prototype[method].call(self[0].document.body.attributes, ...val);
        assert_global(obj)
 
        assert_equals(obj, obj2)
@@ -138,12 +142,13 @@
    ;[["createImageData", 5, 5],
      ["getImageData", 5, 5, 5, 5]].forEach(function(val) {
      test(function() {
-       var c = self[0].document.createElement("canvas").getContext("2d"),
-           obj = c[val[0]](val[1], val[2], val[3], val[4]);
+       const method = val.shift();
+       const c = self[0].document.createElement("canvas").getContext("2d");
+       let obj = c[method](...val);
        assert_global(obj)
        assert_global(obj.data)
 
-       obj = CanvasRenderingContext2D.prototype[val[0]].call(c, val[1], val[2], val[3], val[4]);
+       obj = CanvasRenderingContext2D.prototype[method].call(c, ...val);
        assert_global(obj)
        assert_global(obj.data)
      }, val[0])


### PR DESCRIPTION
In [1], it is reported that Chrome is failing the test calling
`CanvasRenderingContext2D.createImageData()` with

    FAIL message: Failed to execute 'createImageData' on
    'CanvasRenderingContext2D': The provided value is not of type
    '(Uint8ClampedArray or Uint16Array or Float32Array)'

which happens because Chrome implements [2], which introduces a 4-argument
`createImageData()` overload. This overload ends up being used by the test
due to the following call:

    CanvasRenderingContext2D.createImageData(5, 5, undefined, undefined)

Avoid passing a constant number of arguments when we are testing multiple
calls that take a variable number of arguments by using the spread syntax
instead.

[1] https://wpt.fyi/results/WebIDL/current-realm.html?run_id=353010001&run_id=376180001&run_id=381940001&run_id=376170001
[2] https://github.com/WICG/canvas-color-space/