### PR TITLE
[CSS4Pseudo] Added 2 tests and 1 reference on selection and text-shadow

### DIFF
--- a/css/css-pseudo/selection-text-shadow-006-manual.html
+++ b/css/css-pseudo/selection-text-shadow-006-manual.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: partial selection done manually and multiple text-shadow (complex)</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-styling">
+
+  <meta content="interact" name="flags">
+  <meta content="This test checks that text selectedness done manually must affect multiple text shadows." name="assert">
+
+  <style>
+  div
+    {
+      color: blue;
+      font-size: 300%;
+      margin-left: 7.16667em;
+      margin-top: 1.5em;
+      text-shadow: red 0em -1.2em 0em, red -7em 0em 0em, red 7em 0em 0em, red 0em 1.2em 0em;
+    }
+
+  div::selection
+    {
+      background-color: yellow;
+      color: green;
+      text-shadow: none;
+    }
+  </style>
+
+  <p>Instructions: select a few characters from the blue words "Text sample". Select them with mouse dragging (leftwardedly or rightwardedly) or text-highlighting them with <kbd>Shift</kbd> and keyboard arrows when keyboard navigation (also called caret browsing) is enabled.
+
+  <p>Test passes if each of the 4 correspondent red glyph counterparts disappear.
+
+  <div>Text sample</div>

--- a/css/css-pseudo/selection-text-shadow-016-ref.html
+++ b/css/css-pseudo/selection-text-shadow-016-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      color: green;
+      font-size: 300%;
+      margin-left: 0.66667em;
+      margin-top: 1.5em;
+    }
+  </style>
+
+  <p>Test passes if each glyph of "Selected Text" is green and not red.
+
+  <div>Selected Text</div>

--- a/css/css-pseudo/selection-text-shadow-016.html
+++ b/css/css-pseudo/selection-text-shadow-016.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: selection and text-shadow in 4 directions (static variation)</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-styling">
+  <link rel="match" href="selection-text-shadow-016-ref.html">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that text selectedness must affect multiple text shadows." name="assert">
+
+  <style>
+  div
+    {
+      color: blue;
+      font-size: 300%;
+      margin-left: 0.66667em;
+      margin-top: 1.5em;
+      text-shadow: red 0em -0.5em 0em, red -0.5em 0em 0em, red 0.5em 0em 0em, red 0em 0.5em 0em;
+    }
+
+  div::selection
+    {
+      color: green;
+      text-shadow: none;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>Test passes if each glyph of "Selected Text" is green and not red.
+
+  <div id="test">Selected Text</div>


### PR DESCRIPTION
selection-text-shadow-006-manual.html 
selection-text-shadow-016-ref.html 
selection-text-shadow-016.html

This PR is a followup to 
https://github.com/web-platform-tests/wpt/pull/18217
as it addresses all of the requested modifications over there.

I also removed 'position: absolute;', 'left' and 'top' offsets from both tests and used instead 'margin-left', 'margin-top' and static positioning. 
Finally, I added some tiny editorial improvements.