### PR TITLE
Add support for running crashtest tests with webkitgtk

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/epiphany.py
+++ b/tools/wptrunner/wptrunner/browsers/epiphany.py
@@ -2,7 +2,8 @@ from .base import get_timeout_multiplier, maybe_add_args, certificate_domain_lis
 from .webkit import WebKitBrowser
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
-                                           WebDriverRefTestExecutor)  # noqa: F401
+                                           WebDriverRefTestExecutor,  # noqa: F401
+                                           WebDriverCrashtestExecutor)  # noqa: F401
 from ..executors.executorwebkit import WebKitDriverWdspecExecutor  # noqa: F401
 
 __wptrunner__ = {"product": "epiphany",
@@ -11,7 +12,8 @@ __wptrunner__ = {"product": "epiphany",
                  "browser_kwargs": "browser_kwargs",
                  "executor": {"testharness": "WebDriverTestharnessExecutor",
                               "reftest": "WebDriverRefTestExecutor",
-                              "wdspec": "WebKitDriverWdspecExecutor"},
+                              "wdspec": "WebKitDriverWdspecExecutor",
+                              "crashtest": "WebDriverCrashtestExecutor"},
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",
                  "env_options": "env_options",

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -2,7 +2,8 @@ from .base import Browser, ExecutorBrowser, require_arg
 from .base import get_timeout_multiplier, certificate_domain_list  # noqa: F401
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
-                                           WebDriverRefTestExecutor)  # noqa: F401
+                                           WebDriverRefTestExecutor,  # noqa: F401
+                                           WebDriverCrashtestExecutor)  # noqa: F401
 from ..executors.executorwebkit import WebKitDriverWdspecExecutor  # noqa: F401
 from ..webdriver_server import WebKitDriverServer
 
@@ -13,7 +14,8 @@ __wptrunner__ = {"product": "webkit",
                  "browser_kwargs": "browser_kwargs",
                  "executor": {"testharness": "WebDriverTestharnessExecutor",
                               "reftest": "WebDriverRefTestExecutor",
-                              "wdspec": "WebKitDriverWdspecExecutor"},
+                              "wdspec": "WebKitDriverWdspecExecutor",
+                              "crashtest": "WebDriverCrashtestExecutor"},
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",
                  "env_options": "env_options",

--- a/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
+++ b/tools/wptrunner/wptrunner/browsers/webkitgtk_minibrowser.py
@@ -2,7 +2,8 @@ from .base import get_timeout_multiplier, maybe_add_args, certificate_domain_lis
 from .webkit import WebKitBrowser
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorwebdriver import (WebDriverTestharnessExecutor,  # noqa: F401
-                                           WebDriverRefTestExecutor)  # noqa: F401
+                                           WebDriverRefTestExecutor,  # noqa: F401
+                                           WebDriverCrashtestExecutor)  # noqa: F401
 from ..executors.executorwebkit import WebKitDriverWdspecExecutor  # noqa: F401
 
 __wptrunner__ = {"product": "webkitgtk_minibrowser",
@@ -11,7 +12,8 @@ __wptrunner__ = {"product": "webkitgtk_minibrowser",
                  "browser_kwargs": "browser_kwargs",
                  "executor": {"testharness": "WebDriverTestharnessExecutor",
                               "reftest": "WebDriverRefTestExecutor",
-                              "wdspec": "WebKitDriverWdspecExecutor"},
+                              "wdspec": "WebKitDriverWdspecExecutor",
+                              "crashtest": "WebDriverCrashtestExecutor"},
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",
                  "env_options": "env_options",


### PR DESCRIPTION
* This adds support in the webkitgtk_minibrowser, webkit and epiphany
product runners for running crashtest tests.

Related issue #20902