### PR TITLE
Ignore unexpected MessageEvents

### DIFF
--- a/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
+++ b/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
@@ -27,6 +27,9 @@ async_test((t) => {
   });
 
   window.onmessage = t.step_func((e) => {
+    // Ignore messages that are not part of the test.
+    if (e.source != iframe.contentWindow) return;
+
     i++;
     if (i === 1) {
       // 5. This is the first message we receive, from the first load.

--- a/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
+++ b/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
@@ -22,11 +22,15 @@ async_test((t) => {
     iframe.contentWindow.postMessage('What is the result of new PaymentRequest(...)?', '*');
   });
 
-  window.onmessage = t.step_func_done((e) => {
+  window.onmessage = t.step_func((e) => {
+    // Ignore messages that are not part of the test.
+    if (e.source != iframe.contentWindow) return;
+
     assert_equals(e.data.message, 'Exception');
     assert_equals(4, e.data.details.length);
     // The last entry is the error stacktrace. Ignore it in comparison.
     assert_array_equals(e.data.details.slice(0, 3), [true /* ex instanceof DOMException */, DOMException.SECURITY_ERR, 'SecurityError']);
+    t.done();
   });
 
   document.body.appendChild(iframe);

--- a/payment-request/allowpaymentrequest/setting-allowpaymentrequest.https.sub.html
+++ b/payment-request/allowpaymentrequest/setting-allowpaymentrequest.https.sub.html
@@ -20,6 +20,9 @@ async_test((t) => {
   });
 
   window.onmessage = t.step_func((e) => {
+    // Ignore messages that are not part of the test.
+    if (e.source != iframe.contentWindow) return;
+
     i++;
     if (i === 1) {
       assert_equals(e.data.message, 'Exception', 'before navigation');


### PR DESCRIPTION
When running these tests in the web runner, extra `MessageEvent`s sometimes appear before the ones generated by the test iframe and causes the test to fail. This patch modifies the test to ignore any messages that are not from the test iframe to improve the consistency of the test.