### PR TITLE
Address flakiness of service-workers/service-worker/update-no-cache-r…

### DIFF
--- a/service-workers/service-worker/resources/test-request-headers-worker.js
+++ b/service-workers/service-worker/resources/test-request-headers-worker.js
@@ -1,5 +1,5 @@
-// Add a unique timestamp per request to induce service worker script update.
-// Time stamp: %TIMESTAMP%
+// Add a unique UUID per request to induce service worker script update.
+// Time stamp: %UUID%
 
 // The server injects the request headers here as a JSON string.
 const headersAsJson = `%HEADERS%`;

--- a/service-workers/service-worker/resources/test-request-headers-worker.py
+++ b/service-workers/service-worker/resources/test-request-headers-worker.py
@@ -1,6 +1,6 @@
 import json
 import os
-import time
+import uuid
 
 def main(request, response):
   path = os.path.join(os.path.dirname(__file__),
@@ -9,7 +9,7 @@ def main(request, response):
 
   data = {key:request.headers[key] for key,value in request.headers.iteritems()}
   body = body.replace("%HEADERS%", json.dumps(data))
-  body = body.replace("%TIMESTAMP%", str(time.time()))
+  body = body.replace("%UUID%", str(uuid.uuid4()))
 
   headers = []
   headers.append(("ETag", "etag"))


### PR DESCRIPTION
…equest-headers.https.html

The test triggers a registration update and then expects registration.installing to be non-null
once the registration update promise is resolved. This is only true if the content of the service
worker script is different since last update. The script included a timestamp to try and make
the script different every time but it would sometimes not suffice if the update happens quickly
enough (https://bugs.webkit.org/show_bug.cgi?id=205286). To address the issue, include a UUID in
the script instead of a timestamp.