### PR TITLE
[fetch] Designate tests for optional functionality

### DIFF
--- a/fetch/metadata/redirect/multiple-redirect-https-downgrade-upgrade-prefetch.optional.tentative.sub.html
+++ b/fetch/metadata/redirect/multiple-redirect-https-downgrade-upgrade-prefetch.optional.tentative.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/fetch/metadata/resources/helper.js></script>
+<script src=/fetch/metadata/resources/redirectTestHelper.sub.js></script>
+<body>
+<script>
+  "use strict";
+  let nonce = "{{uuid()}}";
+  let expected = {"site": "cross-site", "user": "", "mode": "cors", "dest": ""};
+
+  testPrefetch(nonce, "Https downgrade-upgrade", MultipleRedirectTo, expected);
+</script>
+</body>

--- a/fetch/metadata/redirect/redirect-http-upgrade-prefetch.optional.tentative.sub.html
+++ b/fetch/metadata/redirect/redirect-http-upgrade-prefetch.optional.tentative.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/fetch/metadata/resources/helper.js></script>
+<script src=/fetch/metadata/resources/redirectTestHelper.sub.js></script>
+<body>
+<script>
+  "use strict";
+  let nonce = "{{uuid()}}";
+  let expected = {"site": "cross-site", "user": "", "mode": "cors", "dest": ""};
+
+  testPrefetch(nonce, "Http upgrade", upgradeRedirectTo, expected);
+</script>
+</body>

--- a/fetch/metadata/redirect/redirect-https-downgrade-prefetch.optional.tentative.sub.html
+++ b/fetch/metadata/redirect/redirect-https-downgrade-prefetch.optional.tentative.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/fetch/metadata/resources/helper.js></script>
+<script src=/fetch/metadata/resources/redirectTestHelper.sub.js></script>
+<body>
+<script>
+  "use strict";
+  let nonce = "{{uuid()}}";
+  let expected = {"site": "", "user": "", "mode": "", "dest": ""};
+
+  testPrefetch(nonce, "Https downgrade", downgradeRedirectTo, expected);
+</script>
+</body>


### PR DESCRIPTION
The subtests for "prefetch" have been observed to produce unstable
results in some browsers. Declaring them in a separate test reduces the
impact of this instability and helps to contextualize failures.

---

@jdm @domfarolino The instability in Firefox is blocking gh-20454 and gh-20455.
I have the ability to merge despite the CI failure, but since the problem has
the potential to block future pull requests (and since the "failure" is prone
to be misinterpreted), I think it's preferable to move those tests to dedicated
files.

Firefox will most likely flag these new tests as unstable, but I'll feel more
comfortable overriding the stability check for this pull request.

Ideally, we would express these expectations in a way that produced
deterministic results. I'm all ears if you have ideas for how to do that, but I
think the spec may be too loose to make any guarantees.