### PR TITLE
Use getNoiseStream instead of getUserMedia

### DIFF
--- a/webrtc/RTCDTMFSender-insertDTMF.https.html
+++ b/webrtc/RTCDTMFSender-insertDTMF.https.html
@@ -119,7 +119,7 @@
     const offer = await caller.createOffer();
     await caller.setLocalDescription(offer);
     await callee.setRemoteDescription(offer);
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     callee.addTrack(track, stream);

--- a/webrtc/RTCIceConnectionState-candidate-pair.https.html
+++ b/webrtc/RTCIceConnectionState-candidate-pair.https.html
@@ -14,7 +14,7 @@ promise_test(async t => {
   const callee = new RTCPeerConnection();
   t.add_cleanup(() => callee.close());
 
-  const stream = await navigator.mediaDevices.getUserMedia({audio:true});
+  const stream = await getNoiseStream({audio:true});
   const [track] = stream.getTracks();
   caller.addTrack(track, stream);
   exchangeIceCandidates(caller, callee);

--- a/webrtc/RTCPeerConnection-addTrack.https.html
+++ b/webrtc/RTCPeerConnection-addTrack.https.html
@@ -190,7 +190,7 @@
     assert_equals(transceiver.sender.track, null);
     assert_equals(transceiver.direction, 'sendrecv');
 
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const sender = pc.addTrack(track);
@@ -205,7 +205,7 @@
     const callee = new RTCPeerConnection();
     t.add_cleanup(() => callee.close());
 
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = caller.addTransceiver(track);
@@ -246,7 +246,7 @@
     assert_equals(transceiver.sender.track, null);
     assert_equals(transceiver.direction, 'recvonly');
 
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const sender = pc.addTrack(track);

--- a/webrtc/RTCPeerConnection-addTransceiver.https.html
+++ b/webrtc/RTCPeerConnection-addTransceiver.https.html
@@ -3,6 +3,7 @@
 <title>RTCPeerConnection.prototype.addTransceiver</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
 <script>
   'use strict';
 

--- a/webrtc/RTCPeerConnection-addTransceiver.https.html
+++ b/webrtc/RTCPeerConnection-addTransceiver.https.html
@@ -244,7 +244,7 @@
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
 
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = pc.addTransceiver(track);
@@ -284,7 +284,7 @@
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
 
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver1 = pc.addTransceiver(track);

--- a/webrtc/RTCPeerConnection-connectionState.https.html
+++ b/webrtc/RTCPeerConnection-connectionState.https.html
@@ -239,7 +239,7 @@
     t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
     t.add_cleanup(() => callee.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     caller.addTrack(track, stream);
@@ -256,7 +256,7 @@
     t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
     t.add_cleanup(() => callee.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     caller.addTrack(track, stream);

--- a/webrtc/RTCPeerConnection-iceConnectionState-disconnected.https.html
+++ b/webrtc/RTCPeerConnection-iceConnectionState-disconnected.https.html
@@ -13,7 +13,7 @@
     const callee = new RTCPeerConnection();
     t.add_cleanup(() => callee.close());
 
-    const stream = await navigator.mediaDevices.getUserMedia({audio:true});
+    const stream = await getNoiseStream({audio:true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     caller.addTrack(track, stream);

--- a/webrtc/RTCPeerConnection-iceConnectionState.https.html
+++ b/webrtc/RTCPeerConnection-iceConnectionState.https.html
@@ -223,7 +223,7 @@ async_test(t => {
     t.add_cleanup(() => callee.close());
 
     caller.addTransceiver('audio', {direction:'recvonly'});
-    const stream = await navigator.mediaDevices.getUserMedia({audio:true});
+    const stream = await getNoiseStream({audio:true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     callee.addTrack(track, stream);
@@ -285,7 +285,7 @@ for (let bundle_policy of ['balanced', 'max-bundle', 'max-compat']) {
     promise_test(async t => {
       const caller = new RTCPeerConnection({bundlePolicy: bundle_policy});
       t.add_cleanup(() => caller.close());
-      const stream = await navigator.mediaDevices.getUserMedia(
+      const stream = await getNoiseStream(
           {audio: true, video:true});
       t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
       const [track1, track2] = stream.getTracks();
@@ -341,9 +341,9 @@ promise_test(async t => {
     pc2.iceStates.push(pc2.iceConnectionState);
   };
 
-  const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
-  const localStream2 = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
-  const remoteStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+  const localStream = await getNoiseStream({audio: true, video: true});
+  const localStream2 = await getNoiseStream({audio: true, video: true});
+  const remoteStream = await getNoiseStream({audio: true, video: true});
   for (const stream of [localStream, localStream2, remoteStream]) {
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
   }

--- a/webrtc/RTCPeerConnection-onsignalingstatechanged.https.html
+++ b/webrtc/RTCPeerConnection-onsignalingstatechanged.https.html
@@ -7,7 +7,7 @@
 <script>
 
 promise_test(async t => {
-  const [track] = (await navigator.mediaDevices.getUserMedia({video: true})).getTracks();
+  const [track] = (await getNoiseStream({video: true})).getTracks();
   t.add_cleanup(() => track.stop());
   const pc1 = new RTCPeerConnection();
   t.add_cleanup(() => pc1.close());

--- a/webrtc/RTCPeerConnection-removeTrack.https.html
+++ b/webrtc/RTCPeerConnection-removeTrack.https.html
@@ -36,7 +36,7 @@
    */
   promise_test(async t => {
     const pc = new RTCPeerConnection();
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = pc.addTransceiver(track);
@@ -62,7 +62,7 @@
   promise_test(async t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = pc.addTransceiver(track);
@@ -94,7 +94,7 @@
   promise_test(async t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = pc.addTransceiver(track);
@@ -126,7 +126,7 @@
   promise_test(async t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = pc.addTransceiver(track);
@@ -167,7 +167,7 @@
     t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
     t.add_cleanup(() => callee.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = caller.addTransceiver(track);
@@ -202,7 +202,7 @@
   promise_test(async t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = pc.addTransceiver(track, { direction: 'sendonly' });
@@ -236,7 +236,7 @@
     t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
     t.add_cleanup(() => callee.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = caller.addTransceiver(track, { direction: 'recvonly' });
@@ -270,7 +270,7 @@
   promise_test(async t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const transceiver = pc.addTransceiver(track, { direction: 'inactive' });
@@ -295,7 +295,7 @@
   promise_test(async t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const sender = pc.addTrack(track, stream);

--- a/webrtc/RTCRtpReceiver-getContributingSources.https.html
+++ b/webrtc/RTCRtpReceiver-getContributingSources.https.html
@@ -13,7 +13,7 @@ async function connectAndExpectNoCsrcs(t, kind) {
   const pc2 = new RTCPeerConnection();
   t.add_cleanup(() => pc2.close());
 
-  const stream = await navigator.mediaDevices.getUserMedia({[kind]:true});
+  const stream = await getNoiseStream({[kind]:true});
   const [track] = stream.getTracks();
   t.add_cleanup(() => track.stop());
   pc1.addTrack(track, stream);

--- a/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html
+++ b/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html
@@ -15,7 +15,7 @@ async function initiateSingleTrackCallAndReturnReceiver(t, kind) {
   const pc2 = new RTCPeerConnection();
   t.add_cleanup(() => pc2.close());
 
-  const stream = await navigator.mediaDevices.getUserMedia({[kind]:true});
+  const stream = await getNoiseStream({[kind]:true});
   const [track] = stream.getTracks();
   t.add_cleanup(() => track.stop());
   pc1.addTrack(track, stream);

--- a/webrtc/RTCRtpSender-transport.https.html
+++ b/webrtc/RTCRtpSender-transport.https.html
@@ -13,7 +13,7 @@
   promise_test(async t => {
     const caller = new RTCPeerConnection();
     t.add_cleanup(() => caller.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const sender = caller.addTrack(track);
@@ -24,7 +24,7 @@
   promise_test(async t => {
     const caller = new RTCPeerConnection();
     t.add_cleanup(() => caller.close());
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const [track] = stream.getTracks();
     const sender = caller.addTrack(track);
@@ -45,7 +45,7 @@
     promise_test(async t => {
         const caller = new RTCPeerConnection({bundlePolicy: bundle_policy});
       t.add_cleanup(() => caller.close());
-      const stream = await navigator.mediaDevices.getUserMedia(
+      const stream = await getNoiseStream(
           {audio: true, video:true});
       t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
       const [track1, track2] = stream.getTracks();
@@ -91,7 +91,7 @@
     promise_test(async t => {
         const caller = new RTCPeerConnection({bundlePolicy: bundle_policy});
       t.add_cleanup(() => caller.close());
-      const stream = await navigator.mediaDevices.getUserMedia(
+      const stream = await getNoiseStream(
           {audio: true, video:true});
       t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
       const [track1, track2] = stream.getTracks();

--- a/webrtc/RTCRtpTransceiver.https.html
+++ b/webrtc/RTCRtpTransceiver.https.html
@@ -448,7 +448,7 @@
     t.add_cleanup(() => pc1.close());
     t.add_cleanup(() => pc2.close());
 
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = await getNoiseStream({audio: true});
     t.add_cleanup(() => stopTracks(stream));
     const track = stream.getAudioTracks()[0];
     pc1.addTrack(track, stream);


### PR DESCRIPTION
Avoid dependency on device permission
May enable to switch the tests from https to http (since they should apply generally)