### PR TITLE
Uninstall google-chrome before installing google-chrome-dev

### DIFF
--- a/tools/ci/azure/install_chrome.yml
+++ b/tools/ci/azure/install_chrome.yml
@@ -1,6 +1,8 @@
 steps:
 # This is equivalent to `Homebrew/homebrew-cask-versions/google-chrome-dev`,
 # but the raw URL is used to bypass caching.
-- script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/google-chrome-dev.rb
+- script: |
+    if brew cask list google-chrome; then brew cask uninstall google-chrome; fi
+    HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/google-chrome-dev.rb
   displayName: 'Install Chrome Dev'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
google-chrome now appears to be part of the Azure image, see the failure in  #21097 ("Error: Cask 'google-chrome-dev' conflicts with 'google-chrome'.")