### PR TITLE
[Azure Pipelines] explicitly ignore any`brew cask uninstall` failure

### DIFF
--- a/tools/ci/azure/install_chrome.yml
+++ b/tools/ci/azure/install_chrome.yml
@@ -2,8 +2,8 @@ steps:
 # The conflicting google-chrome and chromedriver casks are first uninstalled.
 # The raw google-chrome-dev cask URL is used to bypass caching.
 - script: |
-    HOMEBREW_NO_AUTO_UPDATE=1 brew cask uninstall google-chrome
-    HOMEBREW_NO_AUTO_UPDATE=1 brew cask uninstall chromedriver
+    HOMEBREW_NO_AUTO_UPDATE=1 brew cask uninstall google-chrome || true
+    HOMEBREW_NO_AUTO_UPDATE=1 brew cask uninstall chromedriver || true
     HOMEBREW_NO_AUTO_UPDATE=1 brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask-versions/master/Casks/google-chrome-dev.rb
   displayName: 'Install Chrome Dev'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))


### PR DESCRIPTION
These commands failing already doesn't fail the step:
https://github.com/web-platform-tests/wpt/pull/21113#issuecomment-572643705

However, this makes it more clear and doesn't require knowledge of how
Azure Pipelines wraps multi-line scripts.