### PR TITLE
Fix `sandbox-disallow-scripts-via-unsandboxed-popup.tentative.html`.

### DIFF
--- a/html/browsers/sandboxing/sandbox-disallow-scripts-via-unsandboxed-popup.tentative.html
+++ b/html/browsers/sandboxing/sandbox-disallow-scripts-via-unsandboxed-popup.tentative.html
@@ -6,9 +6,9 @@
     async_test(t => {
       let i = document.createElement('iframe');
       i.sandbox = "allow-same-origin allow-popups allow-popups-to-escape-sandbox";
-      i.srcdoc = `<a target='_blank'
+      i.srcdoc = `<a target='_blank' rel='opener'
                      href="javascript:window.opener.top.postMessage('FAIL', '*');">Click me!</a>
-                  <a target='_blank'
+                  <a target='_blank' rel='opener'
                      href="./resources/post-done-to-opener.html">Click me next!</a>`;
 
       i.onload = _ => {


### PR DESCRIPTION
https://github.com/whatwg/html/issues/4078 changed `opener` semantics to require
explicit transfer to `_blank` targets via `rel=opener`. This patch brings this test into
line with that behavior.