### PR TITLE
Pass return code through when running wpt --py3

### DIFF
--- a/wpt
+++ b/wpt
@@ -2,11 +2,11 @@
 
 if __name__ == "__main__":
     from tools.wpt import wpt
-    from sys import version_info, argv
+    from sys import version_info, argv, exit
     args, extra = wpt.parse_args(argv[1:])
 
     if args.py3 and version_info.major < 3:
         from subprocess import call
-        call(['python3', argv[0]] + [args.command] + extra)
+        exit(call(['python3', argv[0]] + [args.command] + extra))
     else:
         wpt.main()


### PR DESCRIPTION
This was added in #21372, but let's make this work better.

See, e.g., `./wpt --py3 manifest --bogus; echo $?`