### PR TITLE
Expand tests for DOMParser

### DIFF
--- a/domparsing/DOMParser-parseFromString-encoding.html
+++ b/domparsing/DOMParser-parseFromString-encoding.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<title>DOMParser encoding test</title>
+<meta charset="windows-1252"> <!-- intentional to make sure the results are UTF-8 anyway -->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+function assertEncoding(doc) {
+  assert_equals(doc.charset, "UTF-8", "document.charset");
+  assert_equals(doc.characterSet, "UTF-8", "document.characterSet");
+  assert_equals(doc.inputEncoding, "UTF-8", "document.characterSet");
+}
+
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString("", "text/html");
+
+  assertEncoding(doc);
+}, "HTML: empty");
+
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString("", "text/xml");
+
+  assertEncoding(doc);
+}, "XML: empty");
+
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(`<meta charset="latin2">`, "text/html");
+
+  assertEncoding(doc);
+}, "HTML: meta charset");
+
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(`<?xml version="1.0" encoding="latin2"?><x/>`, "text/xml");
+
+  assertEncoding(doc);
+}, "XML: XML declaration");
+</script>

--- a/domparsing/DOMParser-parseFromString-encoding.html
+++ b/domparsing/DOMParser-parseFromString-encoding.html
@@ -13,6 +13,10 @@ function assertEncoding(doc) {
   assert_equals(doc.inputEncoding, "UTF-8", "document.characterSet");
 }
 
+setup(() => {
+  assert_precondition(document.characterSet === "windows-1252", "the meta charset must be in effect, making the main document windows-1252");
+});
+
 test(() => {
   const parser = new DOMParser();
   const doc = parser.parseFromString("", "text/html");

--- a/domparsing/DOMParser-parseFromString-html.html
+++ b/domparsing/DOMParser-parseFromString-html.html
@@ -31,18 +31,6 @@ test(function() {
 }, 'contentType');
 
 test(function() {
-    assert_equals(doc.characterSet, "UTF-8")
-}, 'characterSet');
-
-test(function() {
-    assert_equals(doc.inputEncoding, "UTF-8")
-}, 'inputEncoding');
-
-test(function() {
-    assert_equals(doc.charset, "UTF-8")
-}, 'charset');
-
-test(function() {
     assert_equals(doc.compatMode, "BackCompat")
 }, 'compatMode');
 
@@ -53,7 +41,7 @@ test(function() {
     assert_equals(doc.compatMode, "CSS1Compat")
 }, 'compatMode for a proper DOCTYPE');
 
-// URL-related stuff tested separately.
+// URL- and encoding-related stuff tested separately.
 
 test(function() {
     assert_equals(doc.location, null,

--- a/domparsing/DOMParser-parseFromString-html.html
+++ b/domparsing/DOMParser-parseFromString-html.html
@@ -6,11 +6,9 @@
 // |expected| should be an object indicating the expected type of node.
 function assert_node(actual, expected) {
     assert_true(actual instanceof expected.type,
-                'Node type mismatch: actual = ' + actual.nodeType + ', expected = ' + expected.nodeType);
+                'Node type mismatch: actual = ' + actual.constructor.name + ', expected = ' + expected.type.name);
     if (typeof(expected.id) !== 'undefined')
         assert_equals(actual.id, expected.id, expected.idMessage);
-    if (typeof(expected.nodeValue) !== 'undefined')
-        assert_equals(actual.nodeValue, expected.nodeValue, expected.nodeValueMessage);
 }
 
 var doc;
@@ -72,10 +70,17 @@ test(() => {
 <style>
   @import url(/dummy.css)
 </style>
-<script>x = 8<\/script>
+<script>document.x = 8<\/script>
 </body></html>`, 'text/html');
 
   assert_not_equals(doc.querySelector('script'), null, 'script must be found');
-  assert_equals(doc.x, undefined, 'script must not be executed');
+  assert_equals(doc.x, undefined, 'script must not be executed on the inner document');
+  assert_equals(document.x, undefined, 'script must not be executed on the outer document');
 }, 'script is found synchronously even when there is a css import');
+
+test(() => {
+    const doc = new DOMParser().parseFromString(`<body><noscript><p id="test1">test1<p id="test2">test2</noscript>`, 'text/html');
+    assert_node(doc.body.firstChild.childNodes[0], { type: HTMLParagraphElement, id: 'test1' });
+    assert_node(doc.body.firstChild.childNodes[1], { type: HTMLParagraphElement, id: 'test2' });
+}, 'must be parsed with scripting disabled, so noscript works');
 </script>

--- a/domparsing/DOMParser-parseFromString-html.html
+++ b/domparsing/DOMParser-parseFromString-html.html
@@ -43,16 +43,17 @@ test(function() {
 }, 'charset');
 
 test(function() {
-    var url = document.URL;
-    assert_equals(doc.documentURI, url,
-                  'The document must have a URL value equal to the URL of the active document.');
-    assert_equals(doc.URL, url,
-                  'The document must have a URL value equal to the URL of the active document.');
-}, 'URL value');
+    assert_equals(doc.compatMode, "BackCompat")
+}, 'compatMode');
 
 test(function() {
-    assert_equals(doc.baseURI, document.URL);
-}, 'baseURI value');
+    var parser = new DOMParser();
+    var input = '<!DOCTYPE html><html id="root"><head></head><body></body></html>';
+    doc = parser.parseFromString(input, 'text/html');
+    assert_equals(doc.compatMode, "CSS1Compat")
+}, 'compatMode for a proper DOCTYPE');
+
+// URL-related stuff tested separately.
 
 test(function() {
     assert_equals(doc.location, null,

--- a/domparsing/DOMParser-parseFromString-url-base-pushstate.html
+++ b/domparsing/DOMParser-parseFromString-url-base-pushstate.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>DOMParser test of how the document's URL is set (base, pushstate)</title>
+<base href="/fake/base-from-outer-frame">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe src="/domparsing/resources/domparser-iframe-base-pushstate.html" onload="window.resolveLoadPromise();"></iframe>
+
+<script>
+"use strict";
+history.pushState(null, "", "/fake/push-state-from-outer-frame");
+</script>
+<script src="/domparsing/resources/domparser-url-tests.js"></script>

--- a/domparsing/DOMParser-parseFromString-url-base.html
+++ b/domparsing/DOMParser-parseFromString-url-base.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>DOMParser test of how the document's URL is set (base, no pushstate)</title>
+<base href="/fake/base-from-outer-frame">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe src="/domparsing/resources/domparser-iframe-base.html" onload="window.resolveLoadPromise();"></iframe>
+<script src="/domparsing/resources/domparser-url-tests.js"></script>

--- a/domparsing/DOMParser-parseFromString-url-pushstate.html
+++ b/domparsing/DOMParser-parseFromString-url-pushstate.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<title>DOMParser test of how the document's URL is set (no base, pushstate)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe src="/domparsing/resources/domparser-iframe-pushstate.html" onload="window.resolveLoadPromise();"></iframe>
+
+<script>
+"use strict";
+history.pushState(null, "", "/fake/push-state-from-outer-frame");
+</script>
+<script src="/domparsing/resources/domparser-url-tests.js"></script>

--- a/domparsing/DOMParser-parseFromString-url.html
+++ b/domparsing/DOMParser-parseFromString-url.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>DOMParser test of how the document's URL is set (no pushstate, no base)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe src="/domparsing/resources/domparser-iframe.html" onload="window.resolveLoadPromise();"></iframe>
+<script src="/domparsing/resources/domparser-url-tests.js"></script>

--- a/domparsing/DOMParser-parseFromString-xml-parsererror.html
+++ b/domparsing/DOMParser-parseFromString-xml-parsererror.html
@@ -35,4 +35,16 @@ const xhtml_prologue = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     assert_equals(parsererrors.length, 1, 'expecting one parsererror');
   }, document.title + ', ' + fragment);
 });
+
+[
+  'text/xml',
+  'application/xml',
+  'application/xhtml+xml',
+  'image/svg+xml'
+].forEach(mimeType => {
+  test(() => {
+    const doc = (new DOMParser()).parseFromString('<span x:test="testing">1</span>', mimeType);
+    assert_equals(doc.contentType, mimeType);
+  }, `${mimeType} is preserved in the error document`);
+})
 </script>

--- a/domparsing/DOMParser-parseFromString-xml.html
+++ b/domparsing/DOMParser-parseFromString-xml.html
@@ -66,8 +66,6 @@ allowedTypes.forEach(function(type) {
     assert_equals(doc.x, undefined, "script must not be executed on the inner document");
     assert_equals(document.x, undefined, "script must not be executed on the outer document");
 
-    console.log(doc.documentElement.outerHTML);
-
     const body = doc.documentElement.children[1];
     assert_equals(body.localName, "body");
     assert_equals(body.children[1].localName, "noscript");

--- a/domparsing/DOMParser-parseFromString-xml.html
+++ b/domparsing/DOMParser-parseFromString-xml.html
@@ -50,5 +50,30 @@ allowedTypes.forEach(function(type) {
     var doc = p.parseFromString("<foo>", type);
     assert_false(doc instanceof XMLDocument, "Should not be XMLDocument");
   }, "XMLDocument interface for incorrectly parsed document with type " + type);
+
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString(`
+      <html>
+        <head></head>
+        <body>
+          <script>document.x = 5;<\/script>
+          <noscript><p>test1</p><p>test2</p></noscript>
+        </body>
+      </html>`
+    , type);
+
+    assert_equals(doc.x, undefined, "script must not be executed on the inner document");
+    assert_equals(document.x, undefined, "script must not be executed on the outer document");
+
+    console.log(doc.documentElement.outerHTML);
+
+    const body = doc.documentElement.children[1];
+    assert_equals(body.localName, "body");
+    assert_equals(body.children[1].localName, "noscript");
+    assert_equals(body.children[1].children.length, 2);
+    assert_equals(body.children[1].children[0].localName, "p");
+    assert_equals(body.children[1].children[1].localName, "p");
+  }, "scripting must be disabled with type " + type);
 });
 </script>

--- a/domparsing/resources/domparser-iframe-base-pushstate.html
+++ b/domparsing/resources/domparser-iframe-base-pushstate.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>An iframe that does DOMParser stuff with base and pushstates itself</title>
+<base href="/fake/base-from-iframe">
+
+<script>
+"use strict";
+history.pushState(null, "", "/fake/push-state-from-iframe");
+</script>
+<script src="/domparsing/resources/domparser-iframe.js"></script>

--- a/domparsing/resources/domparser-iframe-base.html
+++ b/domparsing/resources/domparser-iframe-base.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>An iframe that does DOMParser stuff with base</title>
+<base href="/fake/base-from-iframe">
+
+<script src="/domparsing/resources/domparser-iframe.js"></script>

--- a/domparsing/resources/domparser-iframe-pushstate.html
+++ b/domparsing/resources/domparser-iframe-pushstate.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>An iframe that does DOMParser stuff and pushstates itself</title>
+
+<script>
+"use strict";
+history.pushState(null, "", "/fake/push-state-from-iframe");
+</script>
+<script src="/domparsing/resources/domparser-iframe.js"></script>

--- a/domparsing/resources/domparser-iframe.html
+++ b/domparsing/resources/domparser-iframe.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>An iframe that does DOMParser stuff</title>
+<script src="/domparsing/resources/domparser-iframe.js"></script>

--- a/domparsing/resources/domparser-iframe.js
+++ b/domparsing/resources/domparser-iframe.js
@@ -1,0 +1,4 @@
+window.doParse = (html, mimeType) => {
+  const parser = new DOMParser();
+  return parser.parseFromString(html, mimeType);
+};

--- a/domparsing/resources/domparser-url-tests.js
+++ b/domparsing/resources/domparser-url-tests.js
@@ -1,0 +1,72 @@
+const loadPromise = new Promise(resolve => { window.resolveLoadPromise = resolve; });
+
+function assertURL(doc, expectedURL) {
+  assert_equals(doc.URL, expectedURL, "document.URL");
+  assert_equals(doc.documentURI, expectedURL, "document.documentURI");
+  assert_equals(doc.baseURI, expectedURL, "document.baseURI");
+}
+
+const supportedTypes = [
+  "text/html",
+  "text/xml",
+  "application/xml",
+  "application/xhtml+xml",
+  "image/svg+xml",
+];
+
+const invalidXML = `<span x:test="testing">1</span>`;
+const inputs = {
+  valid: "<html></html>",
+  "invalid XML": invalidXML
+};
+
+for (const mimeType of supportedTypes) {
+  for (const [inputName, input] of Object.entries(inputs)) {
+    if (mimeType === "text/html" && input === invalidXML) {
+      continue;
+    }
+
+    test(() => {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(input, mimeType);
+
+      assertURL(doc, document.URL);
+    }, `${mimeType} ${inputName}: created normally`);
+
+    promise_test(async () => {
+      await loadPromise;
+
+      const parser = new frames[0].DOMParser();
+      const doc = parser.parseFromString(input, mimeType);
+
+      assertURL(doc, frames[0].document.URL);
+    }, `${mimeType} ${inputName}: created using another iframe's DOMParser from this frame`);
+
+    promise_test(async () => {
+      await loadPromise;
+
+      const parser = new frames[0].DOMParser();
+      const doc = frames[0].doParse(input, mimeType);
+
+      assertURL(doc, frames[0].document.URL);
+    }, `${mimeType} ${inputName}: created using another iframe's DOMParser from that frame`);
+
+    promise_test(async () => {
+      await loadPromise;
+
+      const parser = new DOMParser();
+      const doc = frames[0].DOMParser.prototype.parseFromString.call(parser, input, mimeType);
+
+      assertURL(doc, document.URL);
+    }, `${mimeType} ${inputName}: created using a parser from this frame and the method from the iframe`);
+
+    promise_test(async () => {
+      await loadPromise;
+
+      const parser = new frames[0].DOMParser();
+      const doc = DOMParser.prototype.parseFromString.call(parser, input, mimeType);
+
+      assertURL(doc, frames[0].document.URL);
+    }, `${mimeType} ${inputName}: created using a parser from the iframe and the method from this frame`);
+  }
+}


### PR DESCRIPTION
This tests the resulting Document's:

* URL (under a large variety of conditions)
* content type (for parser errors, which were not tested previously)
* compatMode

This largely supercedes @Ms2ger's https://github.com/web-platform-tests/wpt/pull/15548, which never got review 😢. However it doesn't include navigation tests as I wasn't able to easily fit those into the framework I was using. It does reveal some things that his tests don't, which is that Gecko uses the document's base URL, whereas Chromium uses the document's URL. I haven't been able to test Safari yet so I'm not sure which direction the spec should go.

Edit: TaskCluster reports that Safari matches Chromium.

I will be posting a HTML spec PR for moving DOMParser there shortly.