### PR TITLE
Reduce font size of text-transform tests so they fit within the reftest screenshot size.

### DIFF
--- a/css/css-text/text-transform/reference/text-transform-capitalize-001-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-001-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-003-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-003-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 100%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-005-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-005-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-007-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-007-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 100%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-009-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-009-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-010-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-010-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-011-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-011-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-014-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-014-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-016-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-016-ref.html
@@ -12,7 +12,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 100%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-018-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-018-ref.html
@@ -13,7 +13,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 100%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-020-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-020-ref.html
@@ -12,7 +12,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-022-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-022-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-024-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-024-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-026-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-026-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-028-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-028-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-capitalize-030-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-capitalize-030-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-001-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-001-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-002-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-002-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-003-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-003-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-004-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-004-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-005-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-005-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-006-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-006-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-007-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-007-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-008-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-008-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-009-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-009-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-010-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-010-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-011-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-011-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-012-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-012-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-014-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-014-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-015-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-015-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-016-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-016-ref.html
@@ -12,7 +12,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-017-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-017-ref.html
@@ -12,7 +12,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-018-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-018-ref.html
@@ -13,7 +13,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-019-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-019-ref.html
@@ -13,7 +13,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-020-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-020-ref.html
@@ -12,7 +12,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-021-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-021-ref.html
@@ -12,7 +12,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-022-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-022-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-023-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-023-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-024-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-024-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-025-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-025-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-026-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-026-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-027-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-027-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-028-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-028-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-029-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-029-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-030-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-030-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-031-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-031-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-032-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-032-ref.html
@@ -5,7 +5,7 @@
 <title>CSS3 Text, text transform: German sharp S, uppercase</title>
 <link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
 <style type='text/css'>
-.test, .ref { font-size: 200%; line-height: 2.5em; }
+.test, .ref { font-size: 125%; line-height: 1.5em; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-033-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-033-ref.html
@@ -13,7 +13,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-034-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-034-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-035-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-035-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-039-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-039-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-040-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-040-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-041-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-041-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-042-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-042-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-043-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-043-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-044-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-044-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-101-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-101-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-102-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-102-ref.html
@@ -11,7 +11,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-103-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-103-ref.html
@@ -12,7 +12,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/reference/text-transform-upperlower-104-ref.html
+++ b/css/css-text/text-transform/reference/text-transform-upperlower-104-ref.html
@@ -12,7 +12,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 </style>
 </head>

--- a/css/css-text/text-transform/text-transform-capitalize-001.html
+++ b/css/css-text/text-transform/text-transform-capitalize-001.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-003.html
+++ b/css/css-text/text-transform/text-transform-capitalize-003.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 100%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-005.html
+++ b/css/css-text/text-transform/text-transform-capitalize-005.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-007.html
+++ b/css/css-text/text-transform/text-transform-capitalize-007.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 100%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-009.html
+++ b/css/css-text/text-transform/text-transform-capitalize-009.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-010.html
+++ b/css/css-text/text-transform/text-transform-capitalize-010.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-011.html
+++ b/css/css-text/text-transform/text-transform-capitalize-011.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-014.html
+++ b/css/css-text/text-transform/text-transform-capitalize-014.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-016.html
+++ b/css/css-text/text-transform/text-transform-capitalize-016.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 100%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-018.html
+++ b/css/css-text/text-transform/text-transform-capitalize-018.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 100%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-020.html
+++ b/css/css-text/text-transform/text-transform-capitalize-020.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-022.html
+++ b/css/css-text/text-transform/text-transform-capitalize-022.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-024.html
+++ b/css/css-text/text-transform/text-transform-capitalize-024.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-026.html
+++ b/css/css-text/text-transform/text-transform-capitalize-026.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-028.html
+++ b/css/css-text/text-transform/text-transform-capitalize-028.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-capitalize-030.html
+++ b/css/css-text/text-transform/text-transform-capitalize-030.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: capitalize; }

--- a/css/css-text/text-transform/text-transform-upperlower-001.html
+++ b/css/css-text/text-transform/text-transform-upperlower-001.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-002.html
+++ b/css/css-text/text-transform/text-transform-upperlower-002.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-003.html
+++ b/css/css-text/text-transform/text-transform-upperlower-003.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-004.html
+++ b/css/css-text/text-transform/text-transform-upperlower-004.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-005.html
+++ b/css/css-text/text-transform/text-transform-upperlower-005.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-006.html
+++ b/css/css-text/text-transform/text-transform-upperlower-006.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-007.html
+++ b/css/css-text/text-transform/text-transform-upperlower-007.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-008.html
+++ b/css/css-text/text-transform/text-transform-upperlower-008.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-009.html
+++ b/css/css-text/text-transform/text-transform-upperlower-009.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-010.html
+++ b/css/css-text/text-transform/text-transform-upperlower-010.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-011.html
+++ b/css/css-text/text-transform/text-transform-upperlower-011.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-012.html
+++ b/css/css-text/text-transform/text-transform-upperlower-012.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-014.html
+++ b/css/css-text/text-transform/text-transform-upperlower-014.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-015.html
+++ b/css/css-text/text-transform/text-transform-upperlower-015.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-016.html
+++ b/css/css-text/text-transform/text-transform-upperlower-016.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-017.html
+++ b/css/css-text/text-transform/text-transform-upperlower-017.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-018.html
+++ b/css/css-text/text-transform/text-transform-upperlower-018.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-019.html
+++ b/css/css-text/text-transform/text-transform-upperlower-019.html
@@ -16,7 +16,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-020.html
+++ b/css/css-text/text-transform/text-transform-upperlower-020.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-021.html
+++ b/css/css-text/text-transform/text-transform-upperlower-021.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-022.html
+++ b/css/css-text/text-transform/text-transform-upperlower-022.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-023.html
+++ b/css/css-text/text-transform/text-transform-upperlower-023.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-024.html
+++ b/css/css-text/text-transform/text-transform-upperlower-024.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-025.html
+++ b/css/css-text/text-transform/text-transform-upperlower-025.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-026.html
+++ b/css/css-text/text-transform/text-transform-upperlower-026.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-027.html
+++ b/css/css-text/text-transform/text-transform-upperlower-027.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-028.html
+++ b/css/css-text/text-transform/text-transform-upperlower-028.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-029.html
+++ b/css/css-text/text-transform/text-transform-upperlower-029.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-030.html
+++ b/css/css-text/text-transform/text-transform-upperlower-030.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-031.html
+++ b/css/css-text/text-transform/text-transform-upperlower-031.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-032.html
+++ b/css/css-text/text-transform/text-transform-upperlower-032.html
@@ -8,7 +8,7 @@
 <link rel='help' href='https://drafts.csswg.org/css-text-3/#text-transform'>
 <link rel="match" href="reference/text-transform-upperlower-032-ref.html">
 <style type='text/css'>
-.test, .ref { font-size: 200%; line-height: 2.5em; }
+.test, .ref { font-size: 125%; line-height: 1.5em; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-033.html
+++ b/css/css-text/text-transform/text-transform-upperlower-033.html
@@ -16,7 +16,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-034.html
+++ b/css/css-text/text-transform/text-transform-upperlower-034.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Noto Sans Armenian', webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-035.html
+++ b/css/css-text/text-transform/text-transform-upperlower-035.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Gentium Plus', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-039.html
+++ b/css/css-text/text-transform/text-transform-upperlower-039.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-040.html
+++ b/css/css-text/text-transform/text-transform-upperlower-040.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-041.html
+++ b/css/css-text/text-transform/text-transform-upperlower-041.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-042.html
+++ b/css/css-text/text-transform/text-transform-upperlower-042.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-043.html
+++ b/css/css-text/text-transform/text-transform-upperlower-043.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-044.html
+++ b/css/css-text/text-transform/text-transform-upperlower-044.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-101.html
+++ b/css/css-text/text-transform/text-transform-upperlower-101.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-102.html
+++ b/css/css-text/text-transform/text-transform-upperlower-102.html
@@ -14,7 +14,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: webfont, serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: webfont, serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-103.html
+++ b/css/css-text/text-transform/text-transform-upperlower-103.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: uppercase; }

--- a/css/css-text/text-transform/text-transform-upperlower-104.html
+++ b/css/css-text/text-transform/text-transform-upperlower-104.html
@@ -15,7 +15,7 @@
 	font-weight: normal;
 	font-style: normal;
 	}
-.test, .ref { font-size: 200%; line-height: 2.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
+.test, .ref { font-size: 125%; line-height: 1.5em; font-family: 'Doulos SIL', 'Noto Serif', 'Noto Sans', webfont, sans-serif; }
 .test span, .ref span { margin-right: 1em; white-space: nowrap; }
 /* the CSS above is not part of the test */
 .test { text-transform: lowercase; }


### PR DESCRIPTION
Per CSSWG resolution at
https://lists.w3.org/Archives/Public/www-style/2012Sep/0562.html
reftests should fit within a 600x600 screenshot.

This reduces most tests from 250% font-size and 2.5em line-height to
125% font-size and 1.5em line-height.  The small number that don't fit
at that size are further reduced to 100% font-size.

(Firefox has a failure text-transform-upperlower-016.html that is
outside of the screenshot area; this moves it in!)