### PR TITLE
Add test for error image with atrribute width and height

### DIFF
--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio.html
@@ -12,6 +12,8 @@
 <img src="/images/green.png">
 <img src="/images/green.png" width=100 height=125>
 <img src="" width=100 height=125>
+<img src="error.png" width=100 height=125>
+<img src="error.png">
 <script>
 let t = async_test("Image width and height attributes are used to infer aspect-ratio");
 function assert_ratio(img, expected) {
@@ -47,9 +49,10 @@ t.step(function() {
 
 onload = t.step_func_done(function() {
   let images = document.querySelectorAll("img");
-  assert_ratio(images[3], 1.266); // 1.266 is the original aspect ratio of blue.png
-  assert_equals(getComputedStyle(images[2]).height, "0px"); // aspect-ratio doesn't override intrinsic size of images that don't have any src.
-  assert_ratio(images[1], 2.0); // 2.0 is the original aspect ratio of green.png
   assert_ratio(images[0], 2.0); // Loaded image's aspect ratio, at least by default, overrides width / height ratio.
+  assert_ratio(images[1], 2.0); // 2.0 is the original aspect ratio of green.png
+  assert_equals(getComputedStyle(images[2]).height, "0px"); // aspect-ratio doesn't override intrinsic size of images that don't have any src.
+  assert_equals(getComputedStyle(images[3]).height, getComputedStyle(images[4]).height); // aspect-ratio doesn't override intrinsic size of error images.
+  assert_ratio(images[5], 1.266); // 1.266 is the original aspect ratio of blue.png
 });
 </script>


### PR DESCRIPTION
Hi,

This patch added test for <img> with an error src whose intrinsic size shouldn't be overridden by the attribute width height aspect-ratio.

PTAL, thanks:)