### PR TITLE
[Lazyload]: De-flake loading/lazyload/invisble-image.tentative.html

### DIFF
--- a/loading/lazyload/invisible-image.tentative.html
+++ b/loading/lazyload/invisible-image.tentative.html
@@ -12,9 +12,20 @@
 <body>
   <div style="height:1000vh;"></div>
   <img id="visibility_hidden" style="visibility:hidden;" src='resources/image.png?1'>
-  <img id="display_none" style="display:none;" src='resources/image.png?2'>
-  <img id="attribute_hidden" hidden src='resources/image.png?3'>
-  <img id="js_display_none" src='resources/image.png?4'>
+  <img id="visibility_hidden_explicit_eager" style="visibility:hidden;" src='resources/image.png?2'
+       loading="eager">
+
+  <img id="display_none" style="display:none;" src='resources/image.png?3'>
+  <img id="display_none_explicit_eager" style="display:none;" src='resources/image.png?4'
+       loading="eager">
+
+  <img id="attribute_hidden" hidden src='resources/image.png?5'>
+  <img id="attribute_hidden_explicit_eager" hidden src='resources/image.png?6'
+       loading="eager">
+
+  <img id="js_display_none" src='resources/image.png?7'>
+  <img id="js_display_none_explicit_eager" src='resources/image.png?8'
+       loading="eager">
   <script>
     document.getElementById("js_display_none").style = 'display:none;';
   </script>
@@ -26,9 +37,20 @@ Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
 
 <script>
   const visibility_hidden_element = document.getElementById("visibility_hidden");
+  const visibility_hidden_element_explicit_eager =
+    document.getElementById("visibility_hidden_explicit_eager");
+
   const display_none_element = document.getElementById("display_none");
+  const display_none_element_explicit_eager =
+    document.getElementById("display_none_explicit_eager");
+
   const attribute_hidden_element = document.getElementById("attribute_hidden");
+  const attribute_hidden_element_explicit_eager =
+    document.getElementById("attribute_hidden_explicit_eager");
+
   const js_display_none_element = document.getElementById("js_display_none");
+  const js_display_none_element_explicit_eager =
+    document.getElementById("js_display_none_explicit_eager");
 
   let have_images_loaded = false;
 
@@ -41,17 +63,20 @@ Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
 
     Promise.all([
       image_fully_loaded_promise(visibility_hidden_element),
+      image_fully_loaded_promise(visibility_hidden_element_explicit_eager),
       image_fully_loaded_promise(display_none_element),
+      image_fully_loaded_promise(display_none_element_explicit_eager),
       image_fully_loaded_promise(attribute_hidden_element),
-      image_fully_loaded_promise(js_display_none_element)
+      image_fully_loaded_promise(attribute_hidden_element_explicit_eager),
+      image_fully_loaded_promise(js_display_none_element),
+      image_fully_loaded_promise(js_display_none_element_explicit_eager)
     ]).then(t.step_func(() => {
       have_images_loaded = true;
     })).catch(t.unreached_func("All images should load correctly"));
 
     window.addEventListener("load", t.step_func_done(() => {
       assert_true(have_images_loaded,
-                  "The images should have loaded before the window load " +
-                  "event fires");
+                  "The images should block the window load event.");
     }));
 
   }, "Test that below-viewport invisible images that are not marked " +

--- a/loading/lazyload/invisible-image.tentative.html
+++ b/loading/lazyload/invisible-image.tentative.html
@@ -3,18 +3,18 @@
   <title>Test that below-viewport invisible images that are not marked
          loading=lazy still load, and block the window load event</title>
   <link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+  <link rel="author" title="Dom Farolino" href="mailto:dom@chromium.org">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="common.js"></script>
 </head>
 
 <body>
-  <img id="expected" src='resources/image.png?1'>
-  <div style="height:10000px;"></div>
-  <img id="visibility_hidden" style="visibility:hidden;" src='resources/image.png?2'>
-  <img id="display_none" style="display:none;" src='resources/image.png?3'>
-  <img id="attribute_hidden" hidden src='resources/image.png?4'>
-  <img id="js_display_none" src='resources/image.png?5'>.
+  <div style="height:1000vh;"></div>
+  <img id="visibility_hidden" style="visibility:hidden;" src='resources/image.png?1'>
+  <img id="display_none" style="display:none;" src='resources/image.png?2'>
+  <img id="attribute_hidden" hidden src='resources/image.png?3'>
+  <img id="js_display_none" src='resources/image.png?4'>
   <script>
     document.getElementById("js_display_none").style = 'display:none;';
   </script>
@@ -25,35 +25,35 @@ Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
 -->
 
 <script>
-  const expected = document.getElementById("expected");
   const visibility_hidden_element = document.getElementById("visibility_hidden");
   const display_none_element = document.getElementById("display_none");
   const attribute_hidden_element = document.getElementById("attribute_hidden");
   const js_display_none_element = document.getElementById("js_display_none");
 
-  let has_window_loaded = false;
+  let have_images_loaded = false;
 
-  async_test(function(t) {
-    window.addEventListener("load", t.step_func(function() {
-      has_window_loaded = true;
-    }));
-
+  async_test(t => {
     let image_fully_loaded_promise = (element) => {
       return new Promise(resolve => {
-        element.addEventListener("load",
-          t.step_func(() => {
-            assert_true(is_image_fully_loaded(element, expected));
-            assert_false(has_window_loaded);
-            resolve();
-        }));
+        element.addEventListener("load", t.step_func(resolve));
       });
     }
-    Promise.all([image_fully_loaded_promise(visibility_hidden_element),
+
+    Promise.all([
+      image_fully_loaded_promise(visibility_hidden_element),
       image_fully_loaded_promise(display_none_element),
       image_fully_loaded_promise(attribute_hidden_element),
-      image_fully_loaded_promise(js_display_none_element)]).then(() => {
-        t.done();
-    });
+      image_fully_loaded_promise(js_display_none_element)
+    ]).then(t.step_func(() => {
+      have_images_loaded = true;
+    })).catch(t.unreached_func("All images should load correctly"));
+
+    window.addEventListener("load", t.step_func_done(() => {
+      assert_true(have_images_loaded,
+                  "The images should have loaded before the window load " +
+                  "event fires");
+    }));
+
   }, "Test that below-viewport invisible images that are not marked " +
      "loading=lazy still load, and block the window load event");
 </script>


### PR DESCRIPTION
This PR de-flakes invisible-image.tentative.html (I'll look into invisible-lazy-image.tentative.html next).

The cause of the flake was that the test assumed the "expected" image always loaded before all of the other images, so that the call to [`is_image_fully_loaded`](https://github.com/web-platform-tests/wpt/blob/master/loading/lazyload/invisible-image.tentative.html#L45) would return true. In reality, there was nothing in the test assuring this, so if the "expected" image happened to finish after any of the other images `is_image_fully_loaded(...)` would return false, and break the test.

To fix this, we could add a mechanism to ensure "expected" loads first, but I think we can get rid of the call to `is_image_fully_loaded` in general. This function was intro'd to ensure that a placeholder image wasn't being used as a stand-in for an image in Chrome. However, I've separately confirmed that placeholder images are never considered "complete", and the load event doesn't fire for them. Therefore `is_image_fully_loaded` isn't buying us anything extra outside of the image load event, so we can remove it.