### PR TITLE
Revert "webdriver: use long timeout in webdriver/tests/find_element_f…

### DIFF
--- a/webdriver/tests/find_element_from_element/find.py
+++ b/webdriver/tests/find_element_from_element/find.py
@@ -1,4 +1,3 @@
-# META: timeout=long
 import pytest
 
 from webdriver.transport import Response


### PR DESCRIPTION
…rom_element/find.py (#20153) (#20153)"

This reverts commit 2cc5a5ca83698ffd79abf7b6671aebc44c354d04.

This is no longer needed, the test takes around 4 seconds to run in WebKitGTK now.