### PR TITLE
Add harness support to assert DataView type

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1190,6 +1190,10 @@ IdlArray.prototype.assert_type_is = function(value, type)
             assert_regexp_match(value, /^([\x00-\ud7ff\ue000-\uffff]|[\ud800-\udbff][\udc00-\udfff])*$/);
             return;
 
+        case "DataView":
+            assert_equals(typeof value, "DataView");
+            return;
+
         case "object":
             assert_in_array(typeof value, ["object", "function"], "wrong type: not object or function");
             return;


### PR DESCRIPTION
This CL adds harness support to assert DataView type.
I've checked and it fixes Web NFC harness tests at https://wpt.fyi/results/web-nfc/idlharness.https.window.html

FYI @Honry @riju 