### PR TITLE
Replace some "assert_throws({'name': 'jserror'}, stuff)" with assert_throws_js

### DIFF
--- a/IndexedDB/idbcursor-advance-invalid.htm
+++ b/IndexedDB/idbcursor-advance-invalid.htm
@@ -59,19 +59,19 @@ indexeddb_test(
     rq.onsuccess = t.step_func(function(e) {
       var cursor = e.target.result;
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(document); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance({}); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance([]); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(""); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance("1 2"); });
 
       t.done();
@@ -90,14 +90,14 @@ indexeddb_test(
     rq.onsuccess = t.step_func(function(e) {
       var cursor = e.target.result;
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(null); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(undefined); });
 
       var myvar = null;
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(myvar); });
 
       t.done();
@@ -116,7 +116,7 @@ indexeddb_test(
     rq.onsuccess = t.step_func(function(e) {
       var cursor = e.target.result;
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(); });
 
       t.done();
@@ -134,26 +134,26 @@ indexeddb_test(
     rq.onsuccess = t.step_func(function(e) {
       var cursor = e.target.result;
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(-1); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(NaN); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(0); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(-0); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(Infinity); });
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(-Infinity); });
 
       var myvar = -999999;
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(myvar); });
 
       t.done();
@@ -178,7 +178,7 @@ indexeddb_test(
           return;
         }
 
-      assert_throws({ name: "TypeError" },
+      assert_throws_js(TypeError,
                     function() { cursor.advance(0); });
 
       cursor.advance(1);

--- a/IndexedDB/idbdatabase_transaction4.htm
+++ b/IndexedDB/idbdatabase_transaction4.htm
@@ -16,7 +16,7 @@
     };
 
     open_rq.onsuccess = function(e) {
-        assert_throws({ name: 'TypeError' },
+        assert_throws_js(TypeError,
             function() { db.transaction('test', 'whatever'); });
 
         t.done();

--- a/console/console-label-conversion.any.js
+++ b/console/console-label-conversion.any.js
@@ -18,7 +18,7 @@ for (const method of methods) {
   }, `console.${method}()'s label gets converted to string via label.toString() when label is an object`);
 
   test(() => {
-    assert_throws({name: 'Error'}, () => {
+    assert_throws_js(Error, () => {
       console[method]({
         toString() {
           throw new Error('conversion error');

--- a/custom-elements/CustomElementRegistry.html
+++ b/custom-elements/CustomElementRegistry.html
@@ -17,13 +17,13 @@ test(function () {
 }, 'CustomElementRegistry interface must have define as a method');
 
 test(function () {
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('badname', 1); },
+    assert_throws_js(TypeError, function () { customElements.define('badname', 1); },
         'customElements.define must throw a TypeError when the element interface is a number');
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('badname', '123'); },
+    assert_throws_js(TypeError, function () { customElements.define('badname', '123'); },
         'customElements.define must throw a TypeError when the element interface is a string');
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('badname', {}); },
+    assert_throws_js(TypeError, function () { customElements.define('badname', {}); },
         'customElements.define must throw a TypeError when the element interface is an object');
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('badname', []); },
+    assert_throws_js(TypeError, function () { customElements.define('badname', []); },
         'customElements.define must throw a TypeError when the element interface is an array');
 }, 'customElements.define must throw when the element interface is not a constructor');
 
@@ -124,7 +124,7 @@ test(function () {
         }
     });
 
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         customElements.define('element-with-bad-inner-constructor', ElementWithBadInnerConstructor);
     }, 'customElements.define must throw a NotSupportedError if IsConstructor(constructor) is false');
 
@@ -248,16 +248,16 @@ test(function () {
     });
 
     returnedValue = null;
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('element-with-string-prototype', proxy); },
+    assert_throws_js(TypeError, function () { customElements.define('element-with-string-prototype', proxy); },
         'customElements.define must throw when "prototype" property of the constructor is null');
     returnedValue = undefined;
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('element-with-string-prototype', proxy); },
+    assert_throws_js(TypeError, function () { customElements.define('element-with-string-prototype', proxy); },
         'customElements.define must throw when "prototype" property of the constructor is undefined');
     returnedValue = 'hello';
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('element-with-string-prototype', proxy); },
+    assert_throws_js(TypeError, function () { customElements.define('element-with-string-prototype', proxy); },
         'customElements.define must throw when "prototype" property of the constructor is a string');
     returnedValue = 1;
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('element-with-string-prototype', proxy); },
+    assert_throws_js(TypeError, function () { customElements.define('element-with-string-prototype', proxy); },
         'customElements.define must throw when "prototype" property of the constructor is a number');
 
 }, 'customElements.define must throw when "prototype" property of the constructor is not an object');
@@ -302,7 +302,7 @@ test(function () {
             return target[name];
         }
     });
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('element-with-throwing-callback', constructor); });
+    assert_throws_js(TypeError, function () { customElements.define('element-with-throwing-callback', constructor); });
     assert_array_equals(calls, ['connectedCallback', 'disconnectedCallback', 'adoptedCallback'],
         'customElements.define must not get callbacks after one of the conversion throws');
 }, 'customElements.define must rethrow an exception thrown while converting a callback value to Function callback type');
@@ -366,7 +366,7 @@ test(function () {
             return target[name];
         }
     });
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('element-with-invalid-observed-attributes', proxy); });
+    assert_throws_js(TypeError, function () { customElements.define('element-with-invalid-observed-attributes', proxy); });
     assert_array_equals(calls, ['prototype', 'observedAttributes'],
         'customElements.define must get "prototype" and "observedAttributes" on the constructor');
 }, 'customElements.define must rethrow an exception thrown while converting the value of observedAttributes to sequence<DOMString>');
@@ -385,7 +385,7 @@ test(function () {
     var constructor = function () {}
     constructor.prototype.attributeChangedCallback = function () { };
     constructor.observedAttributes = {[Symbol.iterator]: 1};
-    assert_throws({'name': 'TypeError'}, function () { customElements.define('element-with-observed-attributes-with-uncallable-iterator', constructor); });
+    assert_throws_js(TypeError, function () { customElements.define('element-with-observed-attributes-with-uncallable-iterator', constructor); });
 }, 'customElements.define must rethrow an exception thrown while retrieving Symbol.iterator on observedAttributes');
 
 test(function () {
@@ -421,7 +421,7 @@ test(function () {
             return target[name];
         }
     });
-    assert_throws({'name': 'TypeError'}, () => customElements.define('element-with-invalid-disabled-features', proxy));
+    assert_throws_js(TypeError, () => customElements.define('element-with-invalid-disabled-features', proxy));
     assert_array_equals(calls, ['prototype', 'disabledFeatures'],
         'customElements.define must get "prototype" and "disabledFeatures" on the constructor');
 }, 'customElements.define must rethrow an exception thrown while converting the value of disabledFeatures to sequence<DOMString>');
@@ -438,7 +438,7 @@ test(function () {
 test(function () {
     var constructor = function () {}
     constructor.disabledFeatures = {[Symbol.iterator]: 1};
-    assert_throws({'name': 'TypeError'}, () => customElements.define('element-with-disabled-features-with-uncallable-iterator', constructor));
+    assert_throws_js(TypeError, () => customElements.define('element-with-disabled-features-with-uncallable-iterator', constructor));
 }, 'customElements.define must rethrow an exception thrown while retrieving Symbol.iterator on disabledFeatures');
 
 test(function () {
@@ -528,7 +528,7 @@ test(function () {
             return target[name];
         }
     });
-    assert_throws({'name': 'TypeError'},
+    assert_throws_js(TypeError,
         () => customElements.define('element-with-throwing-callback-3', proxy));
     assert_array_equals(calls2, ['connectedCallback', 'disconnectedCallback',
                                  'adoptedCallback', 'attributeChangedCallback',

--- a/custom-elements/HTMLElement-constructor.html
+++ b/custom-elements/HTMLElement-constructor.html
@@ -14,29 +14,29 @@
 
 test(function () {
     customElements.define('html-custom-element', HTMLElement);
-    assert_throws({'name': 'TypeError'}, function () { new HTMLElement(); });
+    assert_throws_js(TypeError, function () { new HTMLElement(); });
 }, 'HTMLElement constructor must throw a TypeError when NewTarget is equal to itself');
 
 test(function () {
     customElements.define('html-proxy-custom-element', new Proxy(HTMLElement, {}));
-    assert_throws({'name': 'TypeError'}, function () { new HTMLElement(); });
+    assert_throws_js(TypeError, function () { new HTMLElement(); });
 }, 'HTMLElement constructor must throw a TypeError when NewTarget is equal to itself via a Proxy object');
 
 test(function () {
     class SomeCustomElement extends HTMLElement {};
-    assert_throws({'name': 'TypeError'}, function () { new SomeCustomElement; });
+    assert_throws_js(TypeError, function () { new SomeCustomElement; });
 }, 'HTMLElement constructor must throw TypeError when it has not been defined by customElements.define');
 
 test(function () {
     class SomeCustomElement extends HTMLParagraphElement {};
     customElements.define('some-custom-element', SomeCustomElement);
-    assert_throws({'name': 'TypeError'}, function () { new SomeCustomElement(); });
+    assert_throws_js(TypeError, function () { new SomeCustomElement(); });
 }, 'Custom element constructor must throw TypeError when it does not extend HTMLElement');
 
 test(function () {
     class SomeCustomButtonElement extends HTMLButtonElement {};
     customElements.define('some-custom-button-element', SomeCustomButtonElement, { extends: "p" });
-    assert_throws({'name': 'TypeError'}, function () { new SomeCustomButtonElement(); });
+    assert_throws_js(TypeError, function () { new SomeCustomButtonElement(); });
 }, 'Custom element constructor must throw TypeError when it does not extend the proper element interface');
 
 test(function () {
@@ -178,7 +178,7 @@ test(function() {
     // define() gets the prototype of the constructor it's passed, so
     // reset the counter.
     getCount = 0;
-    assert_throws({'name': 'TypeError'},
+    assert_throws_js(TypeError,
                   function () { new countingProxy() },
                   "Should not be able to construct an HTMLElement named 'button'");
     assert_equals(getCount, 0, "Should never have gotten .prototype");
@@ -200,7 +200,7 @@ test(function() {
     // define() gets the prototype of the constructor it's passed, so
     // reset the counter.
     getCount = 0;
-    assert_throws({'name': 'TypeError'},
+    assert_throws_js(TypeError,
                   function () { Reflect.construct(HTMLElement, [], countingProxy) },
                   "Should not be able to construct an HTMLElement named 'button'");
     assert_equals(getCount, 0, "Should never have gotten .prototype");
@@ -219,7 +219,7 @@ test(function() {
     });
 
     // Purposefully don't register it.
-    assert_throws({'name': 'TypeError'},
+    assert_throws_js(TypeError,
                   function () { new countingProxy() },
                   "Should not be able to construct an HTMLElement named 'button'");
     assert_equals(getCount, 0, "Should never have gotten .prototype");
@@ -238,7 +238,7 @@ test(function() {
     });
 
     // Purposefully don't register it.
-    assert_throws({'name': 'TypeError'},
+    assert_throws_js(TypeError,
                   function () { Reflect.construct(HTMLElement, [], countingProxy) },
                   "Should not be able to construct an HTMLElement named 'button'");
     assert_equals(getCount, 0, "Should never have gotten .prototype");

--- a/custom-elements/htmlconstructor/newtarget.html
+++ b/custom-elements/htmlconstructor/newtarget.html
@@ -202,7 +202,7 @@ test_with_window(w => {
     // define() gets the prototype of the constructor it's passed, so
     // reset the counter.
     getCount = 0;
-    assert_throws({'name': 'TypeError'},
+    assert_throws_js(TypeError,
                   function () { new countingProxy() },
                   "Should not be able to construct an HTMLParagraphElement not named 'p'");
     assert_equals(getCount, 0, "Should never have gotten .prototype");
@@ -223,7 +223,7 @@ test_with_window(w => {
     // define() gets the prototype of the constructor it's passed, so
     // reset the counter.
     getCount = 0;
-    assert_throws({'name': 'TypeError'},
+    assert_throws_js(TypeError,
                   function () { Reflect.construct(HTMLParagraphElement, [], countingProxy) },
                   "Should not be able to construct an HTMLParagraphElement not named 'p'");
     assert_equals(getCount, 0, "Should never have gotten .prototype");

--- a/dom/ranges/StaticRange-constructor.html
+++ b/dom/ranges/StaticRange-constructor.html
@@ -169,31 +169,31 @@ test(function() {
 }, 'Throw on DocumentType or Attr container');
 
 test(function () {
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         const staticRange = new StaticRange();
     }, 'throw a TypeError when no argument is passed');
 
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         const staticRange = new StaticRange({startOffset: 0, endContainer: testDiv, endOffset: 0});
     }, 'throw a TypeError when a startContainer is not passed');
 
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         const staticRange = new StaticRange({startContainer: testDiv, endContainer: testDiv, endOffset: 0});
     }, 'throw a TypeError when a startOffset is not passed');
 
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         const staticRange = new StaticRange({startContainer: testDiv, startOffset: 0, endOffset: 0});
     }, 'throw a TypeError when an endContainer is not passed');
 
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         const staticRange = new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: testDiv});
     }, 'throw a TypeError when an endOffset is not passed');
 
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         const staticRange = new StaticRange({startContainer: null, startOffset: 0, endContainer: testDiv, endOffset: 0});
     }, 'throw a TypeError when a null startContainer is passed');
 
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         const staticRange = new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: null, endOffset: 0});
     }, 'throw a TypeError when a null endContainer is passed');
 }, 'Throw on missing or invalid arguments');

--- a/media-source/mediasource-append-buffer.html
+++ b/media-source/mediasource-append-buffer.html
@@ -571,7 +571,7 @@
               test.expectEvent(sourceBuffer, "update", "Append success.");
               test.expectEvent(sourceBuffer, "updateend", "Append ended.");
 
-              assert_throws( { name: "TypeError"} ,
+              assert_throws_js( TypeError,
                   function() { sourceBuffer.appendBuffer(null); },
                   "appendBuffer(null) throws an exception.");
               test.done();

--- a/media-source/mediasource-sourcebuffer-mode-timestamps.html
+++ b/media-source/mediasource-sourcebuffer-mode-timestamps.html
@@ -32,7 +32,7 @@ function mediaTest(mime) {
         mediaSource.addEventListener('sourceopen', t.step_func_done(function(e) {
             var sourceBuffer = mediaSource.addSourceBuffer(mime);
             assert_equals(sourceBuffer.updating, false, "SourceBuffer.updating is false");
-            assert_throws({name: 'TypeError'},
+            assert_throws_js(TypeError,
                           function() {
                               sourceBuffer.mode = "segments";
                           },

--- a/media-source/mediasource-timestamp-offset.html
+++ b/media-source/mediasource-timestamp-offset.html
@@ -21,7 +21,7 @@
                       "Initial timestampOffset of a SourceBuffer is 0");
 
                   if (expected == "TypeError")  {
-                      assert_throws({name: "TypeError"},
+                      assert_throws_js(TypeError,
                           function() { sourceBuffer.timestampOffset = value; },
                           "setting timestampOffset to " + description + " throws an exception.");
                   } else {

--- a/orientation-sensor/orientation-sensor-tests.js
+++ b/orientation-sensor/orientation-sensor-tests.js
@@ -33,7 +33,7 @@ async function checkPopulateMatrix(t, sensorProvider, sensorType) {
   const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
 
   // Throws with insufficient buffer space.
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       () => sensor.populateMatrix(new Float32Array(15)));
 
   // Throws if no orientation data available.
@@ -41,7 +41,7 @@ async function checkPopulateMatrix(t, sensorProvider, sensorType) {
       () => sensor.populateMatrix(new Float32Array(16)));
 
   // Throws if passed SharedArrayBuffer view.
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       () => sensor.populateMatrix(new Float32Array(new SharedArrayBuffer(16))));
 
   sensor.start();

--- a/resize-observer/observe.html
+++ b/resize-observer/observe.html
@@ -56,7 +56,7 @@ function test1() {
 
 function test2() {
   test(() => {
-      assert_throws({name: "TypeError"}, _=> {
+      assert_throws_js(TypeError, _=> {
         let ro = new ResizeObserver(() => {});
         ro.observe({});
       });

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-constructor-worker.js
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-constructor-worker.js
@@ -53,8 +53,9 @@ test(function() {
           valueOf: function() { return TEST_OBJECT; } } }).data ==
       TEST_OBJECT);
   assert_equals(createEvent({ get data(){ return 123; } }).data, 123);
-  assert_throws({ name: 'Error' }, function() {
-      createEvent({ get data() { throw { name: 'Error' }; } }); });
+  let thrown = { name: 'Error' };
+  assert_throws_exactly(thrown, function() {
+      createEvent({ get data() { throw thrown; } }); });
 }, '`data` is specified');
 
 test(function() {
@@ -81,8 +82,9 @@ test(function() {
       '[object Object]');
   assert_equals(
       createEvent({ get origin() { return 123; } }).origin, '123');
-  assert_throws({ name: 'Error' }, function() {
-      createEvent({ get origin() { throw { name: 'Error' }; } }); });
+  let thrown = { name: 'Error' };
+  assert_throws_exactly(thrown, function() {
+      createEvent({ get origin() { throw thrown; } }); });
 }, '`origin` is specified');
 
 test(function() {
@@ -112,8 +114,9 @@ test(function() {
   assert_equals(
       createEvent({ get lastEventId() { return 123; } }).lastEventId,
       '123');
-  assert_throws({ name: 'Error' }, function() {
-      createEvent({ get lastEventId() { throw { name: 'Error' }; } }); });
+  let thrown = { name: 'Error' };
+  assert_throws_exactly(thrown, function() {
+      createEvent({ get lastEventId() { throw thrown; } }); });
 }, '`lastEventId` is specified');
 
 test(function() {
@@ -123,8 +126,8 @@ test(function() {
       self.registration.active);
   assert_equals(
       createEvent({ source: CHANNEL1.port1 }).source, CHANNEL1.port1);
-  assert_throws(
-      { name: 'TypeError' }, function() { createEvent({ source: this }); },
+  assert_throws_js(
+      TypeError, function() { createEvent({ source: this }); },
       'source should be Client or ServiceWorker or MessagePort');
 }, '`source` is specified');
 
@@ -138,36 +141,37 @@ test(function() {
   assert_array_equals(createEvent({ ports: undefined }).ports, []);
 
   // Invalid message ports.
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: [1, 2, 3] }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: TEST_OBJECT }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: null }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: this }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: false }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: true }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: '' }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: 'chocolate' }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: 12345 }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: 18446744073709551615 }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ ports: NaN }); });
-  assert_throws({ name: 'TypeError' },
+  assert_throws_js(TypeError,
       function() { createEvent({ get ports() { return 123; } }); });
-  assert_throws({ name: 'Error' }, function() {
-      createEvent({ get ports() { throw { name: 'Error' }; } }); });
+  let thrown = { name: 'Error' };
+  assert_throws_exactly(thrown, function() {
+      createEvent({ get ports() { throw thrown; } }); });
   // Note that valueOf() is not called, when the left hand side is
   // evaluated.
   var valueOf = function() { return PORTS; };
-  assert_throws({ name: 'TypeError' }, function() {
+  assert_throws_js(TypeError, function() {
       createEvent({ ports: { valueOf: valueOf } }); });
 }, '`ports` is specified');
 

--- a/service-workers/service-worker/detached-context.https.html
+++ b/service-workers/service-worker/detached-context.https.html
@@ -117,7 +117,7 @@ test(t => {
     }
     assert_not_equals(get_navigator().serviceWorker, null);
     iframe.remove();
-    assert_throws({name: 'TypeError'}, () => get_navigator());
+    assert_throws_js(TypeError, () => get_navigator());
   }, 'accessing navigator on a removed frame');
 
 // It seems weird that about:blank and blank.html (the test above) have

--- a/shadow-dom/Element-interface-attachShadow.html
+++ b/shadow-dom/Element-interface-attachShadow.html
@@ -32,15 +32,15 @@ test(function () {
 }, 'Nodes other than Element should not have attachShadow');
 
 test(function () {
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         document.createElement('div').attachShadow({})
     }, 'attachShadow must throw a TypeError when mode is omitted');
 
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         document.createElement('div').attachShadow({mode: true})
     }, 'attachShadow must throw a TypeError when mode is a boolean');
 
-    assert_throws({'name': 'TypeError'}, function () {
+    assert_throws_js(TypeError, function () {
         document.createElement('div').attachShadow({mode: 1})
     }, 'attachShadow must throw a TypeError when mode is 1');
 }, 'Element.attachShadow must throw a TypeError if mode is not "open" or "closed"');

--- a/shadow-dom/ShadowRoot-interface.html
+++ b/shadow-dom/ShadowRoot-interface.html
@@ -21,7 +21,7 @@ test(function () {
 }, 'ShadowRoot must inherit from DocumentFragment');
 
 test(function () {
-    assert_throws({'name': 'TypeError'}, function () { new ShadowRoot(); }, 'new ShadowRoot() must throw a TypeError');
+    assert_throws_js(TypeError, function () { new ShadowRoot(); }, 'new ShadowRoot() must throw a TypeError');
 }, 'ShadowRoot must not be a constructor');
 
 function testActiveElement(mode) {

--- a/streams/byte-length-queuing-strategy.any.js
+++ b/streams/byte-length-queuing-strategy.any.js
@@ -27,9 +27,9 @@ test(() => {
     get highWaterMark() { throw error; }
   };
 
-  assert_throws({ name: 'TypeError' }, () => new ByteLengthQueuingStrategy(), 'construction fails with undefined');
-  assert_throws({ name: 'TypeError' }, () => new ByteLengthQueuingStrategy(null), 'construction fails with null');
-  assert_throws({ name: 'Error' }, () => new ByteLengthQueuingStrategy(highWaterMarkObjectGetterThrowing),
+  assert_throws_js(TypeError, () => new ByteLengthQueuingStrategy(), 'construction fails with undefined');
+  assert_throws_js(TypeError, () => new ByteLengthQueuingStrategy(null), 'construction fails with null');
+  assert_throws_js(Error, () => new ByteLengthQueuingStrategy(highWaterMarkObjectGetterThrowing),
     'construction fails with an object with a throwing highWaterMark getter');
 
   // Should not fail:
@@ -50,8 +50,8 @@ test(() => {
   const chunkGetterThrowing = {
     get byteLength() { throw error; }
   };
-  assert_throws({ name: 'TypeError' }, () => ByteLengthQueuingStrategy.prototype.size(), 'size fails with undefined');
-  assert_throws({ name: 'TypeError' }, () => ByteLengthQueuingStrategy.prototype.size(null), 'size fails with null');
+  assert_throws_js(TypeError, () => ByteLengthQueuingStrategy.prototype.size(), 'size fails with undefined');
+  assert_throws_js(TypeError, () => ByteLengthQueuingStrategy.prototype.size(null), 'size fails with null');
   assert_equals(ByteLengthQueuingStrategy.prototype.size('potato'), undefined,
     'size succeeds with undefined with a random non-object type');
   assert_equals(ByteLengthQueuingStrategy.prototype.size({}), undefined,
@@ -60,7 +60,7 @@ test(() => {
     'size succeeds with the right amount with an object with a hwm');
   assert_equals(ByteLengthQueuingStrategy.prototype.size(chunkGetter), size,
     'size succeeds with the right amount with an object with a hwm getter');
-  assert_throws({ name: 'Error' }, () => ByteLengthQueuingStrategy.prototype.size(chunkGetterThrowing),
+  assert_throws_js(Error, () => ByteLengthQueuingStrategy.prototype.size(chunkGetterThrowing),
     'size fails with the error thrown by the getter');
 
 }, 'ByteLengthQueuingStrategy size behaves as expected with strange arguments');

--- a/streams/count-queuing-strategy.any.js
+++ b/streams/count-queuing-strategy.any.js
@@ -27,9 +27,9 @@ test(() => {
     get highWaterMark() { throw error; }
   };
 
-  assert_throws({ name: 'TypeError' }, () => new CountQueuingStrategy(), 'construction fails with undefined');
-  assert_throws({ name: 'TypeError' }, () => new CountQueuingStrategy(null), 'construction fails with null');
-  assert_throws({ name: 'Error' }, () => new CountQueuingStrategy(highWaterMarkObjectGetterThrowing),
+  assert_throws_js(TypeError, () => new CountQueuingStrategy(), 'construction fails with undefined');
+  assert_throws_js(TypeError, () => new CountQueuingStrategy(null), 'construction fails with null');
+  assert_throws_js(Error, () => new CountQueuingStrategy(highWaterMarkObjectGetterThrowing),
     'construction fails with an object with a throwing highWaterMark getter');
 
   // Should not fail:

--- a/web-animations/README.md
+++ b/web-animations/README.md
@@ -59,7 +59,7 @@ Guidelines for writing tests
 
       ```javascript
       test(t => {
-        assert_throws({ name: 'TypeError' }, () => {
+        assert_throws_js(TypeError, () => {
           createDiv(t).animate(null, -1);
         });
       }, 'Setting a negative duration throws a TypeError');

--- a/web-animations/interfaces/AnimationEffect/updateTiming.html
+++ b/web-animations/interfaces/AnimationEffect/updateTiming.html
@@ -58,7 +58,7 @@ test(t => {
 for (const invalid of gBadDelayValues) {
   test(t => {
     const anim = createDiv(t).animate(null);
-    assert_throws({ name: 'TypeError' }, () => {
+    assert_throws_js(TypeError, () => {
       anim.effect.updateTiming({ delay: invalid });
     });
   }, `Throws when setting invalid delay value: ${invalid}`);
@@ -88,14 +88,14 @@ test(t => {
 
 test(t => {
   const anim = createDiv(t).animate(null, 2000);
-  assert_throws({ name: 'TypeError' }, () => {
+  assert_throws_js(TypeError, () => {
     anim.effect.updateTiming({ endDelay: Infinity });
   });
 }, 'Throws when setting the endDelay to infinity');
 
 test(t => {
   const anim = createDiv(t).animate(null, 2000);
-  assert_throws({ name: 'TypeError' }, () => {
+  assert_throws_js(TypeError, () => {
     anim.effect.updateTiming({ endDelay: -Infinity });
   });
 }, 'Throws when setting the endDelay to negative infinity');
@@ -163,7 +163,7 @@ test(t => {
 for (const invalid of gBadIterationStartValues) {
   test(t => {
     const anim = createDiv(t).animate(null);
-    assert_throws({ name: 'TypeError' }, () => {
+    assert_throws_js(TypeError, () => {
       anim.effect.updateTiming({ iterationStart: invalid });
     }, `setting ${invalid}`);
   }, `Throws when setting invalid iterationStart value: ${invalid}`);
@@ -193,7 +193,7 @@ test(t => {
 for (const invalid of gBadIterationsValues) {
   test(t => {
     const anim = createDiv(t).animate(null);
-    assert_throws({ name: 'TypeError' }, () => {
+    assert_throws_js(TypeError, () => {
       anim.effect.updateTiming({ iterations: invalid });
     });
   }, `Throws when setting invalid iterations value: ${invalid}`);

--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -332,7 +332,7 @@ test(() => {
     + ' propagated');
 
 test(() => {
-  assert_throws({ name: 'TypeError' }, () => {
+  assert_throws_js(TypeError, () => {
     new KeyframeEffect(null, createIterable([
       { done: false, value: { left: '100px' } },
       { done: false, value: 1234 },
@@ -415,7 +415,7 @@ test(() => {
       return 42;  // Not an object.
     },
   };
-  assert_throws({ name: 'TypeError' }, () => {
+  assert_throws_js(TypeError, () => {
     new KeyframeEffect(null, keyframe_obj);
   });
 }, 'A non-object returned from the Symbol.iterator property should cause a'

--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html
@@ -66,7 +66,7 @@ test(() => {
   addProp('width');
   keyframe.easing = 'easy-peasy';
 
-  assert_throws({ name: 'TypeError' }, () => {
+  assert_throws_js(TypeError, () => {
     new KeyframeEffect(target, keyframe);
   });
   assert_equals(propAccessCount, 2,
@@ -92,7 +92,7 @@ test(() => {
   addProp(kf2, 'height');
   addProp(kf2, 'width');
 
-  assert_throws({ name: 'TypeError' }, () => {
+  assert_throws_js(TypeError, () => {
     new KeyframeEffect(target, [ kf1, kf2 ]);
   });
   assert_equals(propAccessCount, 4,

--- a/web-animations/timing-model/animations/setting-the-current-time-of-an-animation.html
+++ b/web-animations/timing-model/animations/setting-the-current-time-of-an-animation.html
@@ -26,7 +26,7 @@ promise_test(async t => {
   await anim.ready;
 
   assert_greater_than_equal(anim.currentTime, 0);
-  assert_throws({ name: 'TypeError' }, () => {
+  assert_throws_js(TypeError, () => {
     anim.currentTime = null;
   });
 }, 'Setting the current time of a playing animation to unresolved throws a'
@@ -38,7 +38,7 @@ promise_test(async t => {
   anim.pause();
 
   assert_greater_than_equal(anim.currentTime, 0);
-  assert_throws({ name: 'TypeError' }, () => {
+  assert_throws_js(TypeError, () => {
     anim.currentTime = null;
   });
 }, 'Setting the current time of a paused animation to unresolved throws a'


### PR DESCRIPTION
This a piece-by-piece landing of #21350 due to the size of the original PR. Please excuse the email spam when wpt-pr-bot cc's you to this PR.