### PR TITLE
Update interfaces/DOM-Parsing.idl and associated test

### DIFF
--- a/domparsing/idlharness.window.js
+++ b/domparsing/idlharness.window.js
@@ -10,7 +10,6 @@ idl_test(
   ['dom'],
   idlArray => {
     idlArray.add_objects({
-      DOMParser: ['new DOMParser()'],
       Element: ['document.createElement("div")'],
       Range: ['new Range()'],
       XMLSerializer: ['new XMLSerializer()'],

--- a/interfaces/DOM-Parsing.idl
+++ b/interfaces/DOM-Parsing.idl
@@ -4,20 +4,6 @@
 // Source: DOM Parsing and Serialization (https://w3c.github.io/DOM-Parsing/)
 
 [Exposed=Window]
-interface DOMParser {
-  constructor();
-  [NewObject] Document parseFromString(DOMString str, SupportedType type);
-};
-
-enum SupportedType {
-  "text/html",
-  "text/xml",
-  "application/xml",
-  "application/xhtml+xml",
-  "image/svg+xml"
-};
-
-[Exposed=Window]
 interface XMLSerializer {
   constructor();
   DOMString serializeToString(Node root);


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/wpt/pull/21496

See https://github.com/web-platform-tests/wpt/pull/21488 for where the IDL has moved to