### PR TITLE
Add a lint for assert_throws and promise_rejects

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -879,7 +879,7 @@ that the exception should have as its .constructor.  For example,
 `func` - a function that should throw
 
 ### `assert_throws_exactly(value, func, description)`
-`valie` - the exact value that `func` is expected to throw if called.
+`value` - the exact value that `func` is expected to throw if called.
 
 `func` - a function that should throw
 

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -745,3 +745,37 @@ TESTHARNESS-IN-OTHER-TYPE: svg/extensibility/foreignObject/foreign-object-circul
 TESTHARNESS-IN-OTHER-TYPE: svg/extensibility/foreignObject/foreign-object-under-clip-path-crash.html
 TESTHARNESS-IN-OTHER-TYPE: svg/extensibility/foreignObject/foreign-object-under-defs-crash.html
 TESTHARNESS-IN-OTHER-TYPE: svg/svg-in-svg/svg-in-svg-circular-filter-reference-crash.html
+
+# Remaining uses of promise_rejects
+PROMISE_REJECTS: PeriodicBackgroundSync/periodicsync.https.window.js
+PROMISE_REJECTS: encoding/streams/encode-bad-chunks.any.js
+PROMISE_REJECTS: encoding/streams/realms.window.js
+PROMISE_REJECTS: fetch/range/sw.https.window.js
+PROMISE_REJECTS: html/cross-origin-embedder-policy/none-load-from-cache-storage.https.html
+PROMISE_REJECTS: html/cross-origin-embedder-policy/require-corp-load-from-cache-storage.https.html
+PROMISE_REJECTS: html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-script-error.html
+PROMISE_REJECTS: imagebitmap-renderingcontext/toBlob-origin-clean-offscreen.sub.html
+PROMISE_REJECTS: mediacapture-image/MediaStreamTrack-applyConstraints-fast.html
+PROMISE_REJECTS: payment-request/PaymentRequestUpdateEvent/updateWith-method-abort-update-manual.https.html
+PROMISE_REJECTS: payment-request/show-method-optional-promise-rejects-manual.https.html
+PROMISE_REJECTS: portals/portal-activate-data.html
+PROMISE_REJECTS: portals/portals-activate-empty-browsing-context.html
+PROMISE_REJECTS: resources/test/tests/unit/IdlDictionary/get_inheritance_stack.html
+PROMISE_REJECTS: resources/test/tests/unit/IdlInterface/get_inheritance_stack.html
+PROMISE_REJECTS: resources/test/tests/unit/IdlInterface/test_primary_interface_of_undefined.html
+PROMISE_REJECTS: resources/test/tests/unit/basic.html
+PROMISE_REJECTS: service-workers/service-worker/resources/registration-tests-mime-types.js
+PROMISE_REJECTS: web-locks/acquire.tentative.https.any.js
+PROMISE_REJECTS: web-locks/ifAvailable.tentative.https.any.js
+PROMISE_REJECTS: webrtc-extensions/RTCRtpParameters-maxFramerate.html
+PROMISE_REJECTS: webxr/xrSession_viewer_availability.https.html
+PROMISE_REJECTS: worklets/resources/import-tests.js
+
+# Remaining uses of assert_throws
+ASSERT_THROWS: resources/test/tests/unit/basic.html
+ASSERT_THROWS: resources/test/tests/unit/IdlDictionary/get_inheritance_stack.html
+ASSERT_THROWS: resources/test/tests/unit/IdlInterface/test_primary_interface_of_undefined.html
+ASSERT_THROWS: resources/test/tests/unit/IdlInterface/get_inheritance_stack.html
+
+PROMISE_REJECTS: resources/testharness.js
+ASSERT_THROWS: resources/testharness.js

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -638,29 +638,29 @@ policies and contribution forms [3].
         });
     }
 
-    function promise_rejects(test, expected, promise, description) {
+    function promise_rejects(test, code, promise, description) {
         return promise.then(test.unreached_func("Should have rejected: " + description)).catch(function(e) {
-            assert_throws_DO_NOT_USE(expected, function() { throw e }, description);
+            assert_throws_DO_NOT_USE(code, function() { throw e }, description);
         });
     }
 
-    function promise_rejects_js(test, expected, promise, description) {
+    function promise_rejects_js(test, constructor, promise, description) {
         return promise.then(test.unreached_func("Should have rejected: " + description)).catch(function(e) {
-            assert_throws_js_impl(expected, function() { throw e },
+            assert_throws_js_impl(constructor, function() { throw e },
                                   description, "promise_reject_js");
         });
     }
 
-    function promise_rejects_dom(test, expected, promise, description) {
+    function promise_rejects_dom(test, type, promise, description) {
         return promise.then(test.unreached_func("Should have rejected: " + description)).catch(function(e) {
-            assert_throws_dom_impl(expected, function() { throw e },
+            assert_throws_dom_impl(type, function() { throw e },
                                    description, "promise_rejects_dom");
         });
     }
 
-    function promise_rejects_exactly(test, expected, promise, description) {
+    function promise_rejects_exactly(test, exception, promise, description) {
         return promise.then(test.unreached_func("Should have rejected: " + description)).catch(function(e) {
-            assert_throws_exactly_impl(expected, function() { throw e },
+            assert_throws_exactly_impl(exception, function() { throw e },
                                        description, "promise_rejects_exactly");
         });
     }

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -390,7 +390,9 @@ regexps = [item() for item in  # type: ignore
             rules.PrintRegexp,
             rules.LayoutTestsRegexp,
             rules.MissingDepsRegexp,
-            rules.SpecialPowersRegexp]]
+            rules.SpecialPowersRegexp,
+            rules.AssertThrowsRegexp,
+            rules.PromiseRejectsRegexp]]
 
 
 def check_regexp_line(repo_root, path, f):

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -462,3 +462,19 @@ class TrailingWhitespaceRegexp(Regexp):
     description = "Whitespace at EOL"
     pattern = b"[ \t\f\v]$"
     to_fix = """Remove trailing whitespace from all lines in the file."""
+
+
+class AssertThrowsRegexp(Regexp):
+    pattern = br"assert_throws\("
+    name = "ASSERT_THROWS"
+    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    description = "Test-file line has an `assert_throws(...)` call"
+    to_fix = """Replace with `assert_throws_dom` or `assert_throws_js`"""
+
+
+class PromiseRejectsRegexp(Regexp):
+    pattern = br"promise_rejects\("
+    name = "PROMISE_REJECTS"
+    file_extensions = [".html", ".htm", ".js", ".xht", ".xhtml", ".svg"]
+    description = "Test-file line has a `promise_rejects(...)` call"
+    to_fix = """Replace with promise_rejects_dom or promise_rejects_js"""


### PR DESCRIPTION
This adds a rather large number of existing uses to the allow list