### PR TITLE
Fix beacon referrer test to pass when blocked for mixed content

### DIFF
--- a/beacon/headers/header-referrer-no-referrer-when-downgrade.https.html
+++ b/beacon/headers/header-referrer-no-referrer-when-downgrade.https.html
@@ -15,7 +15,7 @@
       var testBase = get_host_info().HTTPS_ORIGIN + RESOURCES_DIR;
       testReferrerHeader(testBase, referrerUrl);
       testBase = get_host_info().HTTP_ORIGIN + RESOURCES_DIR;
-      testReferrerHeader(testBase, "");
+      testReferrerHeader(testBase, "", true);
     </script>
   </body>
 </html>


### PR DESCRIPTION
A small change to make [/beacon/headers/header-referrer-no-referrer-when-downgrade.https.html](https://wpt.fyi/results/beacon/headers/header-referrer-no-referrer-when-downgrade.https.html?label=master&label=experimental&aligned) pass when the browser (rightfully) blocks the request as mixed content