### PR TITLE
[docs] Update project definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@ The web-platform-tests Project
 
 [![Taskcluster CI Status](https://community-tc.services.mozilla.com/api/github/v1/repository/web-platform-tests/wpt/master/badge.svg)](https://community-tc.services.mozilla.com/api/github/v1/repository/web-platform-tests/wpt/master/latest)
 
-The web-platform-tests Project is a W3C-coordinated attempt to build a
-cross-browser test suite for the Web-platform stack. Writing tests in a way
-that allows them to be run in all browsers gives browser projects
-confidence that they are shipping software that is compatible with other
-implementations, and that later implementations will be compatible with
-their implementations. This in turn gives Web authors/developers
-confidence that they can actually rely on the Web platform to deliver on
-the promise of working across browsers and devices without needing extra
-layers of abstraction to paper over the gaps left by specification
-editors and implementors.
+The web-platform-tests Project is a cross-browser test suite for the
+Web-platform stack. Writing tests in a way that allows them to be run in all
+browsers gives browser projects confidence that they are shipping software that
+is compatible with other implementations, and that later implementations will
+be compatible with their implementations. This in turn gives Web
+authors/developers confidence that they can actually rely on the Web platform
+to deliver on the promise of working across browsers and devices without
+needing extra layers of abstraction to paper over the gaps left by
+specification editors and implementors.
 
 The most important sources of information and activity are:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,14 @@
 # web-platform-tests documentation
 
-The web-platform-tests project is a W3C-coordinated attempt to build a
-cross-browser test suite for [the Web-platform
-stack](https://platform.html5.org). Writing tests in a way that allows them to
-be run in all browsers gives browser projects confidence that they are shipping
-software which is compatible with other implementations, and that later
-implementations will be compatible with their implementations. This in turn
-gives Web authors/developers confidence that they can actually rely on the Web
-platform to deliver on the promise of working across browsers and devices
-without needing extra layers of abstraction to paper over the gaps left by
-specification editors and implementors.
+The web-platform-tests project is a cross-browser test suite for [the
+Web-platform stack](https://platform.html5.org). Writing tests in a way that
+allows them to be run in all browsers gives browser projects confidence that
+they are shipping software which is compatible with other implementations, and
+that later implementations will be compatible with their implementations. This
+in turn gives Web authors/developers confidence that they can actually rely on
+the Web platform to deliver on the promise of working across browsers and
+devices without needing extra layers of abstraction to paper over the gaps left
+by specification editors and implementors.
 
 
 The most important sources of information and activity are:


### PR DESCRIPTION
The project is not coordinated by the W3C. Remove that aspect of the
definition.

Additionally, because WPT is a cross-browser test suite (as evidenced by
its inclusion in the infrastructure of many major browsers), describing
it as "an attempt to build" such a suite is unnecessarily verbose.
Remove that aspect of the definition.

---

@jgraham you wrote this this text back in 2015, and @sideshowbarker included it in the readme via gh-1720. Do you folks think this patch is an appropriate modernization?