### PR TITLE
Don't run build-and-tag workflow on forks

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -8,6 +8,8 @@ on:
       - 'tools/**'
 jobs:
   build-and-tag:
+    # Do not run this job on forks.
+    if: github.repository == 'web-platform-tests/wpt'
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout


### PR DESCRIPTION
Similar to the change made for epochs.yml