### PR TITLE
Rewrite referrer-origin-when-cross-origin.js using get_host_info

### DIFF
--- a/fetch/api/policies/referrer-origin-when-cross-origin.html
+++ b/fetch/api/policies/referrer-origin-when-cross-origin.html
@@ -7,6 +7,7 @@
     <meta name="help" href="https://fetch.spec.whatwg.org/#http-network-or-cache-fetch">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
   </head>
   <body>
     <script src="../resources/utils.js"></script>

--- a/fetch/api/policies/referrer-origin-when-cross-origin.js
+++ b/fetch/api/policies/referrer-origin-when-cross-origin.js
@@ -1,6 +1,7 @@
 if (this.document === undefined) {
   importScripts("/resources/testharness.js");
   importScripts("../resources/utils.js");
+  importScripts("/common/get-host-info.sub.js");
 
   // A nested importScripts() with a referrer-policy should have no effect
   // on overall worker policy.
@@ -8,7 +9,7 @@ if (this.document === undefined) {
 }
 
 var referrerOrigin = location.origin + '/';
-var fetchedUrl = "https://{{domains[www]}}:{{ports[https][0]}}" + dirname(location.pathname) + RESOURCES_DIR + "inspect-headers.py?cors&headers=referer";
+var fetchedUrl = get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "inspect-headers.py?cors&headers=referer";
 
 promise_test(function(test) {
   return fetch(fetchedUrl).then(function(resp) {


### PR DESCRIPTION
This will allow WebKit to pass these tests when running the tests
in the WebKit test harness.