### PR TITLE
Fix running Servo in CI

### DIFF
--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -9,7 +9,9 @@ import subprocess
 import sys
 
 browser_specific_args = {
-    "firefox": ["--install-browser"]
+    "firefox": ["--install-browser"],
+    "servo": ["--install-browser"]
+
 }
 
 

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -68,6 +68,10 @@ def main(product, commit_range, wpt_args):
     ]
     wpt_args += browser_specific_args.get(product, [])
 
+    # Hack to run servo with one process only for wdspec
+    if product == "servo" and "--test-type=wdspec" in wpt_args:
+        wpt_args = [item for item in wpt_args if not item.startswith("--processes")]
+
     command = ["python", "./wpt", "run"] + wpt_args + [product]
 
     logger.info("Executing command: %s" % " ".join(command))

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -10,8 +10,7 @@ import sys
 
 browser_specific_args = {
     "firefox": ["--install-browser"],
-    "servo": ["--install-browser"]
-
+    "servo": ["--install-browser", "--processes=12"]
 }
 
 

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: harjgam/web-platform-tests:0.33
+    image: harjgam/web-platform-tests:0.34
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -15,8 +15,11 @@ RUN apt-get -qqy update \
     fluxbox \
     gdebi \
     git \
+    gstreamer1.0-plugins-bad \
+    libosmesa6-dev \
     libvirt-daemon-system \
     libvirt-clients \
+    libunwind8 \
     locales \
     openjdk-8-jre-headless \
     pulseaudio \

--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -46,6 +46,7 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     rv["pause_after_test"] = kwargs["pause_after_test"]
     if test_type == "wdspec":
         rv["capabilities"] = {}
+        rv["webdriver_binary"] = kwargs["binary"]
     return rv
 
 


### PR DESCRIPTION
Example run https://community-tc.services.mozilla.com/tasks/groups/BtQNCaJjSv2zao9zf0T1Gg

wdspec tests still fail; these seem to be broken for unrelated reasons.