### PR TITLE
COOP: Test history navigation

### DIFF
--- a/html/cross-origin-opener-policy/coop-navigated-history-popup.https.html
+++ b/html/cross-origin-opener-policy/coop-navigated-history-popup.https.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>Cross-Origin-Opener-Policy: a navigating popup that then goes back in history</title>
+<meta content=timeout value=long>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/common.js"></script>
+<script>
+const title = `Popup navigating to other origin with COOP: same-origin and back in history`;
+const channel = title.replace(/ /g,"-");
+const opener = false;
+const openerDOMAccess = false;
+const navigateURL = `${CROSS_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin&coep=&navHistory=-1`;
+
+async_test(t => {
+  url_test(t, `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=&coep=&navigate=${encodeURIComponent(navigateURL)}&avoidBackAndForth=1&channel=${channel}`, channel, opener, openerDOMAccess);
+}, title);
+</script>

--- a/html/cross-origin-opener-policy/coop-navigated-history-popup.https.html
+++ b/html/cross-origin-opener-policy/coop-navigated-history-popup.https.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>Cross-Origin-Opener-Policy: a navigating popup that then goes back in history</title>
-<meta content=timeout value=long>
+<meta name="timeout" content="long">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src="/common/get-host-info.sub.js"></script>

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -2,12 +2,13 @@ const SAME_ORIGIN = {origin: get_host_info().HTTPS_ORIGIN, name: "SAME_ORIGIN"};
 const SAME_SITE = {origin: get_host_info().HTTPS_REMOTE_ORIGIN, name: "SAME_SITE"};
 const CROSS_ORIGIN = {origin: get_host_info().HTTPS_NOTSAMESITE_ORIGIN, name: "CROSS_ORIGIN"}
 
-function url_test(t, url, channelName, hasOpener) {
+function url_test(t, url, channelName, hasOpener, openerDOMAccess) {
   const bc = new BroadcastChannel(channelName);
   bc.onmessage = t.step_func_done(event => {
     const payload = event.data;
     assert_equals(payload.name, hasOpener ? channelName : "");
     assert_equals(payload.opener, hasOpener);
+    assert_equals(payload.openerDOMAccess, openerDOMAccess);
   });
 
   const w = window.open(url, channelName);
@@ -17,8 +18,8 @@ function url_test(t, url, channelName, hasOpener) {
   t.add_cleanup(() => w.close());
 }
 
-function coop_coep_test(t, host, coop, coep, channelName, hasOpener) {
-  url_test(t, `${host.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${encodeURIComponent(coop)}&coep=${coep}&channel=${channelName}`, channelName, hasOpener);
+function coop_coep_test(t, host, coop, coep, channelName, hasOpener, openerDOMAccess) {
+  url_test(t, `${host.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${encodeURIComponent(coop)}&coep=${coep}&channel=${channelName}&openerDOMAccess=${openerDOMAccess}`, channelName, hasOpener, openerDOMAccess);
 }
 
 function coop_test(t, host, coop, channelName, hasOpener) {

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -6,9 +6,9 @@ function url_test(t, url, channelName, hasOpener, openerDOMAccess) {
   const bc = new BroadcastChannel(channelName);
   bc.onmessage = t.step_func_done(event => {
     const payload = event.data;
-    assert_equals(payload.name, hasOpener ? channelName : "");
-    assert_equals(payload.opener, hasOpener);
-    assert_equals(payload.openerDOMAccess, openerDOMAccess);
+    assert_equals(payload.name, hasOpener ? channelName : "", 'name');
+    assert_equals(payload.opener, hasOpener, 'opener');
+    assert_equals(payload.openerDOMAccess, openerDOMAccess, 'openerDOMAccess');
   });
 
   const w = window.open(url, channelName);
@@ -19,7 +19,7 @@ function url_test(t, url, channelName, hasOpener, openerDOMAccess) {
 }
 
 function coop_coep_test(t, host, coop, coep, channelName, hasOpener, openerDOMAccess) {
-  url_test(t, `${host.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${encodeURIComponent(coop)}&coep=${coep}&channel=${channelName}&openerDOMAccess=${openerDOMAccess}`, channelName, hasOpener, openerDOMAccess);
+  url_test(t, `${host.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${encodeURIComponent(coop)}&coep=${coep}&channel=${channelName}`, channelName, hasOpener, openerDOMAccess);
 }
 
 function coop_test(t, host, coop, channelName, hasOpener) {

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -8,7 +8,10 @@ function url_test(t, url, channelName, hasOpener, openerDOMAccess) {
     const payload = event.data;
     assert_equals(payload.name, hasOpener ? channelName : "", 'name');
     assert_equals(payload.opener, hasOpener, 'opener');
-    assert_equals(payload.openerDOMAccess, openerDOMAccess, 'openerDOMAccess');
+    // TODO(zcorpan): add openerDOMAccess expectations to all tests
+    if (openerDOMAccess !== undefined) {
+      assert_equals(payload.openerDOMAccess, openerDOMAccess, 'openerDOMAccess');
+    }
   });
 
   const w = window.open(url, channelName);

--- a/html/cross-origin-opener-policy/resources/coop-coep.py
+++ b/html/cross-origin-opener-policy/resources/coop-coep.py
@@ -21,13 +21,41 @@ def main(request, response):
 <script src="/common/get-host-info.sub.js"></script>
 <iframe></iframe>
 <script>
-  const navigate = new URL(location).searchParams.get("navigate");
-  if (navigate !== null) {
-    self.location = navigate;
+  const params = new URL(location).searchParams;
+  const navHistory = params.get("navHistory");
+  const avoidBackAndForth = params.get("avoidBackAndForth");
+  const navigate = params.get("navigate");
+  const openerDOMAccess = params.get("openerDOMAccess");
+  // Need to wait until the page is fully loaded before navigating
+  // so that it creates a history entry properly.
+  async function fullyLoaded() {
+    return new Promise((resolve, reject) => {
+      addEventListener('load', () => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            resolve();
+          });
+        });
+      });
+    })
+  }
+  if (navHistory !== null) {
+    fullyLoaded().then(() => {
+      history.go(Number(navHistory));
+    });
+  } else if (navigate !== null && (history.length === 1 || !avoidBackAndForth)) {
+    fullyLoaded().then(() => {
+      self.location = navigate;
+    });
   } else {
+    let openerDOMAccessAllowed = false;
+    try {
+      openerDOMAccessAllowed = !!self.opener.document.URL;
+    } catch(ex) {
+    }
     const iframe = document.querySelector("iframe");
     iframe.onload = () => {
-      const payload = { name: self.name, opener: !!self.opener };
+      const payload = { name: self.name, opener: !!self.opener, openerDOMAccess: openerDOMAccessAllowed };
       iframe.contentWindow.postMessage(payload, "*");
     };
     const channelName = new URL(location).searchParams.get("channel");

--- a/html/cross-origin-opener-policy/resources/coop-coep.py
+++ b/html/cross-origin-opener-policy/resources/coop-coep.py
@@ -25,7 +25,6 @@ def main(request, response):
   const navHistory = params.get("navHistory");
   const avoidBackAndForth = params.get("avoidBackAndForth");
   const navigate = params.get("navigate");
-  const openerDOMAccess = params.get("openerDOMAccess");
   // Need to wait until the page is fully loaded before navigating
   // so that it creates a history entry properly.
   async function fullyLoaded() {

--- a/html/cross-origin-opener-policy/resources/coop-coep.py
+++ b/html/cross-origin-opener-policy/resources/coop-coep.py
@@ -27,23 +27,21 @@ def main(request, response):
   const navigate = params.get("navigate");
   // Need to wait until the page is fully loaded before navigating
   // so that it creates a history entry properly.
-  async function fullyLoaded() {
-    return new Promise((resolve, reject) => {
-      addEventListener('load', () => {
+  const fullyLoaded = new Promise((resolve, reject) => {
+    addEventListener('load', () => {
+      requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            resolve();
-          });
+          resolve();
         });
       });
-    })
-  }
+    });
+  });
   if (navHistory !== null) {
-    fullyLoaded().then(() => {
+    fullyLoaded.then(() => {
       history.go(Number(navHistory));
     });
   } else if (navigate !== null && (history.length === 1 || !avoidBackAndForth)) {
-    fullyLoaded().then(() => {
+    fullyLoaded.then(() => {
       self.location = navigate;
     });
   } else {


### PR DESCRIPTION
The top-level page has no COOP, and opens a popup that also has no COOP.
The popup navigates to a cross-origin page with COOP: same-origin.
That page then navigates back in history.

Assert that the final page doesn't have .opener and doesn't have DOM
access to the opener.

Both navigations create a new browsing context group per spec.