### PR TITLE
Replace some "promise_rejects(t, new FooError, stuff)" calls with pro…

### DIFF
--- a/FileAPI/url/cross-global-revoke.sub.html
+++ b/FileAPI/url/cross-global-revoke.sub.html
@@ -20,7 +20,7 @@ async_test(t => {
   self.addEventListener('message', t.step_func(e => {
     if (e.source !== frame.contentWindow) return;
     assert_equals(e.data, 'revoked');
-    promise_rejects(t, new TypeError, fetch(url)).then(t.step_func_done());
+    promise_rejects_js(t, TypeError, fetch(url)).then(t.step_func_done());
   }));
 }, 'It is possible to revoke same-origin blob URLs from different frames.');
 
@@ -31,7 +31,7 @@ async_test(t => {
   const worker = new Worker('resources/revoke-helper.js');
   worker.onmessage = t.step_func(e => {
     assert_equals(e.data, 'revoked');
-    promise_rejects(t, new TypeError, fetch(url)).then(t.step_func_done());
+    promise_rejects_js(t, TypeError, fetch(url)).then(t.step_func_done());
   });
   worker.postMessage({url: url});
 }, 'It is possible to revoke same-origin blob URLs from a different worker global.');

--- a/FileAPI/url/url-lifetime.html
+++ b/FileAPI/url/url-lifetime.html
@@ -20,7 +20,7 @@ promise_test(t => {
   }).then(response => response.text()).then(text => {
     assert_equals(text, blob_contents);
     return new Promise(resolve => t.step_timeout(resolve, 100));
-  }).then(() => promise_rejects(t, new TypeError, fetch(url)));
+  }).then(() => promise_rejects_js(t, TypeError, fetch(url)));
 }, 'Terminating worker revokes its URLs');
 
 promise_test(t => {
@@ -51,6 +51,6 @@ promise_test(t => {
   }).then(response => response.text()).then(text => {
     assert_equals(text, blob_contents);
     return new Promise(resolve => t.step_timeout(resolve, 100));
-  }).then(() => promise_rejects(t, new TypeError, fetch(url)));
+  }).then(() => promise_rejects_js(t, TypeError, fetch(url)));
 }, 'Removing an iframe revokes its URLs');
 </script>

--- a/FileAPI/url/url-with-fetch.any.js
+++ b/FileAPI/url/url-with-fetch.any.js
@@ -5,7 +5,7 @@ function fetch_should_succeed(test, request) {
 }
 
 function fetch_should_fail(test, url, method = 'GET') {
-  return promise_rejects(test, new TypeError, fetch(url, {method: method}));
+  return promise_rejects_js(test, TypeError, fetch(url, {method: method}));
 }
 
 fetch_tests('fetch', fetch_should_succeed, fetch_should_fail);

--- a/background-fetch/content-security-policy.https.window.js
+++ b/background-fetch/content-security-policy.https.window.js
@@ -14,7 +14,7 @@ meta.setAttribute('content', "connect-src 'none'");
 document.head.appendChild(meta);
 
 backgroundFetchTest((t, bgFetch) => {
-  return promise_rejects(
-      t, new TypeError(),
+  return promise_rejects_js(
+      t, TypeError,
       bgFetch.fetch(uniqueId(), 'https://example.com'));
 }, 'fetch blocked by CSP should reject');

--- a/background-fetch/fetch.https.window.js
+++ b/background-fetch/fetch.https.window.js
@@ -23,8 +23,8 @@ promise_test(async test => {
     serviceWorkerRegistration.active, null,
     'There must not be an activated worker');
 
-  await promise_rejects(
-    test, new TypeError(),
+  await promise_rejects_js(
+    test, TypeError,
     serviceWorkerRegistration.backgroundFetch.fetch(
       uniqueId(), ['resources/feature-name.txt']),
       'fetch() must reject on pending and installing workers');
@@ -34,15 +34,15 @@ promise_test(async test => {
 backgroundFetchTest(async (test, backgroundFetch) => {
   // 6.3.1.6: If |requests| is empty, then return a promise rejected with a
   //          TypeError.
-  await promise_rejects(
-    test, new TypeError(), backgroundFetch.fetch(uniqueId(), []),
+  await promise_rejects_js(
+    test, TypeError, backgroundFetch.fetch(uniqueId(), []),
     'Empty sequences are treated as NULL');
 
   // 6.3.1.7.1: Let |internalRequest| be the request of the result of invoking
   //            the Request constructor with |request|. If this throws an
   //            exception, return a promise rejected with the exception.
-  await promise_rejects(
-    test, new TypeError(),
+  await promise_rejects_js(
+    test, TypeError,
     backgroundFetch.fetch(uniqueId(), 'https://user:pass@domain/secret.txt'),
     'Exceptions thrown in the Request constructor are rethrown');
 
@@ -52,8 +52,8 @@ backgroundFetchTest(async (test, backgroundFetch) => {
     const request =
       new Request('resources/feature-name.txt', {mode: 'no-cors'});
 
-    await promise_rejects(
-      test, new TypeError(), backgroundFetch.fetch(uniqueId(), request),
+    await promise_rejects_js(
+      test, TypeError, backgroundFetch.fetch(uniqueId(), request),
       'Requests must not be in no-cors mode');
   }
 
@@ -62,7 +62,7 @@ backgroundFetchTest(async (test, backgroundFetch) => {
 backgroundFetchTest(async (test, backgroundFetch) => {
   // 6.3.1.9.2: If |bgFetchMap[id]| exists, reject |promise| with a TypeError
   //            and abort these steps.
-  return promise_rejects(test, new TypeError(), Promise.all([
+  return promise_rejects_js(test, TypeError, Promise.all([
     backgroundFetch.fetch('my-id', 'resources/feature-name.txt?1'),
     backgroundFetch.fetch('my-id', 'resources/feature-name.txt?2')
   ]));

--- a/background-fetch/get.https.window.js
+++ b/background-fetch/get.https.window.js
@@ -25,8 +25,8 @@ promise_test(async test => {
 
 backgroundFetchTest(async (test, backgroundFetch) => {
   // The |id| parameter to the BackgroundFetchManager.get() method is required.
-  await promise_rejects(test, new TypeError(), backgroundFetch.get());
-  await promise_rejects(test, new TypeError(), backgroundFetch.get(''));
+  await promise_rejects_js(test, TypeError, backgroundFetch.get());
+  await promise_rejects_js(test, TypeError, backgroundFetch.get(''));
 
   const registration = await backgroundFetch.get('my-id');
   assert_equals(registration, undefined);

--- a/background-fetch/mixed-content-and-allowed-schemes.https.window.js
+++ b/background-fetch/mixed-content-and-allowed-schemes.https.window.js
@@ -31,21 +31,21 @@ backgroundFetchTest((t, bgFetch) => {
 }, 'localhost http: fetch should register ok');
 
 backgroundFetchTest((t, bgFetch) => {
-  return promise_rejects(t, new TypeError(),
+  return promise_rejects_js(t, TypeError,
                          bgFetch.fetch(uniqueId(), 'wss:127.0.0.1'));
 }, 'wss: fetch should reject');
 
 backgroundFetchTest((t, bgFetch) => {
-  return promise_rejects(t, new TypeError(),
+  return promise_rejects_js(t, TypeError,
                          bgFetch.fetch(uniqueId(), 'file:///'));
 }, 'file: fetch should reject');
 
 backgroundFetchTest((t, bgFetch) => {
-  return promise_rejects(t, new TypeError(),
+  return promise_rejects_js(t, TypeError,
                          bgFetch.fetch(uniqueId(), 'data:text/plain,foo'));
 }, 'data: fetch should reject');
 
 backgroundFetchTest((t, bgFetch) => {
-  return promise_rejects(t, new TypeError(),
+  return promise_rejects_js(t, TypeError,
                          bgFetch.fetch(uniqueId(), 'foobar:bazqux'));
 }, 'unknown scheme fetch should reject');

--- a/background-fetch/port-blocking.https.window.js
+++ b/background-fetch/port-blocking.https.window.js
@@ -29,7 +29,7 @@ backgroundFetchTest((t, bgFetch) => {
 }, 'fetch to non-default non-bad port (8080) should register ok');
 
 backgroundFetchTest((t, bgFetch) => {
-  return promise_rejects(
-      t, new TypeError(),
+  return promise_rejects_js(
+      t, TypeError,
       bgFetch.fetch(uniqueId(), 'https://example.com:587'));
 }, 'fetch to bad port (SMTP) should reject');

--- a/clipboard-apis/async-navigator-clipboard-basics.https.html
+++ b/clipboard-apis/async-navigator-clipboard-basics.https.html
@@ -20,21 +20,21 @@ promise_test(async () => {
 }, 'navigator.clipboard.write([text/plain ClipboardItem]) succeeds');
 
 promise_test(async t => {
-  await promise_rejects(t, new TypeError(), navigator.clipboard.write());
+  await promise_rejects_js(t, TypeError, navigator.clipboard.write());
 }, 'navigator.clipboard.write() fails (expect [ClipboardItem])');
 
 promise_test(async t => {
-  await promise_rejects(t, new TypeError(), navigator.clipboard.write(null));
+  await promise_rejects_js(t, TypeError, navigator.clipboard.write(null));
 }, 'navigator.clipboard.write(null) fails (expect [ClipboardItem])');
 
 promise_test(async t => {
-  await promise_rejects(t, new TypeError(),
+  await promise_rejects_js(t, TypeError,
                          navigator.clipboard.write('Bad string'));
 }, 'navigator.clipboard.write(DOMString) fails (expect [ClipboardItem])');
 
 promise_test(async t => {
   const blob = new Blob(['hello'], {type: 'text/plain'});
-  await promise_rejects(t, new TypeError(), navigator.clipboard.write(blob));
+  await promise_rejects_js(t, TypeError, navigator.clipboard.write(blob));
 }, 'navigator.clipboard.write(Blob) fails (expect [ClipboardItem])');
 
 promise_test(async () => {
@@ -42,7 +42,7 @@ promise_test(async () => {
 }, 'navigator.clipboard.writeText(DOMString) succeeds');
 
 promise_test(async t => {
-  await promise_rejects(t, new TypeError(),
+  await promise_rejects_js(t, TypeError,
                          navigator.clipboard.writeText());
 }, 'navigator.clipboard.writeText() fails (expect DOMString)');
 

--- a/compression/compression-bad-chunks.tentative.any.js
+++ b/compression/compression-bad-chunks.tentative.any.js
@@ -46,8 +46,8 @@ for (const chunk of badChunks) {
     const writer = cs.writable.getWriter();
     const writePromise = writer.write(chunk.value);
     const readPromise = reader.read();
-    await promise_rejects(t, new TypeError(), writePromise, 'write should reject');
-    await promise_rejects(t, new TypeError(), readPromise, 'read should reject');
+    await promise_rejects_js(t, TypeError, writePromise, 'write should reject');
+    await promise_rejects_js(t, TypeError, readPromise, 'read should reject');
   }, `chunk of type ${chunk.name} should error the stream for gzip`);
 
   promise_test(async t => {
@@ -56,7 +56,7 @@ for (const chunk of badChunks) {
     const writer = cs.writable.getWriter();
     const writePromise = writer.write(chunk.value);
     const readPromise = reader.read();
-    await promise_rejects(t, new TypeError(), writePromise, 'write should reject');
-    await promise_rejects(t, new TypeError(), readPromise, 'read should reject');
+    await promise_rejects_js(t, TypeError, writePromise, 'write should reject');
+    await promise_rejects_js(t, TypeError, readPromise, 'read should reject');
   }, `chunk of type ${chunk.name} should error the stream for deflate`);
 }

--- a/compression/decompression-bad-chunks.tentative.any.js
+++ b/compression/decompression-bad-chunks.tentative.any.js
@@ -54,8 +54,8 @@ for (const chunk of badChunks) {
     const writer = ds.writable.getWriter();
     const writePromise = writer.write(chunk.value);
     const readPromise = reader.read();
-    await promise_rejects(t, new TypeError(), writePromise, 'write should reject');
-    await promise_rejects(t, new TypeError(), readPromise, 'read should reject');
+    await promise_rejects_js(t, TypeError, writePromise, 'write should reject');
+    await promise_rejects_js(t, TypeError, readPromise, 'read should reject');
   }, `chunk of type ${chunk.name} should error the stream for gzip`);
 
   promise_test(async t => {
@@ -64,7 +64,7 @@ for (const chunk of badChunks) {
     const writer = ds.writable.getWriter();
     const writePromise = writer.write(chunk.value);
     const readPromise = reader.read();
-    await promise_rejects(t, new TypeError(), writePromise, 'write should reject');
-    await promise_rejects(t, new TypeError(), readPromise, 'read should reject');
+    await promise_rejects_js(t, TypeError, writePromise, 'write should reject');
+    await promise_rejects_js(t, TypeError, readPromise, 'read should reject');
   }, `chunk of type ${chunk.name} should error the stream for deflate`);
 }

--- a/content-security-policy/inside-worker/support/connect-src-self.sub.js
+++ b/content-security-policy/inside-worker/support/connect-src-self.sub.js
@@ -54,7 +54,7 @@ promise_test(t => {
   var url = "{{location[server]}}/common/redirect-opt-in.py?status=307&location=http://{{domains[www]}}:{{ports[http][1]}}/common/text-plain.txt?cross-origin-fetch";
 
   // TODO(mkwst): A 'securitypolicyviolation' event should fire.
-  return promise_rejects(t, new TypeError, fetch(url));
+  return promise_rejects_js(t, TypeError, fetch(url));
 }, "Same-origin => cross-origin 'fetch()' in " + self.location.protocol + self.location.search);
 
 done();

--- a/cookie-store/change_eventhandler_for_no_name_equals_in_value.tentative.https.window.js
+++ b/cookie-store/change_eventhandler_for_no_name_equals_in_value.tentative.https.window.js
@@ -14,16 +14,16 @@ cookie_test(async t => {
     eventPromise, {changed: [{name: '', value: 'first-value'}]},
     'Observed no-name change');
 
-  await promise_rejects(
+  await promise_rejects_js(
     t,
-    new TypeError(),
+    TypeError,
     cookieStore.set('', 'suspicious-value=resembles-name-and-value'),
     'Expected promise rejection when setting a cookie with' +
       ' no name and "=" in value (via arguments)');
 
-  await promise_rejects(
+  await promise_rejects_js(
     t,
-    new TypeError(),
+    TypeError,
     cookieStore.set(
       {name: '', value: 'suspicious-value=resembles-name-and-value'}),
     'Expected promise rejection when setting a cookie with' +

--- a/cookie-store/cookieStore_delete_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_delete_arguments.tentative.https.any.js
@@ -52,7 +52,7 @@ promise_test(async testCase => {
   const currentDomain = currentUrl.hostname;
   const subDomain = `sub.${currentDomain}`;
 
-  await promise_rejects(testCase, new TypeError(), cookieStore.delete(
+  await promise_rejects_js(testCase, TypeError, cookieStore.delete(
       { name: 'cookie-name', domain: subDomain }));
 }, 'cookieStore.delete with domain set to a subdomain of the current hostname');
 
@@ -63,7 +63,7 @@ promise_test(async testCase => {
       'this test assumes that the current hostname does not start with .');
   const domainSuffix = currentDomain.substr(1);
 
-  await promise_rejects(testCase, new TypeError(), cookieStore.delete(
+  await promise_rejects_js(testCase, TypeError, cookieStore.delete(
       { name: 'cookie-name', domain: domainSuffix }));
 }, 'cookieStore.delete with domain set to a non-domain-matching suffix of ' +
    'the current hostname');
@@ -88,7 +88,7 @@ promise_test(async testCase => {
   const currentDomain = currentUrl.hostname;
   const subDomain = `sub.${currentDomain}`;
 
-  await promise_rejects(testCase, new TypeError(), cookieStore.delete(
+  await promise_rejects_js(testCase, TypeError, cookieStore.delete(
       { name: 'cookie-name', domain: subDomain }));
 }, 'cookieStore.delete with name in options and domain set to a subdomain of ' +
    'the current hostname');
@@ -100,7 +100,7 @@ promise_test(async testCase => {
       'this test assumes that the current hostname does not start with .');
   const domainSuffix = currentDomain.substr(1);
 
-  await promise_rejects(testCase, new TypeError(), cookieStore.delete(
+  await promise_rejects_js(testCase, TypeError, cookieStore.delete(
       { name: 'cookie-name', domain: domainSuffix }));
 }, 'cookieStore.delete with name in options and domain set to a ' +
    'non-domain-matching suffix of the current hostname');

--- a/cookie-store/cookieStore_getAll_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_getAll_arguments.tentative.https.any.js
@@ -115,7 +115,7 @@ promise_test(async testCase => {
     await cookieStore.delete('cookie-name-2');
   });
 
-  await promise_rejects(testCase, new TypeError(), cookieStore.getAll(
+  await promise_rejects_js(testCase, TypeError, cookieStore.getAll(
       { name: 'cookie-name', matchType: 'invalid' }));
 }, 'cookieStore.getAll with invalid matchType');
 
@@ -185,7 +185,7 @@ promise_test(async testCase => {
 
   const invalid_url =
       `${self.location.protocol}//${self.location.host}/different/path`;
-  await promise_rejects(testCase, new TypeError(), cookieStore.getAll(
+  await promise_rejects_js(testCase, TypeError, cookieStore.getAll(
       { url: invalid_url }));
 }, 'cookieStore.getAll with invalid url path in options');
 
@@ -197,6 +197,6 @@ promise_test(async testCase => {
 
   const invalid_url =
       `${self.location.protocol}//www.example.com${self.location.pathname}`;
-  await promise_rejects(testCase, new TypeError(), cookieStore.getAll(
+  await promise_rejects_js(testCase, TypeError, cookieStore.getAll(
       { url: invalid_url }));
 }, 'cookieStore.getAll with invalid url host in options');

--- a/cookie-store/cookieStore_get_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_get_arguments.tentative.https.any.js
@@ -80,7 +80,7 @@ promise_test(async testCase => {
     await cookieStore.delete('cookie-name');
   });
 
-  await promise_rejects(testCase, new TypeError(), cookieStore.get(
+  await promise_rejects_js(testCase, TypeError, cookieStore.get(
       { name: 'cookie-name', matchType: 'invalid' }));
 }, 'cookieStore.get with invalid matchType');
 
@@ -146,7 +146,7 @@ promise_test(async testCase => {
 
   const invalid_url =
       `${self.location.protocol}//${self.location.host}/different/path`;
-  await promise_rejects(testCase, new TypeError(), cookieStore.get(
+  await promise_rejects_js(testCase, TypeError, cookieStore.get(
       { url: invalid_url }));
 }, 'cookieStore.get with invalid url path in options');
 
@@ -158,6 +158,6 @@ promise_test(async testCase => {
 
   const invalid_url =
       `${self.location.protocol}//www.example.com${self.location.pathname}`;
-  await promise_rejects(testCase, new TypeError(), cookieStore.get(
+  await promise_rejects_js(testCase, TypeError, cookieStore.get(
       { url: invalid_url }));
 }, 'cookieStore.get with invalid url host in options');

--- a/cookie-store/cookieStore_set_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_set_arguments.tentative.https.any.js
@@ -160,7 +160,7 @@ promise_test(async testCase => {
   const currentDomain = currentUrl.hostname;
   const subDomain = `sub.${currentDomain}`;
 
-  await promise_rejects(testCase, new TypeError(), cookieStore.set(
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
       'cookie-name', 'cookie-value', { domain: subDomain }));
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
@@ -173,7 +173,7 @@ promise_test(async testCase => {
       'this test assumes that the current hostname does not start with .');
   const domainSuffix = currentDomain.substr(1);
 
-  await promise_rejects(testCase, new TypeError(), cookieStore.set(
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
       'cookie-name', 'cookie-value', { domain: domainSuffix }));
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);

--- a/cookie-store/cookieStore_subscribe_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_subscribe_arguments.tentative.https.any.js
@@ -60,7 +60,7 @@ promise_test(async testCase => {
     });
   }
 
-  await promise_rejects(testCase, new TypeError(),
+  await promise_rejects_js(testCase, TypeError,
       registration.cookies.subscribe(
           { name: 'cookie-name', matchType: 'equals', url: '/wrong/path' }));
 }, 'cookieStore.subscribe with invalid url path in option');

--- a/cors/cors-safelisted-request-header.any.js
+++ b/cors/cors-safelisted-request-header.any.js
@@ -11,7 +11,7 @@ function safelist(headers, expectPreflight = false) {
           checkURL = "resources/preflight.py?check&token=" + uuid,
           request = () => fetch(url, { method: "POST", headers, body: "data" });
     if (expectPreflight) {
-      await promise_rejects(t, TypeError(), request());
+      await promise_rejects_js(t, TypeError, request());
     } else {
       const response = await request();
       assert_equals(response.headers.get("content-type"), "text/plain");

--- a/credential-management/credentialscontainer-create-basics.https.html
+++ b/credential-management/credentialscontainer-create-basics.https.html
@@ -48,7 +48,7 @@ promise_test(function(t) {
 }, "navigator.credentials.create() with valid HTMLFormElement");
 
 promise_test(function(t) {
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
             navigator.credentials.create({password: "bogus password data"}));
 }, "navigator.credentials.create() with bogus password data");
 
@@ -68,12 +68,12 @@ promise_test(function(t) {
 }, "navigator.credentials.create() with valid FederatedCredentialData");
 
 promise_test(function(t) {
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
             navigator.credentials.create({federated: "bogus federated data"}));
 }, "navigator.credentials.create() with bogus federated data");
 
 promise_test(function(t) {
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
             navigator.credentials.create({publicKey: "bogus publicKey data"}));
 }, "navigator.credentials.create() with bogus publicKey data");
 
@@ -96,7 +96,7 @@ promise_test(function(t) {
 }, "navigator.credentials.create() with both PasswordCredentialData and FederatedCredentialData");
 
 promise_test(function(t) {
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
             navigator.credentials.create({
                 password: "bogus password data",
                 federated: "bogus federated data",
@@ -104,7 +104,7 @@ promise_test(function(t) {
 }, "navigator.credentials.create() with bogus password and federated data");
 
 promise_test(function(t) {
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
             navigator.credentials.create({
                 federated: "bogus federated data",
                 publicKey: "bogus publicKey data",
@@ -112,7 +112,7 @@ promise_test(function(t) {
 }, "navigator.credentials.create() with bogus federated and publicKey data");
 
 promise_test(function(t) {
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
             navigator.credentials.create({
                 password: "bogus password data",
                 publicKey: "bogus publicKey data",
@@ -120,7 +120,7 @@ promise_test(function(t) {
 }, "navigator.credentials.create() with bogus password and publicKey data");
 
 promise_test(function(t) {
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
             navigator.credentials.create({
                 password: "bogus password data",
                 federated: "bogus federated data",

--- a/css/cssom-view/MediaQueryList-addListener-handleEvent.html
+++ b/css/cssom-view/MediaQueryList-addListener-handleEvent.html
@@ -71,9 +71,7 @@ promise_test(async t => {
     assert_equals(calls, 1);
 }, "doesn't look up handleEvent method on callable event listeners");
 
-const uncaught_error_test = async (t, getHandleEvent) => {
-    const mql = await createMQL(t);
-
+const uncaught_error_test = async (t, mql, getHandleEvent) => {
     let calls = 0;
     mql.addListener({
         get handleEvent() {
@@ -91,18 +89,25 @@ const uncaught_error_test = async (t, getHandleEvent) => {
     throw event.error;
 };
 
-promise_test(t => {
+promise_test(async t => {
     const error = { name: "test" };
+    const mql = await createMQL(t);
 
     return promise_rejects_exactly(t, error,
-        uncaught_error_test(t, () => { throw error; }));
+        uncaught_error_test(t, mql, () => { throw error; }));
 }, "rethrows errors when getting handleEvent");
 
-promise_test(t => {
-    return promise_rejects(t, new TypeError(), uncaught_error_test(t, () => false));
+promise_test(async t => {
+    const mql = await createMQL(t);
+    const global = getWindow(mql);
+    return promise_rejects_js(t, global.TypeError,
+                              uncaught_error_test(t, mql, () => false));
 }, "throws if handleEvent is falsy and not callable");
 
-promise_test(t => {
-    return promise_rejects(t, new TypeError(), uncaught_error_test(t, () => "str"));
+promise_test(async t => {
+    const mql = await createMQL(t);
+    const global = getWindow(mql);
+    return promise_rejects_js(t, global.TypeError,
+                              uncaught_error_test(t, mql, () => "str"));
 }, "throws if handleEvent is thruthy and not callable");
 </script>

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -213,7 +213,7 @@ function bar() {
 }
 
 promise_test(function(t) {
-  return promise_rejects(t, new TypeError(), bar());
+  return promise_rejects_js(t, TypeError, bar());
 }, "Another example");
 ```
 

--- a/dom/events/EventListener-handleEvent.html
+++ b/dom/events/EventListener-handleEvent.html
@@ -93,10 +93,10 @@ promise_test(t => {
 }, "rethrows errors when getting `handleEvent`");
 
 promise_test(t => {
-    return promise_rejects(t, new TypeError(), uncaught_error_test(t, () => null));
+    return promise_rejects_js(t, TypeError, uncaught_error_test(t, () => null));
 }, "throws if `handleEvent` is falsy and not callable");
 
 promise_test(t => {
-    return promise_rejects(t, new TypeError(), uncaught_error_test(t, () => 42));
+    return promise_rejects_js(t, TypeError, uncaught_error_test(t, () => 42));
 }, "throws if `handleEvent` is thruthy and not callable");
 </script>

--- a/encoding/streams/decode-bad-chunks.any.js
+++ b/encoding/streams/decode-bad-chunks.any.js
@@ -32,7 +32,7 @@ for (const chunk of badChunks) {
     const writer = tds.writable.getWriter();
     const writePromise = writer.write(chunk.value);
     const readPromise = reader.read();
-    await promise_rejects(t, new TypeError(), writePromise, 'write should reject');
-    await promise_rejects(t, new TypeError(), readPromise, 'read should reject');
+    await promise_rejects_js(t, TypeError, writePromise, 'write should reject');
+    await promise_rejects_js(t, TypeError, readPromise, 'read should reject');
   }, `chunk of type ${chunk.name} should error the stream`);
 }

--- a/encoding/streams/decode-incomplete-input.any.js
+++ b/encoding/streams/decode-incomplete-input.any.js
@@ -19,6 +19,6 @@ promise_test(async t => {
   const output = input.pipeThrough(new TextDecoderStream(
       'utf-8', {fatal: true}));
   const reader = output.getReader();
-  await promise_rejects(t, new TypeError(), reader.read(),
+  await promise_rejects_js(t, TypeError, reader.read(),
                         'read should reject');
 }, 'incomplete input with error mode "fatal" should error the stream');

--- a/encoding/streams/decode-non-utf8.any.js
+++ b/encoding/streams/decode-non-utf8.any.js
@@ -67,9 +67,9 @@ for (const encoding of encodings) {
     const writer = stream.writable.getWriter();
     const writePromise = writer.write(new Uint8Array(encoding.invalid));
     const closePromise = writer.close();
-    await promise_rejects(t, new TypeError(), reader.read(),
+    await promise_rejects_js(t, TypeError, reader.read(),
                           'readable should be errored');
-    await promise_rejects(t, new TypeError(),
+    await promise_rejects_js(t, TypeError,
                           Promise.all([writePromise, closePromise]),
                           'writable should be errored');
   }, `TextDecoderStream should be able to reject invalid sequences in ` +

--- a/fetch/api/abort/general.any.js
+++ b/fetch/api/abort/general.any.js
@@ -63,7 +63,7 @@ for (const { args, testName } of badRequestArgTests) {
       // Add signal to 2nd arg
       args[1] = args[1] || {};
       args[1].signal = controller.signal;
-      await promise_rejects(t, new TypeError, fetch(...args));
+      await promise_rejects_js(t, TypeError, fetch(...args));
     }
   }, `TypeError from request constructor takes priority - ${testName}`);
 }

--- a/fetch/api/basic/error-after-response.html
+++ b/fetch/api/basic/error-after-response.html
@@ -14,7 +14,7 @@ function checkReader(test, reader, promiseToTest)
 {
     return reader.read().then((value) => {
         validateBufferFromString(value.value, "TEST_CHUNK", "Should receive first chunk");
-        return promise_rejects(test, new TypeError(), promiseToTest(reader));
+        return promise_rejects_js(test, TypeError, promiseToTest(reader));
     });
 }
 

--- a/fetch/api/basic/header-value-null-byte.any.js
+++ b/fetch/api/basic/header-value-null-byte.any.js
@@ -1,5 +1,5 @@
 // META: global=window,worker
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), fetch("../../../xhr/resources/parse-headers.py?my-custom-header="+encodeURIComponent("x\0x")));
+  return promise_rejects_js(t, TypeError, fetch("../../../xhr/resources/parse-headers.py?my-custom-header="+encodeURIComponent("x\0x")));
 }, "Ensure fetch() rejects null bytes in headers");

--- a/fetch/api/basic/integrity.sub.any.js
+++ b/fetch/api/basic/integrity.sub.any.js
@@ -20,7 +20,7 @@ function integrity(desc, url, integrity, initRequestMode, shouldPass) {
     }, desc);
   } else {
     promise_test(function(test) {
-      return promise_rejects(test, new TypeError(), fetch(url, fetchRequestInit));
+      return promise_rejects_js(test, TypeError, fetch(url, fetchRequestInit));
     }, desc);
   }
 }

--- a/fetch/api/basic/mediasource.window.js
+++ b/fetch/api/basic/mediasource.window.js
@@ -1,5 +1,5 @@
 promise_test(t => {
   const mediaSource = new MediaSource(),
         mediaSourceURL = URL.createObjectURL(mediaSource);
-  return promise_rejects(t, new TypeError(), fetch(mediaSourceURL));
+  return promise_rejects_js(t, TypeError, fetch(mediaSourceURL));
 }, "Cannot fetch blob: URL from a MediaSource");

--- a/fetch/api/basic/mode-same-origin.any.js
+++ b/fetch/api/basic/mode-same-origin.any.js
@@ -9,7 +9,7 @@ function fetchSameOrigin(url, shouldPass) {
         assert_equals(resp.type, "basic", "response type is basic");
       });
     else
-      return promise_rejects(test, new TypeError, fetch(url, {mode: "same-origin"}));
+      return promise_rejects_js(test, TypeError, fetch(url, {mode: "same-origin"}));
   }, "Fetch "+ url + " with same-origin mode");
 }
 

--- a/fetch/api/basic/request-head.any.js
+++ b/fetch/api/basic/request-head.any.js
@@ -1,4 +1,4 @@
 promise_test(function(test) {
   var requestInit = {"method": "HEAD", "body": "test"};
-  return promise_rejects(test, new TypeError(), fetch(".", requestInit));
+  return promise_rejects_js(test, TypeError, fetch(".", requestInit));
 }, "Fetch with HEAD with body");

--- a/fetch/api/basic/scheme-about.any.js
+++ b/fetch/api/basic/scheme-about.any.js
@@ -5,7 +5,7 @@ function checkNetworkError(url, method) {
   const desc = "Fetching " + url.substring(0, 45) + " with method " + method + " is KO"
   promise_test(function(test) {
     var promise = fetch(url, { method: method });
-    return promise_rejects(test, new TypeError(), promise);
+    return promise_rejects_js(test, TypeError, promise);
   }, desc);
 }
 

--- a/fetch/api/basic/scheme-blob.sub.any.js
+++ b/fetch/api/basic/scheme-blob.sub.any.js
@@ -22,7 +22,7 @@ checkFetchResponse(URL.createObjectURL(blob), "Blob's data", "text/plain",  blob
 function checkKoUrl(url, method, desc) {
   promise_test(function(test) {
     var promise = fetch(url, {"method": method});
-    return promise_rejects(test, new TypeError(), promise);
+    return promise_rejects_js(test, TypeError, promise);
   }, desc);
 }
 

--- a/fetch/api/basic/scheme-data.any.js
+++ b/fetch/api/basic/scheme-data.any.js
@@ -35,7 +35,7 @@ function checkKoUrl(url, method, desc) {
   var cut = (url.length >= 40) ? "[...]" : "";
   desc = "Fetching [" + method + "] " + url.substring(0, 45) + cut + " is KO"
   promise_test(function(test) {
-    return promise_rejects(test, new TypeError(), fetch(url, {"method": method}));
+    return promise_rejects_js(test, TypeError, fetch(url, {"method": method}));
   }, desc);
 }
 

--- a/fetch/api/basic/scheme-others.sub.any.js
+++ b/fetch/api/basic/scheme-others.sub.any.js
@@ -5,7 +5,7 @@ function checkKoUrl(url, desc) {
     desc = "Fetching " + url.substring(0, 45) + " is KO"
   promise_test(function(test) {
     var promise = fetch(url);
-    return promise_rejects(test, new TypeError(), promise);
+    return promise_rejects_js(test, TypeError, promise);
   }, desc);
 }
 

--- a/fetch/api/cors/cors-basic.any.js
+++ b/fetch/api/cors/cors-basic.any.js
@@ -17,7 +17,7 @@ function cors(desc, origin) {
   }, desc + " [no-cors mode]");
 
   promise_test(function(test) {
-    return promise_rejects(test, new TypeError(), fetch(url + RESOURCES_DIR + "top.txt", {"mode": "cors"}));
+    return promise_rejects_js(test, TypeError, fetch(url + RESOURCES_DIR + "top.txt", {"mode": "cors"}));
   }, desc + " [server forbid CORS]");
 
   promise_test(function(test) {

--- a/fetch/api/cors/cors-multiple-origins.sub.any.js
+++ b/fetch/api/cors/cors-multiple-origins.sub.any.js
@@ -5,7 +5,7 @@ function corsMultipleOrigins(originList) {
   var url = "http://{{host}}:{{ports[http][1]}}" + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
 
   promise_test(function(test) {
-    return promise_rejects(test, new TypeError(), fetch(url + urlParameters));
+    return promise_rejects_js(test, TypeError, fetch(url + urlParameters));
   }, "Listing multiple origins is illegal: " + originList);
 }
 /* Actual origin */

--- a/fetch/api/cors/cors-origin.any.js
+++ b/fetch/api/cors/cors-origin.any.js
@@ -20,7 +20,7 @@ function corsOrigin(desc, baseURL, method, origin, shouldPass) {
           assert_equals(resp.status, 200, "Response's status is 200");
         });
       } else {
-        return promise_rejects(test, new TypeError(), fetch(url + urlParameters, requestInit));
+        return promise_rejects_js(test, TypeError, fetch(url + urlParameters, requestInit));
       }
     });
   }, desc);

--- a/fetch/api/cors/cors-preflight-redirect.any.js
+++ b/fetch/api/cors/cors-preflight-redirect.any.js
@@ -20,7 +20,7 @@ function corsPreflightRedirect(desc, redirectUrl, redirectLocation, redirectStat
   promise_test(function(test) {
     return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(resp) {
       assert_equals(resp.status, 200, "Clean stash response's status is 200");
-      return promise_rejects(test, new TypeError(), fetch(url + urlParameters, requestInit));
+      return promise_rejects_js(test, TypeError, fetch(url + urlParameters, requestInit));
     });
   }, desc);
 }

--- a/fetch/api/cors/cors-preflight-star.any.js
+++ b/fetch/api/cors/cors-preflight-star.any.js
@@ -27,7 +27,7 @@ function preflightTest(succeeds, withCredentials, allowMethod, allowHeader, useM
         assert_equals(resp.headers.get("x-origin"), origin)
       })
     } else {
-      return promise_rejects(t, new TypeError(), fetch(testURL, requestInit))
+      return promise_rejects_js(t, TypeError, fetch(testURL, requestInit))
     }
   }, "CORS that " + (succeeds ? "succeeds" : "fails") + " with credentials: " + withCredentials + "; method: " + useMethod + " (allowed: " + allowMethod + "); header: " + useHeader + " (allowed: " + allowHeader + ")")
 }

--- a/fetch/api/cors/cors-preflight-status.any.js
+++ b/fetch/api/cors/cors-preflight-status.any.js
@@ -23,7 +23,7 @@ function corsPreflightStatus(desc, corsUrl, preflightStatus) {
           assert_equals(resp.headers.get("x-did-preflight"), "1", "Preflight request has been made");
         });
       } else {
-        return promise_rejects(test, new TypeError(), fetch(url + urlParameters, requestInit));
+        return promise_rejects_js(test, TypeError, fetch(url + urlParameters, requestInit));
       }
     });
   }, desc);

--- a/fetch/api/cors/cors-redirect-credentials.any.js
+++ b/fetch/api/cors/cors-redirect-credentials.any.js
@@ -14,7 +14,7 @@ function corsRedirectCredentials(desc, redirectUrl, redirectLocation, redirectSt
     if(locationCredentials === "") {
       return result;
     } else {
-      return promise_rejects(t, new TypeError(), result);
+      return promise_rejects_js(t, TypeError, result);
     }
   }, desc);
 }

--- a/fetch/api/cors/cors-redirect-preflight.any.js
+++ b/fetch/api/cors/cors-redirect-preflight.any.js
@@ -22,7 +22,7 @@ function corsRedirect(desc, redirectUrl, redirectLocation, redirectStatus, expec
   promise_test(function(test) {
     var uuid_token = token();
     return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(resp) {
-      return promise_rejects(test, new TypeError(), fetch(redirectUrl + "?token=" + uuid_token + "&max_age=0" + urlParametersFailure, requestInit));
+      return promise_rejects_js(test, TypeError, fetch(redirectUrl + "?token=" + uuid_token + "&max_age=0" + urlParametersFailure, requestInit));
     });
   }, desc + " (preflight after redirection failure case)");
 }

--- a/fetch/api/cors/resources/corspreflight.js
+++ b/fetch/api/cors/resources/corspreflight.js
@@ -49,7 +49,7 @@ function corsPreflight(desc, corsUrl, method, allowed, headers, safeHeaders) {
           }
         });
       } else {
-        return promise_rejects(test, new TypeError(), fetch(url + urlParameters, requestInit)).then(function(){
+        return promise_rejects_js(test, TypeError, fetch(url + urlParameters, requestInit)).then(function(){
           return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token);
         });
       }

--- a/fetch/api/headers/header-values-normalize.html
+++ b/fetch/api/headers/header-values-normalize.html
@@ -56,9 +56,9 @@ for(let i = 0; i < 0x21; i++) {
   promise_test((t) => {
     if(fail) {
       return Promise.all([
-        promise_rejects(t, new TypeError(), fetch(url, { headers: {"val1": val1} })),
-        promise_rejects(t, new TypeError(), fetch(url, { headers: {"val2": val2} })),
-        promise_rejects(t, new TypeError(), fetch(url, { headers: {"val3": val3} }))
+        promise_rejects_js(t, TypeError, fetch(url, { headers: {"val1": val1} })),
+        promise_rejects_js(t, TypeError, fetch(url, { headers: {"val2": val2} })),
+        promise_rejects_js(t, TypeError, fetch(url, { headers: {"val3": val3} }))
       ])
     } else {
       return fetch(url, { headers: {"val1": val1, "val2": val2, "val3": val3} }).then((res) => {

--- a/fetch/api/headers/header-values.html
+++ b/fetch/api/headers/header-values.html
@@ -15,7 +15,7 @@
     assert_throws_dom("SyntaxError", () => xhr.setRequestHeader("value-test", val))
   }, "XMLHttpRequest with value " + encodeURI(val) + " needs to throw")
 
-  promise_test(t => promise_rejects(t, new TypeError(), fetch("/", { headers: {"value-test": val} })), "fetch() with value " + encodeURI(val) + " needs to throw")
+  promise_test(t => promise_rejects_js(t, TypeError, fetch("/", { headers: {"value-test": val} })), "fetch() with value " + encodeURI(val) + " needs to throw")
 })
 
 // Valid values

--- a/fetch/api/policies/csp-blocked.js
+++ b/fetch/api/policies/csp-blocked.js
@@ -7,7 +7,7 @@ if (this.document === undefined) {
 cspViolationUrl = RESOURCES_DIR + "top.txt";
 
 promise_test(function(test) {
-  return promise_rejects(test, new TypeError(), fetch(cspViolationUrl));
+  return promise_rejects_js(test, TypeError, fetch(cspViolationUrl));
 }, "Fetch is blocked by CSP, got a TypeError");
 
 done();

--- a/fetch/api/redirect/redirect-count.any.js
+++ b/fetch/api/redirect/redirect-count.any.js
@@ -19,7 +19,7 @@ function redirectCount(desc, redirectUrl, redirectLocation, redirectStatus, maxC
       assert_equals(resp.status, 200, "Clean stash response's status is 200");
 
       if (!shouldPass)
-        return promise_rejects(test, new TypeError(), fetch(url + urlParameters, requestInit));
+        return promise_rejects_js(test, TypeError, fetch(url + urlParameters, requestInit));
 
       return fetch(url + urlParameters, requestInit).then(function(resp) {
         assert_equals(resp.status, 200, "Response's status is 200");

--- a/fetch/api/redirect/redirect-empty-location.any.js
+++ b/fetch/api/redirect/redirect-empty-location.any.js
@@ -6,7 +6,7 @@
 const url = RESOURCES_DIR + 'redirect-empty-location.py';
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), fetch(url, {redirect:'follow'}));
+  return promise_rejects_js(t, TypeError, fetch(url, {redirect:'follow'}));
 }, 'redirect response with empty Location, follow mode');
 
 promise_test(t => {

--- a/fetch/api/redirect/redirect-location.any.js
+++ b/fetch/api/redirect/redirect-location.any.js
@@ -10,7 +10,7 @@ function redirectLocation(desc, redirectUrl, redirectLocation, redirectStatus, r
 
   promise_test(function(test) {
     if (redirectMode === "error" || !shouldPass)
-      return promise_rejects(test, new TypeError(), fetch(url + urlParameters, requestInit));
+      return promise_rejects_js(test, TypeError, fetch(url + urlParameters, requestInit));
     if (redirectMode === "manual")
       return fetch(url + urlParameters, requestInit).then(function(resp) {
         assert_equals(resp.status, 0, "Response's status is 0");

--- a/fetch/api/redirect/redirect-mode.any.js
+++ b/fetch/api/redirect/redirect-mode.any.js
@@ -16,7 +16,7 @@ function testRedirect(origin, redirectStatus, redirectMode, corsMode) {
   promise_test(function(test) {
     if (redirectMode === "error" ||
         (corsMode === "no-cors" && redirectMode !== "follow" && origin !== "same-origin"))
-      return promise_rejects(test, new TypeError(), fetch(url + urlParameters, requestInit));
+      return promise_rejects_js(test, TypeError, fetch(url + urlParameters, requestInit));
     if (redirectMode === "manual")
       return fetch(url + urlParameters, requestInit).then(function(resp) {
         assert_equals(resp.status, 0, "Response's status is 0");

--- a/fetch/api/redirect/redirect-schemes.html
+++ b/fetch/api/redirect/redirect-schemes.html
@@ -17,7 +17,7 @@
   ];
   tests.forEach(function(url) {
     promise_test(function(test) {
-      return promise_rejects(test, new TypeError(), fetch(url))
+      return promise_rejects_js(test, TypeError, fetch(url))
     })
   })
 </script>

--- a/fetch/api/redirect/redirect-to-dataurl.any.js
+++ b/fetch/api/redirect/redirect-to-dataurl.any.js
@@ -10,7 +10,7 @@ function redirectDataURL(desc, redirectUrl, mode) {
     var requestInit = {"mode": mode};
 
     promise_test(function(test) {
-        return promise_rejects(test, new TypeError(), fetch(url, requestInit));
+        return promise_rejects_js(test, TypeError, fetch(url, requestInit));
     }, desc);
 }
 

--- a/fetch/api/request/request-bad-port.html
+++ b/fetch/api/request/request-bad-port.html
@@ -79,7 +79,7 @@
 
     BLOCKED_PORTS_LIST.map(function(a){
     	promise_test(function(t){
-            return promise_rejects(t, new TypeError(), fetch("http://example.com:" + a))
+            return promise_rejects_js(t, TypeError, fetch("http://example.com:" + a))
         }, 'Request on bad port ' + a + ' should throw TypeError.');
     });
 </script>

--- a/fetch/api/request/request-consume-empty.html
+++ b/fetch/api/request/request-consume-empty.html
@@ -62,7 +62,7 @@
     }
 
     function checkBodyFormDataError(test, request) {
-      return promise_rejects(test, new TypeError(), request.formData()).then(function() {
+      return promise_rejects_js(test, TypeError, request.formData()).then(function() {
         assert_false(request.bodyUsed);
       });
     }

--- a/fetch/api/request/request-consume.html
+++ b/fetch/api/request/request-consume.html
@@ -150,7 +150,7 @@
     badJSONValues.forEach(function(value) {
       promise_test(function(test) {
         var request = new Request("", {"method": "POST", "body": value});
-        return promise_rejects(test, new SyntaxError(), request.json());
+        return promise_rejects_js(test, SyntaxError, request.json());
       }, "Trying to consume bad JSON text as JSON: '" + value + "'");
     });
     </script>

--- a/fetch/api/request/request-disturbed.html
+++ b/fetch/api/request/request-disturbed.html
@@ -92,7 +92,7 @@
 
       promise_test(function(test) {
         assert_true(bodyConsumed.bodyUsed , "bodyUsed is true when request is disturbed");
-        return promise_rejects(test, new TypeError(), bodyConsumed.blob());
+        return promise_rejects_js(test, TypeError, bodyConsumed.blob());
       }, "Check consuming a disturbed request");
 
       test(function() {

--- a/fetch/api/request/request-keepalive-quota.html
+++ b/fetch/api/request/request-keepalive-quota.html
@@ -54,7 +54,7 @@
 
             // Test Quota + 1 Byte
             subsetTestByKey("fast", promise_test, function(test) {
-                return promise_rejects(test, TypeError(), fetchKeepAliveRequest(noDelay, expectedQuota + 1));
+                return promise_rejects_js(test, TypeError, fetchKeepAliveRequest(noDelay, expectedQuota + 1));
             }, 'A Keep-Alive fetch() with a body over the Quota Limit should reject.');
 
             // Test the Quota becomes available upon promise completion.
@@ -74,7 +74,7 @@
                 // Now create a single Byte request that will complete quicker.
                 const second = fetchKeepAliveRequest(standardDelay, 1 /* bodySize */).then(() => {
                     // We shouldn't be able to create a 2 Byte request right now as only 1 Byte should have freed up.
-                    return promise_rejects(test, TypeError(), fetchKeepAliveRequest(noDelay, 2 /* bodySize */));
+                    return promise_rejects_js(test, TypeError, fetchKeepAliveRequest(noDelay, 2 /* bodySize */));
                 }).then(() => {
                     // Now validate that we can send another Keep-Alive fetch for just 1 Byte.
                     return fetchKeepAliveRequest(noDelay, 1 /* bodySize */);
@@ -88,7 +88,7 @@
                 // Fill our Quota then try to send a second fetch.
                 const p = fetchKeepAliveRequest(standardDelay, expectedQuota);
 
-                const q = promise_rejects(test, TypeError(), fetchKeepAliveRequest(noDelay, 1 /* bodySize */));
+                const q = promise_rejects_js(test, TypeError, fetchKeepAliveRequest(noDelay, 1 /* bodySize */));
                 return Promise.all([p, q]);
             }, 'A Keep-Alive fetch() should not be allowed if the Quota is used up.');
 

--- a/fetch/api/response/response-consume-empty.html
+++ b/fetch/api/response/response-consume-empty.html
@@ -62,7 +62,7 @@
     }
 
     function checkBodyFormDataError(test, response) {
-      return promise_rejects(test, new TypeError(), response.formData()).then(function() {
+      return promise_rejects_js(test, TypeError, response.formData()).then(function() {
         assert_false(response.bodyUsed);
       });
     }

--- a/fetch/api/response/response-consume.html
+++ b/fetch/api/response/response-consume.html
@@ -138,7 +138,7 @@
     }
 
     function checkBodyFormDataError(test, response, expectedBody) {
-      return promise_rejects(test, new TypeError(), response.formData()).then(function() {
+      return promise_rejects_js(test, TypeError, response.formData()).then(function() {
         assert_true(response.bodyUsed, "body as formData: bodyUsed turned true");
       });
     }

--- a/fetch/api/response/response-error-from-stream.html
+++ b/fetch/api/response/response-error-from-stream.html
@@ -8,33 +8,31 @@
   </head>
   <body>
     <script>
-      function CustomTestError() {
-        const error = Error();
-        error.name = 'custom-test-error';
-        return error;
-      }
-
       function newStreamWithStartError() {
-        return new ReadableStream({
-          start(controller) {
-            controller.error(CustomTestError());
-          }
-        })
+        var err = new Error("Start error " + Math.random());
+        return [new ReadableStream({
+                  start(controller) {
+                      controller.error(err);
+                  }
+                }),
+                err]
       }
 
       function newStreamWithPullError() {
-        return new ReadableStream({
-          pull(controller) {
-            controller.error(CustomTestError());
-          }
-        })
+        var err = new Error("Pull error " + Math.random());
+        return [new ReadableStream({
+                  pull(controller) {
+                      controller.error(err);
+                  }
+                }),
+                err]
       }
 
-      function runRequestPromiseTest(stream, responseReaderMethod, testDescription) {
+      function runRequestPromiseTest([stream, err], responseReaderMethod, testDescription) {
         promise_test(test => {
-          return promise_rejects(
+          return promise_rejects_exactly(
             test,
-            CustomTestError(),
+            err,
             new Response(stream)[responseReaderMethod](),
             'CustomTestError should propagate'
           )
@@ -43,11 +41,13 @@
 
 
       promise_test(test => {
-        return promise_rejects(test, CustomTestError(), newStreamWithStartError().getReader().read(), 'CustomTestError should propagate')
+        var [stream, err] = newStreamWithStartError();
+        return promise_rejects_exactly(test, err, stream.getReader().read(), 'CustomTestError should propagate')
       }, "ReadableStreamDefaultReader Promise receives ReadableStream start() Error")
 
       promise_test(test => {
-        return promise_rejects(test, CustomTestError(), newStreamWithPullError().getReader().read(), 'CustomTestError should propagate')
+        var [stream, err] = newStreamWithPullError();
+        return promise_rejects_exactly(test, err, stream.getReader().read(), 'CustomTestError should propagate')
       }, "ReadableStreamDefaultReader Promise receives ReadableStream pull() Error")
 
 

--- a/fetch/api/response/response-stream-disturbed-2.html
+++ b/fetch/api/response/response-stream-disturbed-2.html
@@ -21,25 +21,25 @@ function createResponseWithLockedReadableStream(callback) {
 
 promise_test(function(test) {
     return createResponseWithLockedReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.blob());
+        return promise_rejects_js(test, TypeError, response.blob());
     });
 }, "Getting blob after getting a locked Response body");
 
 promise_test(function(test) {
     return createResponseWithLockedReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.text());
+        return promise_rejects_js(test, TypeError, response.text());
     });
 }, "Getting text after getting a locked Response body");
 
 promise_test(function(test) {
     return createResponseWithLockedReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.json());
+        return promise_rejects_js(test, TypeError, response.json());
     });
 }, "Getting json after getting a locked Response body");
 
 promise_test(function(test) {
     return createResponseWithLockedReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.arrayBuffer());
+        return promise_rejects_js(test, TypeError, response.arrayBuffer());
     });
 }, "Getting arrayBuffer after getting a locked Response body");
 

--- a/fetch/api/response/response-stream-disturbed-3.html
+++ b/fetch/api/response/response-stream-disturbed-3.html
@@ -22,25 +22,25 @@ function createResponseWithDisturbedReadableStream(callback) {
 
 promise_test(function(test) {
     return createResponseWithDisturbedReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.blob());
+        return promise_rejects_js(test, TypeError, response.blob());
     });
 }, "Getting blob after reading the Response body");
 
 promise_test(function(test) {
     return createResponseWithDisturbedReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.text());
+        return promise_rejects_js(test, TypeError, response.text());
     });
 }, "Getting text after reading the Response body");
 
 promise_test(function(test) {
     return createResponseWithDisturbedReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.json());
+        return promise_rejects_js(test, TypeError, response.json());
     });
 }, "Getting json after reading the Response body");
 
 promise_test(function(test) {
     return createResponseWithDisturbedReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.arrayBuffer());
+        return promise_rejects_js(test, TypeError, response.arrayBuffer());
     });
 }, "Getting arrayBuffer after reading the Response body");
 

--- a/fetch/api/response/response-stream-disturbed-4.html
+++ b/fetch/api/response/response-stream-disturbed-4.html
@@ -21,25 +21,25 @@ function createResponseWithCancelledReadableStream(callback) {
 
 promise_test(function(test) {
     return createResponseWithCancelledReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.blob());
+        return promise_rejects_js(test, TypeError, response.blob());
     });
 }, "Getting blob after cancelling the Response body");
 
 promise_test(function(test) {
     return createResponseWithCancelledReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.text());
+        return promise_rejects_js(test, TypeError, response.text());
     });
 }, "Getting text after cancelling the Response body");
 
 promise_test(function(test) {
     return createResponseWithCancelledReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.json());
+        return promise_rejects_js(test, TypeError, response.json());
     });
 }, "Getting json after cancelling the Response body");
 
 promise_test(function(test) {
     return createResponseWithCancelledReadableStream(function(response) {
-        return promise_rejects(test, new TypeError(), response.arrayBuffer());
+        return promise_rejects_js(test, TypeError, response.arrayBuffer());
     });
 }, "Getting arrayBuffer after cancelling the Response body");
 

--- a/fetch/content-encoding/bad-gzip-body.any.js
+++ b/fetch/content-encoding/bad-gzip-body.any.js
@@ -14,7 +14,7 @@ promise_test((test) => {
   promise_test(t => {
     return fetch("resources/bad-gzip-body.py").then(res => {
       assert_equals(res.status, 200);
-      return promise_rejects(t, new TypeError(), res[method]());
+      return promise_rejects_js(t, TypeError, res[method]());
     });
   }, "Consuming the body of a resource with bad gzip content with " + method + "() should reject");
 });

--- a/fetch/cross-origin-resource-policy/fetch.any.js
+++ b/fetch/cross-origin-resource-policy/fetch.any.js
@@ -31,22 +31,22 @@ promise_test(async (test) => {
 
 promise_test((test) => {
     const remoteURL = notSameSiteBaseURL + "resources/hello.py?corp=same-origin";
-    return promise_rejects(test, new TypeError, fetch(remoteURL, { mode : "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch(remoteURL, { mode : "no-cors" }));
 }, "Cross-origin no-cors fetch with a 'Cross-Origin-Resource-Policy: same-origin' response header.");
 
 promise_test((test) => {
     const remoteURL = notSameSiteBaseURL + "resources/hello.py?corp=same-site";
-    return promise_rejects(test, new TypeError, fetch(remoteURL, { mode: "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch(remoteURL, { mode: "no-cors" }));
 }, "Cross-origin no-cors fetch with a 'Cross-Origin-Resource-Policy: same-site' response header.");
 
 promise_test((test) => {
     const remoteURL = httpsBaseURL + "resources/hello.py?corp=same-site";
-    return promise_rejects(test, new TypeError, fetch(remoteURL, { mode: "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch(remoteURL, { mode: "no-cors" }));
 }, "Cross-scheme (HTTP to HTTPS) no-cors fetch to a same-site URL with a 'Cross-Origin-Resource-Policy: same-site' response header.");
 
 promise_test((test) => {
     const remoteURL = httpsBaseURL + "resources/hello.py?corp=same-origin";
-    return promise_rejects(test, new TypeError, fetch(remoteURL, { mode : "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch(remoteURL, { mode : "no-cors" }));
 }, "Cross-origin no-cors fetch to a same-site URL with a 'Cross-Origin-Resource-Policy: same-origin' response header.");
 
 promise_test(async (test) => {
@@ -54,12 +54,12 @@ promise_test(async (test) => {
 
     await fetch(remoteSameSiteURL, { mode: "no-cors" });
 
-    return promise_rejects(test, new TypeError, fetch(sameSiteBaseURL + "resources/hello.py?corp=same-origin", { mode: "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch(sameSiteBaseURL + "resources/hello.py?corp=same-origin", { mode: "no-cors" }));
 }, "Valid cross-origin no-cors fetch with a 'Cross-Origin-Resource-Policy: same-site' response header.");
 
 promise_test((test) => {
     const finalURL = notSameSiteBaseURL + "resources/hello.py?corp=same-origin";
-    return promise_rejects(test, new TypeError, fetch("resources/redirect.py?redirectTo=" + encodeURIComponent(finalURL), { mode: "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch("resources/redirect.py?redirectTo=" + encodeURIComponent(finalURL), { mode: "no-cors" }));
 }, "Cross-origin no-cors fetch with a 'Cross-Origin-Resource-Policy: same-origin' response header after a redirection.");
 
 promise_test((test) => {
@@ -72,5 +72,5 @@ promise_test(async (test) => {
 
     await fetch(finalURL, { mode: "no-cors" });
 
-    return promise_rejects(test, new TypeError, fetch(notSameSiteBaseURL + "resources/redirect.py?corp=same-origin&redirectTo=" + encodeURIComponent(finalURL), { mode: "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch(notSameSiteBaseURL + "resources/redirect.py?corp=same-origin&redirectTo=" + encodeURIComponent(finalURL), { mode: "no-cors" }));
 }, "Cross-origin no-cors fetch with a 'Cross-Origin-Resource-Policy: same-origin' redirect response header.");

--- a/fetch/cross-origin-resource-policy/fetch.https.any.js
+++ b/fetch/cross-origin-resource-policy/fetch.https.any.js
@@ -28,17 +28,17 @@ promise_test(async (test) => {
 
 promise_test((test) => {
     const remoteURL = notSameSiteBaseURL + "resources/hello.py?corp=same-origin";
-    return promise_rejects(test, new TypeError, fetch(remoteURL, { mode : "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch(remoteURL, { mode : "no-cors" }));
 }, "Cross-origin no-cors fetch with a 'Cross-Origin-Resource-Policy: same-origin' response header.");
 
 promise_test((test) => {
     const remoteURL = notSameSiteBaseURL + "resources/hello.py?corp=same-site";
-    return promise_rejects(test, new TypeError, fetch(remoteURL, { mode: "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch(remoteURL, { mode: "no-cors" }));
 }, "Cross-origin no-cors fetch with a 'Cross-Origin-Resource-Policy: same-site' response header.");
 
 promise_test((test) => {
     const finalURL = notSameSiteBaseURL + "resources/hello.py?corp=same-origin";
-    return promise_rejects(test, new TypeError, fetch("resources/redirect.py?redirectTo=" + encodeURIComponent(finalURL), { mode: "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch("resources/redirect.py?redirectTo=" + encodeURIComponent(finalURL), { mode: "no-cors" }));
 }, "Cross-origin no-cors fetch with a 'Cross-Origin-Resource-Policy: same-origin' response header after a redirection.");
 
 promise_test((test) => {
@@ -51,5 +51,5 @@ promise_test(async (test) => {
 
     await fetch(finalURL, { mode: "no-cors" });
 
-    return promise_rejects(test, new TypeError, fetch(notSameSiteBaseURL + "resources/redirect.py?corp=same-origin&redirectTo=" + encodeURIComponent(finalURL), { mode: "no-cors" }));
+    return promise_rejects_js(test, TypeError, fetch(notSameSiteBaseURL + "resources/redirect.py?corp=same-origin&redirectTo=" + encodeURIComponent(finalURL), { mode: "no-cors" }));
 }, "Cross-origin no-cors fetch with a 'Cross-Origin-Resource-Policy: same-origin' redirect response header.");

--- a/fetch/cross-origin-resource-policy/scheme-restriction.any.js
+++ b/fetch/cross-origin-resource-policy/scheme-restriction.any.js
@@ -1,7 +1,7 @@
 // META: script=/common/get-host-info.sub.js
 
 promise_test(t => {
-  return promise_rejects(t,
-                         new TypeError(),
+  return promise_rejects_js(t,
+                         TypeError,
                          fetch(get_host_info().HTTPS_REMOTE_ORIGIN + "/fetch/cross-origin-resource-policy/resources/hello.py?corp=same-site", { mode: "no-cors" }));
 }, "Cross-Origin-Resource-Policy: same-site blocks retrieving HTTPS from HTTP");

--- a/fetch/data-urls/base64.any.js
+++ b/fetch/data-urls/base64.any.js
@@ -6,7 +6,7 @@ function runBase64Tests(tests) {
           dataURL = "data:;base64," + input;
     promise_test(t => {
       if(output === null) {
-        return promise_rejects(t, new TypeError(), fetch(dataURL));
+        return promise_rejects_js(t, TypeError, fetch(dataURL));
       }
       return fetch(dataURL).then(res => res.arrayBuffer()).then(body => {
         assert_array_equals(new Uint8Array(body), output);

--- a/fetch/data-urls/processing.any.js
+++ b/fetch/data-urls/processing.any.js
@@ -6,7 +6,7 @@ function runDataURLTests(tests) {
           expectedBody = expectedMimeType !== null ? tests[i][2] : null;
     promise_test(t => {
       if(expectedMimeType === null) {
-        return promise_rejects(t, new TypeError(), fetch(input));
+        return promise_rejects_js(t, TypeError, fetch(input));
       } else {
         return fetch(input).then(res => {
           return res.arrayBuffer().then(body => {

--- a/fetch/range/sw.https.window.js
+++ b/fetch/range/sw.https.window.js
@@ -86,7 +86,7 @@ promise_test(async t => {
 
   // Fetching should reject
   const fetchPromise = w.fetch('?action=use-stored-ranged-response', { mode: 'no-cors' });
-  promise_rejects(t, new TypeError(), fetchPromise);
+  promise_rejects_js(t, TypeError, fetchPromise);
 
   // Script loading should error too
   const loadScriptPromise = loadScript('?action=use-stored-ranged-response', { doc: w.document });

--- a/fetch/security/redirect-to-url-with-credentials.https.html
+++ b/fetch/security/redirect-to-url-with-credentials.https.html
@@ -17,7 +17,7 @@ promise_test((test) => {
 }, "No CORS fetch after a redirect with an URL containing credentials");
 
 promise_test((test) => {
-    return promise_rejects(test, new TypeError, fetch(imageURL, {mode: "cors"}));
+    return promise_rejects_js(test, TypeError, fetch(imageURL, {mode: "cors"}));
 }, "CORS fetch after a redirect with a cross origin URL containing credentials");
 
 promise_test((test) => {

--- a/html/cross-origin-embedder-policy/none-sw-from-none.https.html
+++ b/html/cross-origin-embedder-policy/none-sw-from-none.https.html
@@ -38,8 +38,8 @@ promise_test(async (t) => {
 }, 'making a same-origin request for CORP: cross-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('resources/nothing-same-origin-corp.txt'), {mode: 'no-cors'}));
 }, 'making a cross-origin request for CORP: same-origin');
 
@@ -54,8 +54,8 @@ promise_test(async (t) => {
 }, 'making a cross-origin request for CORP: cross-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('resources/nothing-same-origin-corp.txt?passthrough'),
       {mode: 'no-cors'}));
 }, 'making a cross-origin request for CORP: same-origin [PASS THROUGH]');
@@ -71,8 +71,8 @@ promise_test(async (t) => {
 }, 'making a cross-origin request for CORP: cross-origin [PASS THROUGH]');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(), fetch(remote('/common/blank.html'), {mode: 'cors'}));
+  await promise_rejects_js(
+    t, TypeError, fetch(remote('/common/blank.html'), {mode: 'cors'}));
 }, 'making a cross-origin request with CORS without ACAO');
 
 promise_test(async (t) => {

--- a/html/cross-origin-embedder-policy/none-sw-from-require-corp.https.html
+++ b/html/cross-origin-embedder-policy/none-sw-from-require-corp.https.html
@@ -38,14 +38,14 @@ promise_test(async (t) => {
 }, 'making a same-origin request for CORP: cross-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('resources/nothing-same-origin-corp.txt'), {mode: 'no-cors'}));
 }, 'making a cross-origin request for CORP: same-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(), fetch(remote('/common/blank.html'), {mode: 'no-cors'}));
+  await promise_rejects_js(
+    t, TypeError, fetch(remote('/common/blank.html'), {mode: 'no-cors'}));
 }, 'making a cross-origin request for no CORP');
 
 promise_test(async (t) => {
@@ -55,15 +55,15 @@ promise_test(async (t) => {
 }, 'making a cross-origin request for CORP: cross-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('resources/nothing-same-origin-corp.txt?passthrough'),
       {mode: 'no-cors'}));
 }, 'making a cross-origin request for CORP: same-origin [PASS THROUGH]');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('/common/blank.html?passthrough'), {mode: 'no-cors'}));
 }, 'making a cross-origin request for no CORP [PASS THROUGH]');
 
@@ -74,8 +74,8 @@ promise_test(async (t) => {
 }, 'making a cross-origin request for CORP: cross-origin [PASS THROUGH]');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(), fetch(remote('/common/blank.html'), {mode: 'cors'}));
+  await promise_rejects_js(
+    t, TypeError, fetch(remote('/common/blank.html'), {mode: 'cors'}));
 }, 'making a cross-origin request with CORS without ACAO');
 
 promise_test(async (t) => {

--- a/html/cross-origin-embedder-policy/require-corp-sw-from-none.https.html
+++ b/html/cross-origin-embedder-policy/require-corp-sw-from-none.https.html
@@ -39,14 +39,14 @@ promise_test(async (t) => {
 }, 'making a same-origin request for CORP: cross-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('resources/nothing-same-origin-corp.txt'), {mode: 'no-cors'}));
 }, 'making a cross-origin request for CORP: same-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(), fetch(remote('/common/blank.html'), {mode: 'no-cors'}));
+  await promise_rejects_js(
+    t, TypeError, fetch(remote('/common/blank.html'), {mode: 'no-cors'}));
 }, 'making a cross-origin request for no CORP');
 
 promise_test(async (t) => {
@@ -56,8 +56,8 @@ promise_test(async (t) => {
 }, 'making a cross-origin request for CORP: cross-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('resources/nothing-same-origin-corp.txt?passthrough'),
       {mode: 'no-cors'}));
 }, 'making a cross-origin request for CORP: same-origin [PASS THROUGH]');
@@ -73,8 +73,8 @@ promise_test(async (t) => {
 }, 'making a cross-origin request for CORP: cross-origin [PASS THROUGH]');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(), fetch(remote('/common/blank.html'), {mode: 'cors'}));
+  await promise_rejects_js(
+    t, TypeError, fetch(remote('/common/blank.html'), {mode: 'cors'}));
 }, 'making a cross-origin request with CORS without ACAO');
 
 promise_test(async (t) => {

--- a/html/cross-origin-embedder-policy/require-corp-sw-from-require-corp.https.html
+++ b/html/cross-origin-embedder-policy/require-corp-sw-from-require-corp.https.html
@@ -39,14 +39,14 @@ promise_test(async (t) => {
 }, 'making a same-origin request for CORP: cross-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('resources/nothing-same-origin-corp.txt'), {mode: 'no-cors'}));
 }, 'making a cross-origin request for CORP: same-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(), fetch(remote('/common/blank.html'), {mode: 'no-cors'}));
+  await promise_rejects_js(
+    t, TypeError, fetch(remote('/common/blank.html'), {mode: 'no-cors'}));
 }, 'making a cross-origin request for no CORP');
 
 promise_test(async (t) => {
@@ -56,15 +56,15 @@ promise_test(async (t) => {
 }, 'making a cross-origin request for CORP: cross-origin');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('resources/nothing-same-origin-corp.txt?passthrough'),
       {mode: 'no-cors'}));
 }, 'making a cross-origin request for CORP: same-origin [PASS THROUGH]');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     fetch(remote('/common/blank.html?passthrough'), {mode: 'no-cors'}));
 }, 'making a cross-origin request for no CORP [PASS THROUGH]');
 
@@ -75,8 +75,8 @@ promise_test(async (t) => {
 }, 'making a cross-origin request for CORP: cross-origin [PASS THROUGH]');
 
 promise_test(async (t) => {
-  await promise_rejects(
-    t, TypeError(), fetch(remote('/common/blank.html'), {mode: 'cors'}));
+  await promise_rejects_js(
+    t, TypeError, fetch(remote('/common/blank.html'), {mode: 'cors'}));
 }, 'making a cross-origin request with CORS without ACAO');
 
 promise_test(async (t) => {

--- a/html/cross-origin-embedder-policy/require-corp.https.html
+++ b/html/cross-origin-embedder-policy/require-corp.https.html
@@ -129,12 +129,12 @@ promise_test(async t => {
 }, `"require-corp" top-level: fetch() to CORP: cross-origin response should succeed`);
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), fetch(get_host_info().HTTPS_REMOTE_ORIGIN+"/common/blank.html", {mode: "no-cors"}));
+  return promise_rejects_js(t, TypeError, fetch(get_host_info().HTTPS_REMOTE_ORIGIN+"/common/blank.html", {mode: "no-cors"}));
 }, `"require-corp" top-level: fetch() to response without CORP should fail`);
 
 promise_test(t => {
   const w = window.open();
-  return promise_rejects(t, new TypeError(), w.fetch(get_host_info().HTTPS_REMOTE_ORIGIN+"/common/blank.html", {mode: "no-cors"}));
+  return promise_rejects_js(t, w.TypeError, w.fetch(get_host_info().HTTPS_REMOTE_ORIGIN+"/common/blank.html", {mode: "no-cors"}));
 }, `"require-corp" top-level: fetch() to response without CORP through a WindowProxy should fail`);
 
 async_test(t => {

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-fetch-error.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-fetch-error.sub.html
@@ -18,7 +18,7 @@ const cases = [
 
 for (const [label, specifier] of cases) {
   promise_test(t => {
-    return promise_rejects(t, new TypeError, import(specifier));
+    return promise_rejects_js(t, TypeError, import(specifier));
   }, "import() must reject when there is a " + label);
 
   promise_test(async t => {
@@ -28,8 +28,8 @@ for (const [label, specifier] of cases) {
     const promise1 = import(specifier + suffix);
     const promise2 = import(specifier + suffix);
 
-    await promise_rejects(t, new TypeError, promise1, "It must reject the first time");
-    await promise_rejects(t, new TypeError, promise2, "It must reject the second time");
+    await promise_rejects_js(t, TypeError, promise1, "It must reject the first time");
+    await promise_rejects_js(t, TypeError, promise2, "It must reject the second time");
 
     const error1 = await promise1.catch(e => e);
     const error2 = await promise2.catch(e => e);

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
@@ -81,7 +81,7 @@ promise_test(t => {
   );
   dummyDiv.onclick();
 
-  return promise_rejects(t, new TypeError(), promise);
+  return promise_rejects_js(t, TypeError, promise);
 }, "reflected inline event handlers must not inherit the nonce from the triggering script, thus fail");
 
 promise_test(t => {
@@ -99,6 +99,6 @@ promise_test(t => {
   assert_equals(typeof dummyDiv.onclick, "function", "the browser must be able to parse a string containing the import() syntax into a function");
   dummyDiv.click(); // different from **on**click()
 
-  return promise_rejects(t, new TypeError(), promise);
+  return promise_rejects_js(t, TypeError, promise);
 }, "inline event handlers triggered via UA code must not inherit the nonce from the triggering script, thus fail");
 </script>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
@@ -80,7 +80,7 @@ promise_test(t => {
   );
   dummyDiv.onclick();
 
-  return promise_rejects(t, new TypeError(), promise);
+  return promise_rejects_js(t, TypeError, promise);
 }, "reflected inline event handlers must not inherit the nonce from the triggering script, thus fail");
 
 promise_test(t => {
@@ -98,6 +98,6 @@ promise_test(t => {
   assert_equals(typeof dummyDiv.onclick, 'function', "the browser must be able to parse a string containing the import() syntax into a function");
   dummyDiv.click(); // different from **on**click()
 
-  return promise_rejects(t, new TypeError(), promise);
+  return promise_rejects_js(t, TypeError, promise);
 }, "inline event handlers triggered via UA code must not inherit the nonce from the triggering script, thus fail");
 </script>

--- a/import-maps/common/resources/common-test-helper.js
+++ b/import-maps/common/resources/common-test-helper.js
@@ -190,7 +190,7 @@ async function runTests(j) {
         const expected = j.expectedResults[specifier];
         promise_test(async t => {
             if (expected === null) {
-              return promise_rejects(t, new TypeError(),
+              return promise_rejects_js(t, TypeError,
                   resolve(specifier, j.parsedImportMap, j.baseURL));
             } else {
               // Should be resolved to `expected`.

--- a/import-maps/csp/applied-to-target-dynamic.sub.tentative.html
+++ b/import-maps/csp/applied-to-target-dynamic.sub.tentative.html
@@ -14,7 +14,7 @@
 </script>
 <script>
 promise_test(t => {
-    return promise_rejects(t, TypeError(),
+    return promise_rejects_js(t, TypeError,
                            import('../resources/log.js?pipe=sub&name=A'),
                            'Dynamic import should fail');
   }, 'The URL after mapping violates CSP (but not the URL before mapping)');

--- a/kv-storage/secure-context/dynamic-import.html
+++ b/kv-storage/secure-context/dynamic-import.html
@@ -13,6 +13,6 @@ test(() => {
 }, "Prerequisite check");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), import("std:kv-storage"));
+  return promise_rejects_js(t, TypeError, import("std:kv-storage"));
 });
 </script>

--- a/media-capabilities/decodingInfo.any.js
+++ b/media-capabilities/decodingInfo.any.js
@@ -136,7 +136,7 @@ promise_test(t => {
 }, "Test that decodingInfo rejects if the video configuration contentType has one parameter that isn't codecs");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.decodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
     type: 'file',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',

--- a/media-capabilities/decodingInfoEncryptedMedia.https.html
+++ b/media-capabilities/decodingInfoEncryptedMedia.https.html
@@ -70,7 +70,7 @@ promise_test(t => {
 }, "Test that decodingInfo() accepts a key system configuration with audio info.");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.decodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
     type: 'file',
     audio: minimalAudioConfiguration,
     keySystemConfiguration: {
@@ -83,7 +83,7 @@ promise_test(t => {
 }, "Test that decodingInfo() rejects if robustness and configuration do not match (1).");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.decodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
     type: 'file',
     video: minimalVideoConfiguration,
     keySystemConfiguration: {
@@ -96,7 +96,7 @@ promise_test(t => {
 }, "Test that decodingInfo() rejects if robustness and configuration do not match (2).");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.decodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
     type: 'file',
     video: minimalVideoConfiguration,
     keySystemConfiguration: {
@@ -112,7 +112,7 @@ promise_test(t => {
 }, "Test that decodingInfo() rejects if robustness and configuration do not match (3).");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.decodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
     type: 'file',
     audio: minimalAudioConfiguration,
     video: minimalVideoConfiguration,
@@ -130,7 +130,7 @@ promise_test(t => {
 }, "Test that decodingInfo() rejects if persistentState isn't valid.");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.decodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
     type: 'file',
     audio: minimalAudioConfiguration,
     video: minimalVideoConfiguration,
@@ -148,7 +148,7 @@ promise_test(t => {
 }, "Test that decodingInfo() rejects if distinctiveIdentifier isn't valid.");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.decodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.decodingInfo({
     type: 'file',
     audio: minimalAudioConfiguration,
     video: minimalVideoConfiguration,

--- a/media-capabilities/encodingInfo.html
+++ b/media-capabilities/encodingInfo.html
@@ -21,28 +21,28 @@ var minimalAudioConfiguration = {
 };
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo());
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo());
 }, "Test that encodingInfo rejects if it doesn't get a configuration");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({}));
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({}));
 }, "Test that encodingInfo rejects if the MediaConfiguration isn't valid");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     video: minimalVideoConfiguration,
     audio: minimalAudioConfiguration,
   }));
 }, "Test that encodingInfo rejects if the MediaConfiguration does not have a type");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
   }));
 }, "Test that encodingInfo rejects if the configuration doesn't have an audio or video field");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -55,7 +55,7 @@ promise_test(t => {
 }, "Test that encodingInfo rejects if the video configuration has a negative framerate");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -68,7 +68,7 @@ promise_test(t => {
 }, "Test that encodingInfo rejects if the video configuration has a framerate set to 0");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -81,7 +81,7 @@ promise_test(t => {
 }, "Test that encodingInfo rejects if the video configuration has a framerate set to Infinity");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'fgeoa',
@@ -94,7 +94,7 @@ promise_test(t => {
 }, "Test that encodingInfo rejects if the video configuration contentType doesn't parse");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'audio/fgeoa',
@@ -107,7 +107,7 @@ promise_test(t => {
 }, "Test that encodingInfo rejects if the video configuration contentType isn't of type video");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"; foo="bar"',
@@ -120,7 +120,7 @@ promise_test(t => {
 }, "Test that encodingInfo rejects if the video configuration contentType has more than one parameter");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; foo="bar"',
@@ -133,7 +133,7 @@ promise_test(t => {
 }, "Test that encodingInfo rejects if the video configuration contentType has one parameter that isn't codecs");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -146,7 +146,7 @@ promise_test(t => {
 }, "Test that encodingInfo() rejects framerate in the form of x/y");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -159,7 +159,7 @@ promise_test(t => {
 }, "Test that encodingInfo() rejects framerate in the form of x/0");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -172,7 +172,7 @@ promise_test(t => {
 }, "Test that encodingInfo() rejects framerate in the form of 0/y");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -185,7 +185,7 @@ promise_test(t => {
 }, "Test that encodingInfo() rejects framerate in the form of -x/y");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -198,7 +198,7 @@ promise_test(t => {
 }, "Test that encodingInfo() rejects framerate in the form of x/-y");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -211,7 +211,7 @@ promise_test(t => {
 }, "Test that encodingInfo() rejects framerate in the form of x/");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     video: {
       contentType: 'video/webm; codecs="vp09.00.10.08"',
@@ -224,28 +224,28 @@ promise_test(t => {
 }, "Test that encodingInfo() rejects framerate with trailing unallowed characters");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     audio: { contentType: 'fgeoa' },
   }));
 }, "Test that encodingInfo rejects if the audio configuration contenType doesn't parse");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     audio: { contentType: 'video/fgeoa' },
   }));
 }, "Test that encodingInfo rejects if the audio configuration contentType isn't of type audio");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     audio: { contentType: 'audio/webm; codecs="opus"; foo="bar"' },
   }));
 }, "Test that encodingInfo rejects if the audio configuration contentType has more than one parameters");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.mediaCapabilities.encodingInfo({
+  return promise_rejects_js(t, TypeError, navigator.mediaCapabilities.encodingInfo({
     type: 'record',
     audio: { contentType: 'audio/webm; foo="bar"' },
   }));

--- a/native-file-system/script-tests/FileSystemDirectoryHandle-getDirectory.js
+++ b/native-file-system/script-tests/FileSystemDirectoryHandle-getDirectory.js
@@ -55,26 +55,26 @@ directory_test(async (t, root) => {
 }, 'getDirectory() when a file already exists with the same name');
 
 directory_test(async (t, dir) => {
-  await promise_rejects(
-      t, new TypeError(), dir.getDirectory('', {create: true}));
-  await promise_rejects(
-      t, new TypeError(), dir.getDirectory('', {create: false}));
+  await promise_rejects_js(
+      t, TypeError, dir.getDirectory('', {create: true}));
+  await promise_rejects_js(
+      t, TypeError, dir.getDirectory('', {create: false}));
 }, 'getDirectory() with empty name');
 
 directory_test(async (t, dir) => {
-  await promise_rejects(
-      t, new TypeError(), dir.getDirectory(kCurrentDirectory));
-  await promise_rejects(
-      t, new TypeError(), dir.getDirectory(kCurrentDirectory, {create: true}));
+  await promise_rejects_js(
+      t, TypeError, dir.getDirectory(kCurrentDirectory));
+  await promise_rejects_js(
+      t, TypeError, dir.getDirectory(kCurrentDirectory, {create: true}));
 }, `getDirectory() with "${kCurrentDirectory}" name`);
 
 directory_test(async (t, dir) => {
   const subdir = await createDirectory(t, 'subdir-name', /*parent=*/ dir);
 
-  await promise_rejects(
-      t, new TypeError(), subdir.getDirectory(kParentDirectory));
-  await promise_rejects(
-      t, new TypeError(),
+  await promise_rejects_js(
+      t, TypeError, subdir.getDirectory(kParentDirectory));
+  await promise_rejects_js(
+      t, TypeError,
       subdir.getDirectory(kParentDirectory, {create: true}));
 }, `getDirectory() with "${kParentDirectory}" name`);
 
@@ -90,8 +90,8 @@ directory_test(async (t, dir) => {
   for (let i = 0; i < kPathSeparators.length; ++i) {
     const path_with_separator =
         `${first_subdir_name}${kPathSeparators[i]}${second_subdir_name}`;
-    await promise_rejects(
-        t, new TypeError(), dir.getDirectory(path_with_separator),
+    await promise_rejects_js(
+        t, TypeError, dir.getDirectory(path_with_separator),
         `getDirectory() must reject names containing "${kPathSeparators[i]}"`);
   }
 }, 'getDirectory(create=false) with a path separator when the directory exists');
@@ -102,8 +102,8 @@ directory_test(async (t, dir) => {
 
   for (let i = 0; i < kPathSeparators.length; ++i) {
     const path_with_separator = `${subdir_name}${kPathSeparators[i]}file_name`;
-    await promise_rejects(
-        t, new TypeError(),
+    await promise_rejects_js(
+        t, TypeError,
         dir.getDirectory(path_with_separator, {create: true}),
         `getDirectory(true) must reject names containing "${
             kPathSeparators[i]}"`);

--- a/native-file-system/script-tests/FileSystemDirectoryHandle-getFile.js
+++ b/native-file-system/script-tests/FileSystemDirectoryHandle-getFile.js
@@ -53,22 +53,22 @@ directory_test(async (t, dir) => {
 }, 'getFile(create=true) when a directory already exists with the same name');
 
 directory_test(async (t, dir) => {
-  await promise_rejects(t, new TypeError(), dir.getFile('', {create: true}));
-  await promise_rejects(t, new TypeError(), dir.getFile('', {create: false}));
+  await promise_rejects_js(t, TypeError, dir.getFile('', {create: true}));
+  await promise_rejects_js(t, TypeError, dir.getFile('', {create: false}));
 }, 'getFile() with empty name');
 
 directory_test(async (t, dir) => {
-  await promise_rejects(t, new TypeError(), dir.getFile(kCurrentDirectory));
-  await promise_rejects(
-      t, new TypeError(), dir.getFile(kCurrentDirectory, {create: true}));
+  await promise_rejects_js(t, TypeError, dir.getFile(kCurrentDirectory));
+  await promise_rejects_js(
+      t, TypeError, dir.getFile(kCurrentDirectory, {create: true}));
 }, `getFile() with "${kCurrentDirectory}" name`);
 
 directory_test(async (t, dir) => {
   const subdir = await createDirectory(t, 'subdir-name', /*parent=*/ dir);
 
-  await promise_rejects(t, new TypeError(), subdir.getFile(kParentDirectory));
-  await promise_rejects(
-      t, new TypeError(), subdir.getFile(kParentDirectory, {create: true}));
+  await promise_rejects_js(t, TypeError, subdir.getFile(kParentDirectory));
+  await promise_rejects_js(
+      t, TypeError, subdir.getFile(kParentDirectory, {create: true}));
 }, `getFile() with "${kParentDirectory}" name`);
 
 directory_test(async (t, dir) => {
@@ -81,8 +81,8 @@ directory_test(async (t, dir) => {
   for (let i = 0; i < kPathSeparators.length; ++i) {
     const path_with_separator =
         `${subdir_name}${kPathSeparators[i]}${file_name}`;
-    await promise_rejects(
-        t, new TypeError(), dir.getFile(path_with_separator),
+    await promise_rejects_js(
+        t, TypeError, dir.getFile(path_with_separator),
         `getFile() must reject names containing "${kPathSeparators[i]}"`);
   }
 }, 'getFile(create=false) with a path separator when the file exists.');
@@ -93,8 +93,8 @@ directory_test(async (t, dir) => {
 
   for (let i = 0; i < kPathSeparators.length; ++i) {
     const path_with_separator = `${subdir_name}${kPathSeparators[i]}file_name`;
-    await promise_rejects(
-        t, new TypeError(), dir.getFile(path_with_separator, {create: true}),
+    await promise_rejects_js(
+        t, TypeError, dir.getFile(path_with_separator, {create: true}),
         `getFile(true) must reject names containing "${kPathSeparators[i]}"`);
   }
 }, 'getFile(create=true) with a path separator');

--- a/native-file-system/script-tests/FileSystemDirectoryHandle-removeEntry.js
+++ b/native-file-system/script-tests/FileSystemDirectoryHandle-removeEntry.js
@@ -40,17 +40,17 @@ directory_test(async (t, root) => {
 
 directory_test(async (t, root) => {
   const dir = await createDirectory(t, 'dir', root);
-  await promise_rejects(t, new TypeError(), dir.removeEntry(''));
+  await promise_rejects_js(t, TypeError, dir.removeEntry(''));
 }, 'removeEntry() with empty name should fail');
 
 directory_test(async (t, root) => {
   const dir = await createDirectory(t, 'dir', root);
-  await promise_rejects(t, new TypeError(), dir.removeEntry(kCurrentDirectory));
+  await promise_rejects_js(t, TypeError, dir.removeEntry(kCurrentDirectory));
 }, `removeEntry() with "${kCurrentDirectory}" name should fail`);
 
 directory_test(async (t, root) => {
   const dir = await createDirectory(t, 'dir', root);
-  await promise_rejects(t, new TypeError(), dir.removeEntry(kParentDirectory));
+  await promise_rejects_js(t, TypeError, dir.removeEntry(kParentDirectory));
 }, `removeEntry() with "${kParentDirectory}" name should fail`);
 
 directory_test(async (t, root) => {
@@ -62,8 +62,8 @@ directory_test(async (t, root) => {
 
   for (let i = 0; i < kPathSeparators.length; ++i) {
     const path_with_separator = `${dir_name}${kPathSeparators[i]}${file_name}`;
-    await promise_rejects(
-        t, new TypeError(), root.removeEntry(path_with_separator),
+    await promise_rejects_js(
+        t, TypeError, root.removeEntry(path_with_separator),
         `removeEntry() must reject names containing "${kPathSeparators[i]}"`);
   }
 }, 'removeEntry() with a path separator should fail.');

--- a/native-file-system/script-tests/FileSystemWritableFileStream-piped.js
+++ b/native-file-system/script-tests/FileSystemWritableFileStream-piped.js
@@ -128,7 +128,7 @@ directory_test(async (t, root) => {
   await abortController.abort();
 
   await promise_rejects(t, 'AbortError', promise, 'stream is aborted');
-  await promise_rejects(t, TypeError(), wfs.close(), 'stream cannot be closed to flush writes');
+  await promise_rejects_js(t, TypeError, wfs.close(), 'stream cannot be closed to flush writes');
 
   assert_equals(await getFileContents(handle), '');
   assert_equals(await getFileSize(handle), 0);

--- a/native-file-system/script-tests/FileSystemWritableFileStream-write.js
+++ b/native-file-system/script-tests/FileSystemWritableFileStream-write.js
@@ -119,8 +119,8 @@ directory_test(async (t, root) => {
 
   await promise_rejects(
       t, 'InvalidStateError', stream.write({type: 'write', position: 4, data: new Blob(['abc'])}));
-  await promise_rejects(
-      t, TypeError(), stream.close(), 'stream is already closed');
+  await promise_rejects_js(
+      t, TypeError, stream.close(), 'stream is already closed');
 
   assert_equals(await getFileContents(handle), '');
   assert_equals(await getFileSize(handle), 0);
@@ -233,8 +233,8 @@ directory_test(async (t, root) => {
   assert_equals(await getFileContents(handle), 'foo');
   assert_equals(await getFileSize(handle), 3);
 
-  await promise_rejects(
-      t, TypeError(), stream.write('abc'));
+  await promise_rejects_js(
+      t, TypeError, stream.write('abc'));
 }, 'atomic writes: write() after close() fails');
 
 directory_test(async (t, root) => {
@@ -247,7 +247,7 @@ directory_test(async (t, root) => {
   assert_equals(await getFileContents(handle), 'foo');
   assert_equals(await getFileSize(handle), 3);
 
-  await promise_rejects(t, TypeError(), stream.truncate(0));
+  await promise_rejects_js(t, TypeError, stream.truncate(0));
 }, 'atomic writes: truncate() after close() fails');
 
 directory_test(async (t, root) => {
@@ -259,7 +259,7 @@ directory_test(async (t, root) => {
   assert_equals(await getFileContents(handle), 'foo');
   assert_equals(await getFileSize(handle), 3);
 
-  await promise_rejects(t, TypeError(), stream.close());
+  await promise_rejects_js(t, TypeError, stream.close());
 }, 'atomic writes: close() after close() fails');
 
 directory_test(async (t, root) => {
@@ -312,8 +312,8 @@ directory_test(async (t, root) => {
       t, 'content.txt', 'very long string', root);
   const stream = await handle.createWritable();
 
-  await promise_rejects(
-      t, SyntaxError(), stream.write({type: 'truncate'}), 'truncate without size');
+  await promise_rejects_js(
+      t, SyntaxError, stream.write({type: 'truncate'}), 'truncate without size');
 
 }, 'WriteParams: truncate missing size param');
 
@@ -321,8 +321,8 @@ directory_test(async (t, root) => {
   const handle = await createEmptyFile(t, 'content.txt', root);
   const stream = await handle.createWritable();
 
-  await promise_rejects(
-      t, SyntaxError(), stream.write({type: 'write'}), 'write without data');
+  await promise_rejects_js(
+      t, SyntaxError, stream.write({type: 'write'}), 'write without data');
 
 }, 'WriteParams: write missing data param');
 
@@ -331,7 +331,7 @@ directory_test(async (t, root) => {
       t, 'content.txt', 'seekable', root);
   const stream = await handle.createWritable();
 
-  await promise_rejects(
-      t, SyntaxError(), stream.write({type: 'seek'}), 'seek without position');
+  await promise_rejects_js(
+      t, SyntaxError, stream.write({type: 'seek'}), 'seek without position');
 
 }, 'WriteParams: seek missing position param');

--- a/payment-handler/payment-instruments.https.html
+++ b/payment-handler/payment-instruments.https.html
@@ -190,7 +190,7 @@ function runTests(registration) {
         method: 'basic-card',
       },
     );
-    return promise_rejects(t, new TypeError(), setPromise);
+    return promise_rejects_js(t, TypeError, setPromise);
   }, 'Cannot register instruments with invalid icon media type image/jif');
 
   promise_test(async t => {
@@ -209,7 +209,7 @@ function runTests(registration) {
         method: 'basic-card',
       },
     );
-    return promise_rejects(t, new TypeError(), setPromise);
+    return promise_rejects_js(t, TypeError, setPromise);
   }, "Don't crash when registering instruments with very long icon media type image/pngggggg...");
 
   promise_test(async t => {
@@ -243,7 +243,7 @@ function runTests(registration) {
         method: 'basic-card',
       },
     );
-    return promise_rejects(t, new TypeError(), setPromise);
+    return promise_rejects_js(t, TypeError, setPromise);
   }, 'Cannot register instruments with invalid icon size "256 256" (missing "x")');
 
   promise_test(async t => {
@@ -262,7 +262,7 @@ function runTests(registration) {
         method: 'basic-card',
       },
     );
-    return promise_rejects(t, new TypeError(), setPromise);
+    return promise_rejects_js(t, TypeError, setPromise);
   }, 'Cannot register instruments with invalid icon URL (has a null character)');
 
   promise_test(async t => {
@@ -281,7 +281,7 @@ function runTests(registration) {
         method: 'basic-card',
       },
     );
-    return promise_rejects(t, new TypeError(), setPromise);
+    return promise_rejects_js(t, TypeError, setPromise);
   }, 'Cannot register instruments with non-existing non-https icon URL');
 
   promise_test(async t => {
@@ -301,7 +301,7 @@ function runTests(registration) {
         method: 'basic-card',
       },
     );
-    return promise_rejects(t, new TypeError(), setPromise);
+    return promise_rejects_js(t, TypeError, setPromise);
   }, 'Cannot register instruments with an existing non-https icon URL');
 
   async function testUnusualStrings(existingKey, nonExistingKey) {

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html
@@ -73,9 +73,9 @@ function testFireEvents(button) {
       event.updateWith(newDetails);
     });
     const acceptPromise = request.show();
-    await promise_rejects(
+    await promise_rejects_js(
       t,
-      new TypeError(),
+      TypeError,
       acceptPromise,
       "Duplicate shippingOption ids must abort with TypeError"
     );

--- a/payment-request/payment-response/retry-method-manual.https.html
+++ b/payment-request/payment-response/retry-method-manual.https.html
@@ -176,9 +176,9 @@ function abortTheUpdate(button) {
     });
     const retryPromise = response.retry();
     await shipOptionChangePromise;
-    await promise_rejects(
+    await promise_rejects_js(
       t,
-      new TypeError(),
+      TypeError,
       retryPromise,
       "retry() aborts with a TypeError, because totals' value is invalid"
     );

--- a/payment-request/show-method-optional-promise-resolves-manual.https.html
+++ b/payment-request/show-method-optional-promise-resolves-manual.https.html
@@ -164,9 +164,9 @@ const neutralDetails = Object.freeze({
 function smokeTest() {
   promise_test(async t => {
     const request = new PaymentRequest(validMethods, failDetails);
-    await promise_rejects(
+    await promise_rejects_js(
       t,
-      new TypeError(),
+      TypeError,
       request.show({
         total: "This throws a TypeError",
       }),

--- a/payment-request/updateWith-method-pmi-handling-manual.https.html
+++ b/payment-request/updateWith-method-pmi-handling-manual.https.html
@@ -76,7 +76,7 @@ function manualTest(button, { invalidMethod }) {
     // We test against a valid and an invalid modifier
     request.addEventListener("shippingaddresschange", listener, { once: true });
     const showPromise = request.show();
-    await promise_rejects(t, new RangeError(), showPromise);
+    await promise_rejects_js(t, RangeError, showPromise);
   }, button.textContent.trim());
 }
 </script>

--- a/portals/portal-activate-data.html
+++ b/portals/portal-activate-data.html
@@ -82,8 +82,8 @@ promise_test(async t => {
 }, "Uncloneable data has its exception propagated.");
 
 promise_test(async t => {
-  await promise_rejects(
-      t, new TypeError,
+  await promise_rejects_js(
+      t, TypeError,
       openPortalAndActivate('', {data: null, transfer: [null]}));
 }, "Errors during transfer list processing are propagated.");
 </script>

--- a/portals/portals-post-message.sub.html
+++ b/portals/portals-post-message.sub.html
@@ -169,7 +169,7 @@
 
     promise_test(async t => {
       var portal = await createAndInsertPortal(sameOriginUrl);
-      return promise_rejects(t, new TypeError(),
+      return promise_rejects_js(t, TypeError,
                              postMessage(portal, "test", "*", [null]));
     }, "postMessage should fail with invalid ports");
 

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -93,7 +93,7 @@ function throwOrReject(a_test, operation, fn, obj, args, message, cb)
         cb();
     } else {
         try {
-            promise_rejects(a_test, new TypeError(), fn.apply(obj, args), message).then(cb, cb);
+            promise_rejects_js(a_test, TypeError, fn.apply(obj, args), message).then(cb, cb);
         } catch (e){
             a_test.step(function() {
                 assert_unreached("Throws \"" + e + "\" instead of rejecting promise");
@@ -2348,7 +2348,7 @@ IdlInterface.prototype.test_member_attribute = function(member)
                     // do, since it will call done() on a_test.
                     this.do_interface_attribute_asserts(this.get_interface_object().prototype, member, a_test);
                 } else {
-                    promise_rejects(a_test, new TypeError(),
+                    promise_rejects_js(a_test, TypeError,
                                     this.get_interface_object().prototype[member.name])
                         .then(function() {
                             // do_interface_attribute_asserts must be the last
@@ -3018,7 +3018,7 @@ IdlInterface.prototype.do_interface_attribute_asserts = function(obj, member, a_
                 }.bind(this), "calling getter on wrong object type must throw TypeError");
             } else {
                 pendingPromises.push(
-                    promise_rejects(a_test, new TypeError(), desc.get.call({}),
+                    promise_rejects_js(a_test, TypeError, desc.get.call({}),
                                     "calling getter on wrong object type must reject the return promise with TypeError"));
             }
         } else {

--- a/screen-orientation/lock-bad-argument.html
+++ b/screen-orientation/lock-bad-argument.html
@@ -14,13 +14,13 @@ promise_test(t => {
     ["portrait-primary", "landscape-primary"],
   ];
   const promisesToReject = invalid_lock_types.map(type =>
-    promise_rejects(t, new TypeError(), screen.orientation.lock(type))
+    promise_rejects_js(t, TypeError, screen.orientation.lock(type))
   );
   return Promise.all(promisesToReject);
 }, "screen.orientation.lock() must throw given invalid input.");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), screen.orientation.lock());
+  return promise_rejects_js(t, TypeError, screen.orientation.lock());
 }, "screen.orientation.lock() must throw when the input is missing.");
 </script>
 

--- a/service-workers/cache-storage/script-tests/cache-add.js
+++ b/service-workers/cache-storage/script-tests/cache-add.js
@@ -4,9 +4,9 @@ if (self.importScripts) {
 }
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.add(),
       'Cache.add should throw a TypeError when no arguments are given.');
   }, 'Cache.add called with no arguments');
@@ -30,9 +30,9 @@ cache_test(function(cache) {
   }, 'Cache.add called with relative URL specified as a string');
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.add('javascript://this-is-not-http-mmkay'),
       'Cache.add should throw a TypeError for non-HTTP/HTTPS URLs.');
   }, 'Cache.add called with non-HTTP/HTTPS URL');
@@ -49,9 +49,9 @@ cache_test(function(cache) {
 cache_test(function(cache, test) {
     var request = new Request('../resources/simple.txt',
                               {method: 'POST', body: 'This is a body.'});
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.add(request),
       'Cache.add should throw a TypeError for non-GET requests.');
   }, 'Cache.add called with POST request');
@@ -84,9 +84,9 @@ cache_test(function(cache) {
   }, 'Cache.add with request with null body (not consumed)');
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.add('../resources/fetch-status.py?status=206'),
       'Cache.add should reject on partial response');
   }, 'Cache.add with 206 response');
@@ -97,34 +97,34 @@ cache_test(function(cache, test) {
     var requests = urls.map(function(url) {
         return new Request(url);
       });
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.addAll(requests),
       'Cache.addAll should reject with TypeError if any request fails');
   }, 'Cache.addAll with 206 response');
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.add('this-does-not-exist-please-dont-create-it'),
       'Cache.add should reject if response is !ok');
   }, 'Cache.add with request that results in a status of 404');
 
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.add('../resources/fetch-status.py?status=500'),
       'Cache.add should reject if response is !ok');
   }, 'Cache.add with request that results in a status of 500');
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.addAll(),
       'Cache.addAll with no arguments should throw TypeError.');
   }, 'Cache.addAll with no arguments');
@@ -132,9 +132,9 @@ cache_test(function(cache, test) {
 cache_test(function(cache, test) {
     // Assumes the existence of ../resources/simple.txt and ../resources/blank.html
     var urls = ['../resources/simple.txt', undefined, '../resources/blank.html'];
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.addAll(),
       'Cache.addAll should throw TypeError for an undefined argument.');
   }, 'Cache.addAll with a mix of valid and undefined arguments');
@@ -239,9 +239,9 @@ cache_test(function(cache, test) {
     var requests = urls.map(function(url) {
         return new Request(url);
       });
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.addAll(requests),
       'Cache.addAll should reject with TypeError if any request fails')
       .then(function() {

--- a/service-workers/cache-storage/script-tests/cache-delete.js
+++ b/service-workers/cache-storage/script-tests/cache-delete.js
@@ -17,9 +17,9 @@ function new_test_response() {
 }
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.delete(),
       'Cache.delete should reject with a TypeError when called with no ' +
       'arguments.');

--- a/service-workers/cache-storage/script-tests/cache-put.js
+++ b/service-workers/cache-storage/script-tests/cache-put.js
@@ -109,9 +109,9 @@ cache_test(function(cache, test) {
         headers: [['Content-Type', 'text/plain']]
       });
 
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.put(request, response),
       'Cache.put should reject 206 Responses with a TypeError.');
   }, 'Cache.put with synthetic 206 response');
@@ -125,7 +125,7 @@ cache_test(function(cache, test) {
           assert_equals(fetch_result.status, 206,
                         'Test framework error: The status code should be 206.');
           response = fetch_result.clone();
-          return promise_rejects(test, new TypeError, cache.put(request, fetch_result));
+          return promise_rejects_js(test, TypeError, cache.put(request, fetch_result));
         });
   }, 'Cache.put with HTTP 206 response');
 
@@ -217,17 +217,17 @@ cache_test(function(cache) {
   }, 'Cache.put with a string request');
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.put(new Request(test_url), 'Hello world!'),
       'Cache.put should only accept a Response object as the response.');
   }, 'Cache.put with an invalid response');
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.put(new Request('file:///etc/passwd'),
                 new Response(test_body)),
       'Cache.put should reject non-HTTP/HTTPS requests with a TypeError.');
@@ -248,26 +248,26 @@ cache_test(function(cache) {
 
 cache_test(function(cache, test) {
     var request = new Request('http://example.com/foo', { method: 'HEAD' });
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.put(request, new Response(test_body)),
       'Cache.put should throw a TypeError for non-GET requests.');
   }, 'Cache.put with a non-GET request');
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.put(new Request(test_url), null),
       'Cache.put should throw a TypeError for a null response.');
   }, 'Cache.put with a null response');
 
 cache_test(function(cache, test) {
     var request = new Request(test_url, {method: 'POST', body: test_body});
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.put(request, new Response(test_body)),
       'Cache.put should throw a TypeError for a POST request.');
   }, 'Cache.put with a POST request');
@@ -298,18 +298,18 @@ cache_test(function(cache) {
   }, 'getReader() after Cache.put');
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.put(new Request(test_url),
                 new Response(test_body, { headers: { VARY: '*' }})),
       'Cache.put should reject VARY:* Responses with a TypeError.');
   }, 'Cache.put with a VARY:* Response');
 
 cache_test(function(cache, test) {
-    return promise_rejects(
+    return promise_rejects_js(
       test,
-      new TypeError(),
+      TypeError,
       cache.put(new Request(test_url),
                 new Response(test_body,
                              { headers: { VARY: 'Accept-Language,*' }})),

--- a/service-workers/cache-storage/script-tests/cache-storage.js
+++ b/service-workers/cache-storage/script-tests/cache-storage.js
@@ -64,9 +64,9 @@ promise_test(function(t) {
   }, 'CacheStorage.open with an empty name');
 
 promise_test(function(t) {
-    return promise_rejects(
+    return promise_rejects_js(
       t,
-      new TypeError(),
+      TypeError,
       self.caches.open(),
       'CacheStorage.open should throw TypeError if called with no arguments.');
   }, 'CacheStorage.open with no arguments');

--- a/service-workers/service-worker/controller-with-no-fetch-event-handler.https.html
+++ b/service-workers/service-worker/controller-with-no-fetch-event-handler.https.html
@@ -42,7 +42,7 @@ promise_test(async t => {
 promise_test(async t => {
     const url = new URL('cors-denied.txt', remote_base_url);
     const response = frame.contentWindow.fetch(url);
-    await promise_rejects(t, new TypeError(), response);
+    await promise_rejects_js(t, frame.contentWindow.TypeError, response);
 }, 'cross-origin request, cors denied');
 
 promise_test(async t => {

--- a/service-workers/service-worker/fetch-response-taint.https.html
+++ b/service-workers/service-worker/fetch-response-taint.https.html
@@ -67,7 +67,7 @@ function ng_test(url, mode, credentials) {
       return login_and_register
         .then(function(frame) {
             var fetchRequest = frame_fetch(frame, url, mode, credentials);
-            return promise_rejects(t, new TypeError(), fetchRequest);
+            return promise_rejects_js(t, frame.contentWindow.TypeError, fetchRequest);
           });
     }, 'url:\"' + url + '\" mode:\"' + mode +
        '\" credentials:\"' + credentials + '\" should fail.');

--- a/service-workers/service-worker/navigation-preload/get-state.https.html
+++ b/service-workers/service-worker/navigation-preload/get-state.https.html
@@ -68,32 +68,32 @@ promise_test(t => {
     .then(state => {
         expect_navigation_preload_state(state, false, 'null',
                                         'after setHeaderValue to null');
-        return promise_rejects(t,
-            new TypeError,
+        return promise_rejects_js(t,
+            TypeError,
             np.setHeaderValue('what\uDC00\uD800this'),
             'setHeaderValue() should throw if passed surrogates');
       })
     .then(() => {
-        return promise_rejects(t,
-            new TypeError,
+        return promise_rejects_js(t,
+            TypeError,
             np.setHeaderValue('zer\0o'),
             'setHeaderValue() should throw if passed \\0');
       })
     .then(() => {
-        return promise_rejects(t,
-            new TypeError,
+        return promise_rejects_js(t,
+            TypeError,
             np.setHeaderValue('\rcarriage'),
             'setHeaderValue() should throw if passed \\r');
       })
     .then(() => {
-        return promise_rejects(t,
-            new TypeError,
+        return promise_rejects_js(t,
+            TypeError,
             np.setHeaderValue('newline\n'),
             'setHeaderValue() should throw if passed \\n');
       })
     .then(() => {
-        return promise_rejects(t,
-            new TypeError,
+        return promise_rejects_js(t,
+            TypeError,
             np.setHeaderValue(),
             'setHeaderValue() should throw if passed undefined');
       })

--- a/service-workers/service-worker/redirected-response.https.html
+++ b/service-workers/service-worker/redirected-response.https.html
@@ -149,8 +149,8 @@ promise_test(t => setup_and_clean()
   'mode: "manual", non-intercepted request');
 
 promise_test(t => setup_and_clean()
-    .then(() => promise_rejects(
-                   t, new TypeError(),
+    .then(() => promise_rejects_js(
+                   t, TypeError,
                    self.fetch(REDIRECT_TO_TARGET_URL + '&error',
                               {redirect:'error'}),
                    'The redirect response from the server should be treated as' +
@@ -191,8 +191,8 @@ promise_test(t => setup_and_clean()
     .then(() => {
       const url = REDIRECT_TO_TARGET_URL +
                   '&original-redirect-mode=error&sw=follow';
-      return promise_rejects(
-          t, new TypeError(),
+      return promise_rejects_js(
+          t, frame.contentWindow.TypeError,
           frame.contentWindow.fetch(url, {redirect: 'error'}),
           'The redirected response from the service worker should be ' +
           'treated as an error when the redirect flag of request was ' +
@@ -205,8 +205,8 @@ promise_test(t => setup_and_clean()
     .then(() => {
       const url = REDIRECT_TO_TARGET_URL +
                   '&original-redirect-mode=manual&sw=follow';
-      return promise_rejects(
-          t, new TypeError(),
+      return promise_rejects_js(
+          t, frame.contentWindow.TypeError,
           frame.contentWindow.fetch(url, {redirect: 'manual'}),
           'The redirected response from the service worker should be ' +
           'treated as an error when the redirect flag of request was ' +
@@ -223,8 +223,8 @@ promise_test(t => setup_and_clean()
     .then(() => {
       const url = REDIRECT_TO_TARGET_URL +
                   '&original-redirect-mode=follow&sw=manual';
-      return promise_rejects(
-          t, new TypeError(),
+      return promise_rejects_js(
+          t, frame.contentWindow.TypeError,
           frame.contentWindow.fetch(url, {redirect: 'follow'}),
           'The opaqueredirect response from the service worker should ' +
           'be treated as an error when the redirect flag of request was' +
@@ -237,8 +237,8 @@ promise_test(t => setup_and_clean()
     .then(() => {
       const url = REDIRECT_TO_TARGET_URL +
                   '&original-redirect-mode=error&sw=manual';
-      return promise_rejects(
-          t, new TypeError(),
+      return promise_rejects_js(
+          t, frame.contentWindow.TypeError,
           frame.contentWindow.fetch(url, {redirect: 'error'}),
           'The opaqueredirect response from the service worker should ' +
           'be treated as an error when the redirect flag of request was' +
@@ -283,8 +283,8 @@ promise_test(t => setup_and_clean()
       const url = host_info['HTTPS_ORIGIN'] + base_path() +
                   'dummy?url=' + encodeURIComponent(TARGET_URL) +
                   '&original-redirect-mode=error&sw=gen';
-      return promise_rejects(
-          t, new TypeError(),
+      return promise_rejects_js(
+          t, frame.contentWindow.TypeError,
           frame.contentWindow.fetch(url, {redirect: 'error'}),
           'The generated redirect response from the service worker should ' +
           'be treated as an error when the redirect flag of request was' +
@@ -343,8 +343,8 @@ promise_test(t => setup_and_clean()
                     encodeURIComponent(urls[0]));
 
       }
-      return promise_rejects(
-          t, new TypeError(),
+      return promise_rejects_js(
+          t, frame.contentWindow.TypeError,
           frame.contentWindow.fetch(urls[0], {redirect: 'follow'}),
           'Fetch should not follow the redirect response 21 times.')
         .then(() => {

--- a/service-workers/service-worker/registration-updateviacache.https.html
+++ b/service-workers/service-worker/registration-updateviacache.https.html
@@ -197,7 +197,7 @@
     const fail = navigator.serviceWorker.register(
         'resources/malformed-worker.py?parse-error',
         {scope: SCOPE, updateViaCache: 'none'});
-    await promise_rejects(t, new TypeError(), fail);
+    await promise_rejects_js(t, TypeError, fail);
     assert_equals(registration.updateViaCache, 'imports',
                   'after update attempt');
   }, 'updateViaCache is not updated if register() rejects');

--- a/service-workers/service-worker/unregister-then-register-new-script.https.html
+++ b/service-workers/service-worker/unregister-then-register-new-script.https.html
@@ -93,8 +93,8 @@ promise_test(async function(t) {
 
   await registration.unregister();
 
-  await promise_rejects(
-    t, new TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     navigator.serviceWorker.register('this-will-404', { scope })
   );
 

--- a/service-workers/service-worker/update-import-scripts.https.html
+++ b/service-workers/service-worker/update-import-scripts.https.html
@@ -83,7 +83,7 @@ promise_test(async t => {
           t, 'empty.js', 'import-scripts-404.js');
   t.add_cleanup(() => registration.unregister());
 
-  await promise_rejects(t, new TypeError(), registration.update());
+  await promise_rejects_js(t, TypeError, registration.update());
   assert_active_only(registration, expected_url);
 }, 'update() should fail when a new worker imports an unavailable script.');
 
@@ -119,7 +119,7 @@ promise_test(async t => {
        `AdditionalKey=${token()}`);
   t.add_cleanup(() => registration.unregister());
 
-  await promise_rejects(t, new TypeError(), registration.update());
+  await promise_rejects_js(t, TypeError, registration.update());
   assert_active_only(registration, expected_url);
 }, 'update() should find an update in an imported script but update() should ' +
    'result in failure due to missing the other imported script.');

--- a/service-workers/service-worker/update-registration-with-type.https.html
+++ b/service-workers/service-worker/update-registration-with-type.https.html
@@ -173,7 +173,7 @@ promise_test(async t => {
   await wait_for_state(t, firstRegistration.installing, 'activated');
 
   // Re-register with module script type and expect TypeError.
-  return promise_rejects(t, new TypeError, navigator.serviceWorker.register(script, {
+  return promise_rejects_js(t, TypeError, navigator.serviceWorker.register(script, {
     scope: scope,
     type: 'module'
   }), 'Registering with invalid evaluation should be failed.');
@@ -198,7 +198,7 @@ promise_test(async t => {
   await wait_for_state(t, firstRegistration.installing, 'activated');
 
   // Re-register with classic script type and expect TypeError.
-  return promise_rejects(t, new TypeError, navigator.serviceWorker.register(script, {
+  return promise_rejects_js(t, TypeError, navigator.serviceWorker.register(script, {
     scope: scope,
     type: 'classic'
   }), 'Registering with invalid evaluation should be failed.');

--- a/service-workers/service-worker/update.https.html
+++ b/service-workers/service-worker/update.https.html
@@ -106,7 +106,7 @@ promise_test(async t => {
       await prepare_ready_registration_with_mode(t, 'redirect');
   t.add_cleanup(() => registration.unregister());
 
-  await promise_rejects(t, new TypeError(), registration.update());
+  await promise_rejects_js(t, TypeError, registration.update());
   assert_active_only(registration, expected_url);
 }, 'update() should fail when a response for the main script is redirect.');
 
@@ -115,7 +115,7 @@ promise_test(async t => {
       await prepare_ready_registration_with_mode(t, 'syntax_error');
   t.add_cleanup(() => registration.unregister());
 
-  await promise_rejects(t, new TypeError(), registration.update());
+  await promise_rejects_js(t, TypeError, registration.update());
   assert_active_only(registration, expected_url);
 }, 'update() should fail when a new script contains a syntax error.');
 
@@ -139,8 +139,8 @@ promise_test(async t => {
   const frame = await with_iframe(SCOPE);
   t.add_cleanup(() => frame.remove());
 
-  await promise_rejects(
-      t, new TypeError(),
+  await promise_rejects_js(
+      t, TypeError,
       Promise.all([registration.unregister(), registration.update()]));
 }, 'update() should fail when the pending uninstall flag is set.');
 

--- a/streams/piping/abort.any.js
+++ b/streams/piping/abort.any.js
@@ -25,7 +25,7 @@ for (const invalidSignal of [null, 'AbortSignal', true, -1, Object.create(AbortS
   promise_test(t => {
     const rs = recordingReadableStream(errorOnPull, hwm0);
     const ws = recordingWritableStream();
-    return promise_rejects(t, new TypeError(), rs.pipeTo(ws, { signal: invalidSignal }), 'pipeTo should reject')
+    return promise_rejects_js(t, TypeError, rs.pipeTo(ws, { signal: invalidSignal }), 'pipeTo should reject')
         .then(() => {
           assert_equals(rs.events.length, 0, 'no ReadableStream methods should have been called');
           assert_equals(ws.events.length, 0, 'no WritableStream methods should have been called');

--- a/streams/piping/close-propagation-backward.any.js
+++ b/streams/piping/close-propagation-backward.any.js
@@ -102,7 +102,7 @@ for (const truthy of [true, 'a', 1, Symbol(), { }]) {
     writer.close();
     writer.releaseLock();
 
-    return promise_rejects(t, new TypeError(), rs.pipeTo(ws, { preventCancel: truthy })).then(() => {
+    return promise_rejects_js(t, TypeError, rs.pipeTo(ws, { preventCancel: truthy })).then(() => {
       assert_array_equals(rs.eventsWithoutPulls, []);
       assert_array_equals(ws.events, ['close']);
 
@@ -121,7 +121,7 @@ promise_test(t => {
   writer.close();
   writer.releaseLock();
 
-  return promise_rejects(t, new TypeError(), rs.pipeTo(ws, { preventCancel: true, preventAbort: true }))
+  return promise_rejects_js(t, TypeError, rs.pipeTo(ws, { preventCancel: true, preventAbort: true }))
     .then(() => {
       assert_array_equals(rs.eventsWithoutPulls, []);
       assert_array_equals(ws.events, ['close']);
@@ -140,7 +140,7 @@ promise_test(t => {
   writer.close();
   writer.releaseLock();
 
-  return promise_rejects(t, new TypeError(),
+  return promise_rejects_js(t, TypeError,
                          rs.pipeTo(ws, { preventCancel: true, preventAbort: true, preventClose: true }))
   .then(() => {
     assert_array_equals(rs.eventsWithoutPulls, []);

--- a/streams/piping/general.any.js
+++ b/streams/piping/general.any.js
@@ -62,7 +62,7 @@ promise_test(t => {
   assert_true(rs.locked, 'sanity check: the ReadableStream starts locked');
   assert_false(ws.locked, 'sanity check: the WritableStream does not start locked');
 
-  return promise_rejects(t, new TypeError(), rs.pipeTo(ws)).then(() => {
+  return promise_rejects_js(t, TypeError, rs.pipeTo(ws)).then(() => {
     assert_false(ws.locked, 'the WritableStream must still be unlocked');
   });
 
@@ -78,7 +78,7 @@ promise_test(t => {
   assert_false(rs.locked, 'sanity check: the ReadableStream does not start locked');
   assert_true(ws.locked, 'sanity check: the WritableStream starts locked');
 
-  return promise_rejects(t, new TypeError(), rs.pipeTo(ws)).then(() => {
+  return promise_rejects_js(t, TypeError, rs.pipeTo(ws)).then(() => {
     assert_false(rs.locked, 'the ReadableStream must still be unlocked');
   });
 
@@ -192,7 +192,7 @@ for (const preventCancel of [true, false]) {
 promise_test(t => {
   const rs = new ReadableStream();
   const ws = new WritableStream();
-  return promise_rejects(t, new TypeError(), rs.pipeTo(ws, {
+  return promise_rejects_js(t, TypeError, rs.pipeTo(ws, {
     get preventAbort() {
       ws.getWriter();
     }

--- a/streams/readable-byte-streams/detached-buffers.any.js
+++ b/streams/readable-byte-streams/detached-buffers.any.js
@@ -70,7 +70,7 @@ promise_test(t => {
   const view = new Uint8Array([4, 5, 6]);
   return reader.read(view).then(() => {
     // view is now detached
-    return promise_rejects(t, new TypeError(), reader.read(view),
+    return promise_rejects_js(t, TypeError, reader.read(view),
       'read(view) must reject when given an already-detached buffer');
   });
 }, 'ReadableStream with byte source: reading into an already-detached buffer rejects');

--- a/streams/readable-byte-streams/general.any.js
+++ b/streams/readable-byte-streams/general.any.js
@@ -153,7 +153,7 @@ promise_test(t => {
   const reader = stream.getReader();
   reader.releaseLock();
 
-  return promise_rejects(t, new TypeError(), reader.closed, 'closed must reject');
+  return promise_rejects_js(t, TypeError, reader.closed, 'closed must reject');
 }, 'ReadableStream with byte source: getReader(), then releaseLock()');
 
 promise_test(t => {
@@ -164,7 +164,7 @@ promise_test(t => {
   const reader = stream.getReader({ mode: 'byob' });
   reader.releaseLock();
 
-  return promise_rejects(t, new TypeError(), reader.closed, 'closed must reject');
+  return promise_rejects_js(t, TypeError, reader.closed, 'closed must reject');
 }, 'ReadableStream with byte source: getReader() with mode set to byob, then releaseLock()');
 
 promise_test(t => {
@@ -1422,8 +1422,8 @@ promise_test(t => {
   const reader = stream.getReader({ mode: 'byob' });
 
 
-  return promise_rejects(t, new TypeError(), reader.read(new Uint16Array(1)), 'read(view) must fail')
-      .then(() => promise_rejects(t, new TypeError(), reader.closed, 'reader.closed should reject'));
+  return promise_rejects_js(t, TypeError, reader.read(new Uint16Array(1)), 'read(view) must fail')
+      .then(() => promise_rejects_js(t, TypeError, reader.closed, 'reader.closed should reject'));
 }, 'ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must ' +
    'fail');
 
@@ -1448,8 +1448,8 @@ promise_test(t => {
 
   assert_throws_js(TypeError, () => controller.close(), 'controller.close() must throw');
 
-  return promise_rejects(t, new TypeError(), readPromise, 'read(view) must fail')
-      .then(() => promise_rejects(t, new TypeError(), reader.closed, 'reader.closed must reject'));
+  return promise_rejects_js(t, TypeError, readPromise, 'read(view) must fail')
+      .then(() => promise_rejects_js(t, TypeError, reader.closed, 'reader.closed must reject'));
 }, 'ReadableStream with byte source: A stream must be errored if close()-d before fulfilling read(view) with ' +
    'Uint16Array');
 
@@ -1770,7 +1770,7 @@ promise_test(t => {
 
   const reader = stream.getReader({ mode: 'byob' });
 
-  return promise_rejects(t, new TypeError(), reader.read(), 'read() must fail')
+  return promise_rejects_js(t, TypeError, reader.read(), 'read() must fail')
       .then(() => assert_equals(byobRequest, undefined, 'byobRequest must be undefined'));
 }, 'ReadableStream with byte source: read(view) with passing undefined as view must fail');
 
@@ -1785,7 +1785,7 @@ promise_test(t => {
 
   const reader = stream.getReader({ mode: 'byob' });
 
-  return promise_rejects(t, new TypeError(), reader.read(new Uint8Array(0)), 'read(view) must fail')
+  return promise_rejects_js(t, TypeError, reader.read(new Uint8Array(0)), 'read(view) must fail')
       .then(() => assert_equals(byobRequest, undefined, 'byobRequest must be undefined'));
 }, 'ReadableStream with byte source: read(view) with zero-length view must fail');
 
@@ -1796,7 +1796,7 @@ promise_test(t => {
 
   const reader = stream.getReader({ mode: 'byob' });
 
-  return promise_rejects(t, new TypeError(), reader.read({}), 'read(view) must fail');
+  return promise_rejects_js(t, TypeError, reader.read({}), 'read(view) must fail');
 }, 'ReadableStream with byte source: read(view) with passing an empty object as view must fail');
 
 promise_test(t => {
@@ -1806,7 +1806,7 @@ promise_test(t => {
 
   const reader = stream.getReader({ mode: 'byob' });
 
-  return promise_rejects(t, new TypeError(),
+  return promise_rejects_js(t, TypeError,
                          reader.read({ buffer: new ArrayBuffer(10), byteOffset: 0, byteLength: 10 }),
                          'read(view) must fail');
 }, 'ReadableStream with byte source: Even read(view) with passing ArrayBufferView like object as view must fail');

--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -229,7 +229,7 @@ promise_test(async t => {
   const s = new ReadableStream();
   const it = s[Symbol.asyncIterator]();
   await it.return();
-  return promise_rejects(t, new TypeError(), it.return(), 'return should reject');
+  return promise_rejects_js(t, TypeError, it.return(), 'return should reject');
 }, 'Calling return() twice rejects');
 
 promise_test(async () => {
@@ -250,7 +250,7 @@ promise_test(async t => {
   const it = s[Symbol.asyncIterator]();
   it.next();
 
-  await promise_rejects(t, new TypeError(), it.return(), 'return() should reject');
+  await promise_rejects_js(t, TypeError, it.return(), 'return() should reject');
   assert_array_equals(s.events, ['pull']);
 }, 'calling return() while there are pending reads rejects');
 
@@ -340,7 +340,7 @@ promise_test(async t => {
   const rs = new ReadableStream();
   const it = rs.getIterator();
   await it.return();
-  return promise_rejects(t, new TypeError(), it.next(), 'next() should reject');
+  return promise_rejects_js(t, TypeError, it.next(), 'next() should reject');
 }, 'calling next() after return() should reject');
 
 for (const preventCancel of [false, true]) {

--- a/streams/readable-streams/default-reader.any.js
+++ b/streams/readable-streams/default-reader.any.js
@@ -195,7 +195,7 @@ promise_test(t => {
   controller.close();
 
   return Promise.all([
-    promise_rejects(t, new TypeError(), reader1.closed),
+    promise_rejects_js(t, TypeError, reader1.closed),
     reader2.closed
   ]);
 
@@ -270,7 +270,7 @@ promise_test(t => {
   });
 
   return Promise.all([
-    promise_rejects(t, new TypeError(), cancelPromise),
+    promise_rejects_js(t, TypeError, cancelPromise),
     readPromise
   ]);
 

--- a/streams/resources/rs-test-templates.js
+++ b/streams/resources/rs-test-templates.js
@@ -283,8 +283,8 @@ self.templatedRSEmptyReader = (label, factory) => {
     reader.releaseLock();
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), reader.read()),
-      promise_rejects(t, new TypeError(), reader.read())
+      promise_rejects_js(t, TypeError, reader.read()),
+      promise_rejects_js(t, TypeError, reader.read())
     ]);
 
   }, label + ': releasing the lock should cause further read() calls to reject with a TypeError');
@@ -299,7 +299,7 @@ self.templatedRSEmptyReader = (label, factory) => {
 
     assert_equals(closedBefore, closedAfter, 'the closed promise should not change identity');
 
-    return promise_rejects(t, new TypeError(), closedBefore);
+    return promise_rejects_js(t, TypeError, closedBefore);
 
   }, label + ': releasing the lock should cause closed calls to reject with a TypeError');
 
@@ -328,7 +328,7 @@ self.templatedRSEmptyReader = (label, factory) => {
   promise_test(t => {
 
     const stream = factory().stream;
-    return promise_rejects(t, new TypeError(), stream.cancel());
+    return promise_rejects_js(t, TypeError, stream.cancel());
 
   }, label + ': canceling via the stream should fail');
 };
@@ -391,7 +391,7 @@ self.templatedRSClosedReader = (label, factory) => {
 
     return Promise.all([
       closedBefore.then(v => assert_equals(v, undefined, 'reader.closed acquired before release should fulfill')),
-      promise_rejects(t, new TypeError(), closedAfter)
+      promise_rejects_js(t, TypeError, closedAfter)
     ]);
 
   }, label + ': releasing the lock should cause closed to reject and change identity');
@@ -436,7 +436,7 @@ self.templatedRSErroredReader = (label, factory, error) => {
       const closedAfter = reader.closed;
       assert_not_equals(closedBefore, closedAfter, 'the closed promise should change identity');
 
-      return promise_rejects(t, new TypeError(), closedAfter);
+      return promise_rejects_js(t, TypeError, closedAfter);
     });
 
   }, label + ': releasing the lock should cause closed to reject and change identity');
@@ -599,9 +599,9 @@ self.templatedRSTwoChunksClosedReader = function (label, factory, chunks) {
     reader.releaseLock();
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), reader.read()),
-      promise_rejects(t, new TypeError(), reader.read()),
-      promise_rejects(t, new TypeError(), reader.read())
+      promise_rejects_js(t, TypeError, reader.read()),
+      promise_rejects_js(t, TypeError, reader.read()),
+      promise_rejects_js(t, TypeError, reader.read())
     ]);
 
   }, label + ': releasing the lock should cause further read() calls to reject with a TypeError');

--- a/streams/resources/test-utils.js
+++ b/streams/resources/test-utils.js
@@ -3,7 +3,7 @@
 self.getterRejects = (t, obj, getterName, target) => {
   const getter = Object.getOwnPropertyDescriptor(obj, getterName).get;
 
-  return promise_rejects(t, new TypeError(), getter.call(target), getterName + ' should reject with a TypeError');
+  return promise_rejects_js(t, TypeError, getter.call(target), getterName + ' should reject with a TypeError');
 };
 
 self.getterRejectsForAll = (t, obj, getterName, targets) => {
@@ -13,7 +13,7 @@ self.getterRejectsForAll = (t, obj, getterName, targets) => {
 self.methodRejects = (t, obj, methodName, target, args) => {
   const method = obj[methodName];
 
-  return promise_rejects(t, new TypeError(), method.apply(target, args),
+  return promise_rejects_js(t, TypeError, method.apply(target, args),
                          methodName + ' should reject with a TypeError');
 };
 

--- a/streams/transform-streams/strategies.any.js
+++ b/streams/transform-streams/strategies.any.js
@@ -122,7 +122,7 @@ promise_test(t => {
     highWaterMark: 1
   });
   const writer = ts.writable.getWriter();
-  return promise_rejects(t, new RangeError(), writer.write(), 'write should reject');
+  return promise_rejects_js(t, RangeError, writer.write(), 'write should reject');
 }, 'a bad readableStrategy size function should cause writer.write() to reject on an identity transform');
 
 promise_test(t => {
@@ -141,9 +141,9 @@ promise_test(t => {
   const writer = ts.writable.getWriter();
   return writer.write().then(() => {
     return Promise.all([
-      promise_rejects(t, new RangeError(), writer.ready, 'ready should reject'),
-      promise_rejects(t, new RangeError(), writer.closed, 'closed should reject'),
-      promise_rejects(t, new RangeError(), ts.readable.getReader().closed, 'readable closed should reject')
+      promise_rejects_js(t, RangeError, writer.ready, 'ready should reject'),
+      promise_rejects_js(t, RangeError, writer.closed, 'closed should reject'),
+      promise_rejects_js(t, RangeError, ts.readable.getReader().closed, 'readable closed should reject')
     ]);
   });
 }, 'a bad readableStrategy size function should error the stream on enqueue even when transformer.transform() ' +

--- a/streams/transform-streams/terminate.any.js
+++ b/streams/transform-streams/terminate.any.js
@@ -11,7 +11,7 @@ promise_test(t => {
     }
   });
   let pipeToRejected = false;
-  const pipeToPromise = promise_rejects(t, new TypeError(), rs.pipeTo(ts.writable), 'pipeTo should reject').then(() => {
+  const pipeToPromise = promise_rejects_js(t, TypeError, rs.pipeTo(ts.writable), 'pipeTo should reject').then(() => {
     pipeToRejected = true;
   });
   return delay(0).then(() => {
@@ -37,7 +37,7 @@ promise_test(t => {
   return delay(0).then(() => {
     assert_array_equals(ts.events, ['transform', 0], 'transform() should have seen one chunk');
     ts.controller.terminate();
-    return promise_rejects(t, new TypeError(), pipeToPromise, 'pipeTo() should reject');
+    return promise_rejects_js(t, TypeError, pipeToPromise, 'pipeTo() should reject');
   }).then(() => {
     assert_array_equals(ts.events, ['transform', 0], 'transform() should still have seen only one chunk');
   });
@@ -65,7 +65,7 @@ promise_test(t => {
     }
   });
   return Promise.all([
-    promise_rejects(t, new TypeError(), ts.writable.abort(), 'abort() should reject with a TypeError'),
+    promise_rejects_js(t, TypeError, ts.writable.abort(), 'abort() should reject with a TypeError'),
     promise_rejects(t, error1, ts.readable.cancel(), 'cancel() should reject with error1'),
     promise_rejects(t, error1, ts.readable.getReader().closed, 'closed should reject with error1')
   ]);
@@ -79,7 +79,7 @@ promise_test(t => {
     }
   });
   return Promise.all([
-    promise_rejects(t, new TypeError(), ts.writable.abort(), 'abort() should reject with a TypeError'),
+    promise_rejects_js(t, TypeError, ts.writable.abort(), 'abort() should reject with a TypeError'),
     ts.readable.cancel(),
     ts.readable.getReader().closed
   ]);

--- a/streams/writable-streams/aborting.any.js
+++ b/streams/writable-streams/aborting.any.js
@@ -51,7 +51,7 @@ promise_test(t => {
 
   writer.releaseLock();
 
-  return promise_rejects(t, new TypeError(), writer.abort(), 'abort() should reject with a TypeError');
+  return promise_rejects_js(t, TypeError, writer.abort(), 'abort() should reject with a TypeError');
 }, 'abort() on a released writer rejects');
 
 promise_test(t => {
@@ -638,9 +638,9 @@ promise_test(t => {
     writer.releaseLock();
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), writer.ready,
+      promise_rejects_js(t, TypeError, writer.ready,
                       'writer.ready must be rejected with an error indicating release'),
-      promise_rejects(t, new TypeError(), writer.closed,
+      promise_rejects_js(t, TypeError, writer.closed,
                       'writer.closed must be rejected with an error indicating release')
     ]);
   });
@@ -735,9 +735,9 @@ promise_test(t => {
     writer.releaseLock();
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), writer.ready,
+      promise_rejects_js(t, TypeError, writer.ready,
                       'writer.ready must be rejected with an error indicating release'),
-      promise_rejects(t, new TypeError(), writer.closed,
+      promise_rejects_js(t, TypeError, writer.closed,
                       'writer.closed must be rejected with an error indicating release')
     ]);
   });
@@ -781,7 +781,7 @@ promise_test(t => {
     });
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), writer.close(),
+      promise_rejects_js(t, TypeError, writer.close(),
         'writer.close() must reject with an error indicating already closing'),
       promise_rejects(t, error1, writer.ready, 'writer.ready must reject with the error from abort'),
       flushAsyncEvents()
@@ -792,7 +792,7 @@ promise_test(t => {
     controller.error(error2);
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), writer.close(),
+      promise_rejects_js(t, TypeError, writer.close(),
         'writer.close() must reject with an error indicating already closing'),
       promise_rejects(t, error1, writer.ready,
                       'writer.ready must be still rejected with the error indicating abort'),
@@ -817,7 +817,7 @@ promise_test(t => {
                         'closedPromise, abortPromise and writer.closed must fulfill');
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), writer.close(),
+      promise_rejects_js(t, TypeError, writer.close(),
         'writer.close() must reject with an error indicating already closing'),
       promise_rejects(t, error1, writer.ready,
                       'writer.ready must be still rejected with the error indicating abort')
@@ -826,11 +826,11 @@ promise_test(t => {
     writer.releaseLock();
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), writer.close(),
+      promise_rejects_js(t, TypeError, writer.close(),
         'writer.close() must reject with an error indicating release'),
-      promise_rejects(t, new TypeError(), writer.ready,
+      promise_rejects_js(t, TypeError, writer.ready,
                       'writer.ready must be rejected with an error indicating release'),
-      promise_rejects(t, new TypeError(), writer.closed,
+      promise_rejects_js(t, TypeError, writer.closed,
                       'writer.closed must be rejected with an error indicating release')
     ]);
   });
@@ -924,9 +924,9 @@ promise_test(t => {
     writer.releaseLock();
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), writer.ready,
+      promise_rejects_js(t, TypeError, writer.ready,
                       'writer.ready must be rejected with an error indicating release'),
-      promise_rejects(t, new TypeError(), writer.closed,
+      promise_rejects_js(t, TypeError, writer.closed,
                       'writer.closed must be rejected with an error indicating release')
     ]);
   });
@@ -1001,9 +1001,9 @@ promise_test(t => {
     writer.releaseLock();
 
     return Promise.all([
-      promise_rejects(t, new TypeError(), writer.ready,
+      promise_rejects_js(t, TypeError, writer.ready,
                       'writer.ready must be rejected with an error indicating release'),
-      promise_rejects(t, new TypeError(), writer.closed,
+      promise_rejects_js(t, TypeError, writer.closed,
                       'writer.closed must be rejected with an error indicating release')
     ]);
   });
@@ -1028,7 +1028,7 @@ promise_test(t => {
     return Promise.all([
       writePromise,
       abortPromise,
-      promise_rejects(t, new TypeError(), closed, 'closed should reject')]);
+      promise_rejects_js(t, TypeError, closed, 'closed should reject')]);
   });
 }, 'releaseLock() while aborting should reject the original closed promise');
 
@@ -1066,7 +1066,7 @@ promise_test(t => {
       return Promise.all([
         writePromise,
         abortPromise,
-        promise_rejects(t, new TypeError(), closed, 'closed should reject')]);
+        promise_rejects_js(t, TypeError, closed, 'closed should reject')]);
     });
   });
 }, 'releaseLock() during delayed async abort() should reject the writer.closed promise');
@@ -1335,8 +1335,8 @@ promise_test(t => {
     resolveWrite();
     return Promise.all([
       writePromise1,
-      promise_rejects(t, new RangeError(), writePromise2, 'second write() should reject'),
-      promise_rejects(t, new RangeError(), abortPromise, 'abort() should reject')
+      promise_rejects_js(t, RangeError, writePromise2, 'second write() should reject'),
+      promise_rejects_js(t, RangeError, abortPromise, 'abort() should reject')
     ]).then(() => {
       assert_array_equals(ws.events, ['write', 'chunk1'], 'sink abort() should not be called');
     });
@@ -1373,6 +1373,6 @@ promise_test(t => {
 promise_test(t => {
   const ws = new WritableStream();
   const writer = ws.getWriter();
-  return promise_rejects(t, new TypeError(), ws.abort(), 'abort should reject')
+  return promise_rejects_js(t, TypeError, ws.abort(), 'abort should reject')
     .then(() => writer.ready);
 }, 'abort on a locked stream should reject');

--- a/streams/writable-streams/close.any.js
+++ b/streams/writable-streams/close.any.js
@@ -215,7 +215,7 @@ promise_test(t => {
     writer.releaseLock();
     return Promise.all([
       closePromise,
-      promise_rejects(t, new TypeError(), closedPromise, '.closed promise should be rejected')
+      promise_rejects_js(t, TypeError, closedPromise, '.closed promise should be rejected')
     ]);
   });
 }, 'releaseLock() should not change the result of sync close()');
@@ -233,7 +233,7 @@ promise_test(t => {
     writer.releaseLock();
     return Promise.all([
       closePromise,
-      promise_rejects(t, new TypeError(), closedPromise, '.closed promise should be rejected')
+      promise_rejects_js(t, TypeError, closedPromise, '.closed promise should be rejected')
     ]);
   });
 }, 'releaseLock() should not change the result of async close()');
@@ -422,7 +422,7 @@ promise_test(() => {
 promise_test(t => {
   const ws = new WritableStream();
   ws.getWriter();
-  return promise_rejects(t, new TypeError(), ws.close(), 'close should reject');
+  return promise_rejects_js(t, TypeError, ws.close(), 'close should reject');
 }, 'close() on a locked stream should reject');
 
 promise_test(t => {
@@ -443,7 +443,7 @@ promise_test(t => {
   const writer = ws.getWriter();
   return promise_rejects(t, error1, writer.closed, 'closed should reject with the error').then(() => {
     writer.releaseLock();
-    return promise_rejects(t, new TypeError(), ws.close(), 'close should reject');
+    return promise_rejects_js(t, TypeError, ws.close(), 'close should reject');
   });
 }, 'close() on an errored stream should reject');
 
@@ -451,7 +451,7 @@ promise_test(t => {
   const ws = new WritableStream();
   const writer = ws.getWriter();
   return writer.close().then(() => {
-    return promise_rejects(t, new TypeError(), ws.close(), 'close should reject');
+    return promise_rejects_js(t, TypeError, ws.close(), 'close should reject');
   });
 }, 'close() on an closed stream should reject');
 
@@ -466,5 +466,5 @@ promise_test(t => {
   writer.close();
   writer.releaseLock();
 
-  return promise_rejects(t, new TypeError(), ws.close(), 'close should reject');
+  return promise_rejects_js(t, TypeError, ws.close(), 'close should reject');
 }, 'close() on a stream with a pending close should reject');

--- a/streams/writable-streams/reentrant-strategy.any.js
+++ b/streams/writable-streams/reentrant-strategy.any.js
@@ -101,7 +101,7 @@ promise_test(t => {
 
   const ws = recordingWritableStream({}, strategy);
   writer = ws.getWriter();
-  return promise_rejects(t, new TypeError(), writer.write('a'), 'write() promise should reject')
+  return promise_rejects_js(t, TypeError, writer.write('a'), 'write() promise should reject')
       .then(() => {
         assert_array_equals(ws.events, ['close'], 'sink.write() should not be called');
       });
@@ -135,9 +135,9 @@ promise_test(t => {
 
   const ws = recordingWritableStream({}, strategy);
   writer = ws.getWriter();
-  const writePromise = promise_rejects(t, new TypeError(), writer.write('a'), 'write() promise should reject');
-  const readyPromise = promise_rejects(t, new TypeError(), writer.ready, 'ready promise should reject');
-  const closedPromise = promise_rejects(t, new TypeError(), writer.closed, 'closed promise should reject');
+  const writePromise = promise_rejects_js(t, TypeError, writer.write('a'), 'write() promise should reject');
+  const readyPromise = promise_rejects_js(t, TypeError, writer.ready, 'ready promise should reject');
+  const closedPromise = promise_rejects_js(t, TypeError, writer.closed, 'closed promise should reject');
   return Promise.all([writePromise, readyPromise, closedPromise])
       .then(() => {
         assert_array_equals(ws.events, [], 'sink.write() should not be called');
@@ -164,9 +164,9 @@ promise_test(t => {
   };
   ws = recordingWritableStream({}, strategy);
   writer1 = ws.getWriter();
-  const writePromise1 = promise_rejects(t, new TypeError(), writer1.write(1), 'write() promise should reject');
-  const readyPromise = promise_rejects(t, new TypeError(), writer1.ready, 'ready promise should reject');
-  const closedPromise1 = promise_rejects(t, new TypeError(), writer1.closed, 'closed promise should reject');
+  const writePromise1 = promise_rejects_js(t, TypeError, writer1.write(1), 'write() promise should reject');
+  const readyPromise = promise_rejects_js(t, TypeError, writer1.ready, 'ready promise should reject');
+  const closedPromise1 = promise_rejects_js(t, TypeError, writer1.closed, 'closed promise should reject');
   return Promise.all([writePromise1, readyPromise, closedPromise1, writePromise2, closePromise, closedPromise2])
       .then(() => {
         assert_array_equals(ws.events, ['write', 0, 'close'], 'sink.write() should only be called once');

--- a/streams/writable-streams/write.any.js
+++ b/streams/writable-streams/write.any.js
@@ -165,7 +165,7 @@ promise_test(t => {
 
   return promise_rejects(t, error1, writer.write('a'),
                          'write() should reject with the error returned from the sink\'s write method')
-      .then(() => promise_rejects(t, new TypeError(), writer.close(), 'close() should be rejected'));
+      .then(() => promise_rejects_js(t, TypeError, writer.close(), 'close() should be rejected'));
 }, 'when sink\'s write throws an error, the stream should become errored and the promise should reject');
 
 promise_test(t => {
@@ -280,5 +280,5 @@ promise_test(t => {
   const ws = new WritableStream();
   const writer = ws.getWriter();
   writer.releaseLock();
-  return promise_rejects(t, new TypeError(), writer.write(), 'write should reject');
+  return promise_rejects_js(t, TypeError, writer.write(), 'write should reject');
 }, 'writing to a released writer should reject the returned promise');

--- a/wake-lock/wakelock-type.https.any.js
+++ b/wake-lock/wakelock-type.https.any.js
@@ -1,7 +1,7 @@
 //META: title=navigator.wakeLock.request() with invalid type
 
 promise_test(async t => {
-  return promise_rejects(t, new TypeError(), navigator.wakeLock.request());
+  return promise_rejects_js(t, TypeError, navigator.wakeLock.request());
 }, "'TypeError' is thrown when set an empty wake lock type");
 
 promise_test(t => {
@@ -14,6 +14,6 @@ promise_test(t => {
     true
   ];
   return Promise.all(invalidTypes.map(invalidType => {
-    return promise_rejects(t, new TypeError(), navigator.wakeLock.request(invalidType));
+    return promise_rejects_js(t, TypeError, navigator.wakeLock.request(invalidType));
   }));
 }, "'TypeError' is thrown when set an invalid wake lock type");

--- a/wake-lock/wakelockpermissiondescriptor.https.html
+++ b/wake-lock/wakelockpermissiondescriptor.https.html
@@ -7,10 +7,10 @@
 // See https://github.com/web-platform-tests/wpt/issues/5671.
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.permissions.query({ name:'wake-lock' }));
+  return promise_rejects_js(t, TypeError, navigator.permissions.query({ name:'wake-lock' }));
 }, "WakeLockPermissionDescriptor's type attribute is required");
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), navigator.permissions.query({ name: 'wake-lock', type: 'foo' }));
+  return promise_rejects_js(t, TypeError, navigator.permissions.query({ name: 'wake-lock', type: 'foo' }));
 }, "WakeLockPermissionDescriptor's type attribute must be a WakeLockType");
 </script>

--- a/wasm/jsapi/constructor/compile.any.js
+++ b/wasm/jsapi/constructor/compile.any.js
@@ -13,7 +13,7 @@ setup(() => {
 });
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), WebAssembly.compile());
+  return promise_rejects_js(t, TypeError, WebAssembly.compile());
 }, "Missing argument");
 
 promise_test(t => {
@@ -30,7 +30,7 @@ promise_test(t => {
     Array.from(emptyModuleBinary),
   ];
   return Promise.all(invalidArguments.map(argument => {
-    return promise_rejects(t, new TypeError(), WebAssembly.compile(argument),
+    return promise_rejects_js(t, TypeError, WebAssembly.compile(argument),
                            `compile(${format_value(argument)})`);
   }));
 }, "Invalid arguments");

--- a/wasm/jsapi/constructor/instantiate.any.js
+++ b/wasm/jsapi/constructor/instantiate.any.js
@@ -9,7 +9,7 @@ setup(() => {
 });
 
 promise_test(t => {
-  return promise_rejects(t, new TypeError(), WebAssembly.instantiate());
+  return promise_rejects_js(t, TypeError, WebAssembly.instantiate());
 }, "Missing arguments");
 
 promise_test(() => {
@@ -45,7 +45,7 @@ promise_test(t => {
     Array.from(emptyModuleBinary),
   ];
   return Promise.all(invalidArguments.map(argument => {
-    return promise_rejects(t, new TypeError(), WebAssembly.instantiate(argument),
+    return promise_rejects_js(t, TypeError, WebAssembly.instantiate(argument),
                            `instantiate(${format_value(argument)})`);
   }));
 }, "Invalid arguments");

--- a/wasm/webapi/body.any.js
+++ b/wasm/webapi/body.any.js
@@ -6,7 +6,7 @@ for (const method of ["compileStreaming", "instantiateStreaming"]) {
     const buffer = new WasmModuleBuilder().toBuffer();
     const argument = new Response(buffer, { headers: { "Content-Type": "application/wasm" } });
     argument.arrayBuffer();
-    return promise_rejects(t, new TypeError(), WebAssembly[method](argument));
+    return promise_rejects_js(t, TypeError, WebAssembly[method](argument));
   }, `${method} after consumption`);
 
   promise_test(t => {
@@ -14,6 +14,6 @@ for (const method of ["compileStreaming", "instantiateStreaming"]) {
     const argument = new Response(buffer, { headers: { "Content-Type": "application/wasm" } });
     const promise = WebAssembly[method](argument);
     argument.arrayBuffer();
-    return promise_rejects(t, new TypeError(), promise);
+    return promise_rejects_js(t, TypeError, promise);
   }, `${method} before consumption`);
 }

--- a/wasm/webapi/contenttype.any.js
+++ b/wasm/webapi/contenttype.any.js
@@ -14,12 +14,12 @@ const invalidContentTypes = [
 for (const contenttype of invalidContentTypes) {
   promise_test(t => {
     const response = fetch(`/wasm/incrementer.wasm?pipe=header(Content-Type,${encodeURIComponent(contenttype)})`);
-    return promise_rejects(t, new TypeError(), WebAssembly.compileStreaming(response));
+    return promise_rejects_js(t, TypeError, WebAssembly.compileStreaming(response));
   }, `Response with Content-Type ${format_value(contenttype)}: compileStreaming`);
 
   promise_test(t => {
     const response = fetch(`/wasm/incrementer.wasm?pipe=header(Content-Type,${encodeURIComponent(contenttype)})`);
-    return promise_rejects(t, new TypeError(), WebAssembly.instantiateStreaming(response));
+    return promise_rejects_js(t, TypeError, WebAssembly.instantiateStreaming(response));
   }, `Response with Content-Type ${format_value(contenttype)}: instantiateStreaming`);
 }
 

--- a/wasm/webapi/invalid-args.any.js
+++ b/wasm/webapi/invalid-args.any.js
@@ -17,12 +17,12 @@ const invalidArguments = [
 for (const method of ["compileStreaming", "instantiateStreaming"]) {
   for (const [argument, name = format_value(argument)] of invalidArguments) {
     promise_test(t => {
-      return promise_rejects(t, new TypeError(), WebAssembly[method](argument));
+      return promise_rejects_js(t, TypeError, WebAssembly[method](argument));
     }, `${method}: ${name}`);
 
     promise_test(t => {
       const promise = Promise.resolve(argument);
-      return promise_rejects(t, new TypeError(), WebAssembly[method](argument));
+      return promise_rejects_js(t, TypeError, WebAssembly[method](argument));
     }, `${method}: ${name} in a promise`);
   }
 }

--- a/wasm/webapi/origin.sub.any.js
+++ b/wasm/webapi/origin.sub.any.js
@@ -4,12 +4,12 @@ for (const method of ["compileStreaming", "instantiateStreaming"]) {
   promise_test(t => {
     const url = "http://{{domains[www]}}:{{ports[http][0]}}/wasm/incrementer.wasm";
     const response = fetch(url, { "mode": "no-cors" });
-    return promise_rejects(t, new TypeError(), WebAssembly[method](response));
+    return promise_rejects_js(t, TypeError, WebAssembly[method](response));
   }, `Opaque response: ${method}`);
 
   promise_test(t => {
     const url = "/fetch/api/resources/redirect.py?redirect_status=301&location=/wasm/incrementer.wasm";
     const response = fetch(url, { "mode": "no-cors", "redirect": "manual" });
-    return promise_rejects(t, new TypeError(), WebAssembly[method](response));
+    return promise_rejects_js(t, TypeError, WebAssembly[method](response));
   }, `Opaque redirect response: ${method}`);
 }

--- a/wasm/webapi/status.any.js
+++ b/wasm/webapi/status.any.js
@@ -15,7 +15,7 @@ for (const method of ["compileStreaming", "instantiateStreaming"]) {
   for (const status of statuses) {
     promise_test(t => {
       const response = fetch(`status.py?status=${status}`);
-      return promise_rejects(t, new TypeError(), WebAssembly[method](response));
+      return promise_rejects_js(t, TypeError, WebAssembly[method](response));
     }, `Response with status ${status}: ${method}`);
   }
 }

--- a/web-locks/acquire.tentative.https.any.js
+++ b/web-locks/acquire.tentative.https.any.js
@@ -6,17 +6,17 @@
 
 promise_test(async t => {
   const res = uniqueName(t);
-  await promise_rejects(t, new TypeError(), navigator.locks.request());
-  await promise_rejects(t, new TypeError(), navigator.locks.request(res));
+  await promise_rejects_js(t, TypeError, navigator.locks.request());
+  await promise_rejects_js(t, TypeError, navigator.locks.request(res));
 }, 'navigator.locks.request requires a name and a callback');
 
 promise_test(async t => {
   const res = uniqueName(t);
-  await promise_rejects(
-    t, new TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     navigator.locks.request(res, {mode: 'foo'}, lock => {}));
-  await promise_rejects(
-    t, new TypeError(),
+  await promise_rejects_js(
+    t, TypeError,
     navigator.locks.request(res, {mode: null }, lock => {}));
   assert_equals(await navigator.locks.request(
     res, {mode: 'exclusive'}, lock => lock.mode), 'exclusive',
@@ -66,20 +66,20 @@ promise_test(async t => {
 
 promise_test(async t => {
   const res = uniqueName(t);
-  await promise_rejects(
-    t, new TypeError(), navigator.locks.request(res, undefined));
-  await promise_rejects(
-    t, new TypeError(), navigator.locks.request(res, null));
-  await promise_rejects(
-    t, new TypeError(), navigator.locks.request(res, 123));
-  await promise_rejects(
-    t, new TypeError(), navigator.locks.request(res, 'abc'));
-  await promise_rejects(
-    t, new TypeError(), navigator.locks.request(res, []));
-  await promise_rejects(
-    t, new TypeError(), navigator.locks.request(res, {}));
-  await promise_rejects(
-    t, new TypeError(), navigator.locks.request(res, new Promise(r => {})));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, undefined));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, null));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, 123));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, 'abc'));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, []));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, {}));
+  await promise_rejects_js(
+    t, TypeError, navigator.locks.request(res, new Promise(r => {})));
 }, 'callback must be a function');
 
 promise_test(async t => {

--- a/web-locks/signal.tentative.https.any.js
+++ b/web-locks/signal.tentative.https.any.js
@@ -15,8 +15,8 @@ promise_test(async t => {
 
   // These cases should not work:
   for (const signal of ['string', 12.34, false, {}, Symbol(), () => {}, self]) {
-    await promise_rejects(
-      t, new TypeError(),
+    await promise_rejects_js(
+      t, TypeError,
       navigator.locks.request(
         res, {signal}, t.unreached_func('callback should not run')),
       'Bindings should throw if the signal option is a not an AbortSignal');

--- a/web-nfc/NDEFReader_scan.https.html
+++ b/web-nfc/NDEFReader_scan.https.html
@@ -29,7 +29,7 @@ promise_test(async t => {
   const reader = new NDEFReader();
   const promises = [];
   invalid_signals.forEach(invalid_signal => {
-    promises.push(promise_rejects(t, new TypeError(),
+    promises.push(promise_rejects_js(t, TypeError,
         reader.scan({ signal: invalid_signal })));
   });
   await Promise.all(promises);

--- a/web-nfc/NDEFWriter_write.https.html
+++ b/web-nfc/NDEFWriter_write.https.html
@@ -118,7 +118,7 @@ promise_test(async t => {
   const promises = [];
   invalid_type_messages.forEach(message => {
     promises.push(
-      promise_rejects(t, new TypeError(), writer.write(message)));
+      promise_rejects_js(t, TypeError, writer.write(message)));
   });
   await Promise.all(promises);
 }, "Test that promise is rejected with TypeError if NDEFMessageSource is invalid.");
@@ -190,7 +190,7 @@ promise_test(async t => {
   const writer = new NDEFWriter();
   const promises = [];
   invalid_signals.forEach(invalid_signal => {
-    promises.push(promise_rejects(t, new TypeError(),
+    promises.push(promise_rejects_js(t, TypeError,
         writer.write(test_text_data, { signal: invalid_signal })));
   });
   await Promise.all(promises);

--- a/web-share/share-empty.https.html
+++ b/web-share/share-empty.https.html
@@ -10,24 +10,24 @@
   <body>
     <script>
         promise_test(t => {
-          return promise_rejects(t, new TypeError(), navigator.share());
+          return promise_rejects_js(t, TypeError, navigator.share());
         }, 'share with no arguments (same as empty dictionary)');
 
         promise_test(t => {
-          return promise_rejects(t, new TypeError(), navigator.share({}));
+          return promise_rejects_js(t, TypeError, navigator.share({}));
         }, 'share with an empty dictionary');
 
         promise_test(t => {
-          return promise_rejects(t, new TypeError(), navigator.share(undefined));
+          return promise_rejects_js(t, TypeError, navigator.share(undefined));
         }, 'share with a undefined argument (same as empty dictionary)');
 
         promise_test(t => {
-          return promise_rejects(t, new TypeError(), navigator.share(null));
+          return promise_rejects_js(t, TypeError, navigator.share(null));
         }, 'share with a null argument (same as empty dictionary)');
 
         promise_test(t => {
-          return promise_rejects(t,
-              new TypeError(), navigator.share({unused: 'unexpected field'}));
+          return promise_rejects_js(t,
+              TypeError, navigator.share({unused: 'unexpected field'}));
         }, 'share with a dictionary containing only surplus fields');
     </script>
   </body>

--- a/web-share/share-url-invalid.https.html
+++ b/web-share/share-url-invalid.https.html
@@ -12,8 +12,8 @@
           // URL is invalid in that the URL Parser returns failure (port is too
           // large).
           const url = 'http://example.com:65536';
-          return promise_rejects(
-              t, new TypeError(), navigator.share({url}));
+          return promise_rejects_js(
+              t, TypeError, navigator.share({url}));
         }, 'share with an invalid URL');
     </script>
   </body>

--- a/webrtc-quic/RTCQuicStream.https.html
+++ b/webrtc-quic/RTCQuicStream.https.html
@@ -557,7 +557,7 @@ promise_test(async t => {
   const [ localQuicTransport, remoteQuicTransport ] =
       await makeTwoConnectedQuicTransports(t);
   const localStream = localQuicTransport.createStream();
-  await promise_rejects(t, new TypeError(),
+  await promise_rejects_js(t, TypeError,
       localStream.waitForReadable(localStream.maxReadBufferedAmount + 1));
 }, 'waitForReadable() rejects with TypeError if amount is more than ' +
     'maxReadBufferedAmount.');

--- a/webrtc/RTCPeerConnection-addIceCandidate.html
+++ b/webrtc/RTCPeerConnection-addIceCandidate.html
@@ -430,7 +430,7 @@ a=rtcp-rsize
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
-      promise_rejects(t, new TypeError(),
+      promise_rejects_js(t, TypeError,
         pc.addIceCandidate({
           candidate: candidateStr1,
           sdpMid: null,
@@ -445,7 +445,7 @@ a=rtcp-rsize
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
-      promise_rejects(t, new TypeError(),
+      promise_rejects_js(t, TypeError,
         pc.addIceCandidate({
           candidate: candidateStr1
         })));
@@ -458,7 +458,7 @@ a=rtcp-rsize
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
-      promise_rejects(t, new TypeError(),
+      promise_rejects_js(t, TypeError,
         pc.addIceCandidate({
           candidate: invalidCandidateStr,
           sdpMid: null,

--- a/webrtc/RTCPeerConnection-generateCertificate.html
+++ b/webrtc/RTCPeerConnection-generateCertificate.html
@@ -118,7 +118,7 @@
   }, 'generateCertificate() with 0 expires parameter should generate expired cert');
 
   promise_test(t => {
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
       RTCPeerConnection.generateCertificate({
         name: 'ECDSA',
         namedCurve: 'P-256',
@@ -127,7 +127,7 @@
   }, 'generateCertificate() with invalid range for expires should reject with TypeError');
 
   promise_test(t => {
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
       RTCPeerConnection.generateCertificate({
         name: 'ECDSA',
         namedCurve: 'P-256',

--- a/webrtc/RTCRtpParameters-encodings.html
+++ b/webrtc/RTCRtpParameters-encodings.html
@@ -192,7 +192,7 @@
 
     param.encodings = undefined;
 
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
       sender.setParameters(param));
   }, `sender.setParameters() with encodings unset should reject with TypeError`);
 
@@ -232,7 +232,7 @@
     const encoding = getFirstEncoding(param);
 
     encoding.scaleResolutionDownBy = 0.5;
-    return promise_rejects(t, new RangeError(),
+    return promise_rejects_js(t, RangeError,
       sender.setParameters(param));
   }, `setParameters() with encoding.scaleResolutionDownBy field set to less than 1.0 should reject with RangeError`);
 

--- a/webrtc/RTCRtpParameters-transactionId.html
+++ b/webrtc/RTCRtpParameters-transactionId.html
@@ -112,7 +112,7 @@
 
     param.transactionId = undefined;
 
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
       sender.setParameters(param));
   }, `sender.setParameters() with transaction ID unset should reject with TypeError`);
 

--- a/webrtc/RTCRtpSender-replaceTrack.https.html
+++ b/webrtc/RTCRtpSender-replaceTrack.https.html
@@ -59,7 +59,7 @@
     const transceiver = pc.addTransceiver('audio');
     const { sender } = transceiver;
 
-    return promise_rejects(t, new TypeError(),
+    return promise_rejects_js(t, TypeError,
       sender.replaceTrack(track));
   }, 'Calling replaceTrack with track of different kind should reject with TypeError');
 

--- a/webxr/xrSession_requestReferenceSpace.https.html
+++ b/webxr/xrSession_requestReferenceSpace.https.html
@@ -15,7 +15,7 @@
     let fakeDeviceInitParams = TRACKED_IMMERSIVE_DEVICE;
 
     let testFunction = function(session, fakeDeviceController, t) {
-      return promise_rejects(t, new TypeError(), session.requestReferenceSpace('foo'))
+      return promise_rejects_js(t, TypeError, session.requestReferenceSpace('foo'))
         .then(() => Promise.all([
         session.requestReferenceSpace('viewer').then( (referenceSpace) => {
             t.step(() => {


### PR DESCRIPTION
…mise_rejects_js.

This diff was generated by running:

  find . -type f -print0 | xargs -0 perl -pi -e 'BEGIN { $/ = undef; } s/promise_rejects\(([ \n]*[a-zA-Z_]+[ \n]*,[ \n]*)(?:new )?([A-Z][A-Za-z]*Error) *(?:\(\))? *(, *.)/promise_rejects_js(\1\2\3/gs'

(which allows the optional "new" before "FooError" and an optional "()" after
it) and then:

1) Manually editing css/cssom-view/MediaQueryList-addListener-handleEvent.html
to make it get TypeError from the right global.

2) Manually editing fetch/api/response/response-error-from-stream.html to use
promise_rejects_exactly instead of the thing it was doing with a
CustomTestError.

3) Manually editing html/cross-origin-embedder-policy/require-corp.https.html
to use TypeError from the right global in the window.open case.

4) Manually editing
service-workers/service-worker/controller-with-no-fetch-event-handler.https.html
to use TypeError from the right global in the subframe case.

5) Manually editing
service-workers/service-worker/fetch-response-taint.https.html to use TypeError
from the right frame.

6) Manually editing
service-workers/service-worker/redirected-response.https.html to get the
TypeError from the right subframe in various places.