### PR TITLE
De-flake loading/lazyload/invisible-lazy-image.tentative.html

### DIFF
--- a/loading/lazyload/invisible-lazy-image.tentative.html
+++ b/loading/lazyload/invisible-lazy-image.tentative.html
@@ -8,16 +8,19 @@
 </head>
 
 <body>
-  <img id="expected" src='resources/image.png?1'>
+  <!-- These two images should load, the latter not blocking the window load event -->
+  <img id="expected" src='resources/image.png?expected&pipe=trickle(d1)'>
   <img id="visibility_hidden" style="visibility:hidden;"
-       src='resources/image.png?2&pipe=trickle(d1)' loading='lazy'
+       src='resources/image.png?visibility_hidden&pipe=trickle(d2)' loading='lazy'
        onload="visibility_hidden_img.resolve();" onerror="visibility_hidden_img.reject();">
-  <img id="display_none" style="display:none;" src='resources/image.png?3&pipe=trickle(d1)'
+
+  <!-- These images should not load at all -->
+  <img id="display_none" style="display:none;" src='resources/image.png?display_none'
        loading='lazy'
        onload="display_none_img.resolve();" onerror="display_none_img.reject();">
-  <img id="attribute_hidden" hidden src='resources/image.png?4&pipe=trickle(d1)' loading='lazy'
+  <img id="attribute_hidden" hidden src='resources/image.png?attribute_hidden' loading='lazy'
        onload="attribute_hidden_img.resolve();" onerror="attribute_hidden_img.reject();">
-  <img id="js_display_none" src='resources/image.png?5&pipe=trickle(d1)' loading='lazy'
+  <img id="js_display_none" src='resources/image.png?js_display_none' loading='lazy'
        onload="js_display_none_img.resolve();" onerror="js_display_none_img.reject();">
   <script>
     document.getElementById("js_display_none").style = 'display:none;';
@@ -37,31 +40,39 @@ Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
 
   let has_window_loaded = false;
 
-  async_test(function(t) {
-    window.addEventListener("load", t.step_func(function() {
+  async_test(t => {
+    window.addEventListener("load", t.step_func(() => {
       has_window_loaded = true;
     }));
 
-    display_none_img.promise.then(
-      t.unreached_func("The lazy image with display:none should not load since it is hidden.")
-    ).catch(t.unreached_func("The error event should not fire for lazy images with display none."));
+    const unreached_not_rendered_img_func =
+      t.unreached_func("The not-rendered in-viewport loading=lazy images " +
+                       "should not have attempted to load.");
 
-    attribute_hidden_img.promise.then(
-      t.unreached_func("The lazy image with attribute hidden should not load since it is hidden.")
-    ).catch(t.unreached_func("The error event should not fire for lazy image with attribute hidden."));
+    display_none_img.promise
+      .then(unreached_not_rendered_img_func)
+      .catch(unreached_not_rendered_img_func);
 
-    js_display_none_img.promise.then(
-      t.unreached_func("The lazy image with display:none set by JS should not load since it is hidden.")
-    ).catch(t.unreached_func("The error event should not fire for lazy image with display none set by JS."));
+    attribute_hidden_img.promise
+      .then(unreached_not_rendered_img_func)
+      .catch(unreached_not_rendered_img_func);
+
+    js_display_none_img.promise
+      .then(unreached_not_rendered_img_func)
+      .catch(unreached_not_rendered_img_func);
 
     visibility_hidden_img.promise.then(
-      t.step_func(function() {
-        assert_true(is_image_fully_loaded(visibility_hidden_img.element(),
-                                          expected));
-        assert_true(has_window_loaded);
-        t.step_timeout(function() { t.done(); }, 2000);
+      t.step_func_done(() => {
+        assert_true(is_image_fully_loaded(visibility_hidden_img.element(), expected),
+                    "The loading=lazy visibility:hidden image is equivalent " +
+                    "to the expected image.");
+        assert_true(has_window_loaded,
+                    "The loading=lazy visibility:hidden image does not block " +
+                    "the window load event, and finishes loading after the " +
+                    "window load event fires.");
       })
-    ).catch(t.unreached_func("The error event should not fire for lazy image with visibility hidden."));
+    ).catch(t.unreached_func("The loading=lazy visibility:hidden image " +
+                             "should load successfully."));
   }, "Test behavior of in viewport invisible lazy images");
 </script>
 


### PR DESCRIPTION
`invisible-lazy-image.tentative.html` currently flakes in browsers with no lazy loading support because:
  - Any one of the not-supposed-to-load images end up loading in no specific order. Their onload events all have different error messages in their `t.unreached_func`s, so we get different failures on different runs
    - ![Solution](https://lingtalfi.com/services/pngtext?color=00cc00&size=10&text=Solution): Give them all the same t.unreached_func description. This is fine because if any of the not-supposed-to-load images end up loading, we don’t care which one happened to load first. We’re simply testing that they shouldn’t load at all
 - All of the non-supposed-to-load images block the window load event (since the UA doesn’t understand loading=lazy semantics). Therefore, when the supposed-to-load image finishes, the other images may still be loading, and thus still blocking the window load event. We then assert that the window load event has fired, though it _may_ not have yet, because it might still be blocked by the not-supposed-to-load images
    - ![Solution](https://lingtalfi.com/services/pngtext?color=00cc00&size=10&text=Solution): Stop trickle-loading the not-supposed-to-load images. Therefore if they do load (they will in UAs that don't support lazy loading), they finish much quicker than the supposed-to-load image, and their `unreached_func` is reached. This will ensure that we fail immediately in browsers that do not support lazy loading

`invisible-lazy-image.tentative.html` flakes in Chrome because:
 - For some reason, Chrome sometimes makes in-viewport loading=lazy images block the load event, and sometimes not. This causes the Chrome flake
    - ![Solution](https://lingtalfi.com/services/pngtext?color=00cc00&size=10&text=Solution): Make the test more explicit: Trickle the “expected” image over 1s, thus blocking the window load event for ~1s while image-that-should-load is parsed and fetched. Then, make the image-that-should-load take 2s, and assert it does not block the load event. (Chrome fails these load event semantics, which is a separate issue, but the flake should be gone)