### PR TITLE
Restore pull_request_previews.yml to use secrets.DEPLOY_TOKEN

### DIFF
--- a/.github/workflows/pull_request_previews.yml
+++ b/.github/workflows/pull_request_previews.yml
@@ -26,7 +26,4 @@ jobs:
         # "DEPLOY_TOKEN" in this GitHub project.
         #
         # [1] https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows
-        #
-        # Temporarily using 'STEPHEN_TOKEN' for testing. To be removed once we
-        # verify the end-to-end flow.
-        DEPLOY_TOKEN: ${{ secrets.STEPHEN_TOKEN }}
+        DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
As per https://github.com/web-platform-tests/wpt/pull/21560, the re-launch of pull_request_previews.yml appears to work using my personal access token. Switching it back to use DEPLOY_TOKEN to see if that works.