### PR TITLE
html: Fix assert_array_equals usage in pseudo-classes

### DIFF
--- a/html/semantics/selectors/pseudo-classes/utils.js
+++ b/html/semantics/selectors/pseudo-classes/utils.js
@@ -9,12 +9,12 @@ function getElementsByIds(ids) {
 function testSelectorIdsMatch(selector, ids, testName) {
   test(function(){
     var elements = document.querySelectorAll(selector);
-    assert_array_equals(elements, getElementsByIds(ids));
+    assert_array_equals([...elements], getElementsByIds(ids));
   }, testName);
 }
 
 function testSelectorElementsMatch(selector, elements, testName) {
   test(function(){
-    assert_array_equals(document.querySelectorAll(selector), elements);
+    assert_array_equals([...document.querySelectorAll(selector)], elements);
   }, testName);
 }


### PR DESCRIPTION
`document.querySelectorAll` returns a `NodeList`, which does not have a `.slice` method that `assert_array_equals` uses. This fixes [dir.html](https://wpt.fyi/results/html/semantics/selectors/pseudo-classes/dir.html?label=master&label=experimental&aligned) on Firefox, which supports the `:dir` pseudo-class.