### PR TITLE
Add content-aspect-ratio and update the description in canvas-aspect-ratio

### DIFF
--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/canvas-aspect-ratio.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/canvas-aspect-ratio.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>Canvas width and height attributes are used to infer aspect-ratio</title>
+<title>Canvas width and height attributes are used as the surface size</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
@@ -11,7 +11,7 @@
 </style>
 <body>
 <script>
-let t = async_test("Canvas width and height attributes are used to infer aspect-ratio");
+let t = async_test("Canvas width and height attributes are used as the surface size");
 function assert_ratio(img, expected) {
   let epsilon = 0.001;
   assert_approx_equals(parseInt(getComputedStyle(img).width, 10) / parseInt(getComputedStyle(img).height, 10), expected, epsilon);

--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/content-aspect-ratio.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/content-aspect-ratio.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>div with content style's width and height attributes are not used to infer aspect-ratio</title>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=201641#c22">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>

--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/content-aspect-ratio.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/content-aspect-ratio.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>div with content style's width and height attributes are not used to infer aspect-ratio</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  video {
+    width: 100%;
+    max-width: 100px;
+    height: auto;
+  }
+</style>
+<body>
+<script>
+// Create and append a div with content style and immediately check the height.
+let t = test(function() {
+  var div = document.createElement("div");
+  div.setAttribute("style", "content: url('/images/blue.png')");
+  div.setAttribute("width", "250");
+  div.setAttribute("height", "100");
+  document.body.appendChild(div);
+  assert_equals(getComputedStyle(div).height, "0px");
+}, "div with content style's width and height attributes are not used to infer aspect-ratio");
+
+</script>


### PR DESCRIPTION
Hi,
This patch added a test to div with img content style whose aspect-ratio should be inferred by width and height attributes. And also update the describe in canvas-aspect-ratio, attributes width and height determine the intrinsic size of canvas not aspect-ratio.

PTAL, thanks:)