### PR TITLE
GitHub Actions: Work around #20700

### DIFF
--- a/.github/workflows/detect_pull_request_preview.yml
+++ b/.github/workflows/detect_pull_request_preview.yml
@@ -1,4 +1,5 @@
 name: pr-preview-detect
+# This workflow triggers on deployment, which can never happen on a fork.
 on: deployment
 jobs:
   detect-deployment:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         fetch-depth: 50
     - name: Run website_build.sh
+      # Use a conditional step instead of a conditional job to work around #20700.
+      if: github.repository == 'web-platform-tests/wpt'
       uses: ./tools/docker/documentation
       env:
         DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/epochs.yml
+++ b/.github/workflows/epochs.yml
@@ -6,13 +6,13 @@ on:
     - cron: 10 */3 * * *
 jobs:
   update:
-    # Do not run this job on forks.
-    if: github.repository == 'web-platform-tests/wpt'
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Run epochs_update.sh
+      # Use a conditional step instead of a conditional job to work around #20700.
+      if: github.repository == 'web-platform-tests/wpt'
       run: ./tools/ci/epochs_update.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -8,8 +8,6 @@ on:
       - 'tools/**'
 jobs:
   build-and-tag:
-    # Do not run this job on forks.
-    if: github.repository == 'web-platform-tests/wpt'
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout
@@ -21,6 +19,8 @@ jobs:
         sudo apt-get -qqy install zstd
         pip install -r tools/wpt/requirements.txt
     - name: Run manifest_build.py
+      # Use a conditional step instead of a conditional job to work around #20700.
+      if: github.repository == 'web-platform-tests/wpt'
       run: tools/docker/retry.py --delay 60 python tools/ci/manifest_build.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Make sure workflows always contain at least one job even on a fork. Only
skip the steps that require secrets instead of the whole jobs.
