### PR TITLE
Update interface/ whitespace changes from reffy-reports

### DIFF
--- a/interfaces/pointerlock.idl
+++ b/interfaces/pointerlock.idl
@@ -14,7 +14,7 @@ partial interface Document {
 };
 
 partial interface mixin DocumentOrShadowRoot {
-  readonly attribute Element? pointerLockElement;
+  readonly attribute Element ? pointerLockElement;
 };
 
 partial interface MouseEvent {

--- a/interfaces/remote-playback.idl
+++ b/interfaces/remote-playback.idl
@@ -23,7 +23,7 @@ enum RemotePlaybackState {
   "disconnected"
 };
 
-callback RemotePlaybackAvailabilityCallback = void (boolean available);
+callback RemotePlaybackAvailabilityCallback = void(boolean available);
 
 partial interface HTMLMediaElement {
   [SameObject] readonly attribute RemotePlayback remote;

--- a/interfaces/requestidlecallback.idl
+++ b/interfaces/requestidlecallback.idl
@@ -11,10 +11,8 @@ partial interface Window {
 dictionary IdleRequestOptions {
   unsigned long timeout;
 };
-
 [Exposed=Window] interface IdleDeadline {
   DOMHighResTimeStamp timeRemaining();
   readonly attribute boolean didTimeout;
 };
-
 callback IdleRequestCallback = void (IdleDeadline deadline);

--- a/interfaces/resource-timing.idl
+++ b/interfaces/resource-timing.idl
@@ -5,8 +5,8 @@
 
 [Exposed=(Window,Worker)]
 interface PerformanceResourceTiming : PerformanceEntry {
-    readonly        attribute DOMString initiatorType;
-    readonly        attribute DOMString nextHopProtocol;
+    readonly        attribute DOMString           initiatorType;
+    readonly        attribute DOMString           nextHopProtocol;
     readonly        attribute DOMHighResTimeStamp workerStart;
     readonly        attribute DOMHighResTimeStamp redirectStart;
     readonly        attribute DOMHighResTimeStamp redirectEnd;
@@ -19,14 +19,14 @@ interface PerformanceResourceTiming : PerformanceEntry {
     readonly        attribute DOMHighResTimeStamp requestStart;
     readonly        attribute DOMHighResTimeStamp responseStart;
     readonly        attribute DOMHighResTimeStamp responseEnd;
-    readonly        attribute unsigned long long transferSize;
-    readonly        attribute unsigned long long encodedBodySize;
-    readonly        attribute unsigned long long decodedBodySize;
+    readonly        attribute unsigned long long  transferSize;
+    readonly        attribute unsigned long long  encodedBodySize;
+    readonly        attribute unsigned long long  decodedBodySize;
     [Default] object toJSON();
 };
 
 partial interface Performance {
-  void clearResourceTimings();
-  void setResourceTimingBufferSize(unsigned long maxSize);
+  void clearResourceTimings ();
+  void setResourceTimingBufferSize (unsigned long maxSize);
               attribute EventHandler onresourcetimingbufferfull;
 };

--- a/interfaces/vibration.idl
+++ b/interfaces/vibration.idl
@@ -6,5 +6,5 @@
 typedef (unsigned long or sequence<unsigned long>) VibratePattern;
 
 partial interface Navigator {
-    boolean vibrate(VibratePattern pattern);
+    boolean vibrate (VibratePattern pattern);
 };

--- a/interfaces/wake-lock.idl
+++ b/interfaces/wake-lock.idl
@@ -19,12 +19,12 @@ partial interface WorkerNavigator {
   [SameObject] readonly attribute WakeLock wakeLock;
 };
 
-[SecureContext, Exposed=(DedicatedWorker,Window)]
+[SecureContext, Exposed=(DedicatedWorker, Window)]
 interface WakeLock {
   Promise<WakeLockSentinel> request(WakeLockType type);
 };
 
-[SecureContext, Exposed=(DedicatedWorker,Window)]
+[SecureContext, Exposed=(DedicatedWorker, Window)]
 interface WakeLockSentinel : EventTarget {
   readonly attribute WakeLockType type;
   Promise<void> release();

--- a/interfaces/webmidi.idl
+++ b/interfaces/webmidi.idl
@@ -14,21 +14,21 @@ dictionary MIDIOptions {
 };
 
 [SecureContext, Exposed=Window] interface MIDIInputMap {
-  readonly maplike<DOMString, MIDIInput>;
+  readonly maplike <DOMString, MIDIInput>;
 };
 
 [SecureContext, Exposed=Window] interface MIDIOutputMap {
-  readonly maplike<DOMString, MIDIOutput>;
+  readonly maplike <DOMString, MIDIOutput>;
 };
 
-[SecureContext, Exposed=Window] interface MIDIAccess : EventTarget {
+[SecureContext, Exposed=Window] interface MIDIAccess: EventTarget {
   readonly attribute MIDIInputMap inputs;
   readonly attribute MIDIOutputMap outputs;
   attribute EventHandler onstatechange;
   readonly attribute boolean sysexEnabled;
 };
 
-[SecureContext, Exposed=Window] interface MIDIPort : EventTarget {
+[SecureContext, Exposed=Window] interface MIDIPort: EventTarget {
   readonly attribute DOMString id;
   readonly attribute DOMString? manufacturer;
   readonly attribute DOMString? name;
@@ -37,11 +37,11 @@ dictionary MIDIOptions {
   readonly attribute MIDIPortDeviceState state;
   readonly attribute MIDIPortConnectionState connection;
   attribute EventHandler onstatechange;
-  Promise<MIDIPort> open();
-  Promise<MIDIPort> close();
+  Promise <MIDIPort> open();
+  Promise <MIDIPort> close();
 };
 
-[SecureContext, Exposed=Window] interface MIDIInput : MIDIPort {
+[SecureContext, Exposed=Window] interface MIDIInput: MIDIPort {
   attribute EventHandler onmidimessage;
 };
 
@@ -72,7 +72,7 @@ interface MIDIMessageEvent : Event {
   readonly attribute Uint8Array data;
 };
 
-dictionary MIDIMessageEventInit : EventInit {
+dictionary MIDIMessageEventInit: EventInit {
   Uint8Array data;
 };
 
@@ -82,6 +82,6 @@ interface MIDIConnectionEvent : Event {
   readonly attribute MIDIPort port;
 };
 
-dictionary MIDIConnectionEventInit : EventInit {
+dictionary MIDIConnectionEventInit: EventInit {
   MIDIPort port;
 };

--- a/interfaces/webrtc-identity.idl
+++ b/interfaces/webrtc-identity.idl
@@ -3,9 +3,10 @@
 // (https://github.com/tidoust/reffy-reports)
 // Source: Identity for WebRTC 1.0 (https://w3c.github.io/webrtc-identity/identity.html)
 
-[Global, Exposed=RTCIdentityProviderGlobalScope]
+[Global,
+ Exposed=RTCIdentityProviderGlobalScope]
 interface RTCIdentityProviderGlobalScope : WorkerGlobalScope {
-    readonly        attribute RTCIdentityProviderRegistrar rtcIdentityProvider;
+    readonly attribute RTCIdentityProviderRegistrar rtcIdentityProvider;
 };
 
 [Exposed=RTCIdentityProviderGlobalScope]
@@ -18,13 +19,16 @@ dictionary RTCIdentityProvider {
     required ValidateAssertionCallback validateAssertion;
 };
 
-callback GenerateAssertionCallback = Promise<RTCIdentityAssertionResult> (DOMString contents, DOMString origin, RTCIdentityProviderOptions options);
+callback GenerateAssertionCallback = Promise<RTCIdentityAssertionResult> (DOMString contents,
+DOMString origin,
+RTCIdentityProviderOptions options);
 
-callback ValidateAssertionCallback = Promise<RTCIdentityValidationResult> (DOMString assertion, DOMString origin);
+callback ValidateAssertionCallback = Promise<RTCIdentityValidationResult> (DOMString assertion,
+DOMString origin);
 
 dictionary RTCIdentityAssertionResult {
     required RTCIdentityProviderDetails idp;
-    required DOMString assertion;
+    required DOMString                  assertion;
 };
 
 dictionary RTCIdentityProviderDetails {

--- a/interfaces/webrtc-stats.idl
+++ b/interfaces/webrtc-stats.idl
@@ -28,20 +28,20 @@ enum RTCStatsType {
 };
 
 dictionary RTCRtpStreamStats : RTCStats {
-             unsigned long ssrc;
-             DOMString kind;
-             DOMString transportId;
-             DOMString codecId;
+             unsigned long       ssrc;
+             DOMString           kind;
+             DOMString           transportId;
+             DOMString           codecId;
 };
 
 dictionary RTCCodecStats : RTCStats {
              unsigned long payloadType;
-             RTCCodecType codecType;
-             DOMString transportId;
-             DOMString mimeType;
+             RTCCodecType  codecType;
+             DOMString     transportId;
+             DOMString     mimeType;
              unsigned long clockRate;
              unsigned long channels;
-             DOMString sdpFmtpLine;
+             DOMString     sdpFmtpLine;
 };
 
 enum RTCCodecType {
@@ -50,126 +50,126 @@ enum RTCCodecType {
 };
 
 dictionary RTCReceivedRtpStreamStats : RTCRtpStreamStats {
-             unsigned long long packetsReceived;
-             long long packetsLost;
-             double jitter;
-             unsigned long long packetsDiscarded;
-             unsigned long long packetsRepaired;
-             unsigned long long burstPacketsLost;
-             unsigned long long burstPacketsDiscarded;
-             unsigned long burstLossCount;
-             unsigned long burstDiscardCount;
-             double burstLossRate;
-             double burstDiscardRate;
-             double gapLossRate;
-             double gapDiscardRate;
-             unsigned long framesDropped;
-             unsigned long partialFramesLost;
-             unsigned long fullFramesLost;
+             unsigned long long   packetsReceived;
+             long long            packetsLost;
+             double               jitter;
+             unsigned long long   packetsDiscarded;
+             unsigned long long   packetsRepaired;
+             unsigned long long   burstPacketsLost;
+             unsigned long long   burstPacketsDiscarded;
+             unsigned long        burstLossCount;
+             unsigned long        burstDiscardCount;
+             double               burstLossRate;
+             double               burstDiscardRate;
+             double               gapLossRate;
+             double               gapDiscardRate;
+             unsigned long        framesDropped;
+             unsigned long        partialFramesLost;
+             unsigned long        fullFramesLost;
 
 };
 
 dictionary RTCInboundRtpStreamStats : RTCReceivedRtpStreamStats {
- DOMString trackId;
- DOMString receiverId;
- DOMString remoteId;
- unsigned long framesDecoded;
- unsigned long keyFramesDecoded;
- unsigned long frameWidth;
- unsigned long frameHeight;
- unsigned long frameBitDepth;
- double framesPerSecond;
- unsigned long long qpSum;
- double totalDecodeTime;
- double totalInterFrameDelay;
- double totalSquaredInterFrameDelay;
- boolean voiceActivityFlag;
- DOMHighResTimeStamp lastPacketReceivedTimestamp;
- double averageRtcpInterval;
- unsigned long long headerBytesReceived;
- unsigned long long fecPacketsReceived;
- unsigned long long fecPacketsDiscarded;
- unsigned long long bytesReceived;
- unsigned long long packetsFailedDecryption;
- unsigned long long packetsDuplicated;
+ DOMString            trackId;
+ DOMString            receiverId;
+ DOMString            remoteId;
+ unsigned long        framesDecoded;
+ unsigned long        keyFramesDecoded;
+ unsigned long        frameWidth;
+ unsigned long        frameHeight;
+ unsigned long        frameBitDepth;
+ double               framesPerSecond;
+ unsigned long long   qpSum;
+ double               totalDecodeTime;
+ double               totalInterFrameDelay;
+ double               totalSquaredInterFrameDelay;
+ boolean              voiceActivityFlag;
+ DOMHighResTimeStamp  lastPacketReceivedTimestamp;
+ double               averageRtcpInterval;
+ unsigned long long   headerBytesReceived;
+ unsigned long long   fecPacketsReceived;
+ unsigned long long   fecPacketsDiscarded;
+ unsigned long long   bytesReceived;
+ unsigned long long   packetsFailedDecryption;
+ unsigned long long   packetsDuplicated;
  record<USVString, unsigned long long> perDscpPacketsReceived;
- unsigned long nackCount;
- unsigned long firCount;
- unsigned long pliCount;
- unsigned long sliCount;
- DOMHighResTimeStamp estimatedPlayoutTimestamp;
- double jitterBufferDelay;
- unsigned long long jitterBufferEmittedCount;
- unsigned long long totalSamplesReceived;
- unsigned long long samplesDecodedWithSilk;
- unsigned long long samplesDecodedWithCelt;
- unsigned long long concealedSamples;
- unsigned long long silentConcealedSamples;
- unsigned long long concealmentEvents;
- unsigned long long insertedSamplesForDeceleration;
- unsigned long long removedSamplesForAcceleration;
- double audioLevel;
- double totalAudioEnergy;
- double totalSamplesDuration;
- unsigned long framesReceived;
- DOMString decoderImplementation;
+ unsigned long        nackCount;
+ unsigned long        firCount;
+ unsigned long        pliCount;
+ unsigned long        sliCount;
+ DOMHighResTimeStamp  estimatedPlayoutTimestamp;
+ double               jitterBufferDelay;
+ unsigned long long   jitterBufferEmittedCount;
+ unsigned long long   totalSamplesReceived;
+ unsigned long long   samplesDecodedWithSilk;
+ unsigned long long   samplesDecodedWithCelt;
+ unsigned long long   concealedSamples;
+ unsigned long long   silentConcealedSamples;
+ unsigned long long   concealmentEvents;
+ unsigned long long   insertedSamplesForDeceleration;
+ unsigned long long   removedSamplesForAcceleration;
+ double               audioLevel;
+ double               totalAudioEnergy;
+ double               totalSamplesDuration;
+ unsigned long        framesReceived;
+ DOMString            decoderImplementation;
 };
 
 dictionary RTCRemoteInboundRtpStreamStats : RTCReceivedRtpStreamStats {
-             DOMString localId;
-             double roundTripTime;
-             double totalRoundTripTime;
-             double fractionLost;
-             unsigned long long reportsReceived;
-             unsigned long long roundTripTimeMeasurements;
+             DOMString            localId;
+             double               roundTripTime;
+             double               totalRoundTripTime;
+             double               fractionLost;
+             unsigned long long   reportsReceived;
+             unsigned long long   roundTripTimeMeasurements;
 };
 
 dictionary RTCSentRtpStreamStats : RTCRtpStreamStats {
-             unsigned long packetsSent;
+             unsigned long      packetsSent;
              unsigned long long bytesSent;
 };
 
 dictionary RTCOutboundRtpStreamStats : RTCSentRtpStreamStats {
-             DOMString trackId;
-             DOMString mediaSourceId;
-             DOMString senderId;
-             DOMString remoteId;
-             DOMString rid;
-             DOMHighResTimeStamp lastPacketSentTimestamp;
-             unsigned long long headerBytesSent;
-             unsigned long packetsDiscardedOnSend;
-             unsigned long long bytesDiscardedOnSend;
-             unsigned long fecPacketsSent;
-             unsigned long long retransmittedPacketsSent;
-             unsigned long long retransmittedBytesSent;
-             double targetBitrate;
-             unsigned long long totalEncodedBytesTarget;
-             unsigned long frameWidth;
-             unsigned long frameHeight;
-             unsigned long frameBitDepth;
-             double framesPerSecond;
-             unsigned long framesSent;
-             unsigned long hugeFramesSent;
-             unsigned long framesEncoded;
-             unsigned long keyFramesEncoded;
-             unsigned long framesDiscardedOnSend;
-             unsigned long long qpSum;
-             unsigned long long totalSamplesSent;
-             unsigned long long samplesEncodedWithSilk;
-             unsigned long long samplesEncodedWithCelt;
-             boolean voiceActivityFlag;
-             double totalEncodeTime;
-             double totalPacketSendDelay;
-             double averageRtcpInterval;
-             RTCQualityLimitationReason qualityLimitationReason;
+             DOMString            trackId;
+             DOMString            mediaSourceId;
+             DOMString            senderId;
+             DOMString            remoteId;
+             DOMString            rid;
+             DOMHighResTimeStamp  lastPacketSentTimestamp;
+             unsigned long long   headerBytesSent;
+             unsigned long        packetsDiscardedOnSend;
+             unsigned long long   bytesDiscardedOnSend;
+             unsigned long        fecPacketsSent;
+             unsigned long long   retransmittedPacketsSent;
+             unsigned long long   retransmittedBytesSent;
+             double               targetBitrate;
+             unsigned long long   totalEncodedBytesTarget;
+             unsigned long        frameWidth;
+             unsigned long        frameHeight;
+             unsigned long        frameBitDepth;
+             double               framesPerSecond;
+             unsigned long        framesSent;
+             unsigned long        hugeFramesSent;
+             unsigned long        framesEncoded;
+             unsigned long        keyFramesEncoded;
+             unsigned long        framesDiscardedOnSend;
+             unsigned long long   qpSum;
+             unsigned long long   totalSamplesSent;
+             unsigned long long   samplesEncodedWithSilk;
+             unsigned long long   samplesEncodedWithCelt;
+             boolean              voiceActivityFlag;
+             double               totalEncodeTime;
+             double               totalPacketSendDelay;
+             double               averageRtcpInterval;
+             RTCQualityLimitationReason                 qualityLimitationReason;
              record<DOMString, double> qualityLimitationDurations;
-             unsigned long qualityLimitationResolutionChanges;
+             unsigned long        qualityLimitationResolutionChanges;
              record<USVString, unsigned long long> perDscpPacketsSent;
-             unsigned long nackCount;
-             unsigned long firCount;
-             unsigned long pliCount;
-             unsigned long sliCount;
-             DOMString encoderImplementation;
+             unsigned long        nackCount;
+             unsigned long        firCount;
+             unsigned long        pliCount;
+             unsigned long        sliCount;
+             DOMString            encoderImplementation;
 };
 
 enum RTCQualityLimitationReason {
@@ -180,37 +180,37 @@ enum RTCQualityLimitationReason {
 };
 
 dictionary RTCRemoteOutboundRtpStreamStats : RTCSentRtpStreamStats {
-             DOMString localId;
+             DOMString           localId;
              DOMHighResTimeStamp remoteTimestamp;
-             unsigned long long reportsSent;
+             unsigned long long  reportsSent;
 };
 
 dictionary RTCMediaSourceStats : RTCStats {
-             DOMString trackIdentifier;
-             DOMString kind;
+             DOMString       trackIdentifier;
+             DOMString       kind;
 };
 
 dictionary RTCAudioSourceStats : RTCMediaSourceStats {
-              double audioLevel;
-              double totalAudioEnergy;
-              double totalSamplesDuration;
-              double echoReturnLoss;
-              double echoReturnLossEnhancement;
+              double              audioLevel;
+              double              totalAudioEnergy;
+              double              totalSamplesDuration;
+              double              echoReturnLoss;
+              double              echoReturnLossEnhancement;
 };
 
 dictionary RTCVideoSourceStats : RTCMediaSourceStats {
-             unsigned long width;
-             unsigned long height;
-             unsigned long bitDepth;
-             unsigned long frames;
-             unsigned long framesPerSecond;
+             unsigned long   width;
+             unsigned long   height;
+             unsigned long   bitDepth;
+             unsigned long   frames;
+             unsigned long   framesPerSecond;
 };
 
 dictionary RTCRtpContributingSourceStats : RTCStats {
              unsigned long contributorSsrc;
-             DOMString inboundRtpStreamId;
+             DOMString     inboundRtpStreamId;
              unsigned long packetsContributedTo;
-             double audioLevel;
+             double        audioLevel;
 };
 
 dictionary RTCPeerConnectionStats : RTCStats {
@@ -221,7 +221,7 @@ dictionary RTCPeerConnectionStats : RTCStats {
 };
 
 dictionary RTCMediaStreamStats : RTCStats {
-             DOMString streamIdentifier;
+             DOMString           streamIdentifier;
              sequence<DOMString> trackIds;
 };
 
@@ -232,18 +232,18 @@ dictionary RTCRtpTransceiverStats {
 };
 
 dictionary RTCMediaHandlerStats : RTCStats {
-             DOMString trackIdentifier;
-             boolean remoteSource;
-             boolean ended;
-             DOMString kind;
-             RTCPriorityType priority;
+             DOMString           trackIdentifier;
+             boolean             remoteSource;
+             boolean             ended;
+             DOMString           kind;
+             RTCPriorityType     priority;
 };
 
 dictionary RTCVideoHandlerStats : RTCMediaHandlerStats {
 };
 
 dictionary RTCVideoSenderStats : RTCVideoHandlerStats {
-             DOMString mediaSourceId;
+             DOMString           mediaSourceId;
 };
 
 dictionary RTCSenderVideoTrackAttachmentStats : RTCVideoSenderStats {
@@ -256,7 +256,7 @@ dictionary RTCAudioHandlerStats : RTCMediaHandlerStats {
 };
 
 dictionary RTCAudioSenderStats : RTCAudioHandlerStats {
-             DOMString mediaSourceId;
+             DOMString           mediaSourceId;
 };
 
 dictionary RTCSenderAudioTrackAttachmentStats : RTCAudioSenderStats {
@@ -266,33 +266,33 @@ dictionary RTCAudioReceiverStats : RTCAudioHandlerStats {
 };
 
 dictionary RTCDataChannelStats : RTCStats {
-             DOMString label;
-             DOMString protocol;
-             long dataChannelIdentifier;
-             DOMString transportId;
+             DOMString           label;
+             DOMString           protocol;
+             long                dataChannelIdentifier;
+             DOMString           transportId;
              RTCDataChannelState state;
-             unsigned long messagesSent;
-             unsigned long long bytesSent;
-             unsigned long messagesReceived;
-             unsigned long long bytesReceived;
+             unsigned long       messagesSent;
+             unsigned long long  bytesSent;
+             unsigned long       messagesReceived;
+             unsigned long long  bytesReceived;
 };
 
 dictionary RTCTransportStats : RTCStats {
-             unsigned long long packetsSent;
-             unsigned long long packetsReceived;
-             unsigned long long bytesSent;
-             unsigned long long bytesReceived;
-             DOMString rtcpTransportStatsId;
-             RTCIceRole iceRole;
+             unsigned long long    packetsSent;
+             unsigned long long    packetsReceived;
+             unsigned long long    bytesSent;
+             unsigned long long    bytesReceived;
+             DOMString             rtcpTransportStatsId;
+             RTCIceRole            iceRole;
              RTCDtlsTransportState dtlsState;
-             DOMString selectedCandidatePairId;
-             DOMString localCertificateId;
-             DOMString remoteCertificateId;
-             DOMString tlsVersion;
-             DOMString dtlsCipher;
-             DOMString srtpCipher;
-             DOMString tlsGroup;
-             unsigned long selectedCandidatePairChanges;
+             DOMString             selectedCandidatePairId;
+             DOMString             localCertificateId;
+             DOMString             remoteCertificateId;
+             DOMString             tlsVersion;
+             DOMString             dtlsCipher;
+             DOMString             srtpCipher;
+             DOMString             tlsGroup;
+             unsigned long         selectedCandidatePairChanges;
 };
 
 dictionary RTCSctpTransportStats : RTCStats {
@@ -300,15 +300,15 @@ dictionary RTCSctpTransportStats : RTCStats {
 };
 
 dictionary RTCIceCandidateStats : RTCStats {
-             DOMString transportId;
-             RTCNetworkType networkType;
-             DOMString? address;
-             long port;
-             DOMString protocol;
-             RTCIceCandidateType candidateType;
-             long priority;
-             DOMString url;
-             DOMString relayProtocol;
+             DOMString                transportId;
+             RTCNetworkType           networkType;
+             DOMString?               address;
+             long                     port;
+             DOMString                protocol;
+             RTCIceCandidateType      candidateType;
+             long                     priority;
+             DOMString                url;
+             DOMString                relayProtocol;
 };
 
 enum RTCNetworkType {
@@ -322,35 +322,35 @@ enum RTCNetworkType {
 };
 
 dictionary RTCIceCandidatePairStats : RTCStats {
-             DOMString transportId;
-             DOMString localCandidateId;
-             DOMString remoteCandidateId;
+             DOMString                     transportId;
+             DOMString                     localCandidateId;
+             DOMString                     remoteCandidateId;
              RTCStatsIceCandidatePairState state;
-             boolean nominated;
-             unsigned long long packetsSent;
-             unsigned long long packetsReceived;
-             unsigned long long bytesSent;
-             unsigned long long bytesReceived;
-             DOMHighResTimeStamp lastPacketSentTimestamp;
-             DOMHighResTimeStamp lastPacketReceivedTimestamp;
-             DOMHighResTimeStamp firstRequestTimestamp;
-             DOMHighResTimeStamp lastRequestTimestamp;
-             DOMHighResTimeStamp lastResponseTimestamp;
-             double totalRoundTripTime;
-             double currentRoundTripTime;
-             double availableOutgoingBitrate;
-             double availableIncomingBitrate;
-             unsigned long circuitBreakerTriggerCount;
-             unsigned long long requestsReceived;
-             unsigned long long requestsSent;
-             unsigned long long responsesReceived;
-             unsigned long long responsesSent;
-             unsigned long long retransmissionsReceived;
-             unsigned long long retransmissionsSent;
-             unsigned long long consentRequestsSent;
-             DOMHighResTimeStamp consentExpiredTimestamp;
-             unsigned long packetsDiscardedOnSend;
-             unsigned long long bytesDiscardedOnSend;
+             boolean                       nominated;
+             unsigned long long            packetsSent;
+             unsigned long long            packetsReceived;
+             unsigned long long            bytesSent;
+             unsigned long long            bytesReceived;
+             DOMHighResTimeStamp           lastPacketSentTimestamp;
+             DOMHighResTimeStamp           lastPacketReceivedTimestamp;
+             DOMHighResTimeStamp           firstRequestTimestamp;
+             DOMHighResTimeStamp           lastRequestTimestamp;
+             DOMHighResTimeStamp           lastResponseTimestamp;
+             double                        totalRoundTripTime;
+             double                        currentRoundTripTime;
+             double                        availableOutgoingBitrate;
+             double                        availableIncomingBitrate;
+             unsigned long                 circuitBreakerTriggerCount;
+             unsigned long long            requestsReceived;
+             unsigned long long            requestsSent;
+             unsigned long long            responsesReceived;
+             unsigned long long            responsesSent;
+             unsigned long long            retransmissionsReceived;
+             unsigned long long            retransmissionsSent;
+             unsigned long long            consentRequestsSent;
+             DOMHighResTimeStamp           consentExpiredTimestamp;
+             unsigned long                 packetsDiscardedOnSend;
+             unsigned long long            bytesDiscardedOnSend;
 };
 
 enum RTCStatsIceCandidatePairState {


### PR DESCRIPTION
A recent respec update caused a lot of whitespace changes:
https://github.com/web-platform-tests/wpt/pull/20383#issuecomment-557471644

Sync them all manually to get them out of the way.

Source: https://github.com/tidoust/reffy-reports/tree/b60317f12fda1169cc3d0f9b320735d11ac47203/ed/idl