### PR TITLE
[web-animations] Fix test in setting-the-playbackrate-of-an-animation.html

### DIFF
--- a/web-animations/timing-model/animations/setting-the-playback-rate-of-an-animation.html
+++ b/web-animations/timing-model/animations/setting-the-playback-rate-of-an-animation.html
@@ -97,8 +97,8 @@ promise_test(async t => {
 
 promise_test(async t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
-  animation.currentTime = 50 * MS_PER_SEC;
   await animation.ready;
+  animation.currentTime = 50 * MS_PER_SEC;
   animation.playbackRate = 0;
   // Ensure that current time does not drift.
   assert_equals(animation.playState, 'running');


### PR DESCRIPTION
This test assumes that `currentTime` will not change after waiting for
`ready` but the spec does not require that so this patch inverts these two
lines.