### PR TITLE
fix: Revert `HTMLDocument` removal

### DIFF
--- a/html/semantics/scripting-1/the-template-element/definitions/template-contents-owner-document-type.html
+++ b/html/semantics/scripting-1/the-template-element/definitions/template-contents-owner-document-type.html
@@ -18,7 +18,7 @@ testInIFrame('../resources/template-contents.html', function(context) {
     var template = doc.querySelector('template');
     var content_owner = template.content.ownerDocument;
 
-    assert_class_string(content_owner, 'Document',
+    assert_class_string(content_owner, 'HTMLDocument',
             'Template content owner should be a document');
     assert_equals(content_owner.createElement('DIV').localName, 'div',
             'Template content owner should be an HTML document');
@@ -37,7 +37,7 @@ testInIFrame('../resources/template-contents.html', function(context) {
 
     doc.body.appendChild(template);
 
-    assert_class_string(content_owner, 'Document',
+    assert_class_string(content_owner, 'HTMLDocument',
             'Template content owner should be a document');
     assert_equals(div.localName, 'div',
             'Template content owner should be an HTML document');
@@ -56,7 +56,7 @@ test(function() {
 
     doc.body.appendChild(template);
 
-    assert_class_string(content_owner, 'Document',
+    assert_class_string(content_owner, 'HTMLDocument',
             'Template content owner should be a document');
     assert_equals(div.localName, 'div',
             'Template content owner should be an HTML document');
@@ -71,7 +71,7 @@ test(function() {
     var template = doc.querySelector('template');
     var content_owner = template.content.ownerDocument;
 
-    assert_class_string(content_owner, 'Document',
+    assert_class_string(content_owner, 'HTMLDocument',
             'Template content owner should be a document');
     assert_equals(content_owner.createElement('DIV').localName, 'div',
             'Template content owner should be an HTML document');


### PR DESCRIPTION
Updates&nbsp;tests to&nbsp;match <https://github.com/whatwg/html/pull/5104>.

This&nbsp;is&nbsp;already&nbsp;implemented in&nbsp;all&nbsp;major&nbsp;browsers (**Firefox**, **Chrome** and&nbsp;**Safari**).

---

See&nbsp;also: <https://github.com/web-platform-tests/wpt/pull/20403>