### PR TITLE
Rework keyframes-remove-documentElement-crash.html to not use testharness.js

### DIFF
--- a/css/css-animations/keyframes-remove-documentElement-crash.html
+++ b/css/css-animations/keyframes-remove-documentElement-crash.html
@@ -2,8 +2,6 @@
 <html class="test-wait">
 <title>CSS Animations Test: Chrome crash when removing documentElement and @keyframes stylesheet</title>
 <link rel="help" href="https://crbug.com/999522">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
 <style>
   @keyframes anim {
     from { color: pink }

--- a/css/css-animations/keyframes-remove-documentElement-crash.html
+++ b/css/css-animations/keyframes-remove-documentElement-crash.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<html class="test-wait">
 <title>CSS Animations Test: Chrome crash when removing documentElement and @keyframes stylesheet</title>
 <link rel="help" href="https://crbug.com/999522">
 <script src="/resources/testharness.js"></script>
@@ -14,9 +15,16 @@
 </style>
 <div></div>
 <script>
-  test(() => {
-    document.body.offsetTop;
-    document.querySelector("style").remove();
-    document.documentElement.remove();
-  }, "Removing documentElement and @keyframes sheet should not crash.");
+window.addEventListener('load', () => {
+  document.body.offsetTop;
+  document.querySelector("style").remove();
+  // We need the root later to remove the test-wait class.
+  const root = document.documentElement;
+  document.documentElement.remove();
+
+  // rAF to make sure that style runs.
+  requestAnimationFrame(() => {
+    root.classList.remove('test-wait');
+  });
+});
 </script>

--- a/docs/writing-tests/crashtest.md
+++ b/docs/writing-tests/crashtest.md
@@ -12,11 +12,10 @@ The simplest crashtest is a single HTML file with any content. The
 test passes if the load event is reached, and the browser finishes
 painting, without terminating.
 
-In some cases crashtests may need to perform work after the initial
-page load. In this case the test may specify a `class=wait` attribute
-on the root element. The test will not complete until that attribute
-is removed from the root. At the time when the test would otherwise
-have ended a `TestRendered` event is emitted; test authors can use
-this event to perform modifications that are guaranteed not to be
-batched with the initial paint. This matches the behaviour of
-[reftests](reftests).
+In some cases crashtests may need to perform work after the initial page load.
+In this case the test may specify a `class=test-wait` attribute on the root
+element. The test will not complete until that attribute is removed from the
+root. At the time when the test would otherwise have ended a `TestRendered`
+event is emitted; test authors can use this event to perform modifications that
+are guaranteed not to be batched with the initial paint. This matches the
+behaviour of [reftests](reftests).


### PR DESCRIPTION
Previously this test would fail when loaded locally as the
testharness.js cleanup code would try to access
document.documentElement, which had been removed. Instead, use the
crashtest support
(https://web-platform-tests.org/writing-tests/crashtest.html).

Fixes #20020