### PR TITLE
Don't depend on Selenium for resources tests

### DIFF
--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -2,11 +2,12 @@ import io
 import json
 import os
 import ssl
+import sys
+import subprocess
 
 import html5lib
 import py
 import pytest
-from selenium import webdriver
 from six import text_type
 from six.moves import urllib
 
@@ -16,6 +17,9 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 WPT_ROOT = os.path.normpath(os.path.join(HERE, '..', '..'))
 HARNESS = os.path.join(HERE, 'harness.html')
 TEST_TYPES = ('functional', 'unit')
+
+sys.path.insert(0, os.path.normpath(os.path.join(WPT_ROOT, "tools", "webdriver")))
+import webdriver
 
 
 def pytest_addoption(parser):
@@ -37,8 +41,16 @@ def pytest_collect_file(path, parent):
 
 
 def pytest_configure(config):
-    config.driver = webdriver.Firefox(firefox_binary=config.getoption("--binary"))
-    config.add_cleanup(config.driver.quit)
+    config.proc = subprocess.Popen(["geckodriver"])
+    config.add_cleanup(config.proc.kill)
+
+    capabilities = {"alwaysMatch": {"acceptInsecureCerts": True}}
+    if config.getoption("--binary"):
+        capabilities["alwaysMatch"]["moz:firefoxOptions"] = {"binary": config.getoption("--binary")}
+
+    config.driver = webdriver.Session("localhost", 4444,
+                                      capabilities=capabilities)
+    config.add_cleanup(config.driver.end)
 
     config.server = WPTServer(WPT_ROOT)
     config.server.start()
@@ -147,7 +159,7 @@ class HTMLItem(pytest.Item, pytest.Collector):
         driver = self.session.config.driver
         server = self.session.config.server
 
-        driver.get(server.url(HARNESS))
+        driver.url = server.url(HARNESS)
 
         actual = driver.execute_async_script(
             'runTest("%s", "foo", arguments[0])' % self.url
@@ -168,7 +180,7 @@ class HTMLItem(pytest.Item, pytest.Collector):
         driver = self.session.config.driver
         server = self.session.config.server
 
-        driver.get(server.url(HARNESS))
+        driver.url = server.url(HARNESS)
 
         test_url = self.url + variant
         actual = driver.execute_async_script('runTest("%s", "foo", arguments[0])' % test_url)

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -10,7 +10,6 @@ deps =
   html5lib
   pytest>=2.9
   pyvirtualdisplay
-  selenium
   six
   requests
 


### PR DESCRIPTION
We don't use selenium anywhere else and our requirements here are easily met by the built-in webdriver library, so use that instead.