### PR TITLE
Constructable StyleSheets: Assert that empty title is null, rather than empty string

### DIFF
--- a/css/cssom/CSSStyleSheet-constructable.html
+++ b/css/cssom/CSSStyleSheet-constructable.html
@@ -66,7 +66,7 @@ test(() => {
   assert_equals(sheet.cssRules[0].cssText, redStyleTexts[1]);
 
   const sheet2 = new CSSStyleSheet({});
-  assert_equals(sheet2.title, null)
+  assert_equals(sheet2.title, null);
   assert_equals(sheet2.ownerNode, null);
   assert_equals(sheet2.ownerRule, null);
   assert_equals(sheet2.media.length, 0);
@@ -81,7 +81,7 @@ test(() => {
   assert_equals(sheet2.cssRules.length, 0);
 
 const sheet3 = new CSSStyleSheet();
-  assert_equals(sheet3.title, null)
+  assert_equals(sheet3.title, null);
   assert_equals(sheet3.ownerNode, null);
   assert_equals(sheet3.ownerRule, null);
   assert_equals(sheet3.media.length, 0);

--- a/css/cssom/CSSStyleSheet-constructable.html
+++ b/css/cssom/CSSStyleSheet-constructable.html
@@ -80,7 +80,7 @@ test(() => {
   sheet2.deleteRule(0);
   assert_equals(sheet2.cssRules.length, 0);
 
-const sheet3 = new CSSStyleSheet();
+  const sheet3 = new CSSStyleSheet();
   assert_equals(sheet3.title, null);
   assert_equals(sheet3.ownerNode, null);
   assert_equals(sheet3.ownerRule, null);

--- a/css/cssom/CSSStyleSheet-constructable.html
+++ b/css/cssom/CSSStyleSheet-constructable.html
@@ -66,7 +66,7 @@ test(() => {
   assert_equals(sheet.cssRules[0].cssText, redStyleTexts[1]);
 
   const sheet2 = new CSSStyleSheet({});
-  assert_equals(sheet2.title, "")
+  assert_equals(sheet2.title, null)
   assert_equals(sheet2.ownerNode, null);
   assert_equals(sheet2.ownerRule, null);
   assert_equals(sheet2.media.length, 0);
@@ -81,7 +81,7 @@ test(() => {
   assert_equals(sheet2.cssRules.length, 0);
 
 const sheet3 = new CSSStyleSheet();
-  assert_equals(sheet3.title, "")
+  assert_equals(sheet3.title, null)
   assert_equals(sheet3.ownerNode, null);
   assert_equals(sheet3.ownerRule, null);
   assert_equals(sheet3.media.length, 0);


### PR DESCRIPTION
See #21033 for more details.

This PR modifies the WPT for Constructable StyleSheets to assert that empty titles return null, rather than the empty string, as noted in the CSSOM spec ([here](https://drafts.csswg.org/cssom/#dom-stylesheet-title)).