### PR TITLE
Make assertion failures useful on UAs not supporting lazy load

### DIFF
--- a/loading/lazyload/original-base-url-applied-2-tentative.html
+++ b/loading/lazyload/original-base-url-applied-2-tentative.html
@@ -30,13 +30,21 @@ Marked as tentative until https://github.com/whatwg/html/pull/3752 is landed.
 
     below_viewport_img_promise.promise.then(
       t.step_func_done(function() {
-        assert_true(has_window_loaded);
-        assert_true(below_viewport_img_promise.element().complete);
-        assert_greater_than(below_viewport_img_promise.element().naturalWidth, 0);
+        assert_true(has_window_loaded,
+                    "Below-viewport loading=lazy images do not block the " +
+                    "window load event");
+        assert_true(below_viewport_img_promise.element().complete,
+                    "The loading=lazy image should be considered complete " +
+                    "upon load.");
+        assert_greater_than(below_viewport_img_promise.element().naturalWidth,
+                            0,
+                            "The loading=lazy should have non-zero width " +
+                            "upon loading");
       })
     ).catch(t.unreached_func("The image request should not load relative to " +
                              "the current (incorrect) base URL."));
-  }, "Test that when deferred img is loaded, it uses the parse time base URL.");
+  }, "Deferred images with loading='lazy' use the original base URL " +
+     "specified at the parse time");
 </script>
 
 <body>

--- a/loading/lazyload/original-base-url-applied-iframe-tentative.html
+++ b/loading/lazyload/original-base-url-applied-iframe-tentative.html
@@ -31,13 +31,17 @@ specifies this.
 
     below_viewport_iframe_promise.promise.then(
       t.step_func_done(function() {
-        assert_true(has_window_loaded);
+        assert_true(has_window_loaded,
+                    "Below-viewport loading=lazy iframes do not block the " +
+                    "window load event");
         assert_true(below_viewport_iframe_promise.element().contentDocument.body.
-          innerHTML.includes("<p>Subframe</p>"));
+                    innerHTML.includes("<p>Subframe</p>"),
+                    "The loading=lazy iframe's content is accessible upon loading");
       })
     ).catch(t.unreached_func("The iframe request should not load relative to " +
                              "the current (incorrect) base URL."));
-  }, "Test that when deferred iframe is loaded, the parse time base URL is used.");
+  }, "Deferred iframes with loading='lazy' use the original base URL " +
+      "specified at the parse time");
 </script>
 
 <body>


### PR DESCRIPTION
Just realized that these have rather opaque errors in UAs that don't support lazy load. I didn't catch this in review, so I made these changes in a PR