### PR TITLE
Replace some more "assert_throws(new FooError(), stuff)" calls with a…

### DIFF
--- a/css/css-properties-values-api/register-property-syntax-parsing.html
+++ b/css/css-properties-values-api/register-property-syntax-parsing.html
@@ -18,7 +18,7 @@ function assert_valid(syntax, initialValue) {
 function assert_invalid(syntax, initialValue) {
     test(function(){
         var name = '--syntax-test-' + (test_count++);
-        assert_throws(new SyntaxError(),
+        assert_throws_dom("SyntaxError",
             () => CSS.registerProperty({name: name, syntax: syntax, initialValue: initialValue, inherits: false}));
     }, "syntax:'" + syntax + "', initialValue:'" + initialValue + "' is invalid");
 }

--- a/css/css-properties-values-api/register-property.html
+++ b/css/css-properties-values-api/register-property.html
@@ -8,12 +8,12 @@
 // Tests for error checking during property registration
 
 test(function() {
-    assert_throws(new TypeError(), () => CSS.registerProperty());
-    assert_throws(new TypeError(), () => CSS.registerProperty(undefined));
-    assert_throws(new TypeError(), () => CSS.registerProperty(true));
-    assert_throws(new TypeError(), () => CSS.registerProperty(2));
-    assert_throws(new TypeError(), () => CSS.registerProperty("css"));
-    assert_throws(new TypeError(), () => CSS.registerProperty(null));
+    assert_throws_js(TypeError, () => CSS.registerProperty());
+    assert_throws_js(TypeError, () => CSS.registerProperty(undefined));
+    assert_throws_js(TypeError, () => CSS.registerProperty(true));
+    assert_throws_js(TypeError, () => CSS.registerProperty(2));
+    assert_throws_js(TypeError, () => CSS.registerProperty("css"));
+    assert_throws_js(TypeError, () => CSS.registerProperty(null));
 }, "registerProperty requires a Dictionary type");
 
 test(function() {
@@ -23,16 +23,16 @@ test(function() {
     CSS.registerProperty({name: ['--name', 3], inherits: false});
 
     // Invalid property names
-    assert_throws(new TypeError(), () => CSS.registerProperty({}));
-    assert_throws(new SyntaxError(), () => CSS.registerProperty({name: 'no-leading-dash', inherits: false}));
-    assert_throws(new SyntaxError(), () => CSS.registerProperty({name: '', inherits: false}));
-    assert_throws(new SyntaxError(), () => CSS.registerProperty({name: '\\--name', inherits: false}));
+    assert_throws_js(TypeError, () => CSS.registerProperty({}));
+    assert_throws_dom("SyntaxError", () => CSS.registerProperty({name: 'no-leading-dash', inherits: false}));
+    assert_throws_dom("SyntaxError", () => CSS.registerProperty({name: '', inherits: false}));
+    assert_throws_dom("SyntaxError", () => CSS.registerProperty({name: '\\--name', inherits: false}));
 }, "registerProperty requires a name matching <custom-property-name>");
 
 test(function() {
     CSS.registerProperty({name: '--syntax-test-1', syntax: '*', inherits: false});
     CSS.registerProperty({name: '--syntax-test-2', syntax: ' * ', inherits: false});
-    assert_throws(new SyntaxError(),
+    assert_throws_dom("SyntaxError",
         () => CSS.registerProperty({name: '--syntax-test-3', syntax: 'length', inherits: false}));
 }, "registerProperty only allows omitting initialValue if syntax is '*'");
 
@@ -45,7 +45,7 @@ test(function() {
 test(function(){
     CSS.registerProperty({name: '--inherit-test-1', syntax: '<length>', initialValue: '0px', inherits: true});
     CSS.registerProperty({name: '--inherit-test-2', syntax: '<length>', initialValue: '0px', inherits: false});
-    assert_throws(new TypeError(), () => CSS.registerProperty({name: '--inherit-test-3', syntax: '<length>', initialValue: '0px'}));
+    assert_throws_js(TypeError, () => CSS.registerProperty({name: '--inherit-test-3', syntax: '<length>', initialValue: '0px'}));
 }, "registerProperty requires inherits");
 
 test(function(){

--- a/css/css-typed-om/stylevalue-subclasses/numeric-objects/cssMathValue.tentative.html
+++ b/css/css-typed-om/stylevalue-subclasses/numeric-objects/cssMathValue.tentative.html
@@ -17,7 +17,7 @@ const gVariadicMathValueSubclasses = [
 
 for (const {subclass, operator} of gVariadicMathValueSubclasses) {
   test(() => {
-    assert_throws(new SyntaxError(), () => new subclass());
+    assert_throws_dom("SyntaxError", () => new subclass());
   }, 'Constructing a ' + subclass.name + ' with no arguments throws a SyntaxError');
 
   test(() => {
@@ -35,7 +35,7 @@ for (const {subclass, operator} of gVariadicMathValueSubclasses) {
 
   test(() => {
     let result = new subclass(CSS.number(1), CSS.number(2));
-    assert_throws(new TypeError(), () => result.operator = 'foo');
+    assert_throws_js(TypeError, () => result.operator = 'foo');
   }, subclass.name + '.operator is readonly');
 }
 
@@ -57,7 +57,7 @@ for (const {subclass, operator} of gUnaryMathValueSubclasses) {
 
   test(() => {
     let result = new subclass(CSS.number(1));
-    assert_throws(new TypeError(), () => result.operator = 'foo');
+    assert_throws_js(TypeError, () => result.operator = 'foo');
   }, subclass.name + '.operator is readonly');
 }
 

--- a/css/css-typed-om/stylevalue-subclasses/numeric-objects/parse.tentative.html
+++ b/css/css-typed-om/stylevalue-subclasses/numeric-objects/parse.tentative.html
@@ -8,19 +8,19 @@
 'use strict';
 
 test(() => {
-  assert_throws(new SyntaxError(), () => CSSNumericValue.parse('%#('));
+  assert_throws_dom("SyntaxError", () => CSSNumericValue.parse('%#('));
 }, 'Parsing an invalid string throws SyntaxError');
 
 test(() => {
-  assert_throws(new SyntaxError(), () => CSSNumericValue.parse('auto'));
+  assert_throws_dom("SyntaxError", () => CSSNumericValue.parse('auto'));
 }, 'Parsing a string with a non numeric token throws SyntaxError');
 
 test(() => {
-  assert_throws(new SyntaxError(), () => CSSNumericValue.parse('1 2'));
+  assert_throws_dom("SyntaxError", () => CSSNumericValue.parse('1 2'));
 }, 'Parsing a string with left over numeric tokens throws SyntaxError');
 
 test(() => {
-  assert_throws(new SyntaxError(), () => CSSNumericValue.parse('calc(calc(1px * 2s) + 3%)'));
+  assert_throws_dom("SyntaxError", () => CSSNumericValue.parse('calc(calc(1px * 2s) + 3%)'));
 }, 'Parsing a calc with incompatible units throws a SyntaxError');
 
 test(() => {

--- a/css/css-typed-om/stylevalue-subclasses/numeric-objects/to.tentative.html
+++ b/css/css-typed-om/stylevalue-subclasses/numeric-objects/to.tentative.html
@@ -8,19 +8,19 @@
 'use strict';
 
 test(() => {
-  assert_throws(new SyntaxError(), () => CSS.px(1).to('lemon'));
+  assert_throws_dom("SyntaxError", () => CSS.px(1).to('lemon'));
 }, 'Converting a CSSUnitValue to an invalid unit throws SyntaxError');
 
 test(() => {
-  assert_throws(new TypeError(), () => new CSSMathMax(1, CSS.px(1)).to('number'));
+  assert_throws_js(TypeError, () => new CSSMathMax(1, CSS.px(1)).to('number'));
 }, 'Converting a CSSNumericValue with invalid sum value throws TypeError');
 
 test(() => {
-  assert_throws(new TypeError(), () => new CSSMathProduct(CSS.px(1), CSS.s(1)).to('number'));
+  assert_throws_js(TypeError, () => new CSSMathProduct(CSS.px(1), CSS.s(1)).to('number'));
 }, 'Converting a CSSNumericValue with sum value containing more than one value throws TypeError');
 
 test(() => {
-  assert_throws(new TypeError(), () => CSS.px(1).to('number'));
+  assert_throws_js(TypeError, () => CSS.px(1).to('number'));
 }, 'Converting a CSSUnitValue to an incompatible unit throws TypeError');
 
 test(() => {
@@ -52,8 +52,8 @@ test(() => {
 }, 'Converting a CSSMathMin to a single unit finds the min value');
 
 test(() => {
-  assert_throws(new TypeError(), () => new CSSMathMin(CSS.px(2), CSS.s(3)).to('px'));
-  assert_throws(new TypeError(), () => new CSSMathMin(CSS.px(2), 3).to('px'));
+  assert_throws_js(TypeError, () => new CSSMathMin(CSS.px(2), CSS.s(3)).to('px'));
+  assert_throws_js(TypeError, () => new CSSMathMin(CSS.px(2), 3).to('px'));
 }, 'Converting a CSSMathMin to a single unit with different units throws a TypeError');
 
 test(() => {
@@ -61,8 +61,8 @@ test(() => {
 }, 'Converting a CSSMathMax to a single unit finds the max value');
 
 test(() => {
-  assert_throws(new TypeError(), () => new CSSMathMax(CSS.px(2), CSS.s(3)).to('px'));
-  assert_throws(new TypeError(), () => new CSSMathMax(CSS.px(2), 3).to('px'));
+  assert_throws_js(TypeError, () => new CSSMathMax(CSS.px(2), CSS.s(3)).to('px'));
+  assert_throws_js(TypeError, () => new CSSMathMax(CSS.px(2), 3).to('px'));
 }, 'Converting a CSSMathMax to a single unit with different units throws a TypeError');
 
 test(() => {

--- a/css/css-typed-om/stylevalue-subclasses/numeric-objects/toSum.tentative.html
+++ b/css/css-typed-om/stylevalue-subclasses/numeric-objects/toSum.tentative.html
@@ -8,27 +8,27 @@
 'use strict';
 
 test(() => {
-  assert_throws(new SyntaxError(), () => CSS.px(1).toSum('px', 'lemon'));
+  assert_throws_dom("SyntaxError", () => CSS.px(1).toSum('px', 'lemon'));
 }, 'Converting a CSSNumericValue to a sum with invalid units throws SyntaxError');
 
 test(() => {
-  assert_throws(new TypeError(), () => new CSSMathMax(1, CSS.px(1)).toSum('number'));
+  assert_throws_js(TypeError, () => new CSSMathMax(1, CSS.px(1)).toSum('number'));
 }, 'Converting a CSSNumericValue with an invalid sum value to a sum throws TypeError');
 
 test(() => {
-  assert_throws(new TypeError(), () => new CSSMathProduct(CSS.px(1), CSS.px(1)).to('px'));
+  assert_throws_js(TypeError, () => new CSSMathProduct(CSS.px(1), CSS.px(1)).to('px'));
 }, 'Converting a CSSNumericValue with compound units to a sum throws TypeError');
 
 test(() => {
-  assert_throws(new TypeError(), () => CSS.px(1).toSum('number'));
+  assert_throws_js(TypeError, () => CSS.px(1).toSum('number'));
 }, 'Converting a CSSNumericValue to a sum with an incompatible unit throws TypeError');
 
 test(() => {
-  assert_throws(new TypeError(), () => CSS.px(1).toSum('px', 's'));
+  assert_throws_js(TypeError, () => CSS.px(1).toSum('px', 's'));
 }, 'Converting a CSSNumericValue to a sum with units that are not addable throws TypeError');
 
 test(() => {
-  assert_throws(new TypeError(), () => new CSSMathSum(CSS.px(1), CSS.em(1)).toSum('px'));
+  assert_throws_js(TypeError, () => new CSSMathSum(CSS.px(1), CSS.em(1)).toSum('px'));
 }, 'Converting a CSSNumericValue with leftover units to a sum throws TypeError');
 
 test(() => {

--- a/kv-storage/interface.https.html
+++ b/kv-storage/interface.https.html
@@ -79,9 +79,9 @@ test(() => {
     assert_equals(descriptor.value.name, methodName,
       `${methodName} function object should have the right name`);
 
-    assert_throws(new TypeError(), () => descriptor.value.call(StorageArea.prototype),
+    assert_throws_js(TypeError, () => descriptor.value.call(StorageArea.prototype),
       `${methodName} should throw when called on the prototype directly`);
-      assert_throws(new TypeError(), () => descriptor.value.call({}),
+      assert_throws_js(TypeError, () => descriptor.value.call({}),
       `${methodName} should throw when called on an empty object`);
   }
 
@@ -140,29 +140,30 @@ promise_test(async t => {
 
   await frameLoadPromise(iframe);
   const OtherStorageArea = iframe.contentWindow.StorageArea;
+  const TypeError = iframe.contentWindow.TypeError;
 
-  await promise_rejects(t, new TypeError(),
+  await promise_rejects_js(t, TypeError,
     OtherStorageArea.prototype.set.call(storage, "testkey", "testvalue"),
     `set() must reject cross-realm`);
-  await promise_rejects(t, new TypeError(),
+  await promise_rejects_js(t, TypeError,
     OtherStorageArea.prototype.get.call(storage, "testkey"),
     `get() must reject cross-realm`);
-  await promise_rejects(t, new TypeError(),
+  await promise_rejects_js(t, TypeError,
     OtherStorageArea.prototype.delete.call(storage, "testkey"),
     `delete() must reject cross-realm`);
-  await promise_rejects(t, new TypeError(), OtherStorageArea.prototype.clear.call(storage),
+  await promise_rejects_js(t, TypeError, OtherStorageArea.prototype.clear.call(storage),
     `clear() must reject cross-realm`);
 
-  assert_throws(new TypeError(), () => OtherStorageArea.prototype.keys.call(storage),
+  assert_throws_js(TypeError, () => OtherStorageArea.prototype.keys.call(storage),
     `keys() must throw cross-realm`);
-  assert_throws(new TypeError(), () => OtherStorageArea.prototype.values.call(storage),
+  assert_throws_js(TypeError, () => OtherStorageArea.prototype.values.call(storage),
     `values() must throw cross-realm`);
-  assert_throws(new TypeError(), () => OtherStorageArea.prototype.entries.call(storage),
+  assert_throws_js(TypeError, () => OtherStorageArea.prototype.entries.call(storage),
     `entries() must throw cross-realm`);
 
   const otherBackingStoreGetter =
     Object.getOwnPropertyDescriptor(OtherStorageArea.prototype, "backingStore").get;
-  assert_throws(new TypeError(), () => otherBackingStoreGetter.call(storage),
+  assert_throws_js(TypeError, () => otherBackingStoreGetter.call(storage),
     `backingStore must throw cross-realm`);
 }, "Same-realm brand checks");
 

--- a/websockets/stream-tentative/constructor.any.js
+++ b/websockets/stream-tentative/constructor.any.js
@@ -3,23 +3,23 @@
 // META: global=window,worker
 
 test(() => {
-  assert_throws(new TypeError(), () => new WebSocketStream(),
+  assert_throws_js(TypeError, () => new WebSocketStream(),
                 'constructor should throw');
 }, 'constructing with no URL should throw');
 
 test(() => {
-  assert_throws(new SyntaxError(), () => new WebSocketStream('invalid:'),
-                "constructor should throw");
+  assert_throws_dom("SyntaxError", () => new WebSocketStream('invalid:'),
+                    "constructor should throw");
 }, 'constructing with an invalid URL should throw');
 
 test(() => {
-  assert_throws(new TypeError(),
+  assert_throws_js(TypeError,
                 () => new WebSocketStream(`${BASEURL}/`, true),
                 "constructor should throw");
 }, 'constructing with invalid options should throw');
 
 test(() => {
-  assert_throws(new TypeError(),
+  assert_throws_js(TypeError,
                 () => new WebSocketStream(`${BASEURL}/`, {protocols: 'hi'}),
                 "constructor should throw");
 }, 'protocols should be required to be a list');


### PR DESCRIPTION
…ssert_throws_js or assert_throws_dom.

This diff was generated by running:

  find . -type f -print0 | xargs -0 perl -pi -e 'BEGIN { $/ = undef; } s/assert_throws\(([ \n]*)new ([A-Za-z]*Error) *\(\) *(, *.)/assert_throws_js(\1\2\3/gs'

on the relevant files and then:

1) Manually fixing up "assert_throws_js(SyntaxError, ...)" to be 'assert_throws_dom("SyntaxError", ...).

2) Changing kv-storage/interface.https.html to get TypeError from the same global as the object it's testing.

Note: these are the files which had changes to them reverted as part
of landing <https://github.com/web-platform-tests/wpt/pull/21354>.
The two manual fixups there address the issues that led to the revert.