### PR TITLE
Add a test for createImageBitmap inside a worker

### DIFF
--- a/2dcontext/imagebitmap/createImageBitmap-in-worker-transfer.html
+++ b/2dcontext/imagebitmap/createImageBitmap-in-worker-transfer.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>createImageBitmap in worker and transfer</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+promise_test(function(t) {
+    return new Promise(function(resolve, reject) {
+        var worker = new Worker("createImageBitmap-worker.js");
+        worker.addEventListener("message", function(evt) {
+            var bitmap = evt.data;
+            assert_equals(bitmap.width, 20);
+            assert_equals(bitmap.height, 20);
+            resolve();
+        });
+        worker.postMessage('test');
+    });
+}, 'Transfer ImageBitmap created in worker');
+</script>

--- a/2dcontext/imagebitmap/createImageBitmap-worker.js
+++ b/2dcontext/imagebitmap/createImageBitmap-worker.js
@@ -1,0 +1,17 @@
+function makeBlob() {
+    return new Promise(function(resolve, reject) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", '/images/pattern.png');
+        xhr.responseType = 'blob';
+        xhr.send();
+        xhr.onload = function() {
+            resolve(xhr.response);
+        };
+    });
+}
+
+addEventListener("message", () => {
+    makeBlob().then(createImageBitmap).then(bitmap => {
+        postMessage(bitmap, [bitmap]);
+    });
+});


### PR DESCRIPTION
This is tested in the offscreen-canvas tests, but not specifically in the ImageBitmap tests. Given that WebKit at least currently supports the latter and not the former (and this may be true of Gecko?), it'd be worthwhile to test it explicitly.

I ran into this as creation of image bitmaps in WebKit asserted when run off the main thread.