### PR TITLE
[Lazyload]: Simplify and fix disconnected image test

### DIFF
--- a/loading/lazyload/META.yml
+++ b/loading/lazyload/META.yml
@@ -1,0 +1,4 @@
+spec: https://github.com/whatwg/html/pull/3752
+suggested_reviewers:
+  - domfarolino
+  - rwlbuis

--- a/loading/lazyload/disconnected-image-loading-lazy.tentative.html
+++ b/loading/lazyload/disconnected-image-loading-lazy.tentative.html
@@ -3,28 +3,30 @@
 <script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
-async_test(function(t) {
+async_test(t => {
   x = new Image();
   x.loading = "auto";
   x.src = "resources/image.png?auto";
-  x.onload = e => {
-    t.step(function() {
-      t.step_func_done();
-    });
-  };
-  t.step_timeout(function() { t.done(); }, 2000);
+  x.onload = t.step_func_done();
+  t.step_timeout(t.unreached_func("Disconnected loading=auto image loads " +
+                                  "successfully, and doesn't timeout"), 2000);
 }, "loading=auto for disconnected image");
 
-async_test(function(t) {
+async_test(t => {
+  x = new Image();
+  x.loading = "eager";
+  x.src = "resources/image.png?eager";
+  x.onload = t.step_func_done();
+  t.step_timeout(t.unreached_func("Disconnected loading=eager image loads " +
+                                  "successfully, and doesn't timeout"), 2000);
+}, "loading=eager for disconnected image");
+
+async_test(t => {
   x = new Image();
   x.loading = "lazy";
   x.src = "resources/image.png?lazy";
-  x.onload = e => {
-    t.step(function() {
-      t.unreached_func("Disconnected image with loading=lazy should be loaded lazily.");
-    });
-  };
-  t.step_timeout(function() { t.done(); }, 2000);
+  x.onload = t.unreached_func("Disconnected loading=lazy image loads lazily.");
+  t.step_timeout(t.step_func_done(), 2000);
 }, "loading=lazy for disconnected image");
 </script>
 </body>


### PR DESCRIPTION
This PR also adds another disconnected lazy test for explicitly-"eager" images, as well as a META.yml file for suggested reviewers to this directory, before it eventually gets moved somewhere inside of `html/`.