### PR TITLE
Verify that COOP severed the relationship on the Opener's side, with the popup's initial Browsing context closed.

### DIFF
--- a/html/cross-origin-opener-policy/blob-popup.https.html
+++ b/html/cross-origin-opener-policy/blob-popup.https.html
@@ -21,9 +21,11 @@ async_test(t => {
 const w = window.open("${get_host_info().HTTPS_REMOTE_ORIGIN}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=x&coep=x&channel=${bc.name}", "${bc.name}");
 window.opener.furtherPopup = w;
 
-// w will be closed by its postback iframe. When out of process,
-// window.close() does not work.
-window.opener.test.add_cleanup(() => w.close());
+// Close the popup once the test is complete.
+// The window proxy is closed hence use the broadcast channel to trigger the closure.
+window.opener.test.add_cleanup(() => {
+  bc.postMessage( "close" );
+});
 <\/script>`;
   const blob = new Blob([blobContents], { type: "text/html" });
   const blobURL = URL.createObjectURL(blob);

--- a/html/cross-origin-opener-policy/blob-popup.https.html
+++ b/html/cross-origin-opener-policy/blob-popup.https.html
@@ -22,9 +22,9 @@ const w = window.open("${get_host_info().HTTPS_REMOTE_ORIGIN}/html/cross-origin-
 window.opener.furtherPopup = w;
 
 // Close the popup once the test is complete.
-// The window proxy is closed hence use the broadcast channel to trigger the closure.
+// The browsing context is closed hence use the broadcast channel to trigger the closure.
 window.opener.test.add_cleanup(() => {
-  bc.postMessage( "close" );
+  bc.postMessage("close");
 });
 <\/script>`;
   const blob = new Blob([blobContents], { type: "text/html" });

--- a/html/cross-origin-opener-policy/blob-popup.https.html
+++ b/html/cross-origin-opener-policy/blob-popup.https.html
@@ -20,17 +20,17 @@ async_test(t => {
   const blobContents = `<script>
 const w = window.open("${get_host_info().HTTPS_REMOTE_ORIGIN}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=x&coep=x&channel=${bc.name}", "${bc.name}");
 window.opener.furtherPopup = w;
-
-// Close the popup once the test is complete.
-// The browsing context is closed hence use the broadcast channel to trigger the closure.
-window.opener.test.add_cleanup(() => {
-  bc.postMessage("close");
-});
 <\/script>`;
   const blob = new Blob([blobContents], { type: "text/html" });
   const blobURL = URL.createObjectURL(blob);
   const popup = window.open(blobURL);
-  t.add_cleanup(() => popup.close());
+  t.add_cleanup(() => {
+    // Close the popups once the test is complete.
+    // The browsing context of the second popup is closed hence use the
+    //  broadcast channel to trigger the closure.
+    bc.postMessage("close");
+    popup.close();
+  });
   popup.onload = t.step_func(() => {
     assert_equals(popup.opener, window);
     assert_equals(popup.location.href, blobURL);

--- a/html/cross-origin-opener-policy/coop-navigated-popup.https.html
+++ b/html/cross-origin-opener-policy/coop-navigated-popup.https.html
@@ -12,7 +12,12 @@ async_test(t => {
   const noCOOP = "/common/blank.html";
   const popupName = token();
   const popup = window.open(noCOOP, popupName);
-  t.add_cleanup(() => popup.close());
+  // Close the popup once the test is complete.
+  // The window proxy is closed after the navigation hence use the broadcast channel
+  // to trigger the closure.
+  t.add_cleanup(() => {
+    bc.postMessage( "close" );
+  });
   popup.onload = t.step_func(() => {
     assert_equals(popup.name, popupName);
     assert_equals(new URL(popup.document.URL).pathname, noCOOP);
@@ -23,6 +28,7 @@ async_test(t => {
       // string comparison to "" to keep the random token out of error messages.
       assert_equals(payload.name.length, 0);
       assert_false(payload.opener);
+      assert_true(popup.closed);
     });
     const coop = `resources/coop-coep.py?coop=same-origin&coep=&channel=${channel.name}`;
     popup.location = coop;

--- a/html/cross-origin-opener-policy/coop-navigated-popup.https.html
+++ b/html/cross-origin-opener-policy/coop-navigated-popup.https.html
@@ -13,10 +13,10 @@ async_test(t => {
   const popupName = token();
   const popup = window.open(noCOOP, popupName);
   // Close the popup once the test is complete.
-  // The window proxy is closed after the navigation hence use the broadcast channel
+  // The browsing context is closed after the navigation hence use the broadcast channel
   // to trigger the closure.
   t.add_cleanup(() => {
-    bc.postMessage( "close" );
+    bc.postMessage("close");
   });
   popup.onload = t.step_func(() => {
     assert_equals(popup.name, popupName);

--- a/html/cross-origin-opener-policy/popup-redirect-cache.https.html
+++ b/html/cross-origin-opener-policy/popup-redirect-cache.https.html
@@ -15,6 +15,7 @@ function url_test_cache(t, url, channelName, hasOpener) {
     const payload = event.data;
     assert_equals(payload.name, hasOpener ? channelName : "");
     assert_equals(payload.opener, hasOpener);
+    assert_equals(w.closed, !hasOpener);
     bc.close()
 
     // test the same url for cache
@@ -23,9 +24,7 @@ function url_test_cache(t, url, channelName, hasOpener) {
 
   const w = window.open(url, channelName);
 
-  // w will be closed by its postback iframe. When out of process,
-  // window.close() does not work.
-  t.add_cleanup(() => w.close());
+  // The popup is closed by url_test.
 }
 
 // Redirect from hostA to hostB with same coop and coep.

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -12,6 +12,7 @@ function url_test(t, url, channelName, hasOpener, openerDOMAccess) {
     if (openerDOMAccess !== undefined) {
       assert_equals(payload.openerDOMAccess, openerDOMAccess, 'openerDOMAccess');
     }
+    assert_equals(w.closed, !hasOpener, 'Openee window proxy closed');
   });
 
   const w = window.open(url, channelName);

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -12,16 +12,16 @@ function url_test(t, url, channelName, hasOpener, openerDOMAccess) {
     if (openerDOMAccess !== undefined) {
       assert_equals(payload.openerDOMAccess, openerDOMAccess, 'openerDOMAccess');
     }
-    assert_equals(w.closed, !hasOpener, 'Openee window proxy closed');
+    assert_equals(w.closed, !hasOpener, 'Openee browsing context closed');
   });
 
   const w = window.open(url, channelName);
 
   // Close the popup once the test is complete.
-  // The window proxy might be closed hence use the broadcast channel
+  // The browsing context might be closed hence use the broadcast channel
   // to trigger the closure.
   t.add_cleanup(() => {
-    bc.postMessage( "close" );
+    bc.postMessage("close");
   });
 }
 
@@ -49,11 +49,11 @@ function run_coop_test_iframe (documentTitle, iframe_origin, popup_origin, popup
       const frame = document.createElement("iframe");
 
       // Close the popup and remove the frame once the test is
-      // complete. The window proxy might be closed hence use the
+      // complete. The browsing context might be closed hence use the
       // broadcast channel to trigger the closure.
       t.add_cleanup(() => {
         frame.remove();
-        bc.postMessage( "close" );
+        bc.postMessage("close");
       });
 
       const origin = CROSS_ORIGIN.origin;

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -21,7 +21,6 @@ function url_test(t, url, channelName, hasOpener, openerDOMAccess) {
   // The window proxy might be closed hence use the broadcast channel
   // to trigger the closure.
   t.add_cleanup(() => {
-    bc.onmessage = null;
     bc.postMessage( "close" );
   });
 }
@@ -54,7 +53,6 @@ function run_coop_test_iframe (documentTitle, iframe_origin, popup_origin, popup
       // broadcast channel to trigger the closure.
       t.add_cleanup(() => {
         frame.remove();
-        bc.onmessage = null;
         bc.postMessage( "close" );
       });
 

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -17,9 +17,13 @@ function url_test(t, url, channelName, hasOpener, openerDOMAccess) {
 
   const w = window.open(url, channelName);
 
-  // w will be closed by its postback iframe. When out of process,
-  // window.close() does not work.
-  t.add_cleanup(() => w.close());
+  // Close the popup once the test is complete.
+  // The window proxy might be closed hence use the broadcast channel
+  // to trigger the closure.
+  t.add_cleanup(() => {
+    bc.onmessage = null;
+    bc.postMessage( "close" );
+  });
 }
 
 function coop_coep_test(t, host, coop, coep, channelName, hasOpener, openerDOMAccess) {

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -48,7 +48,15 @@ function run_coop_test_iframe (documentTitle, iframe_origin, popup_origin, popup
   const name = iframe_origin.name + "_iframe_opening_" + popup_origin.name + "_popup_with_coop_" + popup_coop;
   async_test(t => {
       const frame = document.createElement("iframe");
-      t.add_cleanup(() => { frame.remove(); });
+
+      // Close the popup and remove the frame once the test is
+      // complete. The window proxy might be closed hence use the
+      // broadcast channel to trigger the closure.
+      t.add_cleanup(() => {
+        frame.remove();
+        bc.onmessage = null;
+        bc.postMessage( "close" );
+      });
 
       const origin = CROSS_ORIGIN.origin;
       const path = new URL("resources/iframe-popup.sub.html", window.location).pathname;

--- a/html/cross-origin-opener-policy/resources/coop-coep.py
+++ b/html/cross-origin-opener-policy/resources/coop-coep.py
@@ -50,6 +50,13 @@ def main(request, response):
       openerDOMAccessAllowed = !!self.opener.document.URL;
     } catch(ex) {
     }
+    // Handle the response from the frame, closing the popup once the
+    // test completes.
+    addEventListener("message", event => {
+      if( event.data == "close" ) {
+        close();
+      }
+    });
     const iframe = document.querySelector("iframe");
     iframe.onload = () => {
       const payload = { name: self.name, opener: !!self.opener, openerDOMAccess: openerDOMAccessAllowed };

--- a/html/cross-origin-opener-policy/resources/coop-coep.py
+++ b/html/cross-origin-opener-policy/resources/coop-coep.py
@@ -53,7 +53,7 @@ def main(request, response):
     // Handle the response from the frame, closing the popup once the
     // test completes.
     addEventListener("message", event => {
-      if( event.data == "close" ) {
+      if (event.data == "close") {
         close();
       }
     });

--- a/html/cross-origin-opener-policy/resources/postback.html
+++ b/html/cross-origin-opener-policy/resources/postback.html
@@ -5,6 +5,5 @@ const channelName = new URL(location).searchParams.get("channel");
 const bc = new BroadcastChannel(channelName);
 window.addEventListener("message", event => {
   bc.postMessage(event.data);
-  window.parent.close();
 });
 </script>

--- a/html/cross-origin-opener-policy/resources/postback.html
+++ b/html/cross-origin-opener-policy/resources/postback.html
@@ -3,6 +3,13 @@
 <script>
 const channelName = new URL(location).searchParams.get("channel");
 const bc = new BroadcastChannel(channelName);
+
+bc.onmessage = event => {
+  if( event.data == "close" ) {
+    parent.close();
+  }
+};
+
 window.addEventListener("message", event => {
   bc.postMessage(event.data);
 });

--- a/html/cross-origin-opener-policy/resources/postback.html
+++ b/html/cross-origin-opener-policy/resources/postback.html
@@ -6,9 +6,9 @@ const bc = new BroadcastChannel(channelName);
 
 // Handle the close message from the test-cleanup, forwarding it to the
 // top level document, as this iframe and the opening document might not
-// be ale to close the popup.
+// be able to close the popup.
 bc.onmessage = event => {
-  if( event.data == "close" ) {
+  if (event.data == "close") {
     top.postMessage("close", "*");
   }
 };

--- a/html/cross-origin-opener-policy/resources/postback.html
+++ b/html/cross-origin-opener-policy/resources/postback.html
@@ -4,9 +4,12 @@
 const channelName = new URL(location).searchParams.get("channel");
 const bc = new BroadcastChannel(channelName);
 
+// Handle the close message from the test-cleanup, forwarding it to the
+// top level document, as this iframe and the opening document might not
+// be ale to close the popup.
 bc.onmessage = event => {
   if( event.data == "close" ) {
-    parent.close();
+    top.postMessage("close", "*");
   }
 };
 


### PR DESCRIPTION
This adds am assertion to verify the windowProxy object is closed.