### PR TITLE
Bump testfiles manifest version to 8

### DIFF
--- a/tools/wpt/tests/test_testfiles.py
+++ b/tools/wpt/tests/test_testfiles.py
@@ -31,7 +31,7 @@ def test_affected_testfiles():
             ]
         },
         "url_base": "/",
-        "version": 7,
+        "version": 8,
     }
     manifest = Manifest.from_json("/", manifest_json)
     with patch("tools.wpt.testfiles.load_manifest", return_value=manifest):


### PR DESCRIPTION
It was failing with ManifestVersionMismatch because the test manifest was using version 7.