### PR TITLE
WebCryptoAPI: Fix HKDF test for illegal hash names

### DIFF
--- a/WebCryptoAPI/derive_bits_keys/hkdf.js
+++ b/WebCryptoAPI/derive_bits_keys/hkdf.js
@@ -86,7 +86,7 @@ function define_tests() {
                             // - illegal name for hash algorithm (NotSupportedError)
                             var badHash = hashName.substring(0, 3) + hashName.substring(4);
                             subsetTest(promise_test, function(test) {
-                                var badAlgorithm = {name: "HKDF", salt: salts[saltSize], hash: badHash};
+                                var badAlgorithm = {name: "HKDF", salt: salts[saltSize], hash: badHash, info: algorithm.info};
                                 return subtle.deriveKey(badAlgorithm, baseKeys[derivedKeySize], derivedKeyType.algorithm, true, derivedKeyType.usages)
                                 .then(function(key) {
                                     assert_unreached("bad hash name should have thrown an NotSupportedError");
@@ -162,7 +162,7 @@ function define_tests() {
                         // - illegal name for hash algorithm (NotSupportedError)
                         var badHash = hashName.substring(0, 3) + hashName.substring(4);
                         subsetTest(promise_test, function(test) {
-                            var badAlgorithm = {name: "HKDF", salt: salts[saltSize], hash: badHash};
+                            var badAlgorithm = {name: "HKDF", salt: salts[saltSize], hash: badHash, info: algorithm.info};
                             return subtle.deriveBits(badAlgorithm, baseKeys[derivedKeySize], 256)
                             .then(function(derivation) {
                                 assert_unreached("bad hash name should have thrown an NotSupportedError");


### PR DESCRIPTION
This test is missing the `required BufferSource info` (see [31.3 of the spec](https://www.w3.org/TR/WebCryptoAPI/#hkdf-params)), causing WebIDL conversion to fail instead of the intended error.

Refs: https://github.com/nodejs/webcrypto/issues/36