### PR TITLE
Do not create wptpr.live deployments for forks

### DIFF
--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -124,6 +124,26 @@ class Project(object):
         return data['items']
 
     @guard('core')
+    def pull_request_is_from_fork(self, pr_number):
+        url = '{}/repos/{}/pulls/{}'.format(
+            self._host, self._github_project, pr_number
+        )
+
+        logger.info('Checking if pull request %s is from a fork', pr_number)
+
+        data = gh_request('GET', url)
+
+        repo_name = data['head']['repo']['full_name']
+        is_fork = repo_name != self._github_project
+
+        logger.info(
+            'Pull request %s is from \'%s\'. Is a fork: %s',
+            pr_number, repo_name, is_fork
+        )
+
+        return is_fork
+
+    @guard('core')
     def create_ref(self, refspec, revision):
         url = '{}/repos/{}/git/refs'.format(self._host, self._github_project)
 
@@ -246,13 +266,15 @@ def has_mirroring_label(pull_request):
 
     return False
 
-def should_be_mirrored(pull_request):
+def should_be_mirrored(pull_request, project):
     return (
         is_open(pull_request) and
         pull_request['user']['login'] not in AUTOMATION_GITHUB_USERS and (
             pull_request['author_association'] in TRUSTED_AUTHOR_ASSOCIATIONS or
             has_mirroring_label(pull_request)
-        )
+        ) and
+        # Query this last as it requires another API call to verify
+        not project.pull_request_is_from_fork(pull_request['number'])
     )
 
 def is_deployed(host, deployment):
@@ -291,7 +313,7 @@ def synchronize(host, github_project, window):
         revision_trusted = remote.get_revision(refspec_trusted)
         revision_open = remote.get_revision(refspec_open)
 
-        if should_be_mirrored(pull_request):
+        if should_be_mirrored(pull_request, project):
             logger.info('Pull Request should be mirrored')
 
             if revision_trusted is None:

--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -124,7 +124,8 @@ class Project(object):
         return data['items']
 
     @guard('core')
-    def pull_request_is_from_fork(self, pr_number):
+    def pull_request_is_from_fork(self, pull_request):
+        pr_number = pull_request['number']
         url = '{}/repos/{}/pulls/{}'.format(
             self._host, self._github_project, pr_number
         )
@@ -266,7 +267,7 @@ def has_mirroring_label(pull_request):
 
     return False
 
-def should_be_mirrored(pull_request, project):
+def should_be_mirrored(project, pull_request):
     return (
         is_open(pull_request) and
         pull_request['user']['login'] not in AUTOMATION_GITHUB_USERS and (
@@ -274,7 +275,7 @@ def should_be_mirrored(pull_request, project):
             has_mirroring_label(pull_request)
         ) and
         # Query this last as it requires another API call to verify
-        not project.pull_request_is_from_fork(pull_request['number'])
+        not project.pull_request_is_from_fork(pull_request)
     )
 
 def is_deployed(host, deployment):
@@ -313,7 +314,7 @@ def synchronize(host, github_project, window):
         revision_trusted = remote.get_revision(refspec_trusted)
         revision_open = remote.get_revision(refspec_open)
 
-        if should_be_mirrored(pull_request, project):
+        if should_be_mirrored(project, pull_request):
             logger.info('Pull Request should be mirrored')
 
             if revision_trusted is None:

--- a/tools/ci/tests/test_pr_preview.py
+++ b/tools/ci/tests/test_pr_preview.py
@@ -115,6 +115,7 @@ class MockServer(HTTPServer, object):
 class Requests(object):
     get_rate = ('GET', '/rate_limit', {})
     search = ('GET', '/search/issues', {})
+    pr_details = ('GET', '/repos/test-org/test-repo/pulls/23', {})
     ref_create_open = (
         'POST', '/repos/test-org/test-repo/git/refs', {'ref':'refs/prs-open/23'}
     )
@@ -376,6 +377,7 @@ def test_synchronize_sync_collaborator():
         (Requests.get_rate, Responses.no_limit),
         (Requests.get_rate, Responses.no_limit),
         (Requests.get_rate, Responses.no_limit),
+        (Requests.get_rate, Responses.no_limit),
         (Requests.search, (
             200,
             {
@@ -389,6 +391,15 @@ def test_synchronize_sync_collaborator():
                     }
                 ],
                 'incomplete_results': False
+            }
+        )),
+        (Requests.pr_details, (200,
+            {
+                'head': {
+                    'repo': {
+                        'full_name': 'test-org/test-repo'
+                    }
+                }
             }
         )),
         (Requests.ref_create_open, (200, {})),
@@ -452,8 +463,44 @@ def test_synchronize_ignore_untrusted_contributor():
     assert returncode == 0
     assert same_members(expected_traffic, actual_traffic)
 
+def test_synchronize_ignore_pull_request_from_fork():
+    expected_traffic = [
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.search, (
+            200,
+            {
+                'items': [
+                    {
+                        'number': 23,
+                        'labels': [],
+                        'closed_at': None,
+                        'user': {'login': 'grace'},
+                        'author_association': 'COLLABORATOR'
+                    }
+                ],
+                'incomplete_results': False
+            }
+        )),
+        (Requests.pr_details, (200,
+            {
+                'head': {
+                    'repo': {
+                        'full_name': 'some-other-org/test-repo'
+                    }
+                }
+            }
+        )),
+    ]
+
+    returncode, actual_traffic, remote_refs = synchronize(expected_traffic)
+
+    assert returncode == 0
+    assert same_members(expected_traffic, actual_traffic)
+
 def test_synchronize_sync_trusted_contributor():
     expected_traffic = [
+        (Requests.get_rate, Responses.no_limit),
         (Requests.get_rate, Responses.no_limit),
         (Requests.get_rate, Responses.no_limit),
         (Requests.get_rate, Responses.no_limit),
@@ -474,6 +521,15 @@ def test_synchronize_sync_trusted_contributor():
                 'incomplete_results': False
             }
         )),
+        (Requests.pr_details, (200,
+            {
+                'head': {
+                    'repo': {
+                        'full_name': 'test-org/test-repo'
+                    }
+                }
+            }
+        )),
         (Requests.ref_create_open, (200, {})),
         (Requests.ref_create_trusted, (200, {})),
         (Requests.deployment_get, (200, [])),
@@ -492,6 +548,7 @@ def test_synchronize_update_collaborator():
         (Requests.get_rate, Responses.no_limit),
         (Requests.get_rate, Responses.no_limit),
         (Requests.get_rate, Responses.no_limit),
+        (Requests.get_rate, Responses.no_limit),
         (Requests.search, (200,
             {
                 'items': [
@@ -504,6 +561,15 @@ def test_synchronize_update_collaborator():
                     }
                 ],
                 'incomplete_results': False
+            }
+        )),
+        (Requests.pr_details, (200,
+            {
+                'head': {
+                    'repo': {
+                        'full_name': 'test-org/test-repo'
+                    }
+                }
             }
         )),
         (Requests.deployment_get, (200, [])),
@@ -528,6 +594,7 @@ def test_synchronize_update_member():
         (Requests.get_rate, Responses.no_limit),
         (Requests.get_rate, Responses.no_limit),
         (Requests.get_rate, Responses.no_limit),
+        (Requests.get_rate, Responses.no_limit),
         (Requests.search, (200,
             {
                 'items': [
@@ -540,6 +607,15 @@ def test_synchronize_update_member():
                     }
                 ],
                 'incomplete_results': False
+            }
+        )),
+        (Requests.pr_details, (200,
+            {
+                'head': {
+                    'repo': {
+                        'full_name': 'test-org/test-repo'
+                    }
+                }
             }
         )),
         (Requests.deployment_get, (200, [{'some': 'deployment'}])),


### PR DESCRIPTION
As far as we can tell, deployment events are not sent for forks, so the
PR is never updated with the information about the deployment (although
wptpr.live does actually see it). To avoid a confusing UI, skip forks
when deciding whether to deploy a PR.

This somewhat reduces the utility of pr_preview.py, as external PRs can
no longer be marked as 'safe to preview'. Future work will attempt to
restore the ability to create a deployment for a PR from a fork (unless
GitHub fix their bug).