### PR TITLE
Don't import webdriver into executors/base.py

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -13,7 +13,6 @@ from abc import ABCMeta, abstractmethod
 
 from ..testrunner import Stop
 from .protocol import Protocol, BaseProtocolPart
-import webdriver as client
 
 here = os.path.split(__file__)[0]
 
@@ -655,6 +654,8 @@ class CallbackHandler(object):
     WebDriver. Things that are more different to WebDriver may need to create a
     fully custom implementation."""
 
+    unimplemented_exc = (NotImplementedError,)
+
     def __init__(self, logger, protocol, test_window):
         self.protocol = protocol
         self.test_window = test_window
@@ -701,7 +702,7 @@ class CallbackHandler(object):
             raise ValueError("Unknown action %s" % action)
         try:
             result = action_handler(payload)
-        except (NotImplementedError, client.UnknownCommandException):
+        except self.unimplemented_exc:
             self.logger.warning("Action %s not implemented" % action)
             self._send_message("complete", "error", "Action %s not implemented" % action)
         except Exception:

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -31,6 +31,10 @@ import webdriver as client
 here = os.path.join(os.path.split(__file__)[0])
 
 
+class WebDriverCallbackHandler(CallbackHandler):
+    unimplemented_exc = (NotImplementedError, client.UnknownCommandException)
+
+
 class WebDriverBaseProtocolPart(BaseProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -376,7 +380,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
                                                            parent_window,
                                                            timeout=5*self.timeout_multiplier)
         self.protocol.base.set_window(test_window)
-        handler = CallbackHandler(self.logger, protocol, test_window)
+        handler = WebDriverCallbackHandler(self.logger, protocol, test_window)
         protocol.webdriver.url = url
 
         if not self.supports_eager_pageload:


### PR DESCRIPTION
This doesn't work with gecko's command dispatch frontend, and means that
the base class is depending on the behaviour of derived classes.