### PR TITLE
Fix OffscreenCanvas.convertToBlob worker exception tests

### DIFF
--- a/offscreen-canvas/convert-to-blob/offscreencanvas.convert.to.blob.html
+++ b/offscreen-canvas/convert-to-blob/offscreencanvas.convert.to.blob.html
@@ -144,5 +144,22 @@ async_test(function(t) {
     }));
 }, "Test that call convertToBlob on a OffscreenCanvas with size 0 throws exception");
 
+async_test(function(t) {
+    var img = new Image();
+    img.src = "/images/green.png";
+    img.crossOrigin = "anonymous";
+    img.onload = t.step_func_done(() => {
+        var offscreenCanvas = new OffscreenCanvas(10, 10);
+        var ctx = offscreenCanvas.getContext("2d");
+        ctx.drawImage(img, 0, 0);
+        offscreenCanvas.convertToBlob().then(t.step_func_done(function() {
+            assert_false("convertToBlob didn't throw, but should");
+        }), t.step_func_done(function(e) {
+            assert_true(e instanceof DOMException);
+            assert_equals(e.name, "SecurityError");
+        }));
+    });
+}, "Test that call convertToBlob on a OffscreenCanvas with tainted origin throws exception");
+
 </script>
 

--- a/offscreen-canvas/convert-to-blob/offscreencanvas.convert.to.blob.w.html
+++ b/offscreen-canvas/convert-to-blob/offscreencanvas.convert.to.blob.w.html
@@ -40,12 +40,9 @@ function testConvertToBlobException1()
     var offscreenCanvas = new OffscreenCanvas(10, 10);
     self.postMessage({offscreenCanvas}, [offscreenCanvas]);
     offscreenCanvas.convertToBlob().then(function() {
-        return false;
+        self.postMessage(false);
     }, function(e) {
-        if (e instanceof DOMException && e.name == "InvalidStateError")
-            return true;
-        else
-            return false;
+        self.postMessage(e instanceof DOMException && e.name == "InvalidStateError");
     });
 }
 
@@ -53,12 +50,9 @@ function testConvertToBlobException2()
 {
     var offscreenCanvas = new OffscreenCanvas(0, 0);
     offscreenCanvas.convertToBlob().then(function() {
-        return false;
+        self.postMessage(false);
     }, function(e) {
-        if (e instanceof DOMException && e.name == "IndexSizeError")
-            return true;
-        else
-            return false;
+        self.postMessage(e instanceof DOMException && e.name == "IndexSizeError");
     });
 }
 
@@ -101,10 +95,10 @@ self.onmessage = function(e) {
             testConvertToBlob("image/webp", 0.2);
             break;
         case 'test13':
-            self.postMessage(testConvertToBlobException1());
+            testConvertToBlobException1();
             break;
         case 'test14':
-            self.postMessage(testConvertToBlobException2());
+            testConvertToBlobException2();
             break;
     }
 };
@@ -289,8 +283,10 @@ async_test(function(t) {
 async_test(function(t) {
     var worker = makeWorker(t);
     worker.addEventListener('message', t.step_func_done(function(msg) {
-        if (msg.data == true || msg.data == false)
-            assert_true(msg.data);
+        if (msg.data instanceof Object)
+            return;
+        assert_true(msg.data);
+        t.done();
     }));
     worker.postMessage('test13');
 }, "Test that call convertToBlob on a detached OffscreenCanvas throws exception in a worker");
@@ -298,8 +294,8 @@ async_test(function(t) {
 async_test(function(t) {
     var worker = makeWorker(t);
     worker.addEventListener('message', t.step_func_done(function(msg) {
-        if (msg.data == true || msg.data == false)
-            assert_true(msg.data);
+        assert_true(msg.data);
+        t.done();
     }));
     worker.postMessage('test14');
 }, "Test that call convertToBlob on a OffscreenCanvas with size 0 throws exception in a worker");

--- a/offscreen-canvas/convert-to-blob/offscreencanvas.convert.to.blob.w.html
+++ b/offscreen-canvas/convert-to-blob/offscreencanvas.convert.to.blob.w.html
@@ -56,7 +56,24 @@ function testConvertToBlobException2()
     });
 }
 
+function testConvertToBlobException3(bitmap)
+{
+    var offscreenCanvas = new OffscreenCanvas(10, 10);
+    var ctx = offscreenCanvas.getContext("2d");
+    ctx.drawImage(bitmap, 0, 0);
+    offscreenCanvas.convertToBlob().then(function() {
+        self.postMessage(false);
+    }, function(e) {
+        self.postMessage(e instanceof DOMException && e.name == "SecurityError");
+    });
+}
+
 self.onmessage = function(e) {
+    if (e.data instanceof ImageBitmap) {
+        testConvertToBlobException3(e.data);
+        return;
+    }
+
     switch(e.data) {
         case 'test1':
             testConvertToBlob("empty", "empty");
@@ -299,6 +316,22 @@ async_test(function(t) {
     }));
     worker.postMessage('test14');
 }, "Test that call convertToBlob on a OffscreenCanvas with size 0 throws exception in a worker");
+
+async_test(function(t) {
+    var img = new Image();
+    img.src = "/images/green.png";
+    img.crossOrigin = "anonymous";
+    img.onload = t.step_func_done(() => {
+        createImageBitmap(img).then(t.step_func_done(bitmap => {
+            var worker = makeWorker(t);
+            worker.addEventListener('message', t.step_func_done(function(msg) {
+                assert_true(msg.data);
+                t.done();
+            }));
+            worker.postMessage(bitmap);
+        }));
+    });
+}, "Test that call convertToBlob on a OffscreenCanvas with tainted origin throws exception in a worker");
 
 </script>
 


### PR DESCRIPTION
Previously they would always pass, regardless of the result. This fixes #20694.