### PR TITLE
Small python3 compatibility fixes

### DIFF
--- a/docs/writing-tests/python-handlers/index.md
+++ b/docs/writing-tests/python-handlers/index.md
@@ -43,6 +43,21 @@ The wptserver implements a number of Python APIs for controlling traffic.
    /tools/wptserve/docs/stash
 ```
 
+### Python3 compatibility
+
+Even though Python3 is not fully supported at this point, some work is being
+done to add compatibility for it. This is why you can see in multiple places
+the use of the `six` python module which is meant to provide a set of simple
+utilities that work for both generation of python (see
+[docs](https://six.readthedocs.io/)). The module is vendored in
+tools/third_party/six/six.py.
+
+When an handler is added, it should be at least syntax-compatible with Python3.
+You can check that by running:
+```
+python3 -m py_compile <path/to/handler.py>
+```
+
 ## Example: Dynamic HTTP headers
 
 The following code defines a Python handler that allows the requester to

--- a/eventsource/resources/cors-cookie.py
+++ b/eventsource/resources/cors-cookie.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+from six import ensure_str
 
 def main(request, response):
-    last_event_id = request.headers.get("Last-Event-Id", "")
+    last_event_id = ensure_str(request.headers.get("Last-Event-Id", ""))
     ident = request.GET.first('ident', "test")
     cookie = "COOKIE" if ident in request.cookies else "NO_COOKIE"
     origin = request.GET.first('origin', request.headers["origin"])

--- a/eventsource/resources/cors.py
+++ b/eventsource/resources/cors.py
@@ -4,7 +4,7 @@ from wptserve import pipes
 def run_other(request, response, path):
     #This is a terrible hack
     environ = {"__file__": path}
-    execfile(path, environ, environ)
+    exec(compile(open(path, "r").read(), path, 'exec'), environ, environ)
     rv = environ["main"](request, response)
     return rv
 

--- a/eventsource/resources/last-event-id.py
+++ b/eventsource/resources/last-event-id.py
@@ -1,7 +1,9 @@
+from six import ensure_str
+
 def main(request, response):
   response.headers.set("Content-Type", "text/event-stream")
 
-  last_event_id = request.headers.get("Last-Event-ID", None)
+  last_event_id = ensure_str(request.headers.get("Last-Event-ID", ""))
   if last_event_id:
     return "data: " + last_event_id + "\n\n"
   else:

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -351,7 +351,7 @@ class RoutesBuilder(object):
         if headers is None:
             headers = {}
         handler = handlers.StaticHandler(path, format_args, content_type, **headers)
-        self.add_handler(b"GET", str(route), handler)
+        self.add_handler("GET", str(route), handler)
 
     def add_mount_point(self, url_base, path):
         url_base = "/%s/" % url_base.strip("/") if url_base != "/" else "/"

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -192,7 +192,7 @@ class TestEnvironment(object):
             data += fp.read()
         with open(os.path.join(here, "testdriver-extra.js"), "rb") as fp:
             data += fp.read()
-        route_builder.add_handler(b"GET", b"/resources/testdriver.js",
+        route_builder.add_handler("GET", "/resources/testdriver.js",
                                   StringHandler(data, "text/javascript"))
 
         for url_base, paths in iteritems(self.test_paths):

--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -7,7 +7,7 @@ import tempfile
 import threading
 import traceback
 import uuid
-from six import iteritems
+from six import ensure_str, iteritems
 
 from mozprocess import ProcessHandler
 
@@ -260,10 +260,10 @@ class ServoRefTestExecutor(ProcessTestExecutor):
             if rv != 0 or not os.path.exists(output_path):
                 return False, ("CRASH", None)
 
-            with open(output_path) as f:
+            with open(output_path, "rb") as f:
                 # Might need to strip variable headers or something here
                 data = f.read()
-                return True, base64.b64encode(data)
+                return True, ensure_str(base64.b64encode(data))
 
     def do_test(self, test):
         result = self.implementation.run_test(test)

--- a/wpt.py
+++ b/wpt.py
@@ -1,3 +1,3 @@
 # This file exists to allow `python wpt <command>` to work on Windows:
 # https://github.com/web-platform-tests/wpt/pull/6907
-execfile("wpt")
+exec(compile(open("wpt", "r").read(), "wpt", 'exec'))


### PR DESCRIPTION
I found some problems again when trying to run servo wpt tests with Python3 (see https://github.com/servo/servo/pull/25377)

This is step in the right direction but not sure yet if it will suffice.