### PR TITLE
Don't set taskcluster variables when we don't want to run the task

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -3,17 +3,6 @@ policy:
   pullRequests: public
 tasks:
   $let:
-    event_str: {$json: {$eval: event}}
-    scopes:
-      $if: 'tasks_for == "github-push"'
-      then:
-        $let:
-          branch:
-            $if: "event.ref[:11] == 'refs/heads/'"
-            then: "${event.ref[11:]}"
-            else: "${event.ref}"
-        in: "assume:repo:github.com/${event.repository.full_name}:branch:${branch}"
-      else: "assume:repo:github.com/${event.repository.full_name}:pull-request"
     run_task:
       $if: 'tasks_for == "github-push"'
       then:
@@ -27,43 +16,56 @@ tasks:
           then: true
           else: false
         else: false
-    rev:
-      $if: 'tasks_for == "github-pull-request"'
-      then: "refs/pull/${event.number}/merge"
-      else: "${event.after}"
   in:
     - $if: run_task
       then:
-        created: {$fromNow: ''}
-        deadline: {$fromNow: '24 hours'}
-        provisionerId: proj-wpt
-        workerType: ci
-        metadata:
-          name: "wpt-decision-task"
-          description: "The task that creates all of the other tasks in the task graph"
-          owner: "${event.sender.login}@users.noreply.github.com"
-          source: ${event.repository.clone_url}
-        payload:
-          image: harjgam/web-platform-tests:0.33
-          maxRunTime: 7200
-          artifacts:
-            public/results:
-              path: /home/test/artifacts
-              type: directory
-          command:
-            - /bin/bash
-            - --login
-            - -c
-            - set -ex;
-              ~/start.sh
-                ${event.repository.clone_url}
-                ${rev};
-              cd ~/web-platform-tests;
-              ./wpt tc-decision --tasks-path=/home/test/artifacts/tasks.json
-          features :
-            taskclusterProxy: true
-        scopes:
-          - ${scopes}
-        extra:
-          github_event: "${event_str}"
+        $let:
+          event_str: {$json: {$eval: event}}
+          scopes:
+            $if: 'tasks_for == "github-push"'
+            then:
+              $let:
+                branch:
+                  $if: "event.ref[:11] == 'refs/heads/'"
+                  then: "${event.ref[11:]}"
+                  else: "${event.ref}"
+              in: "assume:repo:github.com/${event.repository.full_name}:branch:${branch}"
+            else: "assume:repo:github.com/${event.repository.full_name}:pull-request"
+          rev:
+            $if: 'tasks_for == "github-pull-request"'
+            then: "refs/pull/${event.number}/merge"
+            else: "${event.after}"
+        in:
+          created: {$fromNow: ''}
+          deadline: {$fromNow: '24 hours'}
+          provisionerId: proj-wpt
+          workerType: ci
+          metadata:
+            name: "wpt-decision-task"
+            description: "The task that creates all of the other tasks in the task graph"
+            owner: "${event.sender.login}@users.noreply.github.com"
+            source: ${event.repository.clone_url}
+          payload:
+            image: harjgam/web-platform-tests:0.33
+            maxRunTime: 7200
+            artifacts:
+              public/results:
+                path: /home/test/artifacts
+                type: directory
+            command:
+              - /bin/bash
+              - --login
+              - -c
+              - set -ex;
+                ~/start.sh
+                  ${event.repository.clone_url}
+                  ${rev};
+                cd ~/web-platform-tests;
+                ./wpt tc-decision --tasks-path=/home/test/artifacts/tasks.json
+            features :
+              taskclusterProxy: true
+          scopes:
+            - ${scopes}
+          extra:
+            github_event: "${event_str}"
 


### PR DESCRIPTION
Previously we had a single let block setting all the variables for the
.taskcluster.yml file. But this was evaluated even on events for which
we don't run tasks. That caused bogus failures because the logic
didn't account for all the possible event types.

Instead only evaluate the variables used in the task definition in
a block guarded by "if run_task".