### PR TITLE
Automate webauthn tests

### DIFF
--- a/webauthn/createcredential-badargs-attestation.https.html
+++ b/webauthn/createcredential-badargs-attestation.https.html
@@ -5,6 +5,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/createcredential-badargs-authnrselection.https.html
+++ b/webauthn/createcredential-badargs-authnrselection.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>
@@ -53,13 +55,19 @@ standardSetup(function() {
     new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelBadAttachEmptyStr).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection attachment is empty string", TypeError);
     new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelBadAttachEmptyObj).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection attachment is empty object", TypeError);
     new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelBadAttachNull).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection attachment is null", TypeError);
-    // XXX: assumes authnr is behaving like most U2F authnrs; really depends on the authnr or mock configuration
-    new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelAttachPlatform).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection attachment platform", "NotAllowedError");
+    // the physically plugged-in or virtual authenticator should be a cross-platform authenticator.
+    new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelAttachPlatform)
+      .modify("options.publicKey.timeout", 300)
+      .runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection attachment platform", "NotAllowedError");
 
     // authenticatorSelection bad requireResidentKey values
-   // XXX: assumes authnr is behaving like most U2F authnrs; really depends on the authnr or mock configuration
-    new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelRkTrue).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection residentKey true", "NotAllowedError");
-    new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelRkBadString).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection residentKey is string", TypeError);
+    // the physically plugged-in or virtual authenticator should not support resident keys
+    new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelRkTrue)
+      .modify("options.publicKey.timeout", 300)
+      .runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection residentKey true", "NotAllowedError");
+    new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelRkBadString)
+      .modify("options.publicKey.timeout", 300)
+      .runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection residentKey is string", TypeError);
     // TODO: not sure if rk is "boolean" or "truthy"; add test cases if it should only accept boolean values
 
     // authenticatorSelection bad userVerification values
@@ -67,8 +75,11 @@ standardSetup(function() {
     new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelBadUvEmptyObj).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection userVerification empty object", TypeError);
     new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelBadUvStr).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection userVerification bad value", TypeError);
     new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelBadUvNull).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection userVerification null", TypeError);
-    // XXX: assumes this is a mock authenticator the properly reports that it is not doing userVerfication
-    new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelUvRequired).runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection userVerification required", "NotAllowedError");
+    // the physically plugged-in or virtual authenticator should not support user verification
+    new CreateCredentialsTest("options.publicKey.authenticatorSelection", authnrSelUvRequired)
+      // this assertion will time out the test under default parameters since the browser will wait for a platform authenticator
+      .modify("options.publicKey.timeout", 300)
+      .runTest("Bad AuthenticatorSelectionCriteria: authenticatorSelection userVerification required", "NotAllowedError");
 });
 
 /* JSHINT */

--- a/webauthn/createcredential-badargs-challenge.https.html
+++ b/webauthn/createcredential-badargs-challenge.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/createcredential-badargs-rp.https.html
+++ b/webauthn/createcredential-badargs-rp.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/createcredential-badargs-user.https.html
+++ b/webauthn/createcredential-badargs-user.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/createcredential-excludecredentials.https.html
+++ b/webauthn/createcredential-excludecredentials.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/createcredential-extensions.https.html
+++ b/webauthn/createcredential-extensions.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/createcredential-passing.https.html
+++ b/webauthn/createcredential-passing.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/createcredential-pubkeycredparams.https.html
+++ b/webauthn/createcredential-pubkeycredparams.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>
@@ -38,8 +40,12 @@ standardSetup(function() {
     new CreateCredentialsTest("options.publicKey.pubKeyCredParams", [badTypeEmptyString]).runTest("Bad pubKeyCredParams: first param has bad type (\"\")", TypeError);
     new CreateCredentialsTest("options.publicKey.pubKeyCredParams", [badTypeNull]).runTest("Bad pubKeyCredParams: first param has bad type (null)", TypeError);
     new CreateCredentialsTest("options.publicKey.pubKeyCredParams", [badTypeEmptyObj]).runTest("Bad pubKeyCredParams: first param has bad type (empty object)", TypeError);
-    new CreateCredentialsTest("options.publicKey.pubKeyCredParams", [badAlg]).runTest("Bad pubKeyCredParams: first param has bad alg (42)", "NotSupportedError");
-    new CreateCredentialsTest("options.publicKey.pubKeyCredParams", [badAlgZero]).runTest("Bad pubKeyCredParams: first param has bad alg (0)", "NotSupportedError");
+    new CreateCredentialsTest("options.publicKey.pubKeyCredParams", [badAlg])
+      .modify("options.publicKey.timeout", 300)
+      .runTest("Bad pubKeyCredParams: first param has bad alg (42)", "NotSupportedError");
+    new CreateCredentialsTest("options.publicKey.pubKeyCredParams", [badAlgZero])
+      .modify("options.publicKey.timeout", 300)
+      .runTest("Bad pubKeyCredParams: first param has bad alg (0)", "NotSupportedError");
 
     // TODO: come back to this when mock authenticators support multiple cryptos so that we can test the preference ranking
     // function verifyEC256(res) {

--- a/webauthn/createcredential-timeout.https.html
+++ b/webauthn/createcredential-timeout.https.html
@@ -1,48 +1,52 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>WebAuthn navigator.credentials.create() timeout Tests</title>
+<meta name="timeout" content="long">
 <link rel="author" title="Adam Powers" href="mailto:adam@fidoalliance.org">
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>
-standardSetup(function() {
-    "use strict";
+"use strict";
 
-    // bad timeout values
-    // TODO: there is some debate as to whether MAX_UNSIGNED_LONG + 1 and / or -1 should be disallowed since they get converted to valid values internally
-    // new CreateCredentialsTest({path: "options.publicKey.timeout", value: -1}).runTest("Bad timeout: negative", TypeError);
-    // new CreateCredentialsTest({path: "options.publicKey.timeout", value: 4294967295 + 1}).runTest("Bad timeout: too big", TypeError);
+// bad timeout values
+// TODO: there is some debate as to whether MAX_UNSIGNED_LONG + 1 and / or -1 should be disallowed since they get converted to valid values internally
+// new CreateCredentialsTest({path: "options.publicKey.timeout", value: -1}).runTest("Bad timeout: negative", TypeError);
+// new CreateCredentialsTest({path: "options.publicKey.timeout", value: 4294967295 + 1}).runTest("Bad timeout: too big", TypeError);
 
-    // timeout test
-    // XXX: this probably always passes with most mock authenticators unless
-    // some setup happens right here to make sure they don't return a credential
-    // right away. So... uhh... I guess test this with a real authenticator if you
-    // want to see if it really works.
-    promise_test(() => {
-        return new Promise((resolve, reject) => {
-            var args = {
-                options: {
-                    publicKey: {
-                        timeout: 1
-                    }
-                }
-            };
-
-            setTimeout(() => {
-                reject(new Error ("timed out"));
-            }, 1000);
-
-            createCredential(args).then((res) => {
-                resolve(res);
-            });
+// timeout test
+promise_test(async t => {
+    // if available, configure a mock authenticator that does not respond to user input
+    try {
+        await window.test_driver.add_virtual_authenticator({
+            protocol: "ctap1/u2f",
+            transport: "usb",
+            isUserConsenting: false,
         });
-    }, "ensure create credential times out");
-    // TODO: createCredential.timeout > 1s && setTimeout < 1s
-    // TODO: createCredential.timeout < 5s && setTimeout > 5s
-});
+    } catch (error) {
+        if (error.status !== "error" ||
+            error.message !== "Action add_virtual_authenticator not implemented") {
+          throw error;
+        }
+    }
+
+    var args = {
+        options: {
+            publicKey: {
+                // browsers may set an arbitrary minimum timeout and not respect this value
+                timeout: 1
+            }
+        }
+    };
+
+    return promise_rejects(t, "NotAllowedError", createCredential(args));
+}, "ensure create credential times out");
+// TODO: createCredential.timeout > 1s && setTimeout < 1s
+// TODO: createCredential.timeout < 5s && setTimeout > 5s
 
 /* JSHINT */
 /* globals standardSetup, CreateCredentialsTest, createCredential, promise_test */

--- a/webauthn/createcredential-timeout.https.html
+++ b/webauthn/createcredential-timeout.https.html
@@ -43,11 +43,11 @@ promise_test(async t => {
         }
     };
 
-    return promise_rejects(t, "NotAllowedError", createCredential(args));
+    return promise_rejects_dom(t, "NotAllowedError", createCredential(args));
 }, "ensure create credential times out");
 // TODO: createCredential.timeout > 1s && setTimeout < 1s
 // TODO: createCredential.timeout < 5s && setTimeout > 5s
 
 /* JSHINT */
-/* globals standardSetup, CreateCredentialsTest, createCredential, promise_test */
+/* globals standardSetup, CreateCredentialsTest, createCredential, promise_test, promise_rejects_dom*/
 </script>

--- a/webauthn/createcredential-timeout.https.html
+++ b/webauthn/createcredential-timeout.https.html
@@ -28,9 +28,8 @@ promise_test(async t => {
             isUserConsenting: false,
         });
     } catch (error) {
-        if (error.status !== "error" ||
-            error.message !== "Action add_virtual_authenticator not implemented") {
-          throw error;
+        if (error !== "error: Action add_virtual_authenticator not implemented") {
+            throw error;
         }
     }
 

--- a/webauthn/getcredential-badargs-rpid.https.html
+++ b/webauthn/getcredential-badargs-rpid.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/getcredential-badargs-userverification.https.html
+++ b/webauthn/getcredential-badargs-userverification.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>
@@ -27,7 +29,7 @@ standardSetup(function() {
     new GetCredentialsTest("options.publicKey.userVerification", null)
         .addCredential(credPromise)
         .runTest("Bad userVerification: null", TypeError);
-    // XXX: assumes this is a mock authenticator the properly reports that it is not doing userVerfication
+    // mock authenticator does not support user verification
     new GetCredentialsTest("options.publicKey.userVerification", "required")
         .addCredential(credPromise)
         .runTest("Bad userVerification: \"required\"", "NotAllowedError");

--- a/webauthn/getcredential-extensions.https.html
+++ b/webauthn/getcredential-extensions.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/getcredential-passing.https.html
+++ b/webauthn/getcredential-passing.https.html
@@ -6,6 +6,8 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>

--- a/webauthn/getcredential-timeout.https.html
+++ b/webauthn/getcredential-timeout.https.html
@@ -6,13 +6,42 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src=helpers.js></script>
 <body></body>
 <script>
-standardSetup(function() {
+promise_test(async t => {
     "use strict";
 
-    var credPromise = createCredential();
+    let credentialId;
+    try {
+        // if available, set up a mock authenticator that does not respond to user input with a credential
+        let authenticator = await window.test_driver.add_virtual_authenticator({
+            protocol: "ctap1/u2f",
+            transport: "usb",
+            isUserConsenting: false,
+        });
+        const private_key =
+            "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8_zMDQDYAxlU-Q"
+          + "hk1Dwkf0v18GZca1DMF3SaJ9HPdmShRANCAASNYX5lyVCOZLzFZzrIKmeZ2jwU"
+          + "RmgsJYxGP__fWN_S-j5sN4tT15XEpN_7QZnt14YvI6uvAgO0uJEboFaZlOEB";
+        credentialId = new Uint8Array([..."cred-1"].map(c => c.charCodeAt(0)));
+        await window.test_driver.add_credential(authenticator, {
+            credentialId: btoa("cred-1"),
+            rpId: window.location.hostname,
+            privateKey: private_key,
+            signCount: 0,
+            isResidentCredential: false,
+        });
+    } catch (error) {
+        if (error.status !== "error" ||
+            error.message !== "Action add_virtual_authenticator not implemented") {
+          throw error;
+        }
+      // configure a manual authenticator by creating a credential.
+      credentialId = (await createCredential()).rawId;
+    }
 
     // bad timeout values
     // TODO: there is some debate as to whether MAX_UNSIGNED_LONG + 1 and / or -1 should be disallowed since they get converted to valid values internally
@@ -24,24 +53,16 @@ standardSetup(function() {
     //     .runTest("Bad timeout: too big", TypeError);
 
     // timeout test
-    // XXX: this probably always passes with most mock authenticators unless
-    // some setup happens right here to make sure they don't return a credential
-    // right away. So... uhh... I guess test this with a real authenticator if you
-    // want to see if it really works.
-    var timer;
-    function startTimer() {
-        timer = setTimeout(() => {
-            throw new Error("Timer went off before timeout");
-        }, 1000);
-    }
-    function stopTimer() {
-        clearTimeout(timer);
-    }
-    new GetCredentialsTest({path: "options.publicKey.timeout", value: 1})
-        .addCredential(credPromise)
-        .beforeTest(startTimer)
-        .afterTest(stopTimer)
-        .runTest("ensure create credential times out");
+    return promise_rejects(t, "NotAllowedError", navigator.credentials.get({
+        publicKey: {
+            challenge: new Uint8Array([1, 2, 3]),
+            allowCredentials: [{
+                id: credentialId,
+                type: "public-key",
+            }],
+            timeout: 1,
+        },
+    }));
     // TODO: createCredential.timeout > 1s && setTimeout < 1s
     // TODO: createCredential.timeout < 5s && setTimeout > 5s
 });

--- a/webauthn/getcredential-timeout.https.html
+++ b/webauthn/getcredential-timeout.https.html
@@ -35,9 +35,8 @@ promise_test(async t => {
             isResidentCredential: false,
         });
     } catch (error) {
-        if (error.status !== "error" ||
-            error.message !== "Action add_virtual_authenticator not implemented") {
-          throw error;
+        if (error !== "error: Action add_virtual_authenticator not implemented") {
+            throw error;
         }
       // configure a manual authenticator by creating a credential.
       credentialId = (await createCredential()).rawId;

--- a/webauthn/getcredential-timeout.https.html
+++ b/webauthn/getcredential-timeout.https.html
@@ -53,7 +53,7 @@ promise_test(async t => {
     //     .runTest("Bad timeout: too big", TypeError);
 
     // timeout test
-    return promise_rejects(t, "NotAllowedError", navigator.credentials.get({
+    return promise_rejects_dom(t, "NotAllowedError", navigator.credentials.get({
         publicKey: {
             challenge: new Uint8Array([1, 2, 3]),
             allowCredentials: [{
@@ -68,5 +68,5 @@ promise_test(async t => {
 });
 
 /* JSHINT */
-/* globals standardSetup, GetCredentialsTest, createCredential */
+/* globals standardSetup, GetCredentialsTest, createCredential, promise_rejects_dom */
 </script>

--- a/webauthn/helpers.js
+++ b/webauthn/helpers.js
@@ -541,8 +541,7 @@ function standardSetup(cb) {
       protocol: "ctap1/u2f",
       transport: "usb"
     }).then(cb).catch(error => {
-        if (error.status === "error" &&
-            error.message === "Action add_virtual_authenticator not implemented") {
+        if (error === "error: Action add_virtual_authenticator not implemented") {
           // The protocol is not available. Continue manually.
           cb();
           return;

--- a/webauthn/helpers.js
+++ b/webauthn/helpers.js
@@ -535,62 +535,21 @@ function validateAuthenticatorAssertionResponse(assert) {
     // TODO: parseAuthenticatorData() and make sure flags are correct
 }
 
-//************* BEGIN DELETE AFTER 1/1/2018 *************** //
-// XXX for development mode only!!
-// debug() for debugging purposes... we can drop this later if it is considered ugly
-// note that debug is currently an empty function (i.e. - prints no output)
-// and debug only prints output if the polyfill is loaded
-var debug = function() {};
-// if the WebAuthn API doesn't exist load a polyfill for testing
-// note that the polyfill only gets loaded if navigator.credentials create doesn't exist
-// AND if the polyfill script is found at the right path (i.e. - the polyfill is opt-in)
-function ensureInterface() {
-    if (typeof navigator.credentials === "object" && typeof navigator.credentials.create !== "function") {
-        // debug = onsole.log;
-
-        return loadJavaScript("/webauthn/webauthn-polyfill/webauthn-polyfill.js")
-            .then(() => {
-                return loadJavaScript("/webauthn/webauthn-soft-authn/soft-authn.js");
-            });
-    } else {
-        return Promise.resolve();
-    }
-}
-
-function loadJavaScript(path) {
-    return new Promise((resolve, reject) => {
-        // dynamic loading of polyfill script by creating new <script> tag and seeing the src=
-        var scriptElem = document.createElement("script");
-        if (typeof scriptElem !== "object") {
-            debug("ensureInterface: Error creating script element while attempting loading polyfill");
-            return reject(new Error("ensureInterface: Error creating script element while loading polyfill"));
+function standardSetup(cb) {
+    // Setup an automated testing environment if available.
+    window.test_driver.add_virtual_authenticator({
+      protocol: "ctap1/u2f",
+      transport: "usb"
+    }).then(cb).catch(error => {
+        if (error.status === "error" &&
+            error.message === "Action add_virtual_authenticator not implemented") {
+          // The protocol is not available. Continue manually.
+          cb();
+          return;
         }
-        scriptElem.type = "application/javascript";
-        scriptElem.onload = function() {
-            debug("!!! Loaded " + path + " ...");
-            return resolve();
-        };
-        scriptElem.onerror = function() {
-            debug("navigator.credentials.create does not exist");
-            resolve();
-        };
-        scriptElem.src = path;
-        if (document.body) {
-            document.body.appendChild(scriptElem);
-        } else {
-            debug("ensureInterface: DOM has no body");
-            return reject(new Error("ensureInterface: DOM has no body"));
-        }
+        throw error;
     });
 }
-
-function standardSetup(cb) {
-    return ensureInterface()
-        .then(() => {
-            if (cb) return cb();
-        });
-}
-//************* END DELETE AFTER 1/1/2018 *************** //
 
 /* JSHINT */
 /* globals promise_rejects_dom, promise_rejects_js, assert_class_string, assert_equals, assert_idl_attribute, assert_readonly, promise_test */

--- a/webauthn/securecontext.http.html
+++ b/webauthn/securecontext.http.html
@@ -8,41 +8,39 @@
 <script src=helpers.js></script>
 <body></body>
 <script>
-standardSetup(function() {
-    "use strict";
+"use strict";
 
-    // See https://www.w3.org/TR/secure-contexts/
-    // Section 1.1 - 1.4 for list of examples referenced below
+// See https://www.w3.org/TR/secure-contexts/
+// Section 1.1 - 1.4 for list of examples referenced below
 
-    // Example 1
-    // http://example.com/ opened in a top-level browsing context is not a secure context, as it was not delivered over an authenticated and encrypted channel.
-    test (() => {
-        assert_false (typeof navigator.credentials === "object" && typeof navigator.credentials.create === "function");
-    }, "no navigator.credentials.create in non-secure context");
+// Example 1
+// http://example.com/ opened in a top-level browsing context is not a secure context, as it was not delivered over an authenticated and encrypted channel.
+test (() => {
+    assert_false (typeof navigator.credentials === "object" && typeof navigator.credentials.create === "function");
+}, "no navigator.credentials.create in non-secure context");
 
-    // Example 4: TODO
-    // If a non-secure context opens https://example.com/ in a new window, then things are more complicated. The new window’s status depends on how it was opened. If the non-secure context can obtain a reference to the secure context, or vice-versa, then the new window is not a secure context.
-    //
-    // This means that the following will both produce non-secure contexts:
-    //<a href="https://example.com/" target="_blank">Link!</a>
-    // <script>
-    //     var w = window.open("https://example.com/");
-    // < /script>
+// Example 4: TODO
+// If a non-secure context opens https://example.com/ in a new window, then things are more complicated. The new window’s status depends on how it was opened. If the non-secure context can obtain a reference to the secure context, or vice-versa, then the new window is not a secure context.
+//
+// This means that the following will both produce non-secure contexts:
+//<a href="https://example.com/" target="_blank">Link!</a>
+// <script>
+//     var w = window.open("https://example.com/");
+// < /script>
 
-    // Example 6: TODO
-    // If https://example.com/ was somehow able to frame http://non-secure.example.com/ (perhaps the user has overridden mixed content checking?), the top-level frame would remain secure, but the framed content is not a secure context.
+// Example 6: TODO
+// If https://example.com/ was somehow able to frame http://non-secure.example.com/ (perhaps the user has overridden mixed content checking?), the top-level frame would remain secure, but the framed content is not a secure context.
 
-    // Example 7: TODO
-    // If, on the other hand, https://example.com/ is framed inside of http://non-secure.example.com/, then it is not a secure context, as its ancestor is not delivered over an authenticated and encrypted channel.
+// Example 7: TODO
+// If, on the other hand, https://example.com/ is framed inside of http://non-secure.example.com/, then it is not a secure context, as its ancestor is not delivered over an authenticated and encrypted channel.
 
-    // Example 9: TODO
-    // If http://non-secure.example.com/ in a top-level browsing context frames https://example.com/, which runs https://example.com/worker.js, then neither the framed document nor the worker are secure contexts.
+// Example 9: TODO
+// If http://non-secure.example.com/ in a top-level browsing context frames https://example.com/, which runs https://example.com/worker.js, then neither the framed document nor the worker are secure contexts.
 
-    // Example 12: TODO
-    // https://example.com/ nested in http://non-secure.example.com/ may not connect to the secure worker, as it is not a secure context.
+// Example 12: TODO
+// https://example.com/ nested in http://non-secure.example.com/ may not connect to the secure worker, as it is not a secure context.
 
-    // Example 13: TODO
-    // Likewise, if https://example.com/ nested in http://non-secure.example.com/ runs https://example.com/worker.js as a Shared Worker, then both the document and the worker are considered non-secure.
+// Example 13: TODO
+// Likewise, if https://example.com/ nested in http://non-secure.example.com/ runs https://example.com/worker.js as a Shared Worker, then both the document and the worker are considered non-secure.
 
-});
 </script>

--- a/webauthn/securecontext.https.html
+++ b/webauthn/securecontext.https.html
@@ -8,23 +8,21 @@
 <script src=helpers.js></script>
 <body></body>
 <script>
-standardSetup(function() {
-    "use strict";
+"use strict";
 
-    // See https://www.w3.org/TR/secure-contexts/
-    // Section 1.1 - 1.4 for list of examples referenced below
+// See https://www.w3.org/TR/secure-contexts/
+// Section 1.1 - 1.4 for list of examples referenced below
 
-    // Example 2
-    // https://example.com/ opened in a top-level browsing context is a secure context, as it was delivered over an authenticated and encrypted channel.
-    test (() => {
-        assert_true (typeof navigator.credentials === "object" && typeof navigator.credentials.create === "function");
-    }, "navigator.credentials.create exists in secure context");
+// Example 2
+// https://example.com/ opened in a top-level browsing context is a secure context, as it was delivered over an authenticated and encrypted channel.
+test (() => {
+    assert_true (typeof navigator.credentials === "object" && typeof navigator.credentials.create === "function");
+}, "navigator.credentials.create exists in secure context");
 
-    // Example 3: TODO
-    // Example 5: TODO
-    // Example 8: TODO
-    // Example 10: TODO
-    // Example 11: TODO
+// Example 3: TODO
+// Example 5: TODO
+// Example 8: TODO
+// Example 10: TODO
+// Example 11: TODO
 
-});
 </script>


### PR DESCRIPTION
This patch uses the testdriver virtual authenticator API to automate all
webauthn tests when the browser running the tests supports it. The
standardSetup() function is repurposed to create a mock authenticator.

Timeout tests are also updated to use a mock authenticator that
simulates a user not being present.

Depends on #20409.