### PR TITLE
Use long animation in webkit-animation-iteration-event.html

### DIFF
--- a/dom/events/webkit-animation-iteration-event.html
+++ b/dom/events/webkit-animation-iteration-event.html
@@ -15,6 +15,9 @@
 runAnimationEventTests({
   unprefixedType: 'animationiteration',
   prefixedType: 'webkitAnimationIteration',
-  animationCssStyle: '50ms 2',
+  // Use a long duration to avoid missing the animation due to slow machines,
+  // but set a negative delay so that the iteration boundary happens shortly
+  // after the animation starts.
+  animationCssStyle: '100s -99.9s 2',
 });
 </script>


### PR DESCRIPTION
Some CI systems are very slow, so end up skipping short animations and not firing iteration events for them. This commit changes webkit-animation-iteration-event.html to have a very long iteration duration, but uses a negative delay to position the start point right before the end of the first iteration.