### PR TITLE
Add some tests for Node IDL members on Attr objects

### DIFF
--- a/dom/nodes/Node-baseURI.html
+++ b/dom/nodes/Node-baseURI.html
@@ -4,29 +4,59 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-test(function() {
-  var element = document.createElement("div");
-  document.body.appendChild(element);
-  assert_equals(element.baseURI, document.URL);
-}, "For elements belonging to document, baseURI should be document url")
+const elementTests = [
+  {
+    name: "elements belonging to document",
+    creator: () => {
+      const element = document.createElement("div");
+      document.body.appendChild(element);
+      return element;
+    }
+  },
+  {
+    name: "elements unassigned to document",
+    creator: () => document.createElement("div")
+  },
+  {
+    name: "elements belonging to document fragments",
+    creator: () => {
+      const fragment = document.createDocumentFragment();
+      const element = document.createElement("div");
+      fragment.appendChild(element);
+      return element;
+    }
+  },
+  {
+    name: "elements belonging to document fragments in document",
+    creator: () => {
+      const fragment = document.createDocumentFragment();
+      const element = document.createElement("div");
+      fragment.appendChild(element);
+      document.body.appendChild(fragment);
+      return element;
+    }
+  },
+];
 
-test(function() {
-  var element = document.createElement("div");
-  assert_equals(element.baseURI, document.URL);
-}, "For elements unassigned to document, baseURI should be document url")
+const attributeTests = [
+  {
+    name: "attributes unassigned to element",
+    creator: () => document.createAttribute("class")
+  },
+  ...elementTests.map(({ name, creator }) => ({
+    name: "attributes in " + name,
+    creator: () => {
+      const element = creator();
+      element.setAttribute("class", "abc");
+      return element.getAttributeNode("class");
+    }
+  }))
+];
 
-test(function() {
-  var fragment = document.createDocumentFragment();
-  var element = document.createElement("div");
-  fragment.appendChild(element);
-  assert_equals(element.baseURI, document.URL)
-}, "For elements belonging to document fragments, baseURI should be document url")
-
-test(function() {
-  var fragment = document.createDocumentFragment();
-  var element = document.createElement("div");
-  fragment.appendChild(element);
-  document.body.appendChild(fragment);
-  assert_equals(element.baseURI, document.URL)
-}, "After inserting fragment into document, element baseURI should be document url")
+for (const { name, creator } of [...elementTests, ...attributeTests]) {
+  test(function() {
+    const node = creator();
+    assert_equals(node.baseURI, document.URL);
+  }, `For ${name}, baseURI should be document URL`)
+}
 </script>

--- a/dom/nodes/Node-cloneNode.html
+++ b/dom/nodes/Node-cloneNode.html
@@ -222,6 +222,52 @@ test(function() {
 }, "createProcessingInstruction");
 
 test(function() {
+    var attr = document.createAttribute("class");
+    var copy = attr.cloneNode();
+    check_copy(attr, copy, Attr);
+    assert_equals(attr.namespaceURI, copy.namespaceURI);
+    assert_equals(attr.prefix, copy.prefix);
+    assert_equals(attr.localName, copy.localName);
+    assert_equals(attr.value, copy.value);
+
+    attr.value = "abc";
+    assert_equals(attr.namespaceURI, copy.namespaceURI);
+    assert_equals(attr.prefix, copy.prefix);
+    assert_equals(attr.localName, copy.localName);
+    assert_not_equals(attr.value, copy.value);
+
+    var copy2 = attr.cloneNode();
+    check_copy(attr, copy2, Attr);
+    assert_equals(attr.namespaceURI, copy.namespaceURI);
+    assert_equals(attr.prefix, copy.prefix);
+    assert_equals(attr.localName, copy2.localName);
+    assert_equals(attr.value, copy2.value);
+}, "createAttribute");
+
+test(function() {
+    var attr = document.createAttributeNS("http://www.w3.org/1999/xhtml", "foo:class");
+    var copy = attr.cloneNode();
+    check_copy(attr, copy, Attr);
+    assert_equals(attr.namespaceURI, copy.namespaceURI);
+    assert_equals(attr.prefix, copy.prefix);
+    assert_equals(attr.localName, copy.localName);
+    assert_equals(attr.value, copy.value);
+
+    attr.value = "abc";
+    assert_equals(attr.namespaceURI, copy.namespaceURI);
+    assert_equals(attr.prefix, copy.prefix);
+    assert_equals(attr.localName, copy.localName);
+    assert_not_equals(attr.value, copy.value);
+
+    var copy2 = attr.cloneNode();
+    check_copy(attr, copy2, Attr);
+    assert_equals(attr.namespaceURI, copy.namespaceURI);
+    assert_equals(attr.prefix, copy.prefix);
+    assert_equals(attr.localName, copy2.localName);
+    assert_equals(attr.value, copy2.value);
+}, "createAttributeNS");
+
+test(function() {
     var doctype = document.implementation.createDocumentType("html", "public", "system");
     var copy = doctype.cloneNode();
     check_copy(doctype, copy, DocumentType);

--- a/dom/nodes/Node-isSameNode.html
+++ b/dom/nodes/Node-isSameNode.html
@@ -15,7 +15,7 @@ test(function() {
   assert_true(doctype1.isSameNode(doctype1), "self-comparison");
   assert_false(doctype1.isSameNode(doctype2), "same properties");
   assert_false(doctype1.isSameNode(null), "with null other node");
-}, "doctypes should be comapred on reference");
+}, "doctypes should be compared on reference");
 
 test(function() {
 
@@ -95,6 +95,17 @@ test(function() {
   assert_false(document1.isSameNode(document2), "another empty XML document");
   assert_false(document1.isSameNode(null), "with null other node");
 
-}, "documents should not be compared on reference");
+}, "documents should be compared on reference");
+
+test(function() {
+
+  var attr1 = document.createAttribute('href');
+  var attr2 = document.createAttribute('href');
+
+  assert_true(attr1.isSameNode(attr1), "self-comparison");
+  assert_false(attr1.isSameNode(attr2), "same name");
+  assert_false(attr1.isSameNode(null), "with null other node");
+
+}, "attributes should be compared on reference");
 
 </script>


### PR DESCRIPTION
The "For attributes unassigned to element, baseURI should be document URL" currently fails on Firefox. This is since Firefox doesn't treat attributes unassigned to elements as having a node document for purposes of the `baseURI` attribute, in contrary to the [spec](https://dom.spec.whatwg.org/#dom-node-baseuri).