### PR TITLE
Test entry and incumbent settings object for promise jobs

### DIFF
--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry-different-function-realm.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry-different-function-realm.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Entry settings object for promise jobs when the function realm is different from the test realm</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- https://github.com/whatwg/html/pull/5212 -->
+<!-- https://github.com/whatwg/html/issues/1426 -->
+
+<!-- This is what would normally be considered the entry page. However, we use functions from the
+     resources/function/function.html realm. So window.open() should resolve relative to that realm
+     inside promise jobs. -->
+
+<iframe src="resources/promise-job-entry-incumbent.html"></iframe>
+<iframe src="resources/function/function.html" id="function-frame"></iframe>
+
+<script>
+setup({ explicit_done: true });
+
+const relativeURL = "resources/window-to-open.html";
+const expectedURL = (new URL(relativeURL, document.querySelector("#function-frame").src)).href;
+
+const incumbentWindow = frames[0];
+const functionWindow = frames[1];
+const FunctionFromAnotherWindow = frames[1].Function;
+
+window.onload = () => {
+  async_test(t => {
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = arguments[0];
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    Promise.resolve([incumbentWindow, relativeURL, t, assert_equals, expectedURL]).then(func);
+  }, "Fulfillment handler on fulfilled promise");
+
+  async_test(t => {
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = arguments[0];
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    Promise.reject([incumbentWindow, relativeURL, t, assert_equals, expectedURL]).catch(func);
+  }, "Rejection handler on rejected promise");
+
+  async_test(t => {
+    let resolve;
+    const p = new Promise(r => { resolve = r; });
+
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = arguments[0];
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    p.then(func);
+    t.step_timeout(() => resolve([incumbentWindow, relativeURL, t, assert_equals, expectedURL]), 0);
+  }, "Fulfillment handler on pending-then-fulfilled promise");
+
+  async_test(t => {
+    let reject;
+    const p = new Promise((_, r) => { reject = r; });
+
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = arguments[0];
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    p.catch(func);
+    t.step_timeout(() => reject([incumbentWindow, relativeURL, t, assert_equals, expectedURL]), 0);
+  }, "Rejection handler on pending-then-rejected promise");
+
+  async_test(t => {
+    t.add_cleanup(() => { delete frames[1].args; });
+    frames[1].args = [incumbentWindow, relativeURL, t, assert_equals, expectedURL];
+
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = window.args;
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    const thenable = { then: func };
+
+    Promise.resolve(thenable);
+  }, "Thenable resolution");
+
+  done();
+};
+</script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry.html
@@ -26,36 +26,39 @@ window.onload = () => {
   }, "Sanity check: this all works as expected with no promises involved");
 
   async_test(t => {
-    Promise.resolve().then(t.step_func(() => {
+    // No t.step_func because that could change the realms
+    Promise.resolve().then(() => {
       const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
       w.onload = t.step_func_done(() => {
         t.add_cleanup(() => w.close());
         assert_equals(w.location.href, expectedURL);
       });
-    }));
+    });
   }, "Fulfillment handler on fulfilled promise");
 
   async_test(t => {
-    Promise.reject().catch(t.step_func(() => {
+    // No t.step_func because that could change the realms
+    Promise.reject().catch(() => {
       const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
       w.onload = t.step_func_done(() => {
         t.add_cleanup(() => w.close());
         assert_equals(w.location.href, expectedURL);
       });
-    }));
+    });
   }, "Rejection handler on rejected promise");
 
   async_test(t => {
     let resolve;
     const p = new Promise(r => { resolve = r; });
 
-    p.then(t.step_func(() => {
+    // No t.step_func because that could change the realms
+    p.then(() => {
       const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
       w.onload = t.step_func_done(() => {
         t.add_cleanup(() => w.close());
         assert_equals(w.location.href, expectedURL);
       });
-    }));
+    });
 
     t.step_timeout(resolve, 0);
   }, "Fulfillment handler on pending-then-fulfilled promise");
@@ -64,26 +67,28 @@ window.onload = () => {
     let reject;
     const p = new Promise((_, r) => { reject = r; });
 
-    p.catch(t.step_func(() => {
+    // No t.step_func because that could change the realms
+    p.catch(() => {
       const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
       w.onload = t.step_func_done(() => {
         t.add_cleanup(() => w.close());
         assert_equals(w.location.href, expectedURL);
       });
-    }));
+    });
 
     t.step_timeout(reject, 0);
   }, "Rejection handler on pending-then-rejected promise");
 
   async_test(t => {
     const thenable = {
-      then: t.step_func((f) => {
+      // No t.step_func because that could change the realms
+      then(f) {
         const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
         w.onload = t.step_func_done(() => {
           t.add_cleanup(() => w.close());
           assert_equals(w.location.href, expectedURL);
         });
-      })
+      }
     };
 
     Promise.resolve(thenable);

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry.html
@@ -16,9 +16,11 @@ setup({ explicit_done: true });
 const relativeURL = "resources/window-to-open.html";
 const expectedURL = (new URL(relativeURL, location.href)).href;
 
+const incumbentWindow = frames[0];
+
 window.onload = () => {
   async_test(t => {
-    const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+    const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
     w.onload = t.step_func_done(() => {
       t.add_cleanup(() => w.close());
       assert_equals(w.location.href, expectedURL);
@@ -28,7 +30,7 @@ window.onload = () => {
   async_test(t => {
     // No t.step_func because that could change the realms
     Promise.resolve().then(() => {
-      const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
       w.onload = t.step_func_done(() => {
         t.add_cleanup(() => w.close());
         assert_equals(w.location.href, expectedURL);
@@ -39,7 +41,7 @@ window.onload = () => {
   async_test(t => {
     // No t.step_func because that could change the realms
     Promise.reject().catch(() => {
-      const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
       w.onload = t.step_func_done(() => {
         t.add_cleanup(() => w.close());
         assert_equals(w.location.href, expectedURL);
@@ -53,7 +55,7 @@ window.onload = () => {
 
     // No t.step_func because that could change the realms
     p.then(() => {
-      const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
       w.onload = t.step_func_done(() => {
         t.add_cleanup(() => w.close());
         assert_equals(w.location.href, expectedURL);
@@ -69,7 +71,7 @@ window.onload = () => {
 
     // No t.step_func because that could change the realms
     p.catch(() => {
-      const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
       w.onload = t.step_func_done(() => {
         t.add_cleanup(() => w.close());
         assert_equals(w.location.href, expectedURL);
@@ -83,7 +85,7 @@ window.onload = () => {
     const thenable = {
       // No t.step_func because that could change the realms
       then(f) {
-        const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+        const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
         w.onload = t.step_func_done(() => {
           t.add_cleanup(() => w.close());
           assert_equals(w.location.href, expectedURL);

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Entry settings object for promise jobs</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- https://github.com/whatwg/html/pull/5212 -->
+<!-- https://github.com/whatwg/html/issues/1426 -->
+
+<!-- This is the entry page, so window.open() should resolve relative to it, even inside promise jobs. -->
+
+<iframe src="resources/promise-job-entry-incumbent.html"></iframe>
+
+<script>
+setup({ explicit_done: true });
+
+const relativeURL = "resources/window-to-open.html";
+const expectedURL = (new URL(relativeURL, location.href)).href;
+
+window.onload = () => {
+  async_test(t => {
+    const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+    w.onload = t.step_func_done(() => {
+      t.add_cleanup(() => w.close());
+      assert_equals(w.location.href, expectedURL);
+    });
+  }, "Sanity check: this all works as expected with no promises involved");
+
+  async_test(t => {
+    Promise.resolve().then(t.step_func(() => {
+      const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    }));
+  }, "Fulfillment handler on fulfilled promise");
+
+  async_test(t => {
+    Promise.reject().catch(t.step_func(() => {
+      const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    }));
+  }, "Rejection handler on rejected promise");
+
+  async_test(t => {
+    let resolve;
+    const p = new Promise(r => { resolve = r; });
+
+    p.then(t.step_func(() => {
+      const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    }));
+
+    t.step_timeout(resolve, 0);
+  }, "Fulfillment handler on pending-then-fulfilled promise");
+
+  async_test(t => {
+    let reject;
+    const p = new Promise((_, r) => { reject = r; });
+
+    p.catch(t.step_func(() => {
+      const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    }));
+
+    t.step_timeout(reject, 0);
+  }, "Rejection handler on pending-then-rejected promise");
+
+  async_test(t => {
+    const thenable = {
+      then: t.step_func((f) => {
+        const w = frames[0].runWindowOpenVeryIndirectly(relativeURL);
+        w.onload = t.step_func_done(() => {
+          t.add_cleanup(() => w.close());
+          assert_equals(w.location.href, expectedURL);
+        });
+      })
+    };
+
+    Promise.resolve(thenable);
+  }, "Thenable resolution");
+
+  done();
+};
+</script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
@@ -27,13 +27,13 @@ window.onload = () => {
     const thisTestId = testId;
 
     relevantWindow.addEventListener("messagereceived", t.step_func(e => {
-      const [recievedTestId, recievedSourceURL] = e.detail;
+      const [receivedTestId, receivedSourceURL] = e.detail;
 
-      if (recievedTestId !== thisTestId) {
+      if (receivedTestId !== thisTestId) {
         return;
       }
 
-      assert_equals(recievedSourceURL, expectedURL);
+      assert_equals(receivedSourceURL, expectedURL);
       t.done();
     }));
 
@@ -78,7 +78,7 @@ window.onload = () => {
     frames[0].runWindowPostMessageVeryIndirectlyWithNoUserCode(p, "catch", thisTestId, "*");
   }, "Rejection handler on rejected promise, using backup incumbent settings object stack");
 
-  // The following test that we derive the incumbent settings object at promise-job time from
+  // The following tests test that we derive the incumbent settings object at promise-job time from
   // the incumbent realm at the time the handler was added, not at the time the resolve()/reject()
   // was done. See https://github.com/whatwg/html/issues/5213 for the spec side of this issue.
 

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
@@ -3,22 +3,24 @@
 <title>Incumbent settings object for promise jobs</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<!-- https://github.com/whatwg/html/pull/5212 -->
-<!-- https://github.com/whatwg/html/issues/1426 -->
 
-<!-- This is the entry page -->
+<!-- This is the entry page. -->
 
 <iframe src="resources/promise-job-incumbent-incumbent.html"></iframe>
+<iframe src="resources/promise-job-incumbent-resolver.html"></iframe>
 
 <script>
 setup({ explicit_done: true });
 
+// postMessage should pick the incumbent page as its .source value to set on the MessageEvent, even
+// inside promise jobs.
 const expectedURL = (new URL("resources/promise-job-incumbent-incumbent.html", location.href)).href;
 
 let testId = 0;
 
 window.onload = () => {
   const relevantWindow = frames[0].document.querySelector("#r").contentWindow;
+  const runInResolver = frames[1].runWhatYouGiveMe;
 
   function setupTest(t) {
     ++testId;
@@ -60,6 +62,10 @@ window.onload = () => {
     });
   }, "Rejection handler on rejected promise");
 
+  // The following two test that we derive the incumbent settings object at promise-job time from
+  // the incumbent realm at the time the handler was added, not at the time the resolve()/reject()
+  // was done. See https://github.com/whatwg/html/issues/5213 for the spec side of this issue.
+
   async_test(t => {
     const thisTestId = setupTest(t);
 
@@ -70,7 +76,9 @@ window.onload = () => {
       frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
     }));
 
-    t.step_timeout(resolve, 0);
+    t.step_timeout(() => {
+      runInResolver(resolve);
+    }, 0);
   }, "Fulfillment handler on pending-then-fulfilled promise");
 
   async_test(t => {
@@ -83,7 +91,9 @@ window.onload = () => {
       frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
     }));
 
-    t.step_timeout(reject, 0);
+    t.step_timeout(() => {
+      runInResolver(reject);
+    }, 0);
   }, "Rejection handler on pending-then-rejected promise");
 
   async_test(t => {

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
@@ -58,13 +58,27 @@ window.onload = () => {
   async_test(t => {
     const thisTestId = setupTest(t);
 
+    const p = Promise.resolve();
+    frames[0].runWindowPostMessageVeryIndirectlyWithNoUserCode(p, "then", thisTestId, "*");
+  }, "Fulfillment handler on fulfilled promise, using backup incumbent settings object stack");
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
     // No t.step_func because that could change the realms
     Promise.reject().catch(() => {
       frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
     });
   }, "Rejection handler on rejected promise");
 
-  // The following two test that we derive the incumbent settings object at promise-job time from
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
+    const p = Promise.reject();
+    frames[0].runWindowPostMessageVeryIndirectlyWithNoUserCode(p, "catch", thisTestId, "*");
+  }, "Rejection handler on rejected promise, using backup incumbent settings object stack");
+
+  // The following test that we derive the incumbent settings object at promise-job time from
   // the incumbent realm at the time the handler was added, not at the time the resolve()/reject()
   // was done. See https://github.com/whatwg/html/issues/5213 for the spec side of this issue.
 
@@ -87,6 +101,19 @@ window.onload = () => {
   async_test(t => {
     const thisTestId = setupTest(t);
 
+    let resolve;
+    const p = new Promise(r => { resolve = r; });
+
+    frames[0].runWindowPostMessageVeryIndirectlyWithNoUserCode(p, "then", thisTestId, "*");
+
+    t.step_timeout(() => {
+      runInResolver(resolve);
+    }, 0);
+  }, "Fulfillment handler on pending-then-fulfilled promise, using backup incumbent settings object stack");
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
     let reject;
     const p = new Promise((_, r) => { reject = r; });
 
@@ -103,6 +130,19 @@ window.onload = () => {
   async_test(t => {
     const thisTestId = setupTest(t);
 
+    let reject;
+    const p = new Promise((_, r) => { reject = r; });
+
+    frames[0].runWindowPostMessageVeryIndirectlyWithNoUserCode(p, "catch", thisTestId, "*");
+
+    t.step_timeout(() => {
+      runInResolver(reject);
+    }, 0);
+  }, "Rejection handler on pending-then-rejected promise, using backup incumbent settings object stack");
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
     const thenable = {
       // No t.step_func because that could change the realms
       then(f) {
@@ -112,6 +152,12 @@ window.onload = () => {
 
     Promise.resolve(thenable);
   }, "Thenable resolution");
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
+    frames[0].resolveThenableThatRunsWindowPostMessageVeryIndirectlyWithNoUserCode(testId, "*", []);
+  }, "Thenable resolution, using backup incumbent settings object stack");
 
   done();
 };

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
@@ -49,6 +49,7 @@ window.onload = () => {
   async_test(t => {
     const thisTestId = setupTest(t);
 
+    // No t.step_func because that could change the realms
     Promise.resolve().then(() => {
       frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
     });
@@ -57,6 +58,7 @@ window.onload = () => {
   async_test(t => {
     const thisTestId = setupTest(t);
 
+    // No t.step_func because that could change the realms
     Promise.reject().catch(() => {
       frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
     });
@@ -72,9 +74,10 @@ window.onload = () => {
     let resolve;
     const p = new Promise(r => { resolve = r; });
 
-    p.then(t.step_func(() => {
+    // No t.step_func because that could change the realms
+    p.then(() => {
       frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
-    }));
+    });
 
     t.step_timeout(() => {
       runInResolver(resolve);
@@ -87,9 +90,10 @@ window.onload = () => {
     let reject;
     const p = new Promise((_, r) => { reject = r; });
 
-    p.catch(t.step_func(() => {
+    // No t.step_func because that could change the realms
+    p.catch(() => {
       frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
-    }));
+    });
 
     t.step_timeout(() => {
       runInResolver(reject);
@@ -100,9 +104,10 @@ window.onload = () => {
     const thisTestId = setupTest(t);
 
     const thenable = {
-      then: t.step_func((f) => {
+      // No t.step_func because that could change the realms
+      then(f) {
         frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
-      })
+      }
     };
 
     Promise.resolve(thenable);

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-incumbent.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Incumbent settings object for promise jobs</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- https://github.com/whatwg/html/pull/5212 -->
+<!-- https://github.com/whatwg/html/issues/1426 -->
+
+<!-- This is the entry page -->
+
+<iframe src="resources/promise-job-incumbent-incumbent.html"></iframe>
+
+<script>
+setup({ explicit_done: true });
+
+const expectedURL = (new URL("resources/promise-job-incumbent-incumbent.html", location.href)).href;
+
+let testId = 0;
+
+window.onload = () => {
+  const relevantWindow = frames[0].document.querySelector("#r").contentWindow;
+
+  function setupTest(t) {
+    ++testId;
+    const thisTestId = testId;
+
+    relevantWindow.addEventListener("messagereceived", t.step_func(e => {
+      const [recievedTestId, recievedSourceURL] = e.detail;
+
+      if (recievedTestId !== thisTestId) {
+        return;
+      }
+
+      assert_equals(recievedSourceURL, expectedURL);
+      t.done();
+    }));
+
+    return thisTestId;
+  }
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
+    frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
+  }, "Sanity check: this all works as expected with no promises involved");
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
+    Promise.resolve().then(() => {
+      frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
+    });
+  }, "Fulfillment handler on fulfilled promise");
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
+    Promise.reject().catch(() => {
+      frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
+    });
+  }, "Rejection handler on rejected promise");
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
+    let resolve;
+    const p = new Promise(r => { resolve = r; });
+
+    p.then(t.step_func(() => {
+      frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
+    }));
+
+    t.step_timeout(resolve, 0);
+  }, "Fulfillment handler on pending-then-fulfilled promise");
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
+    let reject;
+    const p = new Promise((_, r) => { reject = r; });
+
+    p.catch(t.step_func(() => {
+      frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
+    }));
+
+    t.step_timeout(reject, 0);
+  }, "Rejection handler on pending-then-rejected promise");
+
+  async_test(t => {
+    const thisTestId = setupTest(t);
+
+    const thenable = {
+      then: t.step_func((f) => {
+        frames[0].runWindowPostMessageVeryIndirectly(thisTestId, "*");
+      })
+    };
+
+    Promise.resolve(thenable);
+  }, "Thenable resolution");
+
+  done();
+};
+</script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/README.md
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/README.md
@@ -1,0 +1,5 @@
+A couple notes about the files scattered in this `resources/` directory:
+
+* The nested directory structure is necessary here so that relative URL resolution can be tested; we need different sub-paths for each document.
+
+* The semi-duplicate `window-to-open.html`s scattered throughout are present because Firefox, at least, does not fire `Window` `load` events for 404s, so we want to ensure that no matter which global is used, `window`'s `load` event is hit and our tests can proceed.

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/current.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/current.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>Current page used as a test helper</title>
+

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/current.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/current.html
@@ -1,3 +1,4 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>Current page used as a test helper</title>
 

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/resources/window-to-open.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/resources/window-to-open.html
@@ -1,2 +1,3 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>If the current settings object is used this page will be opened</title>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/resources/window-to-open.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/resources/window-to-open.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>If the current settings object is used this page will be opened</title>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/function/function.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/function/function.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Realm for a "then" function used as a test helper</title>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/function/resources/window-to-open.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/function/resources/window-to-open.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>If the function's settings object is used this page will be opened</title>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-entry-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-entry-incumbent.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Incumbent page used as a test helper</title>
+
+<iframe src="relevant/relevant.html" id="r"></iframe>
+<iframe src="current/current.html" id="c"></iframe>
+
+<script>
+  const relevant = document.querySelector("#r");
+  const current = document.querySelector("#c");
+
+  window.runWindowOpenVeryIndirectly = (...args) => {
+    return current.contentWindow.open.call(relevant.contentWindow, ...args);
+  };
+</script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-entry-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-entry-incumbent.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>Incumbent page used as a test helper</title>
 
 <iframe src="relevant/relevant.html" id="r"></iframe>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-incumbent.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Incumbent page used as a test helper</title>
+
+<iframe src="relevant/relevant.html" id="r"></iframe>
+<iframe src="current/current.html" id="c"></iframe>
+
+<script>
+  const relevant = document.querySelector("#r");
+  const current = document.querySelector("#c");
+
+  window.runWindowPostMessageVeryIndirectly = (...args) => {
+    return current.contentWindow.postMessage.call(relevant.contentWindow, ...args);
+  };
+</script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-incumbent.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>Incumbent page used as a test helper</title>
 
 <iframe src="relevant/relevant.html" id="r"></iframe>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-incumbent.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-incumbent.html
@@ -11,4 +11,16 @@
   window.runWindowPostMessageVeryIndirectly = (...args) => {
     return current.contentWindow.postMessage.call(relevant.contentWindow, ...args);
   };
+
+  // This tests the backup incumbent settings object stack scenario, by avoiding putting user code on the stack.
+  window.runWindowPostMessageVeryIndirectlyWithNoUserCode = (promise, promiseMethod, ...args) => {
+    const runWindowPostMessage = current.contentWindow.postMessage.bind(relevant.contentWindow, ...args);
+    promise[promiseMethod](runWindowPostMessage);
+  };
+
+  window.resolveThenableThatRunsWindowPostMessageVeryIndirectlyWithNoUserCode = (...args) => {
+    Promise.resolve({
+      then: current.contentWindow.postMessage.bind(relevant.contentWindow, ...args)
+    });
+  };
 </script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-resolver.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-resolver.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>Incumbent page used as a test helper</title>
 
 <script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-resolver.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-incumbent-resolver.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>Incumbent page used as a test helper</title>
+
+<script>
+  window.runWhatYouGiveMe = (func) => {
+    func();
+  };
+</script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/relevant.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/relevant.html
@@ -1,3 +1,13 @@
 <!DOCTYPE html>
 <title>Relevant page used as a test helper</title>
 
+<script>
+// promise-job-incumbent will end up posting a message to here. We need to signal back the "source".
+
+window.onmessage = e => {
+  const testId = e.data;
+  const sourceURL = e.source.document.URL;
+
+  window.dispatchEvent(new CustomEvent("messagereceived", { detail: [testId, sourceURL] }));
+};
+</script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/relevant.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/relevant.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>Relevant page used as a test helper</title>
 
 <script>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/relevant.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/relevant.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>Relevant page used as a test helper</title>
+

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/resources/window-to-open.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/resources/window-to-open.html
@@ -1,2 +1,3 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>If the relevant settings object is used this page will be opened</title>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/resources/window-to-open.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/resources/window-to-open.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>If the relevant settings object is used this page will be opened</title>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/resources/window-to-open.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/resources/window-to-open.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>If the incumbent settings object is used this page will be opened</title>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/resources/window-to-open.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/resources/window-to-open.html
@@ -1,2 +1,3 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>If the incumbent settings object is used this page will be opened</title>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/window-to-open.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/window-to-open.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>If the entry settings object is used this page will be opened</title>

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/window-to-open.html
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/window-to-open.html
@@ -1,2 +1,3 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>If the entry settings object is used this page will be opened</title>


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/5212 which specifies entry, and throws in incumbent tests for good measure while we're here.

Chrome and Firefox both seem to pass these, which is somewhat surprising.