### PR TITLE
[lint] WIP non-functional implementation of wpt lint --fix

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -847,6 +847,7 @@ def create_parser():
     parser.add_argument("--ignore-glob", help="Additional file glob to ignore.")
     parser.add_argument("--all", action="store_true", help="If no paths are passed, try to lint the whole "
                         "working directory, not just files that changed")
+    parser.add_argument("--fix", action="store_true", help="Automatically fix some lint errors")
     return parser
 
 
@@ -870,10 +871,12 @@ def main(**kwargs):
 
     ignore_glob = kwargs.get(str("ignore_glob")) or str()
 
-    return lint(repo_root, paths, output_format, str(ignore_glob))
+    auto_fix = kwargs.get(str("fix"))
+
+    return lint(repo_root, paths, output_format, str(ignore_glob), auto_fix)
 
 
-def lint(repo_root, paths, output_format, ignore_glob=str()):
+def lint(repo_root, paths, output_format, ignore_glob=str(), auto_fix=False):
     # type: (str, List[str], str, str) -> int
     error_count = defaultdict(int)  # type: Dict[Text, int]
     last = None
@@ -888,7 +891,15 @@ def lint(repo_root, paths, output_format, ignore_glob=str()):
                      "markdown": output_errors_markdown,
                      "normal": output_errors_text}[output_format]
 
-    def process_errors(errors):
+    def auto_fix_errors(repo_root, errors):
+        """ TODO """
+        print("Autofixing %s lint error in %s (TODO actually implement the fixing)" % errors)
+        #  with open(os.path.join(repo_root, errors[1]), 'rb+') as f:
+        #      read the file into memory
+        #      do the fixups
+        #      write to file
+
+    def process_errors(errors, auto_fix=False):
         # type: (List[rules.Error]) -> Optional[Tuple[Text, Text]]
         """
         Filters and prints the errors, and updates the ``error_count`` object.
@@ -926,6 +937,8 @@ def lint(repo_root, paths, output_format, ignore_glob=str()):
             with open(abs_path, 'rb') as f:
                 errors = check_file_contents(repo_root, path, f)
                 last = process_errors(errors) or last
+            if last and auto_fix:
+                auto_fix_errors(repo_root, last)
 
     errors = check_all_paths(repo_root, paths)
     last = process_errors(errors) or last

--- a/xslt/transformToFragment.tentative.window.js
+++ b/xslt/transformToFragment.tentative.window.js
@@ -1,6 +1,6 @@
 const cases = {
-  internal: '<script>window.internalScript = true;</script>',
-  external: '<script src="externalScript.js"></script>',
+  internal: '<script>window.internalScript = true;</script>', 
+  external: '<script src="externalScript.js"></script>', 
 };
 
 const loaded = new Promise(resolve => {


### PR DESCRIPTION
See https://github.com/web-platform-tests/wpt/issues/20697

This currently only implements the `--fix` flag and calls a new
`auto_fix_errors` function, that currently only prints a message,
but could read the file into memory, apply changes, and write to file.

---

cc @stephenmcgruer

I'm opening this in its current state because I don't expect to be able to continue working on this right now. Hopefully this is of help if anyone else wants to take a stab at this!