### PR TITLE
[taskcluster] Fix the start flags for master push

### DIFF
--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -157,8 +157,11 @@ def build_full_command(event, task):
         options_args.append("--no-hosts")
     else:
         options_args.append("--hosts")
+    # Check out the expected SHA unless it is overridden (e.g. to base_head).
     if options.get("checkout"):
         options_args.append("--checkout=%s" % options["checkout"])
+    else:
+        options_args.append("--checkout=%s" % fetch_sha)
     for browser in options.get("browser", []):
         options_args.append("--browser=%s" % browser)
     if options.get("channel"):


### PR DESCRIPTION
PR #19401 dropped the --checkout flag to run_tc.py for jobs triggered by
master pushes. Luckily, there is a new assertion in place that has
caught the bug. Examples:

Before:
https://community-tc.services.mozilla.com/tasks/BaIMAbGZR_SsgHYyUAWA0g/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FBaIMAbGZR_SsgHYyUAWA0g%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L37
After:
https://community-tc.services.mozilla.com/tasks/L77FVIkURm6XiP96FK3JMg/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FL77FVIkURm6XiP96FK3JMg%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L24

Note: this is NOT covered by unit tests.