### PR TITLE
[Azure Pipelines] don't install Ahem for STP jobs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -362,7 +362,6 @@ jobs:
   - template: tools/ci/azure/pip_install.yml
     parameters:
       packages: virtualenv
-  - template: tools/ci/azure/install_fonts.yml
   - template: tools/ci/azure/install_certs.yml
   - template: tools/ci/azure/install_safari.yml
   - template: tools/ci/azure/update_hosts.yml

--- a/tools/ci/azure/affected_tests.yml
+++ b/tools/ci/azure/affected_tests.yml
@@ -11,7 +11,6 @@ steps:
 - template: pip_install.yml
   parameters:
     packages: virtualenv
-- template: install_fonts.yml
 - template: install_certs.yml
 - template: install_safari.yml
 - template: update_hosts.yml


### PR DESCRIPTION
infrastructure_macOS still needs this because Chrome and Firefox are
also part of that job and they do use Ahem if installed.