### PR TITLE
Fix and refactor some "handleEvent" tests

### DIFF
--- a/css/cssom-view/MediaQueryList-addListener-handleEvent.html
+++ b/css/cssom-view/MediaQueryList-addListener-handleEvent.html
@@ -71,36 +71,38 @@ promise_test(async t => {
     assert_equals(calls, 1);
 }, "doesn't look up handleEvent method on callable event listeners");
 
-const uncaught_error_test = async (t, listener) => {
+const uncaught_error_test = async (t, getHandleEvent) => {
     const mql = await createMQL(t);
-    mql.addListener(listener);
 
-    const eventWatcher = new EventWatcher(t, window, "error");
+    let calls = 0;
+    mql.addListener({
+        get handleEvent() {
+            calls++;
+            return getHandleEvent();
+        },
+    });
+
+    const eventWatcher = new EventWatcher(t, window, "error", waitForChangesReported);
     const errorPromise = eventWatcher.wait_for("error");
     triggerMQLEvent(mql);
 
     const event = await errorPromise;
+    assert_equals(calls, 1, "handleEvent property was not looked up");
     throw event.error;
 };
 
 promise_test(t => {
     const error = { name: "test" };
-    const listener = {
-        get handleEvent() {
-            throw error;
-        },
-    };
 
-    return promise_rejects_exactly(t, error, uncaught_error_test(t, listener));
+    return promise_rejects_exactly(t, error,
+        uncaught_error_test(t, () => { throw error; }));
 }, "rethrows errors when getting handleEvent");
 
 promise_test(t => {
-    const listener = { handleEvent: null };
-    return promise_rejects(t, new TypeError(), uncaught_error_test(t, listener));
+    return promise_rejects(t, new TypeError(), uncaught_error_test(t, () => false));
 }, "throws if handleEvent is falsy and not callable");
 
 promise_test(t => {
-    const listener = { handleEvent: "str" };
-    return promise_rejects(t, new TypeError(), uncaught_error_test(t, listener));
+    return promise_rejects(t, new TypeError(), uncaught_error_test(t, () => "str"));
 }, "throws if handleEvent is thruthy and not callable");
 </script>

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -30,30 +30,6 @@ test(function(t) {
 test(function(t) {
     var type = "foo";
     var target = document.createElement("div");
-    var thrownError = { name: "test" };
-    var uncaughtError;
-    var errorHandler = function(event) {
-        uncaughtError = event.error;
-    };
-
-    window.addEventListener("error", errorHandler);
-    t.add_cleanup(function() {
-        window.removeEventListener("error", errorHandler);
-    });
-
-    target.addEventListener(type, {
-        get handleEvent() {
-            throw thrownError;
-        },
-    });
-
-    target.dispatchEvent(new Event(type));
-    assert_equals(thrownError, uncaughtError);
-}, "rethrows errors when getting `handleEvent`");
-
-test(function(t) {
-    var type = "foo";
-    var target = document.createElement("div");
     var calls = 0;
 
     target.addEventListener(type, {
@@ -81,45 +57,46 @@ test(function(t) {
     assert_equals(calls, 1);
 }, "doesn't call `handleEvent` method on callable `EventListener`");
 
-test(function(t) {
-    var type = "foo";
-    var target = document.createElement("div");
-    var uncaughtError;
-    var errorHandler = function(event) {
-        uncaughtError = event.error;
+const uncaught_error_test = async (t, getHandleEvent) => {
+    const type = "foo";
+    const target = document.createElement("div");
+
+    let calls = 0;
+    target.addEventListener(type, {
+        get handleEvent() {
+            calls++;
+            return getHandleEvent();
+        },
+    });
+
+    const timeout = () => {
+        return new Promise(resolve => {
+            t.step_timeout(resolve, 0);
+        });
     };
 
-    window.addEventListener("error", errorHandler);
-    t.add_cleanup(function() {
-        window.removeEventListener("error", errorHandler);
-    });
-
-    target.addEventListener(type, {
-        handleEvent: null,
-    });
+    const eventWatcher = new EventWatcher(t, window, "error", timeout);
+    const errorPromise = eventWatcher.wait_for("error");
 
     target.dispatchEvent(new Event(type));
-    assert_true(uncaughtError instanceof TypeError);
+
+    const event = await errorPromise;
+    assert_equals(calls, 1, "handleEvent property was not looked up");
+    throw event.error;
+};
+
+promise_test(t => {
+    const error = { name: "test" };
+
+    return promise_rejects_exactly(t, error,
+        uncaught_error_test(t, () => { throw error; }));
+}, "rethrows errors when getting `handleEvent`");
+
+promise_test(t => {
+    return promise_rejects(t, new TypeError(), uncaught_error_test(t, () => null));
 }, "throws if `handleEvent` is falsy and not callable");
 
-test(function(t) {
-    var type = "foo";
-    var target = document.createElement("div");
-    var uncaughtError;
-    var errorHandler = function(event) {
-        uncaughtError = event.error;
-    };
-
-    window.addEventListener("error", errorHandler);
-    t.add_cleanup(function() {
-        window.removeEventListener("error", errorHandler);
-    });
-
-    target.addEventListener(type, {
-        handleEvent: 1,
-    });
-
-    target.dispatchEvent(new Event(type));
-    assert_true(uncaughtError instanceof TypeError);
+promise_test(t => {
+    return promise_rejects(t, new TypeError(), uncaught_error_test(t, () => 42));
 }, "throws if `handleEvent` is thruthy and not callable");
 </script>


### PR DESCRIPTION
WebKit issue: [MediaQueryList should extend EventTarget](https://bugs.webkit.org/show_bug.cgi?id=203288).
Follow-up of #15105 and #20401.

//cc @zcorpan @emilio