### PR TITLE
Replace call to cgi.escape by call to html.escape

### DIFF
--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -1,4 +1,7 @@
-import cgi
+try:
+    import html
+except ImportError:
+    import cgi as html
 import json
 import os
 import sys
@@ -76,7 +79,7 @@ class DirectoryHandler(object):
 <ul>
 %(items)s
 </ul>
-""" % {"path": cgi.escape(url_path),
+""" % {"path": html.escape(url_path),
        "items": "\n".join(self.list_items(url_path, path))}  # noqa: E122
 
     def list_items(self, base_path, path):
@@ -93,14 +96,14 @@ class DirectoryHandler(object):
             yield ("""<li class="dir"><a href="%(link)s">%(name)s</a></li>""" %
                    {"link": link, "name": ".."})
         for item in sorted(os.listdir(path)):
-            link = cgi.escape(quote(item))
+            link = html.escape(quote(item))
             if os.path.isdir(os.path.join(path, item)):
                 link += "/"
                 class_ = "dir"
             else:
                 class_ = "file"
             yield ("""<li class="%(class)s"><a href="%(link)s">%(name)s</a></li>""" %
-                   {"link": link, "name": cgi.escape(item), "class": class_})
+                   {"link": link, "name": html.escape(item), "class": class_})
 
 
 def wrap_pipeline(path, request, response):

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -1,4 +1,7 @@
-from cgi import escape
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
 from collections import deque
 import base64
 import gzip as gzip_module


### PR DESCRIPTION
cgi.escape is deprecated since python>=3.2 and has been removed in
in python3.8