### PR TITLE
Fix email handing for decision task

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -35,6 +35,16 @@ tasks:
             $if: 'tasks_for == "github-pull-request"'
             then: "refs/pull/${event.number}/merge"
             else: "${event.after}"
+          owner:
+            $if: 'tasks_for == "github-push"'
+            then:
+              $if: 'event.pusher.email'
+              then:
+                $if: '"@" in event.pusher.email'
+                then: ${event.pusher.email}
+                else: web-platform-tests@users.noreply.github.com
+              else: web-platform-tests@users.noreply.github.com
+            else: web-platform-tests@users.noreply.github.com
         in:
           created: {$fromNow: ''}
           deadline: {$fromNow: '24 hours'}
@@ -43,7 +53,7 @@ tasks:
           metadata:
             name: "wpt-decision-task"
             description: "The task that creates all of the other tasks in the task graph"
-            owner: "${event.sender.login}@users.noreply.github.com"
+            owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
             image: harjgam/web-platform-tests:0.33

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -194,9 +194,10 @@ cd web-platform-tests;
 
 
 def get_owner(event):
-    pusher = event.get("pusher", {}).get("email", "")
-    if "@" in pusher:
-        return pusher
+    if "pusher" in event:
+        pusher = event.get("pusher", {}).get("email", "")
+        if pusher and "@" in pusher:
+            return pusher
     return "web-platform-tests@users.noreply.github.com"
 
 


### PR DESCRIPTION
This regressed some of the changes to ensure we always have a valid email address that TaskCluster will accept.