### PR TITLE
Change COEP tests relying on onload events for network errors to timeouts

### DIFF
--- a/html/cross-origin-embedder-policy/require-corp-about-blank.html
+++ b/html/cross-origin-embedder-policy/require-corp-about-blank.html
@@ -27,7 +27,6 @@ promise_test(async t => {
   iframe_B.src = "about:blank";
   iframe_C.src = "/common/blank.html";
   let iframe_B_loaded = new Promise(resolve => iframe_B.onload = resolve);
-  let iframe_C_loaded = new Promise(resolve => iframe_C.onload = resolve);
   document.body.appendChild(iframe_B);
 
   // The about:blank frame must be able to load.
@@ -35,13 +34,16 @@ promise_test(async t => {
   assert_not_equals(iframe_B.contentDocument, null);
   iframe_B.contentDocument.body.appendChild(iframe_C);
 
-  // The document nested under about:blank must not load because it does not
-  // specify the Cross-Origin-Embedder-Policy: require-corp header.
-  // An error page must be displayed instead.
-  await iframe_C_loaded;
-  assert_equals(iframe_C.contentDocument, null);
-
-  t.done();
+  t.step_timeout(() => {
+    // The document nested under about:blank must not load because it does not
+    // specify the Cross-Origin-Embedder-Policy: require-corp header.
+    // An error page must be displayed instead.
+    // See https://github.com/whatwg/html/issues/125 for why a timeout is used
+    // here. Long term all network error handling should be similar and have a
+    // reliable event.
+    assert_equals(iframe_C.contentDocument, null);
+    t.done();
+  }, 500);
 }, "A(B(C)) A=require-corp, B=about:blank, C=no-require-corp => C can't load");
 
 </script>

--- a/html/cross-origin-embedder-policy/require-corp-about-srcdoc.html
+++ b/html/cross-origin-embedder-policy/require-corp-about-srcdoc.html
@@ -28,7 +28,6 @@ promise_test(async t => {
   iframe_B.srcdoc = "dummy content";
   iframe_C.src = "/common/blank.html";
   let iframe_B_loaded = new Promise(resolve => iframe_B.onload = resolve);
-  let iframe_C_loaded = new Promise(resolve => iframe_C.onload = resolve);
   document.body.appendChild(iframe_B);
 
   // The about:srcdoc frame must be able to load.
@@ -37,13 +36,17 @@ promise_test(async t => {
   assert_equals(iframe_B.contentDocument.body.innerText, "dummy content");
   iframe_B.contentDocument.body.appendChild(iframe_C);
 
-  // The document nested under about:srcdoc must not load because it does not
-  // specify the Cross-Origin-Embedder-Policy: require-corp header.
-  // An error page must be displayed instead.
-  await iframe_C_loaded;
-  assert_equals(iframe_C.contentDocument, null);
 
-  t.done();
+  t.step_timeout(() => {
+    // The document nested under about:srcdoc must not load because it does not
+    // specify the Cross-Origin-Embedder-Policy: require-corp header.
+    // An error page must be displayed instead.
+    // See https://github.com/whatwg/html/issues/125 for why a timeout is used
+    // here. Long term all network error handling should be similar and have a
+    // reliable event.
+    assert_equals(iframe_C.contentDocument, null);
+    t.done();
+  }, 500);
 }, "A(B(C)) A=require-corp, B=about:srcdoc, C=no-require-corp => C can't load");
 
 </script>


### PR DESCRIPTION
Fix #21300 

CC @ArthurSonzogni 