### PR TITLE
Clean up testharness.css leftovers.

### DIFF
--- a/resources/testharness.css.headers
+++ b/resources/testharness.css.headers
@@ -1,2 +1,0 @@
-Content-Type: text/css;charset=utf-8
-Cache-Control: max-age=3600

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -484,10 +484,6 @@ def check_parsed(repo_root, path, f):
             if len(testharnessreport_nodes) > 1:
                 errors.append(rules.MultipleTestharnessReport.error(path))
 
-        testharnesscss_nodes = source_file.root.findall(".//{http://www.w3.org/1999/xhtml}link[@href='/resources/testharness.css']")
-        if testharnesscss_nodes:
-            errors.append(rules.PresentTestharnessCSS.error(path))
-
         for element in source_file.variant_nodes:
             if "content" not in element.attrib:
                 errors.append(rules.VariantMissing.error(path))

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -199,11 +199,6 @@ class MultipleTestharnessReport(Rule):
     description = "More than one `<script src='/resources/testharnessreport.js'>`"
 
 
-class PresentTestharnessCSS(Rule):
-    name = "PRESENT-TESTHARNESSCSS"
-    description = "Explicit link to testharness.css present"
-
-
 class VariantMissing(Rule):
     name = "VARIANT-MISSING"
     description = collapse("""

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -410,29 +410,6 @@ def test_missing_testdriver_vendor():
             ]
 
 
-def test_present_testharnesscss():
-    code = b"""
-<html xmlns="http://www.w3.org/1999/xhtml">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<link rel="stylesheet" href="/resources/testharness.css"/>
-</html>
-"""
-    error_map = check_with_files(code)
-
-    for (filename, (errors, kind)) in error_map.items():
-        check_errors(errors)
-
-        if kind in ["web-lax", "web-strict"]:
-            assert errors == [
-                ("PRESENT-TESTHARNESSCSS", "Explicit link to testharness.css present", filename, None),
-            ]
-        elif kind == "python":
-            assert errors == [
-                ("PARSE-FAILED", "Unable to parse file", filename, 2),
-            ]
-
-
 def test_testharness_path():
     code = b"""\
 <html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
testharness.css itself was removed in #11143, but its `.headers` file
remained in the tree, and so did some lint checks for a file that no longer
exists.