### PR TITLE
 [wptrunner] Attempt to fix EXTERNAL-TIMEOUT

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -149,7 +149,7 @@ class TimedRunner(object):
         executor = threading.Thread(target=self.run_func)
         executor.start()
 
-        # Add twice the timeout multiplier since the called function is expected to
+        # Add twice the extra timeout since the called function is expected to
         # wait at least self.timeout + self.extra_timeout and this gives some leeway
         timeout = self.timeout + 2 * self.extra_timeout if self.timeout else None
         finished = self.result_flag.wait(timeout)

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -164,7 +164,13 @@ class Test(object):
         self.environment = {"protocol": protocol, "prefs": self.prefs}
 
     def __eq__(self, other):
+        if not isinstance(other, Test):
+            return False
         return self.id == other.id
+
+    # Python 2 does not have this delegation, while Python 3 does.
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def update_metadata(self, metadata=None):
         if metadata is None:


### PR DESCRIPTION
After #20321, we now sometimes see an error from mozlog when the new
external timeout is triggered:
"ERROR test_end for ... logged while not in progress"

A theory is that we call test_ended from a different thread which might
not have all the correct states. This attempted fix switches to sending
a test_ended message to the queue instead, similar to what TestRunner
does normally.

-------------------

This effectively tackles point 1 in https://github.com/web-platform-tests/wpt/issues/20607#issuecomment-562730002. I'm not sure this is the root cause (why would the logger state in the timer thread be different?); even if it is, I'm not sure if this is a proper fix (is it fine to send a message from yet another thread?).