### PR TITLE
[Azure Pipelines] uninstall the google-chrome and chromedriver casks

### DIFF
--- a/tools/ci/azure/install_chrome.yml
+++ b/tools/ci/azure/install_chrome.yml
@@ -1,6 +1,9 @@
 steps:
-# This is equivalent to `Homebrew/homebrew-cask-versions/google-chrome-dev`,
-# but the raw URL is used to bypass caching.
-- script: HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/google-chrome-dev.rb
+# The conflicting google-chrome and chromedriver casks are first uninstalled.
+# The raw google-chrome-dev cask URL is used to bypass caching.
+- script: |
+    HOMEBREW_NO_AUTO_UPDATE=1 brew cask uninstall google-chrome
+    HOMEBREW_NO_AUTO_UPDATE=1 brew cask uninstall chromedriver
+    HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/google-chrome-dev.rb
   displayName: 'Install Chrome Dev'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
These are now installed by default and conflict with our setup:
https://github.com/microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.14-Readme.md#browsers