### PR TITLE
test(HTMLDocument): Assert that the named property getter is HTML‑only

### DIFF
--- a/html/dom/documents/dom-tree-accessors/nameditem-fetch-01.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-fetch-01.html
@@ -8,16 +8,19 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-test(function() {
-  var url = 'data:text/html,<html xmlns="http://www.w3.org/1999/xhtml"><form name="x"/></html>';
-  var xhr = new XMLHttpRequest();
-  xhr.open("GET", url);
-  xhr.responseType = "document";
-  xhr.onload = function() {
-    var doc = xhr.responseXML;
+promise_test(function() {
+  return /** @type {Promise<Document>} */ (new Promise(function (resolve) {
+    var url = 'data:text/html,<html xmlns="http://www.w3.org/1999/xhtml"><form name="x"/></html>';
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", url);
+    xhr.responseType = "document";
+    xhr.onload = function() {
+      resolve(xhr.responseXML);
+    };
+    xhr.send();
+  })).then(function (doc) {
     assert_equals(doc.x, doc.getElementsByTagName("form")[0]);
     assert_equals(doc['x'], doc.getElementsByTagName("form")[0]);
-  };
-  xhr.send();
+  });
 }, "If there is one form, it should be returned (name)");
 </script>

--- a/html/dom/documents/dom-tree-accessors/nameditem-fetch-01.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-fetch-01.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Named items: fetch text/html</title>
+<link rel="author" title="bzbarsky" href="mailto:bzbarsky@mit.edu">
+<link rel="author" title="ExE Boss" href="https://ExE-Boss.tech">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-htmldocument-nameditem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function() {
+  var url = 'data:text/html,<html xmlns="http://www.w3.org/1999/xhtml"><form name="x"/></html>';
+  var xhr = new XMLHttpRequest();
+  xhr.open("GET", url);
+  xhr.responseType = "document";
+  xhr.onload = function() {
+    var doc = xhr.responseXML;
+    assert_equal(doc.x, doc.getElementsByTagName("form"));
+    assert_equal(doc['x'], doc.getElementsByTagName("form"));
+  };
+  xhr.send();
+}, "If there is one form, it should be returned (name)");
+</script>

--- a/html/dom/documents/dom-tree-accessors/nameditem-fetch-01.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-fetch-01.html
@@ -15,8 +15,8 @@ test(function() {
   xhr.responseType = "document";
   xhr.onload = function() {
     var doc = xhr.responseXML;
-    assert_equals(doc.x, doc.getElementsByTagName("form"));
-    assert_equals(doc['x'], doc.getElementsByTagName("form"));
+    assert_equals(doc.x, doc.getElementsByTagName("form")[0]);
+    assert_equals(doc['x'], doc.getElementsByTagName("form")[0]);
   };
   xhr.send();
 }, "If there is one form, it should be returned (name)");

--- a/html/dom/documents/dom-tree-accessors/nameditem-fetch-01.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-fetch-01.html
@@ -15,8 +15,8 @@ test(function() {
   xhr.responseType = "document";
   xhr.onload = function() {
     var doc = xhr.responseXML;
-    assert_equal(doc.x, doc.getElementsByTagName("form"));
-    assert_equal(doc['x'], doc.getElementsByTagName("form"));
+    assert_equals(doc.x, doc.getElementsByTagName("form"));
+    assert_equals(doc['x'], doc.getElementsByTagName("form"));
   };
   xhr.send();
 }, "If there is one form, it should be returned (name)");

--- a/html/dom/documents/dom-tree-accessors/nameditem-fetch-02.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-fetch-02.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Named items: fetch application/xml</title>
+<link rel="author" title="bzbarsky" href="mailto:bzbarsky@mit.edu">
+<link rel="author" title="ExE Boss" href="https://ExE-Boss.tech">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-htmldocument-nameditem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function() {
+  var url = 'data:application/xml,<html xmlns="http://www.w3.org/1999/xhtml"><form name="x"/></html>';
+  var xhr = new XMLHttpRequest();
+  xhr.open("GET", url);
+  xhr.responseType = "document";
+  xhr.onload = function() {
+    var doc = xhr.responseXML;
+    assert_equal(doc.x, undefined);
+    assert_equal(doc['x'], undefined);
+  };
+  xhr.send();
+}, "Named getter is HTML-only");
+</script>

--- a/html/dom/documents/dom-tree-accessors/nameditem-fetch-02.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-fetch-02.html
@@ -8,16 +8,19 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-test(function() {
-  var url = 'data:application/xml,<html xmlns="http://www.w3.org/1999/xhtml"><form name="x"/></html>';
-  var xhr = new XMLHttpRequest();
-  xhr.open("GET", url);
-  xhr.responseType = "document";
-  xhr.onload = function() {
-    var doc = xhr.responseXML;
+promise_test(function() {
+  return /** @type {Promise<Document>} */ (new Promise(function (resolve) {
+    var url = 'data:application/xml,<xml><form xmlns="http://www.w3.org/1999/xhtml" name="x"/></xml>';
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", url);
+    xhr.responseType = "document";
+    xhr.onload = function() {
+      resolve(xhr.responseXML);
+    };
+    xhr.send();
+  })).then(function (doc) {
     assert_equals(doc.x, undefined);
     assert_equals(doc['x'], undefined);
-  };
-  xhr.send();
+  });
 }, "Named getter is HTML-only");
 </script>

--- a/html/dom/documents/dom-tree-accessors/nameditem-fetch-02.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-fetch-02.html
@@ -15,8 +15,8 @@ test(function() {
   xhr.responseType = "document";
   xhr.onload = function() {
     var doc = xhr.responseXML;
-    assert_equal(doc.x, undefined);
-    assert_equal(doc['x'], undefined);
+    assert_equals(doc.x, undefined);
+    assert_equals(doc['x'], undefined);
   };
   xhr.send();
 }, "Named getter is HTML-only");


### PR DESCRIPTION
See&nbsp;issue&nbsp;https://github.com/whatwg/html/issues/4792

This&nbsp;is&nbsp;already&nbsp;implemented in&nbsp;all&nbsp;major&nbsp;browsers (**Firefox**, **Chrome** and&nbsp;**Safari**).

Note&nbsp;that **Chrome**&nbsp;currently has&nbsp;a&nbsp;bug&nbsp;which is&nbsp;caught by&nbsp;the&nbsp;`nameditem‑fetch‑01.html`&nbsp;test.

---

See&nbsp;also: <https://github.com/web-platform-tests/wpt/pull/20676>