### PR TITLE
Convert binary data returned by call() to use it as a string

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1212,7 +1212,7 @@ class WebKitGTKMiniBrowser(WebKit):
         gcc = find_executable("gcc")
         if gcc:
             try:
-                triplet = call(gcc, "-dumpmachine").strip()
+                triplet = call(gcc, "-dumpmachine").decode().strip()
             except subprocess.CalledProcessError:
                 pass
         # Add Debian/Ubuntu path
@@ -1231,7 +1231,7 @@ class WebKitGTKMiniBrowser(WebKit):
         if binary is None:
             return None
         try:  # WebKitGTK MiniBrowser before 2.26.0 doesn't support --version
-            output = call(binary, "--version").strip()
+            output = call(binary, "--version").decode().strip()
         except subprocess.CalledProcessError:
             return None
         # Example output: "WebKitGTK 2.26.1"


### PR DESCRIPTION
subprocess.check_output() returns binary data as output. In python2, binary is basically an alias of str so it can be directly used as a normal string. However in python3 the binary data is different to a string. Inserting binary data into a string in python3 generates strings like '/some/path/with/b'binary'/data/inserted' which are not correct file paths. We must decode() the returned data in order to use it as a string.