### PR TITLE
Avoid pyup updating Pillow beyond Py2 support

### DIFF
--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -2,7 +2,8 @@ html5lib==1.0.1
 mozinfo==1.1.0
 mozlog==5.0
 mozdebug==0.1.1
-pillow==6.2.1
+# Pillow 7 requires Python 3
+pillow==6.2.1  # pyup: <7.0
 urllib3[secure]==1.25.7
 requests==2.22.0
 six==1.13.0


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/wpt/pull/20996. See also, that PR.