### PR TITLE
[cssom-view] Make matchMedia tests not racy.

### DIFF
--- a/css/cssom-view/resources/matchMedia.js
+++ b/css/cssom-view/resources/matchMedia.js
@@ -51,7 +51,9 @@ var getWindow = mql => {
 
 var waitForChangesReported = () => {
     return new Promise(resolve => {
-        step_timeout(resolve, 75);
+        requestAnimationFrame(() => {
+            requestAnimationFrame(resolve);
+        });
     });
 };
 


### PR DESCRIPTION
PRs #18390 #19841 introduced a bunch of new tests. I saw some of them being
filed as flaky in Gecko and this is why.

Random timeout is not a good way to wait for events being reported. Instead,
wait for two RAF callbacks, as that guarantees that "Update the rendering steps"
runs at least once.