### PR TITLE
[Azure Pipelines] limit triggers to branches actually used

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,6 +16,7 @@
 #    https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-windows
 
 trigger:
+# These are the branches referenced in some of the jobs that follow.
 - epochs/daily
 - epochs/three_hourly
 - triggers/edge_dev

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,8 +16,12 @@
 #    https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-windows
 
 trigger:
-- epochs/*
-- triggers/*
+- epochs/daily
+- epochs/three_hourly
+- triggers/edge_dev
+- triggers/edge_canary
+- triggers/safari_stable
+- triggers/safari_preview
 
 jobs:
 # The affected tests jobs are unconditional for speed, as most PRs have one or

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,7 +16,7 @@
 #    https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-windows
 
 trigger:
-# These are the branches referenced in some of the jobs that follow.
+# These are all the branches referenced in the jobs that follow.
 - epochs/daily
 - epochs/three_hourly
 - triggers/edge_dev


### PR DESCRIPTION
Branches like epochs/six_hourly wouldn't do anything, but they create
a lot of entries in the Azure DevOps dashboard:
https://dev.azure.com/web-platform-tests/wpt/_build?definitionId=1

The no-op builds are mostly harmless, but make it harder to find the
interesting builds.