### PR TITLE
Remove failure expectations on Chrome for multiTouchPoints actions infra tests

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPoints.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPoints.html.ini
@@ -1,7 +1,3 @@
 [multiTouchPoints.html]
   expected:
     if product == "firefox" or product == "safari" or product == "epiphany" or product == "webkit": ERROR
-    if product == "chrome" and os == "mac": ERROR
-  [TestDriver actions: two touch points with one moving one pause]
-     expected:
-       if product == "chrome" and os != "mac": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsWithPause.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsWithPause.html.ini
@@ -1,4 +1,3 @@
 [multiTouchPointsWithPause.html]
   expected:
     if product == "firefox" or product == "safari": ERROR
-    if product == "chrome" and os == "mac": ERROR


### PR DESCRIPTION
These tests likely started passing when a new version of Chrome rolling out to dev and containing support for these APIs.

This should address https://github.com/web-platform-tests/wpt/pull/20572#issuecomment-561388226