### PR TITLE
[Documentation] Fix OS string used in manifest example

### DIFF
--- a/tools/wptrunner/docs/expectation.rst
+++ b/tools/wptrunner/docs/expectation.rst
@@ -287,7 +287,7 @@ A more complex manifest with conditional properties might be::
 
   [canvas_test.html]
     expected:
-      if os == "osx": FAIL
+      if os == "mac": FAIL
       if os == "windows" and version == "XP": FAIL
       PASS
 


### PR DESCRIPTION
As far as I understand, the correct OS for Mac devices is 'mac', not 'osx'. 