### PR TITLE
[Azure Pipelines] upgrade to STP 96, bypassing homebrew-cask-versions

### DIFF
--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -5,7 +5,7 @@ parameters:
 steps:
 - ${{ if eq(parameters.channel, 'preview') }}:
   - script: |
-      HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/safari-technology-preview.rb
+      HOMEBREW_NO_AUTO_UPDATE=1 brew cask install tools/ci/azure/safari-technology-preview.rb
       sudo "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable
       defaults write com.apple.SafariTechnologyPreview WebKitJavaScriptCanOpenWindowsAutomatically 1
       defaults write com.apple.SafariTechnologyPreview ExperimentalServerTimingEnabled 1

--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,0 +1,33 @@
+cask 'safari-technology-preview' do
+  if MacOS.version <= :mojave
+    version '96,061-44056-20191120-ac7bb196-2724-4840-bce9-6c83ecdbfb2c'
+    sha256 'e80ceacdff7e75218365993e5af1c81c9bcc4785291ae00abba3d14ac5614317'
+  else
+    version '96,061-47718-20191120-02bc7569-ee6b-4c28-9ec4-0ceeda3c3c3a'
+    sha256 'bbfcdc36bf9b55aec5838d66e34c41dd3f6a64091406bc38f45c888360f191fe'
+  end
+
+  url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
+  appcast 'https://developer.apple.com/safari/download/'
+  name 'Safari Technology Preview'
+  homepage 'https://developer.apple.com/safari/download/'
+
+  auto_updates true
+  depends_on macos: '>= :mojave'
+
+  pkg 'Safari Technology Preview.pkg'
+
+  uninstall delete: '/Applications/Safari Technology Preview.app'
+
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.apple.safaritechnologypreview.sfl*',
+               '~/Library/Caches/com.apple.SafariTechnologyPreview',
+               '~/Library/Preferences/com.apple.SafariTechnologyPreview.plist',
+               '~/Library/SafariTechnologyPreview',
+               '~/Library/Saved Application State/com.apple.SafariTechnologyPreview.savedState',
+               '~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview-com.apple.Safari.UserRequests.plist',
+               '~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview-com.apple.Safari.WebFeedSubscriptions.plist',
+               '~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview.plist',
+               '~/Library/WebKit/com.apple.SafariTechnologyPreview',
+             ]
+end


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask-versions/pull/8219 remains
open, so instead of relying on homebrew-cask-versions, put the cask
directly in wpt.

https://github.com/foolip/safari-technology-preview-updater will be
updated to send PRs to wpt as well to homebrew-cask-versions.