### PR TITLE
Remove temporary failure expectations for multiTouch

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsReleaseFirstPoint.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsReleaseFirstPoint.html.ini
@@ -1,6 +1,3 @@
 [multiTouchPointsReleaseFirstPoint.html]
   expected:
     if product == "firefox" or product == "safari": ERROR
-  [TestDriver actions: two touch points with one moving one pause]
-    expected:
-      if product == "chrome": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsReleaseSecondPoint.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsReleaseSecondPoint.html.ini
@@ -1,6 +1,3 @@
 [multiTouchPointsReleaseSecondPoint.html]
   expected:
     if product == "firefox" or product == "safari": ERROR
-  [TestDriver actions: two touch points with one moving one pause]
-    expected:
-      if product == "chrome": FAIL


### PR DESCRIPTION
In https://github.com/web-platform-tests/wpt/pull/20689, two failure
expectations were added to unblock the PR because the corresponding
change in chromedriver needed to pass the tests hadn't made into the dev
channel yet.

Now that 80.0.3987.7 was just released to Mac dev, we need to remove
these two expectations to avoid the unexpected passes.