### PR TITLE
HTML: "handleEvent" property of EventHandler is ignored

### DIFF
--- a/html/webappapis/scripting/events/event-handler-handleEvent-ignored.html
+++ b/html/webappapis/scripting/events/event-handler-handleEvent-ignored.html
@@ -9,14 +9,14 @@
 "use strict";
 
 test(t => {
-  const el = document.createElement("div");
-  el.onmouseenter = {
-    get handleEvent() {
-      t.step(() => {
-        assert_unreached('"handleEvent" property should not be looked up');
-      });
+  const handler = Object.create(null, {
+    handleEvent: {
+      get: t.unreached_func('"handleEvent" property should not be looked up'),
     },
-  };
+  });
+
+  const el = document.createElement("div");
+  el.onmouseenter = handler;
   el.dispatchEvent(new MouseEvent("mouseenter"));
 }, 'plain object "mouseenter" handler');
 

--- a/html/webappapis/scripting/events/event-handler-handleEvent-ignored.html
+++ b/html/webappapis/scripting/events/event-handler-handleEvent-ignored.html
@@ -30,6 +30,9 @@ async_test(t => {
 
   window.onmessage = handler;
   window.postMessage({}, "*");
-  step_timeout(t.step_func_done());
+
+  step_timeout(() => {
+    t.done();
+  }, 50);
 }, 'non-callable "message" handler that is instance of Function');
 </script>

--- a/html/webappapis/scripting/events/event-handler-handleEvent-ignored.html
+++ b/html/webappapis/scripting/events/event-handler-handleEvent-ignored.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>"handleEvent" property of EventHandler should be ignored</title>
+<link rel="help" href="https://html.spec.whatwg.org/#eventhandler">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+"use strict";
+
+test(t => {
+  const el = document.createElement("div");
+  el.onmouseenter = {
+    get handleEvent() {
+      t.step(() => {
+        assert_unreached('"handleEvent" property should not be looked up');
+      });
+    },
+  };
+  el.dispatchEvent(new MouseEvent("mouseenter"));
+}, 'plain object "mouseenter" handler');
+
+async_test(t => {
+  const handler = Object.create(Function.prototype, {
+    handleEvent: {
+      get: t.unreached_func('"handleEvent" property should not be looked up'),
+    },
+  });
+  assert_true(handler instanceof Function);
+
+  window.onmessage = handler;
+  t.add_cleanup(() => {
+    window.onmessage = null;
+  });
+
+  window.postMessage({}, "*");
+  step_timeout(t.step_func_done());
+}, 'non-callable "message" handler that is instance of Function');
+</script>

--- a/html/webappapis/scripting/events/event-handler-handleEvent-ignored.html
+++ b/html/webappapis/scripting/events/event-handler-handleEvent-ignored.html
@@ -29,10 +29,6 @@ async_test(t => {
   assert_true(handler instanceof Function);
 
   window.onmessage = handler;
-  t.add_cleanup(() => {
-    window.onmessage = null;
-  });
-
   window.postMessage({}, "*");
   step_timeout(t.step_func_done());
 }, 'non-callable "message" handler that is instance of Function');

--- a/html/webappapis/scripting/events/event-handler-onresize.html
+++ b/html/webappapis/scripting/events/event-handler-onresize.html
@@ -6,7 +6,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-var t = async_test("body.onresize should set the window.onload handler")
+var t = async_test("body.onresize should set the window.onresize handler")
 window.onresize = t.step_func(function() {
   assert_unreached("This handler should be overwritten.")
 })


### PR DESCRIPTION
WebKit issue: [Non-callable "handleEvent" property is silently ignored](https://bugs.webkit.org/show_bug.cgi?id=200066).

Related: #15105.