### PR TITLE
Added 1 new ::selection and normal text in SVG object and its reference

### DIFF
--- a/css/css-pseudo/active-selection-065-ref.html
+++ b/css/css-pseudo/active-selection-065-ref.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <meta content="svg" name="flags">
+
+  <style>
+  text
+    {
+      fill: green;
+      /*
+      fill is the shorthand form for fill-color,
+      fill-image, fill-origin, fill-position, fill-size
+      and fill-repeat
+      https://www.w3.org/TR/fill-stroke-3/#fill-shorthand
+      */
+      font-size: 48px;
+      stroke: yellow;
+      /*
+      stroke is the shorthand form for stroke-color,
+      stroke-image, stroke-origin, stroke-position,
+      stroke-size, and stroke-repeat
+      https://www.w3.org/TR/fill-stroke-3/#stroke-shorthand
+      */
+      stroke-width: 2px;
+    }
+  </style>
+
+ <body>
+
+  <p>Test passes if the glyphs of "Selected Text" are green with a yellow outline.
+
+  <div>
+
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="400" height="100" viewbox="0 0 400 100">
+
+      <text x="0" y="46">Selected text</text>
+
+    </svg>
+
+  </div>

--- a/css/css-pseudo/active-selection-065.html
+++ b/css/css-pseudo/active-selection-065.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Test: active selected SVG text styled with fill and stroke</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-styling">
+  <link rel="help" href="https://www.w3.org/TR/fill-stroke-3/#fill-shorthand">
+  <link rel="help" href="https://www.w3.org/TR/fill-stroke-3/#stroke-shorthand">
+  <link rel="match" href="active-selection-065-ref.html">
+
+  <meta content="svg" name="flags">
+  <meta content="This test checks that a selected SVG text can be styled with 'fill' and 'stroke'." name="assert">
+
+  <style>
+  text
+    {
+      fill: red;
+      font-size: 48px;
+    }
+
+  text::selection
+    {
+      fill: green;
+      /*
+      fill is the shorthand form for fill-color,
+      fill-image, fill-origin, fill-position, fill-size
+      and fill-repeat
+      https://www.w3.org/TR/fill-stroke-3/#fill-shorthand
+      */
+      stroke: yellow;
+      /*
+      stroke is the shorthand form for stroke-color,
+      stroke-image, stroke-origin, stroke-position,
+      stroke-size, and stroke-repeat
+      https://www.w3.org/TR/fill-stroke-3/#stroke-shorthand
+      */
+      stroke-width: 2px;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+ <body onload="startTest();">
+
+  <p>Test passes if the glyphs of "Selected Text" are green with a yellow outline.
+
+  <div>
+
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="400" height="100" viewbox="0 0 400 100">
+
+      <text x="0" y="46" id="test">Selected text</text>
+
+    </svg>
+
+  </div>


### PR DESCRIPTION
This is a followup to 
https://github.com/web-platform-tests/wpt/pull/20033#issuecomment-576460334

active-selection-065.html : normal non-curved line of text in a SVG object
active-selection-065-ref.html

On my website:

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/active-selection-065.html
http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/active-selection-065-ref.html
