### PR TITLE
Make canvas-createImageBitmap-video-resize.html compatible

### DIFF
--- a/2dcontext/imagebitmap/canvas-createImageBitmap-video-resize.html
+++ b/2dcontext/imagebitmap/canvas-createImageBitmap-video-resize.html
@@ -55,5 +55,5 @@ video.preload = "auto";
 video.oncanplaythrough = t.step_func(function() {
     return generateTest();
 });
-video.src = "/media/video.ogv";
+video.src = '/media/counting.' + (video.canPlayType('video/ogg') ? 'ogv' : 'mp4');
 </script>


### PR DESCRIPTION
Hi,

There are some browsers that don't support video/ogg type.
This patch makes canvas-createImageBitmap-video-resize.html compatible with these browsers.
If the browser supports video/ogg type, it will use media/counting.ogv, otherwise, use media/counting.mp4.

PTAL, thanks:)