### PR TITLE
Fix metadata for http2-context.sub.h2.any.js.ini

### DIFF
--- a/infrastructure/metadata/infrastructure/server/http2-context.sub.h2.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/http2-context.sub.h2.any.js.ini
@@ -1,4 +1,4 @@
-[secure-context.https.any.sharedworker.html]
+[http2-context.sub.h2.any.sharedworker.html]
   bug: https://bugs.webkit.org/show_bug.cgi?id=149850
   expected:
     if product == "safari" or product == "epiphany" or product == "webkit": ERROR


### PR DESCRIPTION
A copy/paste error had left the wrong generated test name in the metadata, so Safari errors were failing Azure Pipeline jobs.