### PR TITLE
Re-land pull_request_previews.yml workflow

### DIFF
--- a/.github/workflows/pull_request_previews.yml
+++ b/.github/workflows/pull_request_previews.yml
@@ -1,0 +1,32 @@
+name: pr-preview-sync
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+jobs:
+  update-pr-preview:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install dependency
+      run: pip install requests
+    - name: Synchronize state
+      run:
+        ./tools/ci/pr_preview.py
+          --host https://api.github.com
+          --github-project web-platform-tests/wpt
+          synchronize
+          --window 480
+      env:
+        # This Workflow must trigger further workflows. The GitHub-provided
+        # `GITHUB_TOKEN` secret is incapable of doing this [1], so a
+        # user-generated token must be specified instead. This token requires
+        # the "repo" scope, and is should be stored as a Secret named
+        # "DEPLOY_TOKEN" in this GitHub project.
+        #
+        # [1] https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows
+        #
+        # Temporarily using 'STEPHEN_TOKEN' for testing. To be removed once we
+        # verify the end-to-end flow.
+        DEPLOY_TOKEN: ${{ secrets.STEPHEN_TOKEN }}

--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -308,6 +308,9 @@ def synchronize(host, github_project, window):
                 project.create_deployment(
                     pull_request, revision_latest
                 )
+                # Temporarily bail after creating one deployment, to verify the
+                # end-to-end flow without spamming many PRs.
+                logger.info('Created one deployment, returning for testing purposes')
         else:
             logger.info('Pull Request should not be mirrored')
 


### PR DESCRIPTION
This attempts to re-land the pull_request_previews.yml workflow, to
create deployments for wptpr.live. This was previously reverted because
it was not properly triggering the dependent deployment workflow. I've
tested it on my local fork of wpt with my personal token and can't
reproduce the failure (i.e. it is working), so I'm landing this again to
see if it works now.

This reverts commit 462f3c4680dc9d4c5dd4740742947cd16d6fc1df. I've
changed two main things:

  * Use my personal token temporarily, to mimic the local setup.
  * Only deploy one PR per run of the workflow, to avoid spamming.