### PR TITLE
Add --py3 parameter to run wpt commands using python3

### DIFF
--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -40,13 +40,14 @@ def load_commands():
     return rv
 
 
-def parse_args(argv, commands):
+def parse_args(argv, commands = load_commands()):
     parser = argparse.ArgumentParser()
     parser.add_argument("--venv", action="store", help="Path to an existing virtualenv to use")
     parser.add_argument("--skip-venv-setup", action="store_true",
                         dest="skip_venv_setup",
                         help="Whether to use the virtualenv as-is. Must set --venv as well")
     parser.add_argument("--debug", action="store_true", help="Run the debugger in case of an exception")
+    parser.add_argument("--py3", action="store_true", help="Run with python3. NO command is supported so far.")
     subparsers = parser.add_subparsers(dest="command")
     for command, props in iteritems(commands):
         subparsers.add_parser(command, help=props["help"], add_help=False)

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -47,7 +47,7 @@ def parse_args(argv, commands = load_commands()):
                         dest="skip_venv_setup",
                         help="Whether to use the virtualenv as-is. Must set --venv as well")
     parser.add_argument("--debug", action="store_true", help="Run the debugger in case of an exception")
-    parser.add_argument("--py3", action="store_true", help="Run with python3. NO command is supported so far.")
+    parser.add_argument("--py3", action="store_true", help="Run with python3")
     subparsers = parser.add_subparsers(dest="command")
     for command, props in iteritems(commands):
         subparsers.add_parser(command, help=props["help"], add_help=False)

--- a/wpt
+++ b/wpt
@@ -2,4 +2,11 @@
 
 if __name__ == "__main__":
     from tools.wpt import wpt
-    wpt.main()
+    from sys import version_info, argv
+    args, extra = wpt.parse_args(argv[1:])
+
+    if args.py3 and version_info.major < 3:
+        from subprocess import call
+        call(['python3', argv[0]] + [args.command] + extra)
+    else:
+        wpt.main()


### PR DESCRIPTION
In order to ease the transition to python3 we'll start by adding a new parameter to `wpt` called `--py3` which will basically execute the `wpt` script using python3 if required. No command is supported so far, we'll be migrating them one by one.