### PR TITLE
[html] Reduce reliance on global state

### DIFF
--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -26,7 +26,7 @@ function coop_test(t, host, coop, channelName, hasOpener) {
 }
 
 function run_coop_tests(documentCOOPValueTitle, testArray) {
-  for (const test of tests) {
+  for (const test of testArray) {
     async_test(t => {
       coop_test(t, test[0], test[1],
                 `${documentCOOPValueTitle}_to_${test[0].name}_${test[1].replace(/ /g,"-")}`,


### PR DESCRIPTION
Currently, all tests which invoke the `run_coop_tests` utility function
happen to define a global binding named `tests`. The utility function
has been designed to accept that value as a formal parameter, but its
internal implementation references the global binding instead.

Update the `run_coop_tests` utility function to operate on the input
array.