### PR TITLE
Temporarily disable allowed-to-play.html test in Firefox

### DIFF
--- a/infrastructure/metadata/infrastructure/assumptions/allowed-to-play.html.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/allowed-to-play.html.ini
@@ -1,4 +1,6 @@
 [allowed-to-play.html]
+  disabled:
+    if product == "firefox": https://bugzilla.mozilla.org/show_bug.cgi?id=1607802
   expected:
     if product == "safari": ERROR # https://bugs.webkit.org/show_bug.cgi?id=190775
 


### PR DESCRIPTION
This is causing timeouts in unrelated infra PRs. The bug is tracked in
https://bugzilla.mozilla.org/show_bug.cgi?id=1607802 and the test
should be reenabled once that bug is fixed.