### PR TITLE
Do not attempt to push to epochs on forks

### DIFF
--- a/.github/workflows/epochs.yml
+++ b/.github/workflows/epochs.yml
@@ -6,6 +6,8 @@ on:
     - cron: 10 */3 * * *
 jobs:
   update:
+    # Do not run this job on forks.
+    if: github.repository == "web-platform-tests/wpt"
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout


### PR DESCRIPTION
GITHUB_TOKEN on forks only has read access to the repo. Fixes #20392.