### PR TITLE
[TC] Fix up #20557: hard reset to expected head

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -300,11 +300,12 @@ def setup_repository(args):
         if task_head != expected_head:
             if not is_pr:
                 try:
-                    run(["git", "fetch", "origin", "%s:task_head" % expected_head])
+                    run(["git", "fetch", "origin", expected_head])
+                    run(["git", "reset", "--hard", expected_head])
                 except subprocess.CalledProcessError:
                     print("CRITICAL: task_head points at %s, expected %s and "
                           "unable to fetch expected commit.\n"
-                          "This may be because the branch was updated" % (task_head, args.rev))
+                          "This may be because the branch was updated" % (task_head, expected_head))
                     sys.exit(1)
             else:
                 # Convert the refs/pulls/<id>/merge to refs/pulls/<id>/head
@@ -317,7 +318,7 @@ def setup_repository(args):
                     sys.exit(1)
                 if remote_head != args.head_rev:
                     print("CRITICAL: task_head points at %s, expected %s. "
-                          "This may be because the branch was updated" % (task_head, args.rev))
+                          "This may be because the branch was updated" % (task_head, expected_head))
                     sys.exit(1)
                 print("INFO: Merge commit changed from %s to %s due to base branch changes. "
                       "Running task anyway." % (expected_head, task_head))


### PR DESCRIPTION
`git fetch origin expected_head:task_head` fails when we are already on
`task_head` branch: "fatal: Refusing to fetch into current branch
refs/heads/task_head of non-bare repository".

We can't use --update-head-ok here, either, since we often want to check
out an earlier commit, which is not a fast-forward. The sane way to do
this is to use a separate `git reset --hard`.

Also fix another unrelated AttributeError in the error messages printed
when handling exceptions.

This is a follow-up fix for #20557 . Example failure: https://community-tc.services.mozilla.com/tasks/fkcTyeAATU2K6t-tXYFeqg/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FfkcTyeAATU2K6t-tXYFeqg%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log