### PR TITLE
[fetch] Correct redirection utility function

### DIFF
--- a/fetch/metadata/resources/redirectTestHelper.sub.js
+++ b/fetch/metadata/resources/redirectTestHelper.sub.js
@@ -23,7 +23,7 @@ let insecureTestURL = 'http://{{host}}:{{ports[http][0]}}/fetch/metadata/';
 // simulate us downgrading then upgrading again during the same redirect chain.
 function MultipleRedirectTo(partialPath) {
   let finalURL = insecureRedirectURL + encodeURIComponent(secureTestURL + partialPath);
-  return insecureRedirectURL + encodeURIComponent(finalURL);
+  return secureRedirectURL + encodeURIComponent(finalURL);
 }
 
 // Helper to craft an URL that will go from HTTP => HTTPS to simulate upgrading a


### PR DESCRIPTION
`MultipleRedirectTo` is documented as follows:

> go from HTTPS => HTTP => HTTPS to simulate us downgrading then
> upgrading again during the same redirect chain.

However, the redirect chain constructed actually began with an HTTP URL
and therefore did not demonstrate the expected downgrade.

Change the initial URL in the sequence to use HTTPS.

---

This change does not influence the results reported by Chromium today.

On `master`:

    $./wpt run --headless --log-mach - --channel experimental --binary $(which chromium-browser) chrome $(git grep -l redirectTestHelper)
    [...]
    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 176 checks (169 subtests, 7 tests)
    Expected results: 170
    Unexpected results: 6
      subtest: 6 (6 fail)

With this patch applied:

    $./wpt run --headless --log-mach - --channel experimental --binary $(which chromium-browser) chrome $(git grep -l redirectTestHelper)
    [...]
    web-platform-test
    ~~~~~~~~~~~~~~~~~
    Ran 176 checks (169 subtests, 7 tests)
    Expected results: 170
    Unexpected results: 6
      subtest: 6 (6 fail)

This is expected, but the error should still be corrected in the interest of improving coverage.