### PR TITLE
COOP: remove popup-meta-http-equiv.https.html.headers

### DIFF
--- a/html/cross-origin-opener-policy/popup-meta-http-equiv.https.html.headers
+++ b/html/cross-origin-opener-policy/popup-meta-http-equiv.https.html.headers
@@ -1,1 +1,0 @@
-Cross-Origin-Opener-Policy: same-origin


### PR DESCRIPTION
This file was accidentally added in #20874.
The test was added in #20875 but it should not have a .headers file
since it's testing that `<meta>` has no effect.

---

cc @ArthurSonzogni