### PR TITLE
Add instrumentation facility to wptrunner

### DIFF
--- a/tools/wptrunner/wptrunner/instruments.py
+++ b/tools/wptrunner/wptrunner/instruments.py
@@ -1,0 +1,117 @@
+import time
+import threading
+from Queue import Queue
+
+"""Instrumentation for measuring high-level time spent on various tasks inside the runner.
+
+This is lower fidelity than an actual profile, but allows custom data to be considered,
+so that we can see the time spent in specific tests and test directories.
+
+
+Instruments are intended to be used as context managers with the return value of __enter__
+containing the user-facing API e.g.
+
+with Instrument(*args) as recording:
+    recording.set(["init"])
+    do_init()
+    recording.pause()
+    for thread in test_threads:
+       thread.start(recording, *args)
+    for thread in test_threads:
+       thread.join()
+    recording.set(["teardown"])   # un-pauses the Instrument
+    do_teardown()
+"""
+
+class NullInstrument(object):
+    def set(self, stack):
+        """Set the current task to stack
+
+        :param stack: A list of strings defining the current task.
+                      These are interpreted like a stack trace so that ["foo"] and
+                      ["foo", "bar"] both show up as descendants of "foo"
+        """
+        pass
+
+    def pause(self):
+        """Stop recording a task on the current thread. This is useful if the thread
+        is purely waiting on the results of other threads"""
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        return
+
+
+class InstrumentWriter(object):
+    def __init__(self, queue):
+        self.queue = queue
+
+    def set(self, stack):
+        stack.insert(0, threading.current_thread().name)
+        stack = self._check_stack(stack)
+        self.queue.put(("set", threading.current_thread().ident, time.time(), stack))
+
+    def pause(self):
+        self.queue.put(("pause", threading.current_thread().ident, time.time(), None))
+
+    def _check_stack(self, stack):
+        assert isinstance(stack, (tuple, list))
+        return [item.replace(" ", "_") for item in stack]
+
+
+class Instrument(object):
+    def __init__(self, file_path):
+        """Instrument that collects data from multiple threads and sums the time in each
+        thread. The output is in the format required by flamegraph.pl to enable visualisation
+        of the time spent in each task.
+
+        :param file_path: - The path on which to write instrument output. Any existing file
+                            at the path will be overwritten
+        """
+        self.path = file_path
+        self.queue = None
+        self.current = None
+        self.start_time = None
+        self.thread = None
+
+    def __enter__(self):
+        assert self.thread is None
+        assert self.queue is None
+        self.queue = Queue()
+        self.thread = threading.Thread(target=self.run)
+        self.thread.start()
+        return InstrumentWriter(self.queue)
+
+    def __exit__(self, *args, **kwargs):
+        self.queue.put(("stop", None, time.time(), None))
+        self.thread.join()
+        self.thread = None
+        self.queue = None
+
+    def run(self):
+        known_commands = {"stop", "pause", "set"}
+        with open(self.path, "w") as f:
+            thread_data = {}
+            while True:
+                command, thread, time_stamp, stack = self.queue.get()
+                assert command in known_commands
+
+                # If we are done recording, dump the information from all threads to the file
+                # before exiting. Otherwise for either 'set' or 'pause' we only need to dump
+                # information from the current stack (if any) that was recording on the reporting
+                # thread (as that stack is no longer active).
+                items = []
+                if command == "stop":
+                    items = thread_data.values()
+                elif thread in thread_data:
+                    items.append(thread_data.pop(thread))
+                for output_stack, start_time in items:
+                    f.write("%s %d\n" % (";".join(output_stack), int(1000 * (time_stamp - start_time))))
+
+                if command == "set":
+                    thread_data[thread] = (stack, time_stamp)
+                elif command == "stop":
+                    break

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -280,7 +280,7 @@ class TestRunnerManager(threading.Thread):
     def __init__(self, suite_name, test_queue, test_source_cls, browser_cls, browser_kwargs,
                  executor_cls, executor_kwargs, stop_flag, rerun=1, pause_after_test=False,
                  pause_on_unexpected=False, restart_on_unexpected=True, debug_info=None,
-                 capture_stdio=True):
+                 capture_stdio=True, recording=None):
         """Thread that owns a single TestRunner process and any processes required
         by the TestRunner (e.g. the Firefox binary).
 
@@ -318,6 +318,8 @@ class TestRunnerManager(threading.Thread):
         self.debug_info = debug_info
 
         self.manager_number = next_manager_number()
+        assert recording is not None
+        self.recording = recording
 
         self.command_queue = Queue()
         self.remote_queue = Queue()
@@ -350,6 +352,7 @@ class TestRunnerManager(threading.Thread):
         may also have a stop flag set by the main thread indicating
         that the manager should shut down the next time the event loop
         spins."""
+        self.recording.set(["testrunner", "startup"])
         self.logger = structuredlog.StructuredLogger(self.suite_name)
         with self.browser_cls(self.logger, **self.browser_kwargs) as browser:
             self.browser = BrowserManager(self.logger,
@@ -467,6 +470,7 @@ class TestRunnerManager(threading.Thread):
 
     def start_init(self):
         test, test_group, group_metadata = self.get_next_test()
+        self.recording.set(["testrunner", "init"])
         if test is None:
             return RunnerManagerState.stop()
         else:
@@ -556,6 +560,7 @@ class TestRunnerManager(threading.Thread):
                                                  self.state.test_group,
                                                  self.state.group_metadata)
 
+        self.recording.set(["testrunner", "test"] + self.state.test.id.split("/")[1:])
         self.logger.test_start(self.state.test.id)
         if self.rerun > 1:
             self.logger.info("Run %d/%d" % (self.run_count, self.rerun))
@@ -672,6 +677,7 @@ class TestRunnerManager(threading.Thread):
                                ((subtest_unexpected or is_unexpected) and
                                 self.restart_on_unexpected))
 
+        self.recording.set(["testrunner", "after-test"])
         if (not file_result.status == "CRASH" and
             self.pause_after_test or
             (self.pause_on_unexpected and (subtest_unexpected or is_unexpected))):
@@ -720,6 +726,7 @@ class TestRunnerManager(threading.Thread):
 
     def stop_runner(self, force=False):
         """Stop the TestRunner and the browser binary."""
+        self.recording.set(["testrunner", "stop_runner"])
         if self.test_runner_proc is None:
             return
 
@@ -738,6 +745,7 @@ class TestRunnerManager(threading.Thread):
         self.remote_queue.close()
         self.command_queue = None
         self.remote_queue = None
+        self.recording.pause()
 
     def ensure_runner_stopped(self):
         self.logger.debug("ensure_runner_stopped")
@@ -825,7 +833,8 @@ class ManagerGroup(object):
                  pause_on_unexpected=False,
                  restart_on_unexpected=True,
                  debug_info=None,
-                 capture_stdio=True):
+                 capture_stdio=True,
+                 recording=None):
         self.suite_name = suite_name
         self.size = size
         self.test_source_cls = test_source_cls
@@ -840,6 +849,8 @@ class ManagerGroup(object):
         self.debug_info = debug_info
         self.rerun = rerun
         self.capture_stdio = capture_stdio
+        self.recording = recording
+        assert recording is not None
 
         self.pool = set()
         # Event that is polled by threads so that they can gracefully exit in the face
@@ -877,7 +888,8 @@ class ManagerGroup(object):
                                         self.pause_on_unexpected,
                                         self.restart_on_unexpected,
                                         self.debug_info,
-                                        self.capture_stdio)
+                                        self.capture_stdio,
+                                        recording=self.recording)
             manager.start()
             self.pool.add(manager)
         self.wait()

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -219,6 +219,8 @@ scheme host and port.""")
                               help="Run browser in headless mode", default=None)
     config_group.add_argument("--no-headless", action="store_false", dest="headless",
                               help="Don't run browser in headless mode")
+    config_group.add_argument("--instrument-to-file", action="store",
+                              help="Path to write instrumentation logs to")
 
     build_type = parser.add_mutually_exclusive_group()
     build_type.add_argument("--debug-build", dest="debug", action="store_true",


### PR DESCRIPTION
Add simple high-level instrumentation to record time spent in
different kinds of tasks, and particularly in different tests
and directories. This is based on explicit annotations in the
code to say which kind of task is currently running.

The output is intended to be compatible with flamegraph.pl to
generate visualisations of the time spent doing different tasks.