### PR TITLE
[Azure Pipelines] add a `safaridriver_diagnose` variable for extra logs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -25,6 +25,11 @@ trigger:
 - triggers/safari_stable
 - triggers/safari_preview
 
+# Set safaridriver_diagnose to true to enable safaridriver diagnostics. The
+# logs won't appear in `./wpt run` output but will be uploaded as an artifact.
+variables:
+  safaridriver_diagnose: false
+
 jobs:
 # The affected tests jobs are unconditional for speed, as most PRs have one or
 # more affected tests: https://github.com/web-platform-tests/wpt/issues/13936.
@@ -108,11 +113,7 @@ jobs:
     displayName: 'Run tests (Firefox Nightly)'
   - script: no_proxy='*' ./wpt run --yes --no-manifest-update --manifest MANIFEST.json --metadata infrastructure/metadata/ --log-mach - --log-mach-level info --channel preview safari infrastructure/
     displayName: 'Run tests (Safari Technology Preview)'
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish results'
-    inputs:
-      artifactName: 'infrastructure'
-    condition: always()
+  - template: tools/ci/azure/publish_logs.yml
 
 - job: tools_unittest_mac
   displayName: 'tools/ unittests: macOS'
@@ -616,6 +617,7 @@ jobs:
     displayName: 'Publish results'
     inputs:
       artifactName: 'safari-results'
+  - template: tools/ci/azure/publish_logs.yml
 - template: tools/ci/azure/fyi_hook.yml
   parameters:
     dependsOn: results_safari
@@ -651,6 +653,7 @@ jobs:
     displayName: 'Publish results'
     inputs:
       artifactName: 'safari-preview-results'
+  - template: tools/ci/azure/publish_logs.yml
 - template: tools/ci/azure/fyi_hook.yml
   parameters:
     dependsOn: results_safari_preview

--- a/docs/running-tests/safari.md
+++ b/docs/running-tests/safari.md
@@ -42,3 +42,6 @@ argument:
 
 The logs will be in `~/Library/Logs/com.apple.WebDriver/`.
 See `man safaridriver` for more information.
+
+To enable safaridriver diagnostics in Azure Pipelines, set
+`safaridriver_diagnose` to `true` in `.azure-pipelines.yml`.

--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -3,6 +3,9 @@ parameters:
 
 # Should match https://web-platform-tests.org/running-tests/safari.html
 steps:
+- script: defaults write com.apple.WebDriver DiagnosticsEnabled 1
+  displayName: 'Enable safaridriver diagnostics'
+  condition: eq(variables['safaridriver_diagnose'], true)
 - ${{ if eq(parameters.channel, 'preview') }}:
   - script: |
       HOMEBREW_NO_AUTO_UPDATE=1 brew cask install tools/ci/azure/safari-technology-preview.rb

--- a/tools/ci/azure/publish_logs.yml
+++ b/tools/ci/azure/publish_logs.yml
@@ -1,0 +1,7 @@
+steps:
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish safaridriver logs'
+  inputs:
+    pathtoPublish: /Users/runner/Library/Logs/com.apple.WebDriver/
+    artifactName: safaridriver-logs
+  condition: eq(variables['safaridriver_diagnose'], true)


### PR DESCRIPTION
Note that the existing 'Publish results' step for infrastructure_macOS
wasn't doing anything as nothing was put in the artifact directory, so
it was removed.