### PR TITLE
Test EventListener invocation order in AT_TARGET phase

### DIFF
--- a/dom/events/Event-dispatch-order-at-target.html
+++ b/dom/events/Event-dispatch-order-at-target.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Listeners are invoked in correct order (AT_TARGET phase)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+"use strict";
+
+test(() => {
+    const el = document.createElement("div");
+    const expectedOrder = ["capturing", "bubbling"];
+
+    let actualOrder = [];
+    el.addEventListener("click", evt => {
+        assert_equals(evt.eventPhase, Event.AT_TARGET);
+        actualOrder.push("bubbling");
+    }, false);
+    el.addEventListener("click", evt => {
+        assert_equals(evt.eventPhase, Event.AT_TARGET);
+        actualOrder.push("capturing");
+    }, true);
+
+    el.dispatchEvent(new Event("click", {bubbles: true}));
+    assert_array_equals(actualOrder, expectedOrder, "bubbles: true");
+
+    actualOrder = [];
+    el.dispatchEvent(new Event("click", {bubbles: false}));
+    assert_array_equals(actualOrder, expectedOrder, "bubbles: false");
+}, "Listeners are invoked in correct order (AT_TARGET phase)");
+</script>


### PR DESCRIPTION
Chrome 78.0: ❌
Firefox 70.0: ❌
Safari 12.1: ✅

See https://github.com/whatwg/dom/issues/746.