### PR TITLE
Drop pypy from tox.ini

### DIFF
--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,pypy,{py27,py35,py36,py37,py38}-flake8,{py35,py36,py37,py38}-mypy
+envlist = py27,py35,py36,py37,py38,{py27,py35,py36,py37,py38}-flake8,{py35,py36,py37,py38}-mypy
 skipsdist=True
 skip_missing_interpreters = False
 


### PR DESCRIPTION
This has been broken for a while due to https://bitbucket.org/pypy/pypy/issues/3157. This means, at least on my local ArchLinux x86_64 install, all environments currently pass (i.e., including those we don't run on CI).