### PR TITLE
Replace some "promise_rejects(t, 'SomeDOMError', stuff)" calls with p…

### DIFF
--- a/audio-output/setSinkId.https.html
+++ b/audio-output/setSinkId.https.html
@@ -13,7 +13,7 @@ const audio = new Audio();
 
 promise_test(t => audio.setSinkId(""), "setSinkId on default audio output should always work");
 
-promise_test(t => promise_rejects(t, "NotFoundError", audio.setSinkId("nonexistent_device_id")),
+promise_test(t => promise_rejects_dom(t, "NotFoundError", audio.setSinkId("nonexistent_device_id")),
   "setSinkId fails with NotFoundError on made up deviceid");
 
 promise_test(async t => {

--- a/background-fetch/fetch.https.window.js
+++ b/background-fetch/fetch.https.window.js
@@ -170,7 +170,7 @@ backgroundFetchTest(async (test, backgroundFetch) => {
 
   // Very large download total that will definitely exceed the quota.
   const options = {downloadTotal: Number.MAX_SAFE_INTEGER};
-  await promise_rejects(
+  await promise_rejects_dom(
     test, 'QUOTA_EXCEEDED_ERR',
     backgroundFetch.fetch(registrationId, 'resources/feature-name.txt', options),
     'This fetch should have thrown a quota exceeded error');

--- a/battery-status/battery-disabled-by-feature-policy.https.sub.html
+++ b/battery-status/battery-disabled-by-feature-policy.https.sub.html
@@ -12,7 +12,7 @@ const cross_origin_src = 'https://{{domains[www]}}:{{ports[https][0]}}' +
 const header = 'Feature-Policy header {"battery" : []}';
 
 promise_test(async t => {
-  await promise_rejects(t, 'NotAllowedError', navigator.getBattery());
+  await promise_rejects_dom(t, 'NotAllowedError', navigator.getBattery());
 }, `${header} disallows the top-level document.`);
 
 async_test(t => {

--- a/battery-status/battery-disallowed-in-cross-origin-iframe.https.sub.html
+++ b/battery-status/battery-disallowed-in-cross-origin-iframe.https.sub.html
@@ -21,7 +21,7 @@ promise_test(async t => {
   const path = location.pathname.substring(0, location.pathname.lastIndexOf('/') + 1);
   const src = 'https://{{domains[www1]}}:{{ports[https][0]}}' + path + 'support-iframe.html';
   iframe = await load_iframe(iframe, src);
-  await promise_rejects(t, 'NotAllowedError', iframe.contentWindow.navigator.getBattery());
+  await promise_rejects_dom(t, 'NotAllowedError', iframe.contentWindow.navigator.getBattery());
 }, "throw a 'NotAllowedError' when invoking navigator.getBattery() within cross-origin iframe");
 
 </script>

--- a/battery-status/battery-insecure-context.html
+++ b/battery-status/battery-insecure-context.html
@@ -21,7 +21,7 @@
 <script>
 
 promise_test(t => {
-  return promise_rejects(t, 'SecurityError', navigator.getBattery());
+  return promise_rejects_dom(t, 'SecurityError', navigator.getBattery());
 }, "navigator.getBattery() shall throw a 'SecurityError' in an insecure context");
 
 </script>

--- a/bluetooth/characteristic/writeValue/buffer-is-detached.https.window.js
+++ b/bluetooth/characteristic/writeValue/buffer-is-detached.https.window.js
@@ -13,11 +13,11 @@ bluetooth_test(async (t) => {
 
   const typed_array = Uint8Array.of(1, 2);
   detachBuffer(typed_array.buffer);
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'InvalidStateError', characteristic.writeValue(typed_array));
 
   const array_buffer = Uint8Array.of(3, 4).buffer;
   detachBuffer(array_buffer);
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'InvalidStateError', characteristic.writeValue(array_buffer));
 }, test_desc);

--- a/bluetooth/descriptor/writeValue/buffer-is-detached.https.window.js
+++ b/bluetooth/descriptor/writeValue/buffer-is-detached.https.window.js
@@ -13,11 +13,11 @@ bluetooth_test(async (t) => {
 
   const typed_array = Uint8Array.of(1, 2);
   detachBuffer(typed_array.buffer);
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'InvalidStateError', descriptor.writeValue(typed_array));
 
   const array_buffer = Uint8Array.of(3, 4).buffer;
   detachBuffer(array_buffer);
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'InvalidStateError', descriptor.writeValue(array_buffer));
 }, test_desc);

--- a/clipboard-apis/async-write-image-read-image-manual.https.html
+++ b/clipboard-apis/async-write-image-read-image-manual.https.html
@@ -66,7 +66,7 @@ promise_test(async t => {
   const invalidPngBlob = new Blob(['this text is not a valid png image'],
       {type: "image/png"});
   const clipboardItemInput = new ClipboardItem({'image/png' : invalidPngBlob});
-  await promise_rejects(t, "DataError",
+  await promise_rejects_dom(t, "DataError",
       navigator.clipboard.write([clipboardItemInput]));
 }, 'Verify write error on malformed data [image/png ClipboardItem]');
 </script>

--- a/clipboard-apis/clipboard-item.https.html
+++ b/clipboard-apis/clipboard-item.https.html
@@ -86,7 +86,7 @@ promise_test(async () => {
 promise_test(async t => {
   const item =
       new ClipboardItem({'text/plain': blob, 'not a/real type': blob2});
-  promise_rejects(t, "NotFoundError", item.getType('type not in item'));
-  promise_rejects(t, "NotFoundError", item.getType('text/plain:subtype'));
+  promise_rejects_dom(t, "NotFoundError", item.getType('type not in item'));
+  promise_rejects_dom(t, "NotFoundError", item.getType('text/plain:subtype'));
 }, "getType(DOMString type) rejects correctly when querying for missing type");
 </script>

--- a/content-security-policy/support/testharness-helper.js
+++ b/content-security-policy/support/testharness-helper.js
@@ -136,7 +136,7 @@ function assert_service_worker_is_blocked(url, description) {
           assert_equals(e.violatedDirective, "worker-src");
           assert_equals(e.effectiveDirective, "worker-src");
         })),
-      promise_rejects(t, "SecurityError", navigator.serviceWorker.register(url, { scope: url }))
+      promise_rejects_dom(t, "SecurityError", navigator.serviceWorker.register(url, { scope: url }))
     ]);
   }, description);
 }

--- a/credential-management/credentialscontainer-create-basics.https.html
+++ b/credential-management/credentialscontainer-create-basics.https.html
@@ -4,12 +4,12 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 promise_test(function(t) {
-    return promise_rejects(t, "NotSupportedError",
+    return promise_rejects_dom(t, "NotSupportedError",
             navigator.credentials.create());
 }, "navigator.credentials.create() with no argument.");
 
 promise_test(function(t) {
-    return promise_rejects(t, "NotSupportedError",
+    return promise_rejects_dom(t, "NotSupportedError",
             navigator.credentials.create({}));
 }, "navigator.credentials.create() with empty argument.");
 
@@ -88,7 +88,7 @@ promise_test(function(t) {
         provider: 'https://example.com/',
     };
 
-    return promise_rejects(t, "NotSupportedError",
+    return promise_rejects_dom(t, "NotSupportedError",
             navigator.credentials.create({
                 password: credential_data,
                 federated: federated_data,
@@ -129,7 +129,7 @@ promise_test(function(t) {
 }, "navigator.credentials.create() with bogus password, federated, and publicKey data");
 
 promise_test(function(t) {
-    return promise_rejects(t, "NotSupportedError",
+    return promise_rejects_dom(t, "NotSupportedError",
             navigator.credentials.create({bogus_key: "bogus data"}));
 }, "navigator.credentials.create() with bogus data");
 </script>

--- a/css/css-animations/CSSAnimation-finished.tentative.html
+++ b/css/css-animations/CSSAnimation-finished.tentative.html
@@ -31,7 +31,7 @@ promise_test(async t => {
   div.style.animation = '';
   getComputedStyle(div).animation;
 
-  await promise_rejects(t, 'AbortError', originalFinishedPromise,
+  await promise_rejects_dom(t, 'AbortError', originalFinishedPromise,
                         'finished promise is rejected with AbortError');
 
   assert_not_equals(animation.finished, originalFinishedPromise,
@@ -55,7 +55,7 @@ promise_test(async t => {
   div.style.animation = 'def 100s';
   getComputedStyle(div).animation;
 
-  await promise_rejects(t, 'AbortError', originalFinishedPromise,
+  await promise_rejects_dom(t, 'AbortError', originalFinishedPromise,
                         'finished promise is rejected with AbortError');
 
   assert_not_equals(animation.finished, originalFinishedPromise,

--- a/css/css-animations/CSSAnimation-ready.tentative.html
+++ b/css/css-animations/CSSAnimation-ready.tentative.html
@@ -42,7 +42,7 @@ promise_test(async t => {
   div.style.animation = '';
   getComputedStyle(div).animation;
 
-  await promise_rejects(t, 'AbortError', readyPromise,
+  await promise_rejects_dom(t, 'AbortError', readyPromise,
                         'ready promise is rejected with AbortError');
 }, 'ready promise is rejected when an animation is canceled by resetting'
    + ' the animation property');
@@ -64,7 +64,7 @@ promise_test(async t => {
   div.style.animation = 'def 100s';
   getComputedStyle(div).animation;
 
-  await promise_rejects(t, 'AbortError', readyPromise,
+  await promise_rejects_dom(t, 'AbortError', readyPromise,
                         'ready promise is rejected with AbortError');
 }, 'ready promise is rejected when an animation is canceled by updating'
    + ' the animation property');

--- a/css/css-font-loading/font-face-reject.html
+++ b/css/css-font-loading/font-face-reject.html
@@ -10,7 +10,7 @@
 promise_test(function(t) {
     var testFontFace = new FontFace('TestFontFace', 'local("nonexistentfont-9a1a9f78-c8d4-11e9-af16-448a5b2c326f")');
     document.fonts.add(testFontFace);
-  return promise_rejects(t, 'NetworkError', testFontFace.loaded);
+  return promise_rejects_dom(t, 'NetworkError', testFontFace.loaded);
 })
 </script>
 <body>

--- a/css/css-fonts/format-specifiers-variations.html
+++ b/css/css-fonts/format-specifiers-variations.html
@@ -36,7 +36,7 @@ function runTestOnFormatSpecifiers(formats, expectFail) {
             if (!expectFail) {
                 return fontFace.load();
             } else {
-                return promise_rejects(testDetails, "NetworkError", fontFace.load());
+                return promise_rejects_dom(testDetails, "NetworkError", fontFace.load());
             }
         }, (expectFail ? "Do not load" : "Load") + " Ahem with format " + formats[i], {
             "format": formats[i]

--- a/css/geometry/structured-serialization.html
+++ b/css/geometry/structured-serialization.html
@@ -160,6 +160,6 @@ function defineThrowingGetters(object, attrs) {
 
 promise_test((t) => {
   const object = document.getElementById('log').getClientRects();
-  return promise_rejects(t, "DataCloneError", clone(object));
+  return promise_rejects_dom(t, "DataCloneError", clone(object));
 }, 'DOMRectList clone');0
 </script>

--- a/feature-policy/reporting/encrypted-media-reporting.https.html
+++ b/feature-policy/reporting/encrypted-media-reporting.https.html
@@ -22,7 +22,7 @@ promise_test(async t => {
     new ReportingObserver((reports, observer) => resolve([reports, observer]),
                           {types: ['feature-policy-violation']}).observe();
   });
-  await promise_rejects(t, "SecurityError",
+  await promise_rejects_dom(t, "SecurityError",
     navigator.requestMediaKeySystemAccess("org.w3.clearkey",
       [{
         initDataTypes: ["webm"],

--- a/feature-policy/reporting/midi-reporting.https.html
+++ b/feature-policy/reporting/midi-reporting.https.html
@@ -22,7 +22,7 @@ promise_test(async (t) => {
     new ReportingObserver((reports, observer) => resolve([reports, observer]),
                           {types: ['feature-policy-violation']}).observe();
   });
-  await promise_rejects(t, 'SecurityError', navigator.requestMIDIAccess(),
+  await promise_rejects_dom(t, 'SecurityError', navigator.requestMIDIAccess(),
                         "MIDI device access should not be allowed in this document.");
   const [reports, observer] = await report;
   check_report_format(reports, observer);

--- a/feature-policy/reporting/picture-in-picture-reporting.html
+++ b/feature-policy/reporting/picture-in-picture-reporting.html
@@ -36,7 +36,7 @@ promise_pip_test(async (t) => {
   });
   const videoElement = await loadVideo();
   await test_driver.bless('picture-in-picture');
-  await promise_rejects(t, 'SecurityError', videoElement.requestPictureInPicture(),
+  await promise_rejects_dom(t, 'SecurityError', videoElement.requestPictureInPicture(),
                         "Picture-in-Picture should not be allowed in this document.");
   const [reports, observer] = await report;
   check_report_format(reports, observer);

--- a/feature-policy/reporting/vr-reporting.https.html
+++ b/feature-policy/reporting/vr-reporting.https.html
@@ -22,7 +22,7 @@ promise_test(async (t) => {
     new ReportingObserver((reports, observer) => resolve([reports, observer]),
                           {types: ['feature-policy-violation']}).observe();
   });
-  await promise_rejects(t, 'SecurityError', navigator.getVRDisplays(),
+  await promise_rejects_dom(t, 'SecurityError', navigator.getVRDisplays(),
                         "VR device access should not be allowed in this document.");
   const [reports, observer] = await report;
   check_report_format(reports, observer);

--- a/feature-policy/reporting/xr-reporting.https.html
+++ b/feature-policy/reporting/xr-reporting.https.html
@@ -22,7 +22,7 @@ promise_test(async (t) => {
     new ReportingObserver((reports, observer) => resolve([reports, observer]),
                           {types: ['feature-policy-violation']}).observe();
   });
-  await promise_rejects(t, 'SecurityError',
+  await promise_rejects_dom(t, 'SecurityError',
                         navigator.xr.isSessionSupported('immersive-vr'),
                         "XR spatial tracking should not be allowed in this document.");
   const [reports, observer] = await report;

--- a/fetch/api/abort/general.any.js
+++ b/fetch/api/abort/general.any.js
@@ -28,7 +28,7 @@ promise_test(async t => {
 
   const fetchPromise = fetch('../resources/data.json', { signal });
 
-  await promise_rejects(t, "AbortError", fetchPromise);
+  await promise_rejects_dom(t, "AbortError", fetchPromise);
 }, "Aborting rejects with AbortError");
 
 promise_test(async t => {
@@ -44,7 +44,7 @@ promise_test(async t => {
     mode: 'no-cors'
   });
 
-  await promise_rejects(t, "AbortError", fetchPromise);
+  await promise_rejects_dom(t, "AbortError", fetchPromise);
 }, "Aborting rejects with AbortError - no-cors");
 
 // Test that errors thrown from the request constructor take priority over abort errors.
@@ -88,7 +88,7 @@ promise_test(async t => {
 
   const fetchPromise = fetch(request);
 
-  await promise_rejects(t, "AbortError", fetchPromise);
+  await promise_rejects_dom(t, "AbortError", fetchPromise);
 }, "Signal on request object");
 
 promise_test(async t => {
@@ -101,7 +101,7 @@ promise_test(async t => {
 
   const fetchPromise = fetch(requestFromRequest);
 
-  await promise_rejects(t, "AbortError", fetchPromise);
+  await promise_rejects_dom(t, "AbortError", fetchPromise);
 }, "Signal on request object created from request object");
 
 promise_test(async t => {
@@ -114,7 +114,7 @@ promise_test(async t => {
 
   const fetchPromise = fetch(requestFromRequest);
 
-  await promise_rejects(t, "AbortError", fetchPromise);
+  await promise_rejects_dom(t, "AbortError", fetchPromise);
 }, "Signal on request object created from request object, with signal on second request");
 
 promise_test(async t => {
@@ -127,7 +127,7 @@ promise_test(async t => {
 
   const fetchPromise = fetch(requestFromRequest);
 
-  await promise_rejects(t, "AbortError", fetchPromise);
+  await promise_rejects_dom(t, "AbortError", fetchPromise);
 }, "Signal on request object created from request object, with signal on second request overriding another");
 
 promise_test(async t => {
@@ -139,7 +139,7 @@ promise_test(async t => {
 
   const fetchPromise = fetch(request, {method: 'POST'});
 
-  await promise_rejects(t, "AbortError", fetchPromise);
+  await promise_rejects_dom(t, "AbortError", fetchPromise);
 }, "Signal retained after unrelated properties are overridden by fetch");
 
 promise_test(async t => {
@@ -205,7 +205,7 @@ for (const bodyMethod of BODY_METHODS) {
       Promise.resolve().then(() => log.push('next-microtask'))
     ]);
 
-    await promise_rejects(t, "AbortError", bodyPromise);
+    await promise_rejects_dom(t, "AbortError", bodyPromise);
 
     assert_array_equals(log, [`${bodyMethod}-reject`, 'next-microtask']);
   }, `response.${bodyMethod}() rejects if already aborted`);
@@ -252,7 +252,7 @@ promise_test(async t => {
   }
 
   for (const fetchPromise of fetches) {
-    await promise_rejects(t, "AbortError", fetchPromise);
+    await promise_rejects_dom(t, "AbortError", fetchPromise);
   }
 }, "Already aborted signal can be used for many fetches");
 
@@ -278,7 +278,7 @@ promise_test(async t => {
   }
 
   for (const fetchPromise of fetches) {
-    await promise_rejects(t, "AbortError", fetchPromise);
+    await promise_rejects_dom(t, "AbortError", fetchPromise);
   }
 }, "Signal can be used to abort other fetches, even if another fetch succeeded before aborting");
 
@@ -366,7 +366,7 @@ for (const bodyMethod of BODY_METHODS) {
 
     controller.abort();
 
-    await promise_rejects(t, "AbortError", bodyPromise);
+    await promise_rejects_dom(t, "AbortError", bodyPromise);
 
     const start = Date.now();
 
@@ -394,8 +394,8 @@ promise_test(async t => {
 
   controller.abort();
 
-  await promise_rejects(t, "AbortError", reader.read());
-  await promise_rejects(t, "AbortError", reader.closed);
+  await promise_rejects_dom(t, "AbortError", reader.read());
+  await promise_rejects_dom(t, "AbortError", reader.closed);
 
   // The connection won't close immediately, but it should close at some point:
   const start = Date.now();
@@ -425,8 +425,8 @@ promise_test(async t => {
 
   controller.abort();
 
-  await promise_rejects(t, "AbortError", reader.read());
-  await promise_rejects(t, "AbortError", reader.closed);
+  await promise_rejects_dom(t, "AbortError", reader.read());
+  await promise_rejects_dom(t, "AbortError", reader.closed);
 
   // The connection won't close immediately, but it should close at some point:
   const start = Date.now();
@@ -488,7 +488,7 @@ promise_test(async t => {
   assert_equals(cancelReason.constructor, DOMException);
   assert_equals(cancelReason.name, 'AbortError');
 
-  await promise_rejects(t, "AbortError", fetchPromise);
+  await promise_rejects_dom(t, "AbortError", fetchPromise);
 
   const fetchErr = await fetchPromise.catch(e => e);
 

--- a/fetch/api/abort/serviceworker-intercepted.https.html
+++ b/fetch/api/abort/serviceworker-intercepted.https.html
@@ -46,7 +46,7 @@
 
     const fetchPromise = w.fetch('data.json', { signal });
 
-    await promise_rejects(t, "AbortError", fetchPromise);
+    await promise_rejects_dom(t, "AbortError", fetchPromise);
 
     await w.fetch('data.json?no-abort');
 
@@ -76,7 +76,7 @@
         Promise.resolve().then(() => log.push('next-microtask'))
       ]);
 
-      await promise_rejects(t, "AbortError", bodyPromise);
+      await promise_rejects_dom(t, "AbortError", bodyPromise);
 
       assert_array_equals(log, [`${bodyMethod}-reject`, 'next-microtask']);
     }, `response.${bodyMethod}() rejects if already aborted`);
@@ -97,8 +97,8 @@
 
     controller.abort();
 
-    await promise_rejects(t, "AbortError", reader.read());
-    await promise_rejects(t, "AbortError", reader.closed);
+    await promise_rejects_dom(t, "AbortError", reader.read());
+    await promise_rejects_dom(t, "AbortError", reader.closed);
   }, "Stream errors once aborted.");
 </script>
 </body>

--- a/geolocation-sensor/GeolocationSensor-disabled-by-feature-policy.https.html
+++ b/geolocation-sensor/GeolocationSensor-disabled-by-feature-policy.https.html
@@ -11,7 +11,7 @@
 run_fp_tests_disabled('GeolocationSensor');
 
 promise_test(async t => {
-  await promise_rejects(t, 'SecurityError', GeolocationSensor.read());
+  await promise_rejects_dom(t, 'SecurityError', GeolocationSensor.read());
 }, "GeolocationSensor.read(): 'SecurityError' is thrown when disabled by Feature Policy");
 
 promise_test(async t => {
@@ -19,7 +19,7 @@ promise_test(async t => {
   const signal = controller.signal;
   controller.abort();
 
-  await promise_rejects(t, 'AbortError', GeolocationSensor.read({ signal }));
+  await promise_rejects_dom(t, 'AbortError', GeolocationSensor.read({ signal }));
 }, "GeolocationSensor.read(): 'AbortError' takes priority");
 </script>
 </body>

--- a/geolocation-sensor/GeolocationSensor_read.https.html
+++ b/geolocation-sensor/GeolocationSensor_read.https.html
@@ -34,6 +34,6 @@ promise_test(async t => {
   const signal = controller.signal;
   controller.abort();
 
-  await promise_rejects(t, 'AbortError', GeolocationSensor.read({ signal }));
+  await promise_rejects_dom(t, 'AbortError', GeolocationSensor.read({ signal }));
 }, "Test that read() method rejects 'AbortError' if signal's aborted flag is set");
 </script>

--- a/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
+++ b/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
@@ -274,7 +274,7 @@ addPromiseTest(async function(win, test_obj) {
       if ("value" in desc) {
         if (typeof desc.value === "function" && String(desc.value).includes("[native code]")) {
           if (allowedlists.promiseMethods.includes(prop)) {
-            await promise_rejects(test_obj, "SecurityError", desc.value.call(otherObj),
+            await promise_rejects_dom(test_obj, "SecurityError", desc.value.call(otherObj),
                                   `Should throw when calling ${objName}.${prop} with cross-origin this object`);
           } else if (!allowedlists.methods.includes(prop)) {
             for (let args of methodArgs.get(prop) || [[]]) {

--- a/html/cross-origin-embedder-policy/require-corp-load-from-cache-storage.https.html
+++ b/html/cross-origin-embedder-policy/require-corp-load-from-cache-storage.https.html
@@ -109,7 +109,7 @@ function test(
     const cache = await caches.open('v1');
 
     if (response_type === 'error') {
-      await promise_rejects(t, 'InvalidAccessError', cache.match(url));
+      await promise_rejects_dom(t, 'InvalidAccessError', cache.match(url));
       return;
     }
 

--- a/html/semantics/embedded-content/media-elements/event_pause_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_pause_noautoplay.html
@@ -23,7 +23,7 @@ promise_test(function(t) {
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
   var play_promise = a.play();
   a.pause();
-  return promise_rejects(t, "AbortError", play_promise, "pause() should reject all pending play Promises");
+  return promise_rejects_dom(t, "AbortError", play_promise, "pause() should reject all pending play Promises");
 }, "audio events - pause");
 
 promise_test(function(t) {
@@ -35,7 +35,7 @@ promise_test(function(t) {
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   var play_promise = v.play()
   v.pause();
-  return promise_rejects(t, "AbortError", play_promise, "pause() should reject all pending play Promises");
+  return promise_rejects_dom(t, "AbortError", play_promise, "pause() should reject all pending play Promises");
 }, "video events - pause");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_play_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_play_noautoplay.html
@@ -22,7 +22,7 @@ promise_test(function(t) {
     async_t.done();
   }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
-  return promise_rejects(t, "AbortError", a.play(), "pause() should reject all pending play Promises");
+  return promise_rejects_dom(t, "AbortError", a.play(), "pause() should reject all pending play Promises");
 }, "audio events - play");
 
 promise_test(function(t) {
@@ -33,7 +33,7 @@ promise_test(function(t) {
     async_t.done();
   }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
-  return promise_rejects(t, "AbortError", v.play(), "pause() should reject all pending play Promises");
+  return promise_rejects_dom(t, "AbortError", v.play(), "pause() should reject all pending play Promises");
 }, "video events - play");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document-networkState.html
+++ b/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document-networkState.html
@@ -21,7 +21,7 @@ promise_test(async function(t) {
 
   await watcher.wait_for('pause');
 
-  await promise_rejects(t, 'AbortError', p, 'We expect promise being rejected');
+  await promise_rejects_dom(t, 'AbortError', p, 'We expect promise being rejected');
   assert_true(v.paused, 'paused after removing and stable state');
 });
 </script>

--- a/html/semantics/embedded-content/the-img-element/decode/image-decode-iframe.html
+++ b/html/semantics/embedded-content/the-img-element/decode/image-decode-iframe.html
@@ -37,7 +37,7 @@ promise_test(function(t) {
   img.src = "/images/green.png";
   frame.parentNode.removeChild(frame);
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Decode from removed iframe fails (img not loaded)");
 
 promise_test(function(t) {
@@ -47,7 +47,7 @@ promise_test(function(t) {
   // First request a promise, then remove the iframe.
   var promise = img.decode();
   frame.parentNode.removeChild(frame);
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Decode from iframe, later removed, fails (img not loaded)");
 
 </script>

--- a/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative.html
+++ b/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes-svg.tentative.html
@@ -16,7 +16,7 @@ promise_test(function(t) {
   img.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', "/images/green.png");
   var promise = img.decode();
   img.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', "/images/green.svg");
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " xlink:href changes fail decode.");
 
 promise_test(function(t) {
@@ -24,7 +24,7 @@ promise_test(function(t) {
   img.setAttribute('href', "/images/green.png");
   var promise = img.decode();
   img.setAttribute('href', "/images/green.svg");
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " href changes fail decode.");
 
 promise_test(function(t) {
@@ -35,7 +35,7 @@ promise_test(function(t) {
   var second_promise = img.decode();
   assert_not_equals(first_promise, second_promise);
   return Promise.all([
-    promise_rejects(t, "EncodingError", first_promise),
+    promise_rejects_dom(t, "EncodingError", first_promise),
     second_promise
   ]);
 }, document.title + " xlink:href changes fail decode; following good decode succeeds.");
@@ -48,7 +48,7 @@ promise_test(function(t) {
   var second_promise = img.decode();
   assert_not_equals(first_promise, second_promise);
   return Promise.all([
-    promise_rejects(t, "EncodingError", first_promise),
+    promise_rejects_dom(t, "EncodingError", first_promise),
     second_promise
   ]);
 }, document.title + " href changes fail decode; following good decode succeeds.");
@@ -61,8 +61,8 @@ promise_test(function(t) {
   var second_promise = img.decode();
   assert_not_equals(first_promise, second_promise);
   return Promise.all([
-    promise_rejects(t, "EncodingError", first_promise),
-    promise_rejects(t, "EncodingError", second_promise)
+    promise_rejects_dom(t, "EncodingError", first_promise),
+    promise_rejects_dom(t, "EncodingError", second_promise)
   ]);
 }, document.title + " xlink:href changes fail decode; following bad decode fails.");
 
@@ -74,8 +74,8 @@ promise_test(function(t) {
   var second_promise = img.decode();
   assert_not_equals(first_promise, second_promise);
   return Promise.all([
-    promise_rejects(t, "EncodingError", first_promise),
-    promise_rejects(t, "EncodingError", second_promise)
+    promise_rejects_dom(t, "EncodingError", first_promise),
+    promise_rejects_dom(t, "EncodingError", second_promise)
   ]);
 }, document.title + " href changes fail decode; following bad decode fails.");
 

--- a/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes.html
+++ b/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes.html
@@ -17,7 +17,7 @@ promise_test(function(t) {
   img.src = "/images/green.png";
   var promise = img.decode();
   img.src = "/images/green.svg";
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " src changes fail decode.");
 
 promise_test(function(t) {
@@ -28,7 +28,7 @@ promise_test(function(t) {
   var second_promise = img.decode();
   assert_not_equals(first_promise, second_promise);
   return Promise.all([
-    promise_rejects(t, "EncodingError", first_promise),
+    promise_rejects_dom(t, "EncodingError", first_promise),
     second_promise
   ]);
 }, document.title + " src changes fail decode; following good png decode succeeds.");
@@ -41,7 +41,7 @@ promise_test(function(t) {
   var second_promise = img.decode();
   assert_not_equals(first_promise, second_promise);
   return Promise.all([
-    promise_rejects(t, "EncodingError", first_promise),
+    promise_rejects_dom(t, "EncodingError", first_promise),
     second_promise
   ]);
 }, document.title + " src changes fail decode; following good svg decode succeeds.");
@@ -54,8 +54,8 @@ promise_test(function(t) {
   var second_promise = img.decode();
   assert_not_equals(first_promise, second_promise);
   return Promise.all([
-    promise_rejects(t, "EncodingError", first_promise),
-    promise_rejects(t, "EncodingError", second_promise)
+    promise_rejects_dom(t, "EncodingError", first_promise),
+    promise_rejects_dom(t, "EncodingError", second_promise)
   ]);
 }, document.title + " src changes fail decode; following bad decode fails.");
 
@@ -89,7 +89,7 @@ promise_test(function(t) {
   img.srcset = "/images/green.png 100w";
   var promise = img.decode();
   img.srcset = "/images/green.svg 100w";
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " srcset changes fail decode.");
 
 promise_test(function(t) {
@@ -100,7 +100,7 @@ promise_test(function(t) {
   var second_promise = img.decode();
   assert_not_equals(first_promise, second_promise);
   return Promise.all([
-    promise_rejects(t, "EncodingError", first_promise),
+    promise_rejects_dom(t, "EncodingError", first_promise),
     second_promise
   ]);
 }, document.title + " srcset changes fail decode; following good decode succeeds.");
@@ -113,8 +113,8 @@ promise_test(function(t) {
   var second_promise = img.decode();
   assert_not_equals(first_promise, second_promise);
   return Promise.all([
-    promise_rejects(t, "EncodingError", first_promise),
-    promise_rejects(t, "EncodingError", second_promise)
+    promise_rejects_dom(t, "EncodingError", first_promise),
+    promise_rejects_dom(t, "EncodingError", second_promise)
   ]);
 }, document.title + " srcset changes fail decode; following bad decode fails.");
 

--- a/html/semantics/embedded-content/the-img-element/decode/image-decode-picture.html
+++ b/html/semantics/embedded-content/the-img-element/decode/image-decode-picture.html
@@ -82,7 +82,7 @@ promise_test(function(t) {
   source.srcset = "/non/existent/path.png";
 
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Non-existent source fails decode.");
 
 promise_test(function(t) {
@@ -96,7 +96,7 @@ promise_test(function(t) {
   source.srcset = "data:image/png;base64,iVBO00PDR0BADBEEF00KGg";
 
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Corrupt image in src fails decode.");
 
 promise_test(function(t) {
@@ -108,7 +108,7 @@ promise_test(function(t) {
   picture.appendChild(img);
 
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Image without srcset fails decode.");
 
 promise_test(function() {

--- a/html/semantics/embedded-content/the-img-element/decode/image-decode-svg.tentative.html
+++ b/html/semantics/embedded-content/the-img-element/decode/image-decode-svg.tentative.html
@@ -71,34 +71,34 @@ promise_test(function(t) {
   var img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
   img.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', "/non/existent/path.png");
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Non-existent xlink:href fails decode.");
 
 promise_test(function(t) {
   var img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
   img.setAttribute('href', "/non/existent/path.png");
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Non-existent href fails decode.");
 
 promise_test(function(t) {
   var img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
   img.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', "data:image/png;base64,iVBO00PDR0BADBEEF00KGg");
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Corrupt image in xlink:href fails decode.");
 
 promise_test(function(t) {
   var img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
   img.setAttribute('href', "data:image/png;base64,iVBO00PDR0BADBEEF00KGg");
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Corrupt image in href fails decode.");
 
 promise_test(function(t) {
   var img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Image without xlink:href or href fails decode.");
 
 promise_test(function() {

--- a/html/semantics/embedded-content/the-img-element/decode/image-decode.html
+++ b/html/semantics/embedded-content/the-img-element/decode/image-decode.html
@@ -43,7 +43,7 @@ promise_test(function(t) {
   var img = new Image();
   img.src = "/non/existent/path.png";
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Non-existent src fails decode.");
 
 promise_test(function(t) {
@@ -51,7 +51,7 @@ promise_test(function(t) {
   var img = inactive_doc.createElement("img");
   img.src = "/images/green.png";
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Inactive document fails decode.");
 
 promise_test(function(t) {
@@ -60,7 +60,7 @@ promise_test(function(t) {
   img.src = "/images/green.png";
   var promise = img.decode();
   inactive_doc.body.appendChild(img);
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Adopted active image into inactive document fails decode.");
 
 promise_test(function() {
@@ -77,13 +77,13 @@ promise_test(function(t) {
   var img = new Image();
   img.src = "data:image/png;base64,iVBO00PDR0BADBEEF00KGg";
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Corrupt image in src fails decode.");
 
 promise_test(function(t) {
   var img = new Image();
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Image without src/srcset fails decode.");
 
 promise_test(function() {
@@ -120,7 +120,7 @@ promise_test(function(t) {
   var img = new Image();
   img.srcset = "/non/existent/path.png 100w";
   var promise = img.decode();
-  return promise_rejects(t, "EncodingError", promise);
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Non-existent srcset fails decode.");
 
 promise_test(function() {

--- a/keyboard-lock/navigator-keyboard-lock-two-parallel-requests.https.html
+++ b/keyboard-lock/navigator-keyboard-lock-two-parallel-requests.https.html
@@ -7,7 +7,7 @@
 promise_test((t) => {
   const p1 = navigator.keyboard.lock(["KeyA", "KeyB"]);
   const p2 = navigator.keyboard.lock(["KeyC", "KeyD"]);
-  return Promise.all([promise_rejects(t, "AbortError", p1), p2]);
+  return Promise.all([promise_rejects_dom(t, "AbortError", p1), p2]);
 }, '[Keyboard Lock] keyboard.lock twice in parallel');
 
 </script>

--- a/kv-storage/cause-errors-via-idb.https.html
+++ b/kv-storage/cause-errors-via-idb.https.html
@@ -35,7 +35,7 @@ for (const [method, testFn] of Object.entries(mustFail)) {
 
     const result = testFn(area);
 
-    await promise_rejects(t, "VersionError", result);
+    await promise_rejects_dom(t, "VersionError", result);
   }, `${method}: upgrading the database must cause a "VersionError" DOMException`);
 
   testWithAreaNoCleanup(async (area, t) => {
@@ -48,7 +48,7 @@ for (const [method, testFn] of Object.entries(mustFail)) {
 
     const result = testFn(area);
 
-    await promise_rejects(t, "InvalidStateError", result);
+    await promise_rejects_dom(t, "InvalidStateError", result);
   }, `${method}: creating a same-named database with no object store must cause an "InvalidStateError" DOMException`);
 
   testWithAreaNoCleanup(async (area, t) => {
@@ -60,7 +60,7 @@ for (const [method, testFn] of Object.entries(mustFail)) {
 
     const result = testFn(area);
 
-    await promise_rejects(t, "InvalidStateError", result);
+    await promise_rejects_dom(t, "InvalidStateError", result);
   }, `${method}: creating a same-named database with a single object store with the wrong name must cause an "InvalidStateError" DOMException`);
 
   testWithAreaNoCleanup(async (area, t) => {
@@ -73,7 +73,7 @@ for (const [method, testFn] of Object.entries(mustFail)) {
 
     const result = testFn(area);
 
-    await promise_rejects(t, "InvalidStateError", result);
+    await promise_rejects_dom(t, "InvalidStateError", result);
   }, `${method}: creating a same-named database with more than one object store must cause an "InvalidStateError" DOMException`);
 
   testWithAreaNoCleanup(async (area, t) => {
@@ -85,7 +85,7 @@ for (const [method, testFn] of Object.entries(mustFail)) {
 
     const result = testFn(area);
 
-    await promise_rejects(t, "InvalidStateError", result);
+    await promise_rejects_dom(t, "InvalidStateError", result);
   }, `${method}: creating a same-named database the right object store but a bad schema (autoIncrement = true) must cause an "InvalidStateError" DOMException`);
 
   testWithAreaNoCleanup(async (area, t) => {
@@ -97,7 +97,7 @@ for (const [method, testFn] of Object.entries(mustFail)) {
 
     const result = testFn(area);
 
-    await promise_rejects(t, "InvalidStateError", result);
+    await promise_rejects_dom(t, "InvalidStateError", result);
   }, `${method}: creating a same-named database the right object store but a bad schema (keyPath != null) must cause an "InvalidStateError" DOMException`);
 
   testWithAreaNoCleanup(async (area, t) => {
@@ -110,7 +110,7 @@ for (const [method, testFn] of Object.entries(mustFail)) {
 
     const result = testFn(area);
 
-    await promise_rejects(t, "InvalidStateError", result);
+    await promise_rejects_dom(t, "InvalidStateError", result);
   }, `${method}: creating a same-named database the right object store but a bad schema (has indices) must cause an "InvalidStateError" DOMException`);
 }
 </script>

--- a/kv-storage/key-types.https.html
+++ b/kv-storage/key-types.https.html
@@ -38,13 +38,13 @@ const methods = ["delete", "get", "set"];
 for (const method of methods) {
   testWithArea(async (area, t) => {
     for (const [description, key] of Object.entries(invalidKeys)) {
-      await promise_rejects(t, "DataError", area[method](key), description);
+      await promise_rejects_dom(t, "DataError", area[method](key), description);
     }
   }, `${method}: invalid keys`);
 
   testWithArea(async (area, t) => {
     for (const [description, key] of Object.entries(invalidKeys)) {
-      await promise_rejects(t, "DataError", area[method]([key]), description);
+      await promise_rejects_dom(t, "DataError", area[method]([key]), description);
     }
   }, `${method}: invalid keys, nested in arrays`);
 

--- a/kv-storage/keys-values-entries.https.html
+++ b/kv-storage/keys-values-entries.https.html
@@ -53,8 +53,8 @@ for (const method of ["keys", "values", "entries"]) {
     const iterResultPromise1 = iter.next();
     const iterResultPromise2 = iter.next();
 
-    await promise_rejects(t, "VersionError", iterResultPromise1, "first next()");
-    await promise_rejects(t, "VersionError", iterResultPromise2, "second next()");
+    await promise_rejects_dom(t, "VersionError", iterResultPromise1, "first next()");
+    await promise_rejects_dom(t, "VersionError", iterResultPromise2, "second next()");
 
     const iterResultPromise3 = iter.next();
 
@@ -65,7 +65,7 @@ for (const method of ["keys", "values", "entries"]) {
     assert_not_equals(iterResultPromise2, iterResultPromise3,
       "Two promises, one retrieved after waiting for the other, must be different (2 vs 3)");
 
-    await promise_rejects(t, "VersionError", iterResultPromise2, "third next()");
+    await promise_rejects_dom(t, "VersionError", iterResultPromise2, "third next()");
 
     const reason1 = await iterResultPromise1.catch(r => r);
     const reason2 = await iterResultPromise2.catch(r => r);

--- a/media-capabilities/decodingInfoEncryptedMedia.http.html
+++ b/media-capabilities/decodingInfoEncryptedMedia.http.html
@@ -21,7 +21,7 @@ var minimalKeySystemConfiguration = {
 };
 
 promise_test(t => {
-  return promise_rejects(t, 'SecurityError', navigator.mediaCapabilities.decodingInfo({
+  return promise_rejects_dom(t, 'SecurityError', navigator.mediaCapabilities.decodingInfo({
     type: 'file',
     video: minimalVideoConfiguration,
     keySystemConfiguration: minimalKeySystemConfiguration,

--- a/mediacapture-image/ImageCapture-creation.https.html
+++ b/mediacapture-image/ImageCapture-creation.https.html
@@ -23,7 +23,7 @@ function makeAsyncTest(modifyTrack, message) {
 
       modifyTrack(videoTrack);
 
-      promise_rejects(test,
+      promise_rejects_dom(test,
                       'InvalidStateError',
                       capturer.grabFrame(),
                       'Should throw InvalidStateError.')

--- a/mediacapture-image/getPhotoCapabilities.html
+++ b/mediacapture-image/getPhotoCapabilities.html
@@ -54,7 +54,7 @@ promise_test(t => {
   let capturer = new ImageCapture(videoTrack);
   assert_equals(videoTrack.readyState, 'ended');
 
-  return promise_rejects(t, 'InvalidStateError', capturer.getPhotoCapabilities())
+  return promise_rejects_dom(t, 'InvalidStateError', capturer.getPhotoCapabilities())
 
 }, 'getPhotoCapabilities() of an ended Track should throw "InvalidStateError"');
 

--- a/mediacapture-image/getPhotoSettings.html
+++ b/mediacapture-image/getPhotoSettings.html
@@ -39,7 +39,7 @@ promise_test(t => {
   let capturer = new ImageCapture(videoTrack);
   assert_equals(videoTrack.readyState, 'ended');
 
-  return promise_rejects(t, 'InvalidStateError', capturer.getPhotoSettings())
+  return promise_rejects_dom(t, 'InvalidStateError', capturer.getPhotoSettings())
 
 }, 'getPhotoSettings() of an ended Track should throw "InvalidStateError"');
 

--- a/mediacapture-image/takePhoto.html
+++ b/mediacapture-image/takePhoto.html
@@ -54,7 +54,7 @@ promise_test(t => {
   let capturer = new ImageCapture(videoTrack);
   assert_equals(videoTrack.readyState, 'ended');
 
-  return promise_rejects(t, 'InvalidStateError', capturer.takePhoto())
+  return promise_rejects_dom(t, 'InvalidStateError', capturer.takePhoto())
 
 }, 'takePhoto() of an ended Track should throw "InvalidStateError"');
 

--- a/native-file-system/script-tests/FileSystemDirectoryHandle-getDirectory.js
+++ b/native-file-system/script-tests/FileSystemDirectoryHandle-getDirectory.js
@@ -1,5 +1,5 @@
 directory_test(async (t, root) => {
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'NotFoundError', root.getDirectory('non-existing-dir'));
 }, 'getDirectory(create=false) rejects for non-existing directories');
 
@@ -47,10 +47,10 @@ directory_test(async (t, root) => {
 directory_test(async (t, root) => {
   await createEmptyFile(t, 'file-name', root);
 
-  await promise_rejects(t, 'TypeMismatchError', root.getDirectory('file-name'));
-  await promise_rejects(
+  await promise_rejects_dom(t, 'TypeMismatchError', root.getDirectory('file-name'));
+  await promise_rejects_dom(
       t, 'TypeMismatchError', root.getDirectory('file-name', {create: false}));
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'TypeMismatchError', root.getDirectory('file-name', {create: true}));
 }, 'getDirectory() when a file already exists with the same name');
 

--- a/native-file-system/script-tests/FileSystemDirectoryHandle-getFile.js
+++ b/native-file-system/script-tests/FileSystemDirectoryHandle-getFile.js
@@ -1,5 +1,5 @@
 directory_test(async (t, dir) => {
-  await promise_rejects(t, 'NotFoundError', dir.getFile('non-existing-file'));
+  await promise_rejects_dom(t, 'NotFoundError', dir.getFile('non-existing-file'));
 }, 'getFile(create=false) rejects for non-existing files');
 
 directory_test(async (t, dir) => {
@@ -41,14 +41,14 @@ directory_test(async (t, dir) => {
   const dir_handle = await dir.getDirectory('dir-name', {create: true});
   t.add_cleanup(() => dir.removeEntry('dir-name', {recursive: true}));
 
-  await promise_rejects(t, 'TypeMismatchError', dir.getFile('dir-name'));
+  await promise_rejects_dom(t, 'TypeMismatchError', dir.getFile('dir-name'));
 }, 'getFile(create=false) when a directory already exists with the same name');
 
 directory_test(async (t, dir) => {
   const dir_handle = await dir.getDirectory('dir-name', {create: true});
   t.add_cleanup(() => dir.removeEntry('dir-name', {recursive: true}));
 
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'TypeMismatchError', dir.getFile('dir-name', {create: true}));
 }, 'getFile(create=true) when a directory already exists with the same name');
 

--- a/native-file-system/script-tests/FileSystemDirectoryHandle-removeEntry.js
+++ b/native-file-system/script-tests/FileSystemDirectoryHandle-removeEntry.js
@@ -6,7 +6,7 @@ directory_test(async (t, root) => {
   await root.removeEntry('file-to-remove');
 
   assert_array_equals(await getSortedDirectoryEntries(root), ['file-to-keep']);
-  await promise_rejects(t, 'NotFoundError', getFileContents(handle));
+  await promise_rejects_dom(t, 'NotFoundError', getFileContents(handle));
 }, 'removeEntry() to remove a file');
 
 directory_test(async (t, root) => {
@@ -14,7 +14,7 @@ directory_test(async (t, root) => {
       await createFileWithContents(t, 'file-to-remove', '12345', root);
   await root.removeEntry('file-to-remove');
 
-  await promise_rejects(t, 'NotFoundError', root.removeEntry('file-to-remove'));
+  await promise_rejects_dom(t, 'NotFoundError', root.removeEntry('file-to-remove'));
 }, 'removeEntry() on an already removed file should fail');
 
 directory_test(async (t, root) => {
@@ -23,7 +23,7 @@ directory_test(async (t, root) => {
   await root.removeEntry('dir-to-remove');
 
   assert_array_equals(await getSortedDirectoryEntries(root), ['file-to-keep']);
-  await promise_rejects(t, 'NotFoundError', getSortedDirectoryEntries(dir));
+  await promise_rejects_dom(t, 'NotFoundError', getSortedDirectoryEntries(dir));
 }, 'removeEntry() to remove an empty directory');
 
 directory_test(async (t, root) => {
@@ -31,7 +31,7 @@ directory_test(async (t, root) => {
   t.add_cleanup(() => root.removeEntry('dir-to-remove', {recursive: true}));
   await createEmptyFile(t, 'file-in-dir', dir);
 
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'InvalidModificationError', root.removeEntry('dir-to-remove'));
   assert_array_equals(
       await getSortedDirectoryEntries(root), ['dir-to-remove/']);

--- a/native-file-system/script-tests/FileSystemWritableFileStream-piped.js
+++ b/native-file-system/script-tests/FileSystemWritableFileStream-piped.js
@@ -127,7 +127,7 @@ directory_test(async (t, root) => {
   const promise = body.pipeTo(wfs, { signal });
   await abortController.abort();
 
-  await promise_rejects(t, 'AbortError', promise, 'stream is aborted');
+  await promise_rejects_dom(t, 'AbortError', promise, 'stream is aborted');
   await promise_rejects_js(t, TypeError, wfs.close(), 'stream cannot be closed to flush writes');
 
   assert_equals(await getFileContents(handle), '');

--- a/native-file-system/script-tests/FileSystemWritableFileStream-write.js
+++ b/native-file-system/script-tests/FileSystemWritableFileStream-write.js
@@ -117,7 +117,7 @@ directory_test(async (t, root) => {
   const handle = await createEmptyFile(t, 'bad_offset', root);
   const stream = await handle.createWritable();
 
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'InvalidStateError', stream.write({type: 'write', position: 4, data: new Blob(['abc'])}));
   await promise_rejects_js(
       t, TypeError, stream.close(), 'stream is already closed');
@@ -202,7 +202,7 @@ directory_test(async (t, root) => {
   await stream.write('foo');
 
   await root.removeEntry('parent_dir', {recursive: true});
-  await promise_rejects(t, 'NotFoundError', stream.close());
+  await promise_rejects_dom(t, 'NotFoundError', stream.close());
 }, 'atomic writes: close() fails when parent directory is removed');
 
 directory_test(async (t, root) => {
@@ -285,7 +285,7 @@ directory_test(async (t, root) => {
   await stream.write('bar');
 
   await dir.removeEntry(file_name);
-  await promise_rejects(t, 'NotFoundError', getFileContents(handle));
+  await promise_rejects_dom(t, 'NotFoundError', getFileContents(handle));
 
   await stream.close();
   assert_equals(await getFileContents(handle), 'bar');

--- a/native-file-system/script-tests/FileSystemWritableFileStream.js
+++ b/native-file-system/script-tests/FileSystemWritableFileStream.js
@@ -28,7 +28,7 @@ directory_test(async (t, root) => {
   const handle = await createEmptyFile(t, file_name, dir);
 
   await root.removeEntry('parent_dir', {recursive: true});
-  await promise_rejects(t, 'NotFoundError', handle.createWritable());
+  await promise_rejects_dom(t, 'NotFoundError', handle.createWritable());
 }, 'createWritable() fails when parent directory is removed');
 
 directory_test(async (t, root) => {
@@ -38,7 +38,7 @@ directory_test(async (t, root) => {
   const stream = await handle.createWritable();
 
   await root.removeEntry('parent_dir', {recursive: true});
-  await promise_rejects(t, 'NotFoundError', stream.write('foo'));
+  await promise_rejects_dom(t, 'NotFoundError', stream.write('foo'));
 }, 'write() fails when parent directory is removed');
 
 directory_test(async (t, root) => {
@@ -48,7 +48,7 @@ directory_test(async (t, root) => {
   const stream = await handle.createWritable();
 
   await root.removeEntry('parent_dir', {recursive: true});
-  await promise_rejects(t, 'NotFoundError', stream.truncate(0));
+  await promise_rejects_dom(t, 'NotFoundError', stream.truncate(0));
 }, 'truncate() fails when parent directory is removed');
 
 directory_test(async (t, root) => {

--- a/native-file-system/script-tests/FileSystemWriter.js
+++ b/native-file-system/script-tests/FileSystemWriter.js
@@ -36,7 +36,7 @@ directory_test(async (t, root) => {
   const handle = await createEmptyFile(t, 'bad_offset', root);
   const writer = await handle.createWriter();
 
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'InvalidStateError', writer.write(4, new Blob(['abc'])));
   await writer.close();
 
@@ -142,7 +142,7 @@ directory_test(async (t, root) => {
   const handle = await createEmptyFile(t, file_name, dir);
 
   await root.removeEntry('parent_dir', {recursive: true});
-  await promise_rejects(t, 'NotFoundError', handle.createWriter());
+  await promise_rejects_dom(t, 'NotFoundError', handle.createWriter());
 }, 'createWriter() fails when parent directory is removed');
 
 directory_test(async (t, root) => {
@@ -152,7 +152,7 @@ directory_test(async (t, root) => {
   const writer = await handle.createWriter();
 
   await root.removeEntry('parent_dir', {recursive: true});
-  await promise_rejects(t, 'NotFoundError', writer.write(0, new Blob(['foo'])));
+  await promise_rejects_dom(t, 'NotFoundError', writer.write(0, new Blob(['foo'])));
 }, 'write() fails when parent directory is removed');
 
 directory_test(async (t, root) => {
@@ -162,7 +162,7 @@ directory_test(async (t, root) => {
   const writer = await handle.createWriter();
 
   await root.removeEntry('parent_dir', {recursive: true});
-  await promise_rejects(t, 'NotFoundError', writer.truncate(0));
+  await promise_rejects_dom(t, 'NotFoundError', writer.truncate(0));
 }, 'truncate() fails when parent directory is removed');
 
 directory_test(async (t, root) => {
@@ -173,7 +173,7 @@ directory_test(async (t, root) => {
   await writer.write(0, new Blob(['foo']));
 
   await root.removeEntry('parent_dir', {recursive: true});
-  await promise_rejects(t, 'NotFoundError', writer.close());
+  await promise_rejects_dom(t, 'NotFoundError', writer.close());
 }, 'atomic writes: close() fails when parent directory is removed');
 
 directory_test(async (t, root) => {
@@ -204,7 +204,7 @@ directory_test(async (t, root) => {
   assert_equals(await getFileContents(handle), 'foo');
   assert_equals(await getFileSize(handle), 3);
 
-  await promise_rejects(
+  await promise_rejects_dom(
       t, 'InvalidStateError', writer.write(0, new Blob(['abc'])));
 }, 'atomic writes: write() after close() fails');
 
@@ -218,7 +218,7 @@ directory_test(async (t, root) => {
   assert_equals(await getFileContents(handle), 'foo');
   assert_equals(await getFileSize(handle), 3);
 
-  await promise_rejects(t, 'InvalidStateError', writer.truncate(0));
+  await promise_rejects_dom(t, 'InvalidStateError', writer.truncate(0));
 }, 'atomic writes: truncate() after close() fails');
 
 directory_test(async (t, root) => {
@@ -230,7 +230,7 @@ directory_test(async (t, root) => {
   assert_equals(await getFileContents(handle), 'foo');
   assert_equals(await getFileSize(handle), 3);
 
-  await promise_rejects(t, 'InvalidStateError', writer.close());
+  await promise_rejects_dom(t, 'InvalidStateError', writer.close());
 }, 'atomic writes: close() after close() fails');
 
 directory_test(async (t, root) => {
@@ -279,7 +279,7 @@ directory_test(async (t, root) => {
   await writer.write(0, new Blob(['bar']));
 
   await dir.removeEntry(file_name);
-  await promise_rejects(t, 'NotFoundError', getFileContents(handle));
+  await promise_rejects_dom(t, 'NotFoundError', getFileContents(handle));
 
   await writer.close();
   assert_equals(await getFileContents(handle), 'bar');

--- a/payment-handler/can-make-payment-event.https.html
+++ b/payment-handler/can-make-payment-event.https.html
@@ -123,7 +123,7 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return false.',
   );
-  await promise_rejects(t, 'NotSupportedError', request.show());
+  await promise_rejects_dom(t, 'NotSupportedError', request.show());
 }, 'If a payment handler is not installed, then the payment method is not supported.');
 
 promise_test(async t => {
@@ -145,7 +145,7 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return false.',
   );
-  await promise_rejects(t, 'NotSupportedError', request.show());
+  await promise_rejects_dom(t, 'NotSupportedError', request.show());
 }, 'If CanMakePaymentEvent.respondWith(false) is called, then the payment method is not supported.');
 
 promise_test(async t => {
@@ -167,7 +167,7 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return false.',
   );
-  await promise_rejects(t, 'NotSupportedError', request.show());
+  await promise_rejects_dom(t, 'NotSupportedError', request.show());
 }, 'If CanMakePaymentEvent.respondWith(Promise.resolve(false)) is called, then the payment method is not supported.');
 
 promise_test(async t => {
@@ -191,7 +191,7 @@ promise_test(async t => {
   );
   const acceptPromise = request.show();
   await request.abort();
-  await promise_rejects(t, 'AbortError', acceptPromise);
+  await promise_rejects_dom(t, 'AbortError', acceptPromise);
 }, 'If CanMakePaymentEvent.respondWith(true) is called, then the payment method is supported.');
 
 promise_test(async t => {
@@ -215,7 +215,7 @@ promise_test(async t => {
   );
   const acceptPromise = request.show();
   await request.abort();
-  await promise_rejects(t, 'AbortError', acceptPromise);
+  await promise_rejects_dom(t, 'AbortError', acceptPromise);
 }, 'If CanMakePaymentEvent.respondWith(Promise.resolve(true)) is called, then the payment method is supported.');
 
 promise_test(async t => {
@@ -237,7 +237,7 @@ promise_test(async t => {
     paymentRequestCanMakePaymentResult,
     'canMakePayment() must return false.',
   );
-  await promise_rejects(t, 'NotSupportedError', request.show());
+  await promise_rejects_dom(t, 'NotSupportedError', request.show());
 }, 'If CanMakePaymentEvent.respondWith(Promise.reject(error)) is called, then the payment method is not supported.');
 
 promise_test(async t => {

--- a/payment-handler/change-payment-method-manual.https.html
+++ b/payment-handler/change-payment-method-manual.https.html
@@ -50,7 +50,7 @@
         () => request.show()
       );
 
-      return promise_rejects(t, 'AbortError', response_promise);
+      return promise_rejects_dom(t, 'AbortError', response_promise);
     }, 'If updateWith(details) is rejected, abort the PaymentRequest.show().');
 
     promise_test(async (t) => {
@@ -71,7 +71,7 @@
         () => request.show()
       );
 
-      return promise_rejects(t, 'AbortError', response_promise);
+      return promise_rejects_dom(t, 'AbortError', response_promise);
     }, 'If updateWith(details) throws inside of the promise, abort the PaymentRequest.show().');
 
     promise_test(async (t) => {

--- a/payment-method-basic-card/apply_the_modifiers.html
+++ b/payment-method-basic-card/apply_the_modifiers.html
@@ -68,7 +68,7 @@
         modifiers: [visaModifier],
       });
       const showPromise = new PaymentRequest(basicCard, defaultDetails).show();
-      await promise_rejects(t, "AbortError", showPromise);
+      await promise_rejects_dom(t, "AbortError", showPromise);
     }, testableAssertion.trim());
   }
 
@@ -78,7 +78,7 @@
         modifiers: [modifier],
       });
       const showPromise = new PaymentRequest(basicCard, defaultDetails).show();
-      await promise_rejects(t, "AbortError", showPromise);
+      await promise_rejects_dom(t, "AbortError", showPromise);
     }, testableAssertion.trim());
   }
 
@@ -87,7 +87,7 @@
       const modifiers = [Object.assign({}, modifier, { data: {} })];
       const details = Object.assign({}, defaultDetails, { modifiers });
       const showPromise = new PaymentRequest(basicCard, defaultDetails).show();
-      await promise_rejects(t, "AbortError", showPromise);
+      await promise_rejects_dom(t, "AbortError", showPromise);
     }, testableAssertion.trim());
   }
 
@@ -98,7 +98,7 @@
       ];
       const details = Object.assign({}, defaultDetails, { modifiers });
       const showPromise = new PaymentRequest(basicCard, defaultDetails).show();
-      await promise_rejects(t, "AbortError", showPromise);
+      await promise_rejects_dom(t, "AbortError", showPromise);
     }, testableAssertion.trim());
   }
 
@@ -107,7 +107,7 @@
       const modifiers = [failModifier, modifier, notBasicCardModifier];
       const details = Object.assign({}, defaultDetails, { modifiers });
       const showPromise = new PaymentRequest(basicCard, defaultDetails).show();
-      await promise_rejects(t, "AbortError", showPromise);
+      await promise_rejects_dom(t, "AbortError", showPromise);
     }, testableAssertion.trim());
   }
 </script>

--- a/payment-method-basic-card/steps_for_selecting_the_payment_handler.html
+++ b/payment-method-basic-card/steps_for_selecting_the_payment_handler.html
@@ -29,7 +29,7 @@
         },
       ];
       const showPromise = new PaymentRequest(methodData, defaultDetails).show();
-      await promise_rejects(t, "AbortError", showPromise);
+      await promise_rejects_dom(t, "AbortError", showPromise);
     }, testableAssertion.trim());
   }
 
@@ -53,7 +53,7 @@
         },
       ];
       const showPromise = new PaymentRequest(methodData, defaultDetails).show();
-      await promise_rejects(t, "AbortError", showPromise);
+      await promise_rejects_dom(t, "AbortError", showPromise);
     }, testableAssertion.trim());
   }
 
@@ -72,7 +72,7 @@
         },
       ];
       const showPromise = new PaymentRequest(methodData, defaultDetails).show();
-      await promise_rejects(t, "AbortError", showPromise);
+      await promise_rejects_dom(t, "AbortError", showPromise);
     }, testableAssertion.trim());
   }
 </script>

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-call-immediate-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-call-immediate-manual.https.html
@@ -71,7 +71,7 @@ function testImmediateUpdate({ textContent: testName }) {
       );
     });
     const acceptPromise = request.show();
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       eventPromise,
@@ -103,7 +103,7 @@ function testSubsequentUpdateWithCalls({ textContent: testName }) {
       });
     });
     const responsePromise = request.show();
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       eventPromise,

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-method-abort-update-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-method-abort-update-manual.https.html
@@ -166,7 +166,7 @@ function testBadUpdate(button, badDetails, expectedError, errorCode) {
       "badDetails must cause acceptPromise to reject with expectedError"
     );
     // The request [[state]] is now "closed", so let's check for InvalidStateError
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       request.show(),

--- a/payment-request/algorithms-manual.https.html
+++ b/payment-request/algorithms-manual.https.html
@@ -110,9 +110,9 @@ async function runAbortTest(button) {
   promise_test(async t => {
     const request = new PaymentRequest(methods, detailsNoShippingOptions);
     // Await the user to abort
-    await promise_rejects(t, "AbortError", request.show());
+    await promise_rejects_dom(t, "AbortError", request.show());
     // [[state]] is now closed
-    await promise_rejects(t, "InvalidStateError", request.show());
+    await promise_rejects_dom(t, "InvalidStateError", request.show());
   }, testName.trim());
 }
 </script>

--- a/payment-request/payment-is-showing.https.html
+++ b/payment-request/payment-is-showing.https.html
@@ -78,7 +78,7 @@
           return [request1.show(), request2.show()];
         },
       );
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         showPromise2,
@@ -86,7 +86,7 @@
       );
 
       await request1.abort();
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         showPromise1,
@@ -97,7 +97,7 @@
       // it will again result in promise rejected with an InvalidStateError.
       // See: https://github.com/w3c/payment-request/pull/821
       const rejectedPromise = request2.show();
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "InvalidStateError",
         rejectedPromise,
@@ -130,7 +130,7 @@
         },
       );
 
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         showPromise,
@@ -160,7 +160,7 @@
         },
       );
 
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         iframeShowPromise,
@@ -169,7 +169,7 @@
 
       // Cleanup
       await windowRequest.abort();
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         windowShowPromise,
@@ -206,7 +206,7 @@
         },
       );
 
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         windowShowPromise,
@@ -214,7 +214,7 @@
       );
 
       await popupRequest.abort();
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         popupShowPromise,
@@ -260,14 +260,14 @@
         },
       );
       // popupRequest and iframeRequest will both reject
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         popupShowPromise,
         "Expected popupShowPromise to reject, request is already showing.",
       );
 
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         iframeShowPromise,
@@ -275,7 +275,7 @@
       );
 
       await windowRequest.abort();
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         windowShowPromise,
@@ -316,14 +316,14 @@
       });
 
       // windowShowPromise and iframeRequest will both reject
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         windowShowPromise,
         "Expected windowShowPromise to reject, the popup is showing a payment request.",
       );
 
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         iframeShowPromise,
@@ -331,7 +331,7 @@
       );
 
       await popupRequest.abort();
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         popupShowPromise,
@@ -377,14 +377,14 @@
       );
 
       // windowShowPromise and iframeRequest will both reject
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         windowShowPromise,
         "Expected windowShowPromise to reject, the popup is showing a payment request.",
       );
 
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         popupShowPromise,
@@ -392,7 +392,7 @@
       );
 
       await iframeRequest.abort();
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         iframeShowPromise,
@@ -415,7 +415,7 @@
       // and the request is showing boolean to become false.
       iframe.src = "blank.html?abc=123";
       await new Promise(resolve => (iframe.onload = resolve));
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "AbortError",
         iframeShowPromise,

--- a/payment-request/payment-request-abort-method.https.html
+++ b/payment-request/payment-request-abort-method.https.html
@@ -39,7 +39,7 @@ const defaultDetails = Object.freeze({
 promise_test(async t => {
   // request is in "created" state
   const request = new PaymentRequest(defaultMethods, defaultDetails);
-  await promise_rejects(t, "InvalidStateError", request.abort());
+  await promise_rejects_dom(t, "InvalidStateError", request.abort());
 }, `Throws if the promise [[state]] is not "interactive"`);
 
 promise_test(async t => {
@@ -60,17 +60,17 @@ promise_test(async t => {
     });
 
   await abortPromise;
-  await promise_rejects(t, "AbortError", acceptPromise);
+  await promise_rejects_dom(t, "AbortError", acceptPromise);
   // As request is now "closed", trying to show it will fail
-  await promise_rejects(t, "InvalidStateError", request.show());
+  await promise_rejects_dom(t, "InvalidStateError", request.show());
 }, "The same request cannot be shown multiple times.");
 
 promise_test(async t => {
   // request is in "created" state.
   const request = new PaymentRequest(defaultMethods, defaultDetails);
-  await promise_rejects(t, "InvalidStateError", request.abort());
+  await promise_rejects_dom(t, "InvalidStateError", request.abort());
   // Call it again, for good measure.
-  await promise_rejects(t, "InvalidStateError", request.abort());
+  await promise_rejects_dom(t, "InvalidStateError", request.abort());
   // The request's state is "created", so let's show it
   // which changes the state to "interactive.".
   const [abortPromise, acceptPromise] = await test_driver.bless(
@@ -84,8 +84,8 @@ promise_test(async t => {
 
   await abortPromise;
   // The request is now "closed", so...
-  await promise_rejects(t, "InvalidStateError", request.abort());
-  await promise_rejects(t, "AbortError", acceptPromise);
+  await promise_rejects_dom(t, "InvalidStateError", request.abort());
+  await promise_rejects_dom(t, "AbortError", acceptPromise);
 }, "Aborting a request before it is shown doesn't prevent it from being shown later.");
 </script>
 <small>

--- a/payment-request/payment-request-canmakepayment-method.https.html
+++ b/payment-request/payment-request-canmakepayment-method.https.html
@@ -89,12 +89,12 @@ promise_test(async t => {
       return [acceptPromise, canMakePaymentPromise];
     });
 
-  await promise_rejects(t, "InvalidStateError", canMakePaymentPromise);
+  await promise_rejects_dom(t, "InvalidStateError", canMakePaymentPromise);
   request.abort();
-  await promise_rejects(t, "AbortError", acceptPromise);
+  await promise_rejects_dom(t, "AbortError", acceptPromise);
 
   // The state should be "closed"
-  await promise_rejects(t, "InvalidStateError", request.canMakePayment());
+  await promise_rejects_dom(t, "InvalidStateError", request.canMakePayment());
 }, 'If request.[[state]] is "interactive", then return a promise rejected with an "InvalidStateError" DOMException.');
 
 promise_test(async t => {
@@ -109,8 +109,8 @@ promise_test(async t => {
     });
 
   await abortPromise;
-  await promise_rejects(t, "AbortError", acceptPromise);
-  await promise_rejects(t, "InvalidStateError", request.canMakePayment());
+  await promise_rejects_dom(t, "AbortError", acceptPromise);
+  await promise_rejects_dom(t, "InvalidStateError", request.canMakePayment());
 }, 'If request.[[state]] is "closed", then return a promise rejected with an "InvalidStateError" DOMException.');
 </script>
 

--- a/payment-request/payment-request-hasenrolledinstrument-method.tentative.https.html
+++ b/payment-request/payment-request-hasenrolledinstrument-method.tentative.https.html
@@ -47,10 +47,10 @@ promise_test(async t => {
         const hasEnrolledInstrumentPromise = request.hasEnrolledInstrument();
         return [acceptPromise, hasEnrolledInstrumentPromise];
       });
-  await promise_rejects(t, "InvalidStateError", hasEnrolledInstrumentPromise);
+  await promise_rejects_dom(t, "InvalidStateError", hasEnrolledInstrumentPromise);
 
   await request.abort();
-  await promise_rejects(t, "AbortError", acceptPromise);
+  await promise_rejects_dom(t, "AbortError", acceptPromise);
 }, `If request.[[state]] is "interactive", then return a promise rejected with an "InvalidStateError" DOMException.`);
 
 promise_test(async t => {
@@ -62,10 +62,10 @@ promise_test(async t => {
     return [abortPromise, acceptPromise];
   });
   await abortPromise;
-  await promise_rejects(t, "AbortError", acceptPromise);
+  await promise_rejects_dom(t, "AbortError", acceptPromise);
 
   const hasEnrolledInstrumentPromise = request.hasEnrolledInstrument();
-  await promise_rejects(t, "InvalidStateError", hasEnrolledInstrumentPromise);
+  await promise_rejects_dom(t, "InvalidStateError", hasEnrolledInstrumentPromise);
 }, `If request.[[state]] is "closed", then return a promise rejected with an "InvalidStateError" DOMException.`);
 </script>
 

--- a/payment-request/payment-request-show-method.https.html
+++ b/payment-request/payment-request-show-method.https.html
@@ -43,7 +43,7 @@ promise_test(async t => {
     request.abort();
   }, 2000);
 
-  await promise_rejects(t, "SecurityError", acceptPromise);
+  await promise_rejects_dom(t, "SecurityError", acceptPromise);
 }, `Calling show() without being triggered by user interaction throws`);
 
 promise_test(async t => {
@@ -54,9 +54,9 @@ promise_test(async t => {
       const acceptPromise = request.show(); // Sets state to "interactive"
       return [acceptPromise];
     });
-  await promise_rejects(t, "InvalidStateError", request.show());
+  await promise_rejects_dom(t, "InvalidStateError", request.show());
   await request.abort();
-  await promise_rejects(t, "AbortError", acceptPromise);
+  await promise_rejects_dom(t, "AbortError", acceptPromise);
 }, "Throws if the promise [[state]] is not 'created'.");
 
 promise_test(async t => {
@@ -67,12 +67,12 @@ promise_test(async t => {
     async () => {
       const acceptPromise1 = request1.show();
       const acceptPromise2 = request2.show();
-      await promise_rejects(t, "AbortError", acceptPromise2);
+      await promise_rejects_dom(t, "AbortError", acceptPromise2);
       return [acceptPromise1];
     });
 
   await request1.abort();
-  await promise_rejects(t, "AbortError", acceptPromise1);
+  await promise_rejects_dom(t, "AbortError", acceptPromise1);
 }, `If the user agent's "payment request is showing" boolean is true, then return a promise rejected with an "AbortError" DOMException.`);
 
 promise_test(async t => {
@@ -86,7 +86,7 @@ promise_test(async t => {
       const acceptPromise = request.show();
       return [acceptPromise];
     });
-  await promise_rejects(t, "NotSupportedError", acceptPromise);
+  await promise_rejects_dom(t, "NotSupportedError", acceptPromise);
 }, `If payment method consultation produces no supported method of payment, then return a promise rejected with a "NotSupportedError" DOMException.`);
 
 promise_test(async t => {
@@ -102,11 +102,11 @@ promise_test(async t => {
   const promises = new Set([p1, p2, p3]);
   assert_equals(promises.size, 3, "Must have three unique objects");
 
-  await promise_rejects(t, "InvalidStateError", p2);
-  await promise_rejects(t, "InvalidStateError", p3);
+  await promise_rejects_dom(t, "InvalidStateError", p2);
+  await promise_rejects_dom(t, "InvalidStateError", p3);
 
   await request.abort();
-  await promise_rejects(t, "AbortError", p1);
+  await promise_rejects_dom(t, "AbortError", p1);
 }, "Calling show() multiple times always returns a new promise.");
 
 </script>

--- a/payment-request/payment-response/complete-method-manual.https.html
+++ b/payment-request/payment-response/complete-method-manual.https.html
@@ -21,7 +21,7 @@ async function runManualTest({ completeWith: result }, button) {
       assert_true(completePromise instanceof Promise, "returns a promise");
       // Immediately calling complete() again yields a rejected promise.
       invalidComplete = response.complete(result);
-      await promise_rejects(t, "InvalidStateError", invalidComplete);
+      await promise_rejects_dom(t, "InvalidStateError", invalidComplete);
       // but the original promise is unaffected
       const returnedValue = await completePromise;
       assert_equals(
@@ -32,7 +32,7 @@ async function runManualTest({ completeWith: result }, button) {
       // We now call .complete() again, to force an exception
       // because [[complete]] is true.
       afterComplete = response.complete(result);
-      await promise_rejects(t, "InvalidStateError", afterComplete);
+      await promise_rejects_dom(t, "InvalidStateError", afterComplete);
       button.innerHTML = `✅  ${button.textContent}`;
     } catch (err) {
       button.innerHTML = `❌  ${button.textContent}`;

--- a/payment-request/payment-response/payerdetailschange-updateWith-immediate-manual.https.html
+++ b/payment-request/payment-response/payerdetailschange-updateWith-immediate-manual.https.html
@@ -30,7 +30,7 @@ function testImmediateUpdate({ textContent: testName }) {
     const retryPromise = response.retry({
       payer: { name: "Change me!" },
     });
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       eventPromise,

--- a/payment-request/payment-response/payerdetailschange-updateWith-manual.https.html
+++ b/payment-request/payment-response/payerdetailschange-updateWith-manual.https.html
@@ -24,7 +24,7 @@ function runTest(button) {
     await response.retry({
       payer: { name: "Change me!" },
     });
-    await promise_rejects(t, "InvalidStateError", eventPromise);
+    await promise_rejects_dom(t, "InvalidStateError", eventPromise);
     await response.complete("success");
   }, button.textContent.trim());
 }

--- a/payment-request/payment-response/rejects_if_not_active-manual.https.html
+++ b/payment-request/payment-response/rejects_if_not_active-manual.https.html
@@ -72,7 +72,7 @@ function methodNotFullyActive(button, method, ...args) {
     // Now, response's relevant global object's document is no longer active.
     // So, promise needs to reject appropriately.
     const promise = response[methodName](...args);
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "AbortError",
       promise,
@@ -107,7 +107,7 @@ function methodBecomesNotFullyActive(button, methodName, ...args) {
 
     // Now, response's relevant global object's document is no longer active.
     // So, promise needs to reject appropriately.
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "AbortError",
       promise,

--- a/payment-request/payment-response/retry-method-manual.https.html
+++ b/payment-request/payment-response/retry-method-manual.https.html
@@ -25,7 +25,7 @@ function checkCompletedCantRetry(button) {
     const { response } = await getPaymentRequestResponse();
     // sets response.[[complete]] to true.
     await response.complete("success");
-    return promise_rejects(
+    return promise_rejects_dom(
       t,
       "InvalidStateError",
       response.retry(),
@@ -39,7 +39,7 @@ function repeatedCallsToRetry(button) {
   promise_test(async t => {
     const { response } = await getPaymentRequestResponse();
     const retryPromise = response.retry();
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       response.retry(),
@@ -62,13 +62,13 @@ function callCompleteWhileRetrying(button) {
       completePromise2,
       "complete() must return unique promises"
     );
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       completePromise1,
       "Calling complete() while retrying rejects with an InvalidStateError"
     );
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       completePromise2,
@@ -89,7 +89,7 @@ function callingRequestAbortMustNotAbort(button) {
   promise_test(async t => {
     const { response, request } = await getPaymentRequestResponse();
     const retryPromise = response.retry();
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       request.abort(),
@@ -115,7 +115,7 @@ function canRetryMultipleTimes(button) {
       "Expected undefined as the resolve value"
     );
     await response.complete("success");
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       response.retry(),
@@ -128,19 +128,19 @@ function userCanAbortARetry(button) {
   button.disabled = true;
   promise_test(async t => {
     const { response } = await getPaymentRequestResponse();
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "AbortError",
       response.retry(),
       "The user aborting a retry rejects with a AbortError"
     );
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       response.retry(),
       "After the user aborts, response [[complete]] is true so retry() must reject with InvalidStateError"
     );
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       response.complete("success"),
@@ -182,7 +182,7 @@ function abortTheUpdate(button) {
       retryPromise,
       "retry() aborts with a TypeError, because totals' value is invalid"
     );
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       response.complete("success"),

--- a/payment-request/rejects_if_not_active-manual.https.html
+++ b/payment-request/rejects_if_not_active-manual.https.html
@@ -68,7 +68,7 @@ function testAbortShowIfDocumentIsNotActive() {
     );
     // Now, request1's relevant global object's document is no longer active.
     // So, call .show(), and make sure it rejects appropriately.
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "AbortError",
       request1.show(),
@@ -77,7 +77,7 @@ function testAbortShowIfDocumentIsNotActive() {
     // request2 has an active document tho, so confirm it's working as expected:
     request2.show();
     await request2.abort();
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       request2.show(),
@@ -125,7 +125,7 @@ function testAbortShowIfDocumentIsNotFullyActive() {
     // (it is the active document of the inner iframe), but is not fully active
     // (since the parent of the inner iframe is itself no longer active).
     // So, call request.show() and make sure it rejects appropriately.
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "AbortError",
       showPromise,

--- a/payment-request/show-method-optional-promise-resolves-manual.https.html
+++ b/payment-request/show-method-optional-promise-resolves-manual.https.html
@@ -190,7 +190,7 @@ function runUpdateDetailsAlgorithm(
     const detailsPromise = Promise.resolve(details);
     const acceptPromise = request.show(detailsPromise);
     assert_equals(request.id, "this cannot be changed", "id must never change.");
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "AbortError",
       acceptPromise,

--- a/payment-request/user-abort-algorithm-manual.https.html
+++ b/payment-request/user-abort-algorithm-manual.https.html
@@ -50,9 +50,9 @@ async function runAbortTest(button) {
   promise_test(async t => {
     const request = new PaymentRequest(validMethods, validDetails);
     // Await the user to abort
-    await promise_rejects(t, "AbortError", request.show());
+    await promise_rejects_dom(t, "AbortError", request.show());
     // [[state]] is now closed
-    await promise_rejects(t, "InvalidStateError", request.show());
+    await promise_rejects_dom(t, "InvalidStateError", request.show());
   }, testName.trim());
 }
 </script>

--- a/payment-request/user-accepts-payment-request-algo-manual.https.html
+++ b/payment-request/user-accepts-payment-request-algo-manual.https.html
@@ -97,7 +97,7 @@ function testAcceptRequestAlgorithm(
     await response.complete("success");
     // For good measure, test that subsequent complete()
     for (const state of [undefined, "success", "fail", "unknown"]) {
-      await promise_rejects(
+      await promise_rejects_dom(
         t,
         "InvalidStateError",
         response.complete(state),
@@ -143,7 +143,7 @@ function testAcceptRequestAlgorithm(
         `response.${attr} must be ${expectedValue}`
       );
     }
-    await promise_rejects(
+    await promise_rejects_dom(
       t,
       "InvalidStateError",
       request.show(),

--- a/picture-in-picture/disable-picture-in-picture.html
+++ b/picture-in-picture/disable-picture-in-picture.html
@@ -28,7 +28,7 @@ test(t => {
 promise_test(async t => {
   const video = await loadVideo();
   video.disablePictureInPicture = true;
-  return promise_rejects(t, 'InvalidStateError',
+  return promise_rejects_dom(t, 'InvalidStateError',
       requestPictureInPictureWithTrustedClick(video));
 }, 'Request Picture-in-Picture rejects if disablePictureInPicture is true');
 
@@ -37,7 +37,7 @@ promise_test(async t => {
   await test_driver.bless('request Picture-in-Picture');
   const promise = video.requestPictureInPicture();
   video.disablePictureInPicture = true;
-  await promise_rejects(t, 'InvalidStateError', promise);
+  await promise_rejects_dom(t, 'InvalidStateError', promise);
   assert_equals(document.pictureInPictureElement, null);
 }, 'Request Picture-in-Picture rejects if disablePictureInPicture becomes ' +
    'true before promise resolves.');

--- a/picture-in-picture/exit-picture-in-picture.html
+++ b/picture-in-picture/exit-picture-in-picture.html
@@ -15,7 +15,7 @@ promise_test(async t => {
 }, 'Exit Picture-in-Picture resolves when there is a Picture-in-Picture video');
 
 promise_test(t => {
-  return promise_rejects(t, 'InvalidStateError',
+  return promise_rejects_dom(t, 'InvalidStateError',
       document.exitPictureInPicture());
 }, 'Exit Picture-in-Picture rejects when there is no Picture-in-Picture video');
 </script>

--- a/picture-in-picture/request-picture-in-picture-twice.html
+++ b/picture-in-picture/request-picture-in-picture-twice.html
@@ -14,7 +14,7 @@ promise_test(async t => {
   const video2 = await loadVideo();
   await test_driver.bless('request Picture-in-Picture');
   const promise = video1.requestPictureInPicture();
-  await promise_rejects(t, 'NotAllowedError', video2.requestPictureInPicture());
+  await promise_rejects_dom(t, 'NotAllowedError', video2.requestPictureInPicture());
   return promise;
 }, 'request Picture-in-Picture consumes user gesture');
 

--- a/picture-in-picture/request-picture-in-picture.html
+++ b/picture-in-picture/request-picture-in-picture.html
@@ -10,12 +10,12 @@
 <script>
 promise_test(async t => {
   const video = await loadVideo();
-  return promise_rejects(t, 'NotAllowedError', video.requestPictureInPicture());
+  return promise_rejects_dom(t, 'NotAllowedError', video.requestPictureInPicture());
 }, 'request Picture-in-Picture requires a user gesture');
 
 promise_test(t => {
   const video = document.createElement('video');
-  return promise_rejects(t, 'InvalidStateError',
+  return promise_rejects_dom(t, 'InvalidStateError',
       requestPictureInPictureWithTrustedClick(video));
 }, 'request Picture-in-Picture requires loaded metadata for the video element');
 
@@ -25,7 +25,7 @@ promise_test(async t => {
     video.src = getAudioURI('/media/sound_5');
     video.onloadeddata = resolve;
   }).then(() => {
-    return promise_rejects(t, 'InvalidStateError',
+    return promise_rejects_dom(t, 'InvalidStateError',
       requestPictureInPictureWithTrustedClick(video));
   })
 }, 'request Picture-in-Picture requires video track for the video element');

--- a/portals/about-blank-cannot-host.html
+++ b/portals/about-blank-cannot-host.html
@@ -11,7 +11,7 @@ promise_test(async (t) => {
   portal.src = "resources/simple-portal.html";
   hostWindow.document.body.appendChild(portal);
 
-  await promise_rejects(t, "InvalidStateError", portal.activate());
+  await promise_rejects_dom(t, "InvalidStateError", portal.activate());
 }, "about:blank cannot host a portal");
 
 </script>

--- a/portals/portal-activate-data.html
+++ b/portals/portal-activate-data.html
@@ -70,7 +70,7 @@ promise_test(async () => {
 }, "A message port can be passed through activate data.");
 
 promise_test(async t => {
-await promise_rejects(
+await promise_rejects_dom(
     t, 'DataCloneError',
     openPortalAndActivate('', {data: new SharedArrayBuffer}));
 }, "A SharedArrayBuffer cannot be passed through activate data.");

--- a/portals/portals-activate-inside-iframe.html
+++ b/portals/portals-activate-inside-iframe.html
@@ -12,7 +12,7 @@
       document.body.appendChild(iframe);
       await waitForLoad;
       const portal = iframe.contentDocument.getElementById("portal");
-      return promise_rejects(t, "InvalidStateError", portal.activate());
+      return promise_rejects_dom(t, "InvalidStateError", portal.activate());
     }, "activating portal inside iframe should fail");
   </script>
 </body>

--- a/portals/portals-activate-no-browsing-context.html
+++ b/portals/portals-activate-no-browsing-context.html
@@ -4,6 +4,6 @@
 <script>
 promise_test(async t => {
   let activatePromise = document.createElement('portal').activate();
-  await promise_rejects(t, 'InvalidStateError', activatePromise);
+  await promise_rejects_dom(t, 'InvalidStateError', activatePromise);
 }, "A portal with nothing in it cannot be activated");
 </script>

--- a/portals/portals-post-message.sub.html
+++ b/portals/portals-post-message.sub.html
@@ -157,13 +157,13 @@
 
     promise_test(async t => {
       var portal = document.createElement("portal");
-      return promise_rejects(t, "InvalidStateError",
+      return promise_rejects_dom(t, "InvalidStateError",
                              postMessage(portal, "test message"));
     }, "cannot call postMessage on portal without portal browsing context");
 
     promise_test(async t => {
       var portal = await createAndInsertPortal(sameOriginUrl);
-      return promise_rejects(t, "DataCloneError",
+      return promise_rejects_dom(t, "DataCloneError",
                              postMessage(portal, document.body));
     }, "postMessage should fail if message serialization fails");
 

--- a/presentation-api/controlling-ua/reconnectToPresentation_notfound_error-manual.https.html
+++ b/presentation-api/controlling-ua/reconnectToPresentation_notfound_error-manual.https.html
@@ -31,7 +31,7 @@
       }
     });
 
-    await promise_rejects(t, 'NotFoundError', request1.reconnect(wrongPresentationId),
+    await promise_rejects_dom(t, 'NotFoundError', request1.reconnect(wrongPresentationId),
       'Reconnecting with an unknown presentation ID fails with a NotFoundError exception.');
 
     setup({explicit_timeout: true});
@@ -50,7 +50,7 @@
     connection1.close();
     await eventWatcher1.wait_for('close');
 
-    await promise_rejects(t, 'NotFoundError', request2.reconnect(connection1.id),
+    await promise_rejects_dom(t, 'NotFoundError', request2.reconnect(connection1.id),
       'Reconnecting with a presentation ID on a presentation request with a different URL fails with a NotFoundError exception.');
 
     await request1.reconnect(connection1.id);

--- a/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html
+++ b/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html
@@ -178,7 +178,7 @@
             return Promise.all([ eventWatcher.wait_for('terminate'), waitForMessage().then(parseResult) ]);
         }).then(() => {
             // Try to reconnect to the presentation, while all presentation connection have already been terminated
-            return promise_rejects(t, 'NotFoundError', request.reconnect(presentationId),
+            return promise_rejects_dom(t, 'NotFoundError', request.reconnect(presentationId),
                 'Reconnecting to a terminated presentation rejects a promise with a "NotFoundError" exception.');
         });
     });

--- a/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html
+++ b/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html
@@ -36,7 +36,7 @@
                     connection.terminate();
             });
 
-            return promise_rejects(t, 'NotAllowedError', request.start().then(function(c) { connection = c; }));
+            return promise_rejects_dom(t, 'NotAllowedError', request.start().then(function(c) { connection = c; }));
         });
     };
     // -----------------------------------------

--- a/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html
+++ b/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html
@@ -36,7 +36,7 @@
                     connection.terminate();
             });
 
-            return promise_rejects(t, 'NotFoundError', request.start().then(function(c) { connection = c; }));
+            return promise_rejects_dom(t, 'NotFoundError', request.start().then(function(c) { connection = c; }));
         });
     };
     // -----------------------------------------

--- a/presentation-api/controlling-ua/startNewPresentation_error.https.html
+++ b/presentation-api/controlling-ua/startNewPresentation_error.https.html
@@ -11,7 +11,7 @@
     // -----------------------------------
     promise_test(function (t) {
       var request = new PresentationRequest('presentation.html');
-      return promise_rejects(t, 'InvalidAccessError', request.start());
+      return promise_rejects_dom(t, 'InvalidAccessError', request.start());
     }, "The presentation could not start, because a user gesture is required.");
     // ----------------------------------
     // Launch New Presentation Test - end

--- a/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.https.html
+++ b/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.https.html
@@ -35,7 +35,7 @@
             var request1 = new PresentationRequest(presentationUrls),
                 request2 = new PresentationRequest(presentationUrls);
             request1.start().then(terminate, function(){});
-            return promise_rejects(t, 'OperationError', request2.start().then(terminate));
+            return promise_rejects_dom(t, 'OperationError', request2.start().then(terminate));
         });
     };
     // -----------------------------------------

--- a/remote-playback/disable-remote-playback-prompt-throws.html
+++ b/remote-playback/disable-remote-playback-prompt-throws.html
@@ -10,7 +10,7 @@ promise_test(t => {
   v.src = getVideoURI('/media/movie_5');
   v.disableRemotePlayback = true;
 
-  return promise_rejects(t, 'InvalidStateError', v.remote.prompt());
+  return promise_rejects_dom(t, 'InvalidStateError', v.remote.prompt());
 }, 'Test that calling prompt() when disableRemotePlayback attribute is set throws an exception.');
 </script>
 </html>

--- a/remote-playback/disable-remote-playback-watch-availability-throws.html
+++ b/remote-playback/disable-remote-playback-watch-availability-throws.html
@@ -10,7 +10,7 @@ promise_test(t => {
   v.src = getVideoURI('/media/movie_5');
   v.disableRemotePlayback = true;
 
-  return promise_rejects(t, 'InvalidStateError',
+  return promise_rejects_dom(t, 'InvalidStateError',
                          v.remote.watchAvailability(function() {}));
 }, 'Test that calling watchAvailability() when disableRemotePlayback attribute is set throws an exception.');
 </script>

--- a/screen-orientation/lock-unlock-check.html
+++ b/screen-orientation/lock-unlock-check.html
@@ -24,7 +24,7 @@
         r(screen.orientation.lock("any"));
       };
     });
-    await promise_rejects(t, "AbortError", pMustReject);
+    await promise_rejects_dom(t, "AbortError", pMustReject);
     await pMustResolve;
   }, "Re-locking orientation during event dispatch must reject existing orientationPendingPromise");
 </script>

--- a/service-workers/cache-storage/script-tests/cache-abort.js
+++ b/service-workers/cache-storage/script-tests/cache-abort.js
@@ -23,7 +23,7 @@ for (const method in methodsToTest) {
     const signal = controller.signal;
     controller.abort();
     const request = new Request('../resources/simple.txt', { signal });
-    return promise_rejects(test, 'AbortError', perform(cache, request),
+    return promise_rejects_dom(test, 'AbortError', perform(cache, request),
                           `${method} should reject`);
   }, `${method}() on an already-aborted request should reject with AbortError`);
 
@@ -33,7 +33,7 @@ for (const method in methodsToTest) {
     const request = new Request('../resources/simple.txt', { signal });
     const promise = perform(cache, request);
     controller.abort();
-    return promise_rejects(test, 'AbortError', promise,
+    return promise_rejects_dom(test, 'AbortError', promise,
                           `${method} should reject`);
   }, `${method}() synchronously followed by abort should reject with ` +
      `AbortError`);
@@ -69,7 +69,7 @@ for (const method in methodsToTest) {
 
     controller.abort();
 
-    await promise_rejects(test, 'AbortError', promise,
+    await promise_rejects_dom(test, 'AbortError', promise,
                           `${method} should reject`);
 
     // infinite-slow-response.py doesn't know when to stop.

--- a/service-workers/cache-storage/script-tests/cache-add.js
+++ b/service-workers/cache-storage/script-tests/cache-add.js
@@ -259,7 +259,7 @@ cache_test(function(cache, test) {
 
 cache_test(function(cache, test) {
     var request = new Request('../resources/simple.txt');
-    return promise_rejects(
+    return promise_rejects_dom(
       test,
       'InvalidStateError',
       cache.addAll([request, request]),
@@ -283,7 +283,7 @@ cache_test(async function(cache, test) {
       new Request(url, { headers: { 'x-shape': 'circle' }}),
       new Request(url, { headers: { 'x-shape': 'circle' }}),
     ];
-    await promise_rejects(
+    await promise_rejects_dom(
       test,
       'InvalidStateError',
       cache.addAll(requests),
@@ -329,7 +329,7 @@ cache_test(async function(cache, test) {
                                     'x-size': 'big' },
                          credentials: 'omit' }),
     ];
-    await promise_rejects(
+    await promise_rejects_dom(
       test,
       'InvalidStateError',
       cache.addAll(requests),
@@ -337,7 +337,7 @@ cache_test(async function(cache, test) {
       'matching an earlier entry.');
 
     // Test the reverse order now.
-    await promise_rejects(
+    await promise_rejects_dom(
       test,
       'InvalidStateError',
       cache.addAll(requests.reverse()),

--- a/service-workers/service-worker/Service-Worker-Allowed-header.https.html
+++ b/service-workers/service-worker/Service-Worker-Allowed-header.https.html
@@ -39,7 +39,7 @@ function register_fail_test(script, scope, description) {
     });
 
     await service_worker_unregister(t, scope);
-    await promise_rejects(t,
+    await promise_rejects_dom(t,
                           'SecurityError',
                           navigator.serviceWorker.register(script, {scope}));
   }, description);

--- a/service-workers/service-worker/navigation-preload/get-state.https.html
+++ b/service-workers/service-worker/navigation-preload/get-state.https.html
@@ -195,13 +195,13 @@ promise_test(t => {
         np = registration.navigationPreload;
         add_completion_callback(() => registration.unregister());
         return Promise.all([
-            promise_rejects(
+            promise_rejects_dom(
                 t, 'InvalidStateError', np.enable(),
                 'enable should reject if there is no active worker'),
-            promise_rejects(
+            promise_rejects_dom(
                 t, 'InvalidStateError', np.disable(),
                 'disable should reject if there is no active worker'),
-            promise_rejects(
+            promise_rejects_dom(
                 t, 'InvalidStateError', np.setHeaderValue('umm'),
                 'setHeaderValue should reject if there is no active worker')]);
       })

--- a/service-workers/service-worker/update.https.html
+++ b/service-workers/service-worker/update.https.html
@@ -97,7 +97,7 @@ promise_test(async t => {
       await prepare_ready_registration_with_mode(t, 'bad_mime_type');
   t.add_cleanup(() => registration.unregister());
 
-  await promise_rejects(t, 'SecurityError', registration.update());
+  await promise_rejects_dom(t, 'SecurityError', registration.update());
   assert_active_only(registration, expected_url);
 }, 'update() should fail when mime type is invalid.');
 

--- a/shape-detection/shapedetection-cross-origin.sub.https.html
+++ b/shape-detection/shapedetection-cross-origin.sub.https.html
@@ -30,7 +30,7 @@ for (let crossOriginTest of crossOriginTests) {
     img.src = IMAGE_URL;
     await imgWatcher.wait_for("load");
     const detector = crossOriginTest.createDetector();
-    promise_rejects(t, "SecurityError", detector.detect(img));
+    promise_rejects_dom(t, "SecurityError", detector.detect(img));
   }, crossOriginTest.detectorType
   + " should reject cross-origin HTMLImageElements with a SecurityError.");
 
@@ -42,7 +42,7 @@ for (let crossOriginTest of crossOriginTests) {
     await imgWatcher.wait_for("load");
     const imgBitmap = await createImageBitmap(img);
     const detector = crossOriginTest.createDetector();
-    promise_rejects(t, "SecurityError", detector.detect(imgBitmap));
+    promise_rejects_dom(t, "SecurityError", detector.detect(imgBitmap));
   }, crossOriginTest.detectorType
   + " should reject cross-origin ImageBitmaps with a SecurityError.");
 
@@ -53,7 +53,7 @@ for (let crossOriginTest of crossOriginTests) {
     video.src = VIDEO_URL;
     await videoWatcher.wait_for("loadeddata");
     const detector = crossOriginTest.createDetector();
-    promise_rejects(t, "SecurityError", detector.detect(video));
+    promise_rejects_dom(t, "SecurityError", detector.detect(video));
   }, crossOriginTest.detectorType
   + " should reject cross-origin HTMLVideoElements with a SecurityError.");
 

--- a/sms/interceptor.https.html
+++ b/sms/interceptor.https.html
@@ -119,7 +119,7 @@ promise_test(async t => {
   const signal = controller.signal;
 
   controller.abort();
-  await promise_rejects(t, 'AbortError', navigator.sms.receive({signal}));
+  await promise_rejects_dom(t, 'AbortError', navigator.sms.receive({signal}));
 }, 'Should abort request');
 
 promise_test(async t => {
@@ -128,7 +128,7 @@ promise_test(async t => {
 
   let error = navigator.sms.receive({signal});
   controller.abort();
-  await promise_rejects(t, 'AbortError', error);
+  await promise_rejects_dom(t, 'AbortError', error);
 }, 'Should abort request even while request is in progress.');
 
 </script>

--- a/streams/piping/abort.any.js
+++ b/streams/piping/abort.any.js
@@ -39,10 +39,10 @@ promise_test(t => {
   const abortController = new AbortController();
   const signal = abortController.signal;
   abortController.abort();
-  return promise_rejects(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject')
+  return promise_rejects_dom(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject')
       .then(() => Promise.all([
         rs.getReader().closed,
-        promise_rejects(t, 'AbortError', ws.getWriter().closed, 'writer.closed should reject')
+        promise_rejects_dom(t, 'AbortError', ws.getWriter().closed, 'writer.closed should reject')
       ]))
       .then(() => {
         assert_equals(rs.events.length, 2, 'cancel should have been called');
@@ -83,7 +83,7 @@ promise_test(t => {
   const abortController = new AbortController();
   const signal = abortController.signal;
   abortController.abort();
-  return promise_rejects(t, 'AbortError', rs.pipeTo(ws, { signal, preventCancel: true }), 'pipeTo should reject')
+  return promise_rejects_dom(t, 'AbortError', rs.pipeTo(ws, { signal, preventCancel: true }), 'pipeTo should reject')
       .then(() => assert_equals(rs.events.length, 0, 'cancel should not be called'));
 }, 'preventCancel should prevent canceling the readable');
 
@@ -93,7 +93,7 @@ promise_test(t => {
   const abortController = new AbortController();
   const signal = abortController.signal;
   abortController.abort();
-  return promise_rejects(t, 'AbortError', rs.pipeTo(ws, { signal, preventAbort: true }), 'pipeTo should reject')
+  return promise_rejects_dom(t, 'AbortError', rs.pipeTo(ws, { signal, preventAbort: true }), 'pipeTo should reject')
       .then(() => {
         assert_equals(ws.events.length, 0, 'writable should not have been aborted');
         return ws.getWriter().ready;
@@ -106,7 +106,7 @@ promise_test(t => {
   const abortController = new AbortController();
   const signal = abortController.signal;
   abortController.abort();
-  return promise_rejects(t, 'AbortError', rs.pipeTo(ws, { signal, preventCancel: true, preventAbort: true }),
+  return promise_rejects_dom(t, 'AbortError', rs.pipeTo(ws, { signal, preventCancel: true, preventAbort: true }),
                          'pipeTo should reject')
     .then(() => {
       assert_equals(rs.events.length, 0, 'cancel should not be called');
@@ -130,7 +130,7 @@ promise_test(t => {
       abortController.abort();
     }
   });
-  return promise_rejects(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject')
+  return promise_rejects_dom(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject')
       .then(() => {
         assert_equals(ws.events.length, 4, 'only chunk "a" should have been written');
         assert_array_equals(ws.events.slice(0, 3), ['write', 'a', 'abort'], 'events should match');
@@ -163,7 +163,7 @@ promise_test(t => {
     abortController.abort();
     readController.close(); // Make sure the test terminates when signal is not implemented.
     resolveWrite();
-    return promise_rejects(t, 'AbortError', pipeToPromise, 'pipeTo should reject');
+    return promise_rejects_dom(t, 'AbortError', pipeToPromise, 'pipeTo should reject');
   }).then(() => {
     assert_equals(ws.events.length, 6, 'chunks "a" and "b" should have been written');
     assert_array_equals(ws.events.slice(0, 5), ['write', 'a', 'write', 'b', 'abort'], 'events should match');
@@ -234,7 +234,7 @@ promise_test(t => {
   const abortController = new AbortController();
   const signal = abortController.signal;
   abortController.abort();
-  return promise_rejects(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject');
+  return promise_rejects_dom(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject');
 }, 'abort signal takes priority over closed readable');
 
 promise_test(t => {
@@ -247,7 +247,7 @@ promise_test(t => {
   const abortController = new AbortController();
   const signal = abortController.signal;
   abortController.abort();
-  return promise_rejects(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject');
+  return promise_rejects_dom(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject');
 }, 'abort signal takes priority over errored readable');
 
 promise_test(t => {
@@ -263,7 +263,7 @@ promise_test(t => {
   const writer = ws.getWriter();
   return writer.close().then(() => {
     writer.releaseLock();
-    return promise_rejects(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject');
+    return promise_rejects_dom(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject');
   });
 }, 'abort signal takes priority over closed writable');
 
@@ -281,7 +281,7 @@ promise_test(t => {
   const abortController = new AbortController();
   const signal = abortController.signal;
   abortController.abort();
-  return promise_rejects(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject');
+  return promise_rejects_dom(t, 'AbortError', rs.pipeTo(ws, { signal }), 'pipeTo should reject');
 }, 'abort signal takes priority over errored writable');
 
 promise_test(() => {

--- a/wake-lock/wakelock-active-document.https.window.js
+++ b/wake-lock/wakelock-active-document.https.window.js
@@ -27,7 +27,7 @@ promise_test(async t => {
   );
   // Now, wakeLock1's relevant global object's document is no longer active.
   // So, call .request(), and make sure it rejects appropriately.
-  await promise_rejects(
+  await promise_rejects_dom(
     t,
     "NotAllowedError",
     wakeLock1.request('screen'),
@@ -70,7 +70,7 @@ promise_test(async t => {
   // (it is the active document of the inner iframe), but is not fully active
   // (since the parent of the inner iframe is itself no longer active).
   // So, call request.show() and make sure it rejects appropriately.
-  await promise_rejects(
+  await promise_rejects_dom(
     t,
     "NotAllowedError",
     wakeLock.request('screen'),

--- a/wake-lock/wakelock-disabled-by-feature-policy.https.sub.html
+++ b/wake-lock/wakelock-disabled-by-feature-policy.https.sub.html
@@ -12,7 +12,7 @@
     "https://{{domains[www]}}:{{ports[https][0]}}" + same_origin_src;
 
   promise_test(t => {
-    return promise_rejects(t, "NotAllowedError", navigator.wakeLock.request("screen"));
+    return promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request("screen"));
   }, 'Feature-Policy header {"wake-lock" : []} disallows the top-level document.');
 
   async_test(t => {

--- a/wake-lock/wakelock-document-hidden-manual.https.html
+++ b/wake-lock/wakelock-document-hidden-manual.https.html
@@ -16,7 +16,7 @@ promise_test(async t => {
   await eventWatcher.wait_for("visibilitychange");
   assert_true(document.hidden, "document is hidden after the visibilitychange event");
   await screenWakeLockReleased;
-  await promise_rejects(t, "NotAllowedError", navigator.wakeLock.request('screen'),
+  await promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request('screen'),
       "new screen locks are not allowed when the page is not visible");
 
   await eventWatcher.wait_for("visibilitychange");

--- a/wake-lock/wakelock-screen-type-on-worker.https.worker.js
+++ b/wake-lock/wakelock-screen-type-on-worker.https.worker.js
@@ -2,7 +2,7 @@
 importScripts("/resources/testharness.js");
 
 promise_test(t => {
-  return promise_rejects(t, "NotAllowedError", navigator.wakeLock.request('screen'));
+  return promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request('screen'));
 }, "Screen wake lock should not be allowed in dedicated worker");
 
 done();

--- a/web-animations/timing-model/animations/canceling-an-animation.html
+++ b/web-animations/timing-model/animations/canceling-an-animation.html
@@ -49,7 +49,7 @@ promise_test(async t => {
   const originalPromise = animation.ready;
   animation.cancel();
 
-  await promise_rejects(t, 'AbortError', originalPromise,
+  await promise_rejects_dom(t, 'AbortError', originalPromise,
                         'Cancel should abort ready promise');
 }, 'A pause-pending ready promise should be rejected when the animation is'
    + ' canceled');
@@ -66,7 +66,7 @@ test(t => {
   const promise = animation.ready;
   animation.cancel();
   assert_not_equals(animation.ready, promise);
-  promise_rejects(t, 'AbortError', promise, 'Cancel should abort ready promise');
+  promise_rejects_dom(t, 'AbortError', promise, 'Cancel should abort ready promise');
 }, 'The ready promise should be replaced when the animation is canceled');
 
 promise_test(t => {

--- a/web-locks/acquire.tentative.https.any.js
+++ b/web-locks/acquire.tentative.https.any.js
@@ -28,7 +28,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   const res = uniqueName(t);
-  await promise_rejects(
+  await promise_rejects_dom(
     t, 'NotSupportedError',
     navigator.locks.request(
       res, {steal: true, ifAvailable: true}, lock => {}),
@@ -38,7 +38,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   const res = uniqueName(t);
-  await promise_rejects(
+  await promise_rejects_dom(
     t, 'NotSupportedError',
     navigator.locks.request(res, {mode: 'shared', steal: true}, lock => {}),
     'Request with mode=shared and steal=true should fail');
@@ -47,7 +47,7 @@ promise_test(async t => {
 promise_test(async t => {
   const res = uniqueName(t);
   const controller = new AbortController();
-  await promise_rejects(
+  await promise_rejects_dom(
     t, 'NotSupportedError',
     navigator.locks.request(
       res, {signal: controller.signal, steal: true}, lock => {}),
@@ -57,7 +57,7 @@ promise_test(async t => {
 promise_test(async t => {
   const res = uniqueName(t);
   const controller = new AbortController();
-  await promise_rejects(
+  await promise_rejects_dom(
     t, 'NotSupportedError',
     navigator.locks.request(
       res, {signal: controller.signal, ifAvailable: true}, lock => {}),

--- a/web-locks/resource-names.tentative.https.any.js
+++ b/web-locks/resource-names.tentative.https.any.js
@@ -43,7 +43,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   for (const name of ['-', '-foo']) {
-    await promise_rejects(
+    await promise_rejects_dom(
       t, 'NotSupportedError',
       navigator.locks.request(name, lock => {}),
       'Names starting with "-" should be rejected');

--- a/web-locks/signal.tentative.https.any.js
+++ b/web-locks/signal.tentative.https.any.js
@@ -28,7 +28,7 @@ promise_test(async t => {
   const controller = new AbortController();
   controller.abort();
 
-  await promise_rejects(
+  await promise_rejects_dom(
     t, 'AbortError',
     navigator.locks.request(res, {signal: controller.signal},
                             t.unreached_func('callback should not run')),
@@ -55,7 +55,7 @@ promise_test(async t => {
   assert_equals(state.pending.filter(lock => lock.name === res).length, 1,
                 'Number of pending locks');
 
-  const rejected = promise_rejects(
+  const rejected = promise_rejects_dom(
     t, 'AbortError', promise, 'Request should reject with AbortError');
 
   controller.abort();
@@ -83,7 +83,7 @@ promise_test(async t => {
   assert_equals(state.pending.filter(lock => lock.name === res).length, 1,
                 'Number of pending locks');
 
-  const rejected = promise_rejects(
+  const rejected = promise_rejects_dom(
     t, 'AbortError', promise, 'Request should reject with AbortError');
 
   let callback_called = false;
@@ -122,7 +122,7 @@ promise_test(async t => {
   // Even though lock is grantable, this abort should be processed synchronously.
   controller.abort();
 
-  await promise_rejects(t, 'AbortError', p, 'Request should abort');
+  await promise_rejects_dom(t, 'AbortError', p, 'Request should abort');
 
   assert_false(got_lock, 'Request should be aborted if signal is synchronous');
 

--- a/web-locks/steal.tentative.https.any.js
+++ b/web-locks/steal.tentative.https.any.js
@@ -37,7 +37,7 @@ promise_test(async t => {
 
   // Grab and hold the lock.
   const promise = navigator.locks.request(res, lock => never_settled);
-  const assertion = promise_rejects(
+  const assertion = promise_rejects_dom(
     t, 'AbortError', promise, `Initial request's promise should reject`);
 
   // Steal it.

--- a/web-nfc/NDEFReader_scan.https.html
+++ b/web-nfc/NDEFReader_scan.https.html
@@ -22,7 +22,7 @@ const invalid_signals = [
 
 function waitSyntaxErrorPromise(t, scan_options) {
   const reader = new NDEFReader();
-  return promise_rejects(t, 'SyntaxError', reader.scan(scan_options));
+  return promise_rejects_dom(t, 'SyntaxError', reader.scan(scan_options));
 }
 
 promise_test(async t => {
@@ -42,7 +42,7 @@ promise_test(async t => {
                                     location.origin, location.origin);
   }
   const reader = new NDEFReader();
-  await promise_rejects(t, 'NotAllowedError', reader.scan());
+  await promise_rejects_dom(t, 'NotAllowedError', reader.scan());
 }, "NDEFReader.scan should fail if user permission is not granted.");
 
 // We do not provide NFC mock here to simulate that there has no available
@@ -57,7 +57,7 @@ promise_test(async t => {
   const promise = readerWatcher.wait_for("error").then(event => {
     assert_true(event instanceof ErrorEvent);
   });
-  await promise_rejects(t, 'NotSupportedError', reader.scan());
+  await promise_rejects_dom(t, 'NotSupportedError', reader.scan());
   await promise;
 }, "Test that an error event happens if no implementation for NFC Mojo interface \
 is available.");
@@ -65,13 +65,13 @@ is available.");
 nfc_test(async (t, mockNFC) => {
   mockNFC.setHWStatus(NFCHWStatus.DISABLED);
   const reader = new NDEFReader();
-  await promise_rejects(t, 'NotReadableError', reader.scan());
+  await promise_rejects_dom(t, 'NotReadableError', reader.scan());
 }, "NDEFReader.scan should fail if NFC HW is disabled.");
 
 nfc_test(async (t, mockNFC) => {
   mockNFC.setHWStatus(NFCHWStatus.NOT_SUPPORTED);
   const reader = new NDEFReader();
-  await promise_rejects(t, 'NotSupportedError', reader.scan());
+  await promise_rejects_dom(t, 'NotSupportedError', reader.scan());
 }, "NDEFReader.scan should fail if NFC HW is not supported.");
 
 nfc_test(async (t, mockNFC) => {
@@ -106,7 +106,7 @@ nfc_test(async (t, mockNFC) => {
   const reader = new NDEFReader();
   const controller = new AbortController();
   controller.abort();
-  await promise_rejects(t, 'AbortError', reader.scan({signal: controller.signal}));
+  await promise_rejects_dom(t, 'AbortError', reader.scan({signal: controller.signal}));
 }, "Test that NDEFReader.scan rejects if NDEFScanOptions.signal is already aborted.");
 
 nfc_test(async (t, mockNFC) => {
@@ -114,7 +114,7 @@ nfc_test(async (t, mockNFC) => {
   const controller = new AbortController();
   const promise = reader.scan({signal: controller.signal});
   controller.abort();
-  await promise_rejects(t, 'AbortError', promise);
+  await promise_rejects_dom(t, 'AbortError', promise);
 }, "Test that NDEFReader.scan rejects if NDEFScanOptions.signal aborts right after \
 the scan invocation.");
 

--- a/web-nfc/NDEFWriter_write.https.html
+++ b/web-nfc/NDEFWriter_write.https.html
@@ -128,7 +128,7 @@ promise_test(async t => {
   const promises = [];
   invalid_syntax_messages.forEach(message => {
     promises.push(
-      promise_rejects(t, 'SyntaxError', writer.write(message)));
+      promise_rejects_dom(t, 'SyntaxError', writer.write(message)));
   });
   await Promise.all(promises);
 }, "Test that promise is rejected with SyntaxError if NDEFMessageSource contains\
@@ -141,7 +141,7 @@ promise_test(async t => {
                                     location.origin, location.origin);
   }
   const writer = new NDEFWriter();
-  await promise_rejects(t, 'NotAllowedError', writer.write(test_text_data));
+  await promise_rejects_dom(t, 'NotAllowedError', writer.write(test_text_data));
 }, 'NDEFWriter.write should fail if user permission is not granted.');
 
 // We do not provide NFC mock here to simulate that there has no available
@@ -153,7 +153,7 @@ promise_test(async t => {
                                     location.origin, location.origin);
   }
   const writer = new NDEFWriter();
-  await promise_rejects(t, 'NotSupportedError', writer.write(test_text_data));
+  await promise_rejects_dom(t, 'NotSupportedError', writer.write(test_text_data));
 }, 'NDEFWriter.write should fail if no implementation for NFC Mojo interface is available.');
 
 nfc_test(async (t, mockNFC) => {
@@ -163,7 +163,7 @@ nfc_test(async (t, mockNFC) => {
   //Make sure push is pending
   mockNFC.setPendingPushCompleted(false);
   const p = writer.write(test_text_data, { signal: controller.signal });
-  const rejected = promise_rejects(t, 'AbortError', p);
+  const rejected = promise_rejects_dom(t, 'AbortError', p);
   let callback_called = false;
   await new Promise(resolve => {
     t.step_timeout(() => {
@@ -182,7 +182,7 @@ promise_test(async t => {
   assert_false(controller.signal.aborted);
   controller.abort();
   assert_true(controller.signal.aborted);
-  await promise_rejects(t, 'AbortError',
+  await promise_rejects_dom(t, 'AbortError',
       writer.write(test_text_data, { signal: controller.signal }));
 }, "NDEFWriter.write should fail if signal's aborted flag is set.");
 
@@ -205,7 +205,7 @@ nfc_test(async (t, mockNFC) => {
   // Even though write request is grantable,
   // this abort should be processed synchronously.
   controller.abort();
-  await promise_rejects(t, 'AbortError', p1);
+  await promise_rejects_dom(t, 'AbortError', p1);
 
   await writer2.write(test_text_data);
   assertNDEFMessagesEqual(test_text_data, mockNFC.pushedMessage());
@@ -214,13 +214,13 @@ nfc_test(async (t, mockNFC) => {
 nfc_test(async (t, mockNFC) => {
   const writer = new NDEFWriter();
   mockNFC.setHWStatus(NFCHWStatus.DISABLED);
-  await promise_rejects(t, 'NotReadableError', writer.write(test_text_data));
+  await promise_rejects_dom(t, 'NotReadableError', writer.write(test_text_data));
 }, "NDEFWriter.write should fail when NFC HW is disabled.");
 
 nfc_test(async (t, mockNFC) => {
   const writer = new NDEFWriter();
   mockNFC.setHWStatus(NFCHWStatus.NOT_SUPPORTED);
-  await promise_rejects(t, 'NotSupportedError', writer.write(test_text_data));
+  await promise_rejects_dom(t, 'NotSupportedError', writer.write(test_text_data));
 }, "NDEFWriter.write should fail when NFC HW is not supported.");
 
 promise_test(async () => {
@@ -436,7 +436,7 @@ nfc_test(async (t, mockNFC) => {
   await reader.scan();
 
   mockNFC.simulateNonNDEFTagDiscovered();
-  await promise_rejects(t, 'NotSupportedError', promise);
+  await promise_rejects_dom(t, 'NotSupportedError', promise);
 }, "NDEFWriter.write should fail when the NFC device coming up does not expose \
 NDEF technology.");
 
@@ -460,14 +460,14 @@ nfc_test(async (t, mockNFC) => {
   const writer = new NDEFWriter();
   const p = writer.write(test_text_data, { overwrite: false });
   mockNFC.setIsFormattedTag(true);
-  await promise_rejects(t, 'NotAllowedError', p);
+  await promise_rejects_dom(t, 'NotAllowedError', p);
 }, "NDEFWriter.write should fail when there are NDEF records on the NFC device \
 and NDEFWriteOptions.overwrite is false.");
 
 nfc_test(async (t, mockNFC) => {
   const writer = new NDEFWriter();
   mockNFC.simulateDataTransferFails();
-  await promise_rejects(t, 'NetworkError', writer.write(test_text_data));
+  await promise_rejects_dom(t, 'NetworkError', writer.write(test_text_data));
 }, "NDEFWriter.write should fail with NetworkError when NFC data transfer fails.");
 
 </script>

--- a/web-share/share-cancel-manual.https.html
+++ b/web-share/share-cancel-manual.https.html
@@ -14,7 +14,7 @@
         setupManualShareTestRequiringCancellation();
 
         promise_test(t => {
-          return callWhenButtonClicked(() => promise_rejects(
+          return callWhenButtonClicked(() => promise_rejects_dom(
               t, 'AbortError',
               navigator.share({title: 'the title', text: 'the message',
                                url: 'https://example.com'})));

--- a/web-share/share-sharePromise-internal-slot.https.html
+++ b/web-share/share-sharePromise-internal-slot.https.html
@@ -29,8 +29,8 @@
         test_driver.click(button);
         const [, promise2, promise3] = await p;
         await Promise.all([
-          promise_rejects(t, "InvalidStateError", promise2),
-          promise_rejects(t, "InvalidStateError", promise3)
+          promise_rejects_dom(t, "InvalidStateError", promise2),
+          promise_rejects_dom(t, "InvalidStateError", promise3)
         ]);
       }, "Only allow one share call at a time, which is controlled by the [[sharePromise]] internal slot.");
     </script>

--- a/web-share/share-without-user-gesture.https.html
+++ b/web-share/share-without-user-gesture.https.html
@@ -9,7 +9,7 @@
   <body>
     <script>
         promise_test(t => {
-          return promise_rejects(
+          return promise_rejects_dom(
               t, 'NotAllowedError',
               navigator.share({title: 'the title', text: 'the message',
                                url: 'https://example.com'}));

--- a/webrtc-identity/RTCPeerConnection-getIdentityAssertion.sub.https.html
+++ b/webrtc-identity/RTCPeerConnection-getIdentityAssertion.sub.https.html
@@ -202,7 +202,7 @@
       usernameHint: `alice@${idpDomain}`,
     });
 
-    return promise_rejects(t, 'OperationError',
+    return promise_rejects_dom(t, 'OperationError',
       pc.getIdentityAssertion());
   }, `getIdentityAssertion() should reject with OperationError if mock-idp.js return invalid result`);
 
@@ -371,7 +371,7 @@
       usernameHint: `alice@${idpDomain}`
     });
 
-    return promise_rejects(t, 'OperationError',
+    return promise_rejects_dom(t, 'OperationError',
       pc.createOffer());
   }, 'createOffer() should reject with OperationError if identity assertion request fails');
 
@@ -389,7 +389,7 @@
     .createOffer()
     .then(offer => pc.setRemoteDescription(offer))
     .then(() =>
-      promise_rejects(t, 'OperationError',
+      promise_rejects_dom(t, 'OperationError',
         pc.createAnswer()));
 
   }, 'createAnswer() should reject with OperationError if identity assertion request fails');

--- a/webrtc-identity/RTCPeerConnection-peerIdentity.https.html
+++ b/webrtc-identity/RTCPeerConnection-peerIdentity.https.html
@@ -103,9 +103,9 @@
 
     const offer = await pc1.createOffer();
 
-    await promise_rejects(t, 'OperationError',
+    await promise_rejects_dom(t, 'OperationError',
       pc2.setRemoteDescription(offer));
-    await promise_rejects(t, 'OperationError',
+    await promise_rejects_dom(t, 'OperationError',
       pc2.peerIdentity);
   }, 'setRemoteDescription() on offer with a=identity that resolve to value different from target peer identity should reject with OperationError');
 
@@ -146,9 +146,9 @@
 
     return pc1.createOffer()
     .then(offer => Promise.all([
-      promise_rejects(t, 'IdpError',
+      promise_rejects_dom(t, 'IdpError',
         pc2.setRemoteDescription(offer)),
-      promise_rejects(t, 'OperationError',
+      promise_rejects_dom(t, 'OperationError',
         peerIdentityPromise)
     ]));
   }, 'setRemoteDescription() with peerIdentity set and with IdP proxy that return validationAssertion with mismatch contents should reject with OperationError');
@@ -195,9 +195,9 @@
       return pc1.createOffer();
     })
     .then(offer => Promise.all([
-      promise_rejects(t, 'OperationError',
+      promise_rejects_dom(t, 'OperationError',
         pc2.setRemoteDescription(offer)),
-      promise_rejects(t, 'OperationError',
+      promise_rejects_dom(t, 'OperationError',
         pc2.peerIdentity)
     ]));
   }, 'setRemoteDescription() and peerIdentity should reject with OperationError if IdP return validated identity that is different from its own domain');

--- a/webrtc-quic/RTCQuicStream.https.html
+++ b/webrtc-quic/RTCQuicStream.https.html
@@ -403,8 +403,8 @@ promise_test(async t => {
   const promise2 = localStream.waitForWriteBufferedAmountBelow(0);
   localStream.write({ finish: true });
   await Promise.all([
-      promise_rejects(t, 'InvalidStateError', promise1),
-      promise_rejects(t, 'InvalidStateError', promise2)]);
+      promise_rejects_dom(t, 'InvalidStateError', promise1),
+      promise_rejects_dom(t, 'InvalidStateError', promise2)]);
 }, 'Pending waitForWriteBufferedAmountBelow() promises rejected after ' +
     'write() with finish.');
 
@@ -419,8 +419,8 @@ promise_test(async t => {
   const promise1 = localStream.waitForWriteBufferedAmountBelow(0);
   const promise2 = localStream.waitForWriteBufferedAmountBelow(0);
   await Promise.all([
-      promise_rejects(t, 'InvalidStateError', promise1),
-      promise_rejects(t, 'InvalidStateError', promise2)]);
+      promise_rejects_dom(t, 'InvalidStateError', promise1),
+      promise_rejects_dom(t, 'InvalidStateError', promise2)]);
 }, 'waitForWriteBufferedAmountBelow() promises immediately rejected after ' +
     'wrote finish.');
 
@@ -435,8 +435,8 @@ promise_test(async t => {
   const promise2 = localStream.waitForWriteBufferedAmountBelow(0);
   localStream.reset();
   await Promise.all([
-      promise_rejects(t, 'InvalidStateError', promise1),
-      promise_rejects(t, 'InvalidStateError', promise2)]);
+      promise_rejects_dom(t, 'InvalidStateError', promise1),
+      promise_rejects_dom(t, 'InvalidStateError', promise2)]);
 }, 'Pending waitForWriteBufferedAmountBelow() promises rejected after ' +
     'reset().');
 
@@ -451,13 +451,13 @@ promise_test(async t => {
   const promise2 = localStream.waitForWriteBufferedAmountBelow(0);
   localQuicTransport.stop();
   await Promise.all([
-      promise_rejects(t, 'InvalidStateError', promise1),
-      promise_rejects(t, 'InvalidStateError', promise2)]);
+      promise_rejects_dom(t, 'InvalidStateError', promise1),
+      promise_rejects_dom(t, 'InvalidStateError', promise2)]);
 }, 'Pending waitForWriteBufferedAmountBelow() promises rejected after ' +
     'RTCQuicTransport stop().');
 
 closed_stream_test(async (t, stream) => {
-  await promise_rejects(t, 'InvalidStateError',
+  await promise_rejects_dom(t, 'InvalidStateError',
       stream.waitForWriteBufferedAmountBelow(0));
 }, 'waitForWriteBufferedBelow() rejects with InvalidStateError.');
 
@@ -577,8 +577,8 @@ promise_test(async t => {
   const promise1 = remoteStream.waitForReadable(10);
   const promise2 = remoteStream.waitForReadable(10);
   await Promise.all([
-      promise_rejects(t, 'InvalidStateError', promise1),
-      promise_rejects(t, 'InvalidStateError', promise2)]);
+      promise_rejects_dom(t, 'InvalidStateError', promise1),
+      promise_rejects_dom(t, 'InvalidStateError', promise2)]);
 }, 'waitForReadable() promises immediately rejected with InvalidStateError ' +
     'after finish is read out.');
 
@@ -590,8 +590,8 @@ promise_test(async t => {
   const promise2 = localStream.waitForReadable(10);
   localStream.reset();
   await Promise.all([
-promise_rejects(t, 'InvalidStateError', promise1),
-      promise_rejects(t, 'InvalidStateError', promise2)]);
+promise_rejects_dom(t, 'InvalidStateError', promise1),
+      promise_rejects_dom(t, 'InvalidStateError', promise2)]);
 }, 'Pending waitForReadable() promises rejected after reset().');
 
 promise_test(async t => {
@@ -605,8 +605,8 @@ promise_test(async t => {
   const promise2 = remoteStream.waitForReadable(10);
   localStream.reset();
   await Promise.all([
-      promise_rejects(t, 'InvalidStateError', promise1),
-      promise_rejects(t, 'InvalidStateError', promise2)]);
+      promise_rejects_dom(t, 'InvalidStateError', promise1),
+      promise_rejects_dom(t, 'InvalidStateError', promise2)]);
 }, 'Pending waitForReadable() promises rejected after remote reset().');
 
 promise_test(async t => {
@@ -617,8 +617,8 @@ promise_test(async t => {
   const promise2 = localStream.waitForReadable(10);
   localQuicTransport.stop();
   await Promise.all([
-      promise_rejects(t, 'InvalidStateError', promise1),
-      promise_rejects(t, 'InvalidStateError', promise2)]);
+      promise_rejects_dom(t, 'InvalidStateError', promise1),
+      promise_rejects_dom(t, 'InvalidStateError', promise2)]);
 }, 'Pending waitForReadable() promises rejected after RTCQuicTransport ' +
    'stop().');
 
@@ -633,13 +633,13 @@ promise_test(async t => {
   const promise2 = remoteStream.waitForReadable(10);
   localQuicTransport.stop();
   await Promise.all([
-      promise_rejects(t, 'InvalidStateError', promise1),
-      promise_rejects(t, 'InvalidStateError', promise2)]);
+      promise_rejects_dom(t, 'InvalidStateError', promise1),
+      promise_rejects_dom(t, 'InvalidStateError', promise2)]);
 }, 'Pending waitForReadable() promises rejected after remote RTCQuicTransport ' +
     'stop().');
 
 closed_stream_test(async (t, stream) => {
-  await promise_rejects(t, 'InvalidStateError',
+  await promise_rejects_dom(t, 'InvalidStateError',
       stream.waitForReadable(1));
 }, 'waitForReadable() rejects with InvalidStateError.');
 

--- a/webrtc-quic/RTCQuicTransport.https.html
+++ b/webrtc-quic/RTCQuicTransport.https.html
@@ -249,7 +249,7 @@ promise_test(async t => {
 promise_test(async t => {
   const quicTransport = makeStandaloneQuicTransport(t);
   const promise = quicTransport.getStats();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'getStats() promises immediately rejected with InvalidStateError ' +
     `if called before 'connecting'.`);
 
@@ -258,7 +258,7 @@ promise_test(async t => {
       await makeTwoConnectedQuicTransports(t);
   const promise = localQuicTransport.getStats();
   localQuicTransport.stop();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'getStats() promises rejected  with InvalidStateError if stop() ' +
    'is called before being fulfilled.');
 
@@ -267,7 +267,7 @@ promise_test(async t => {
       await makeTwoConnectedQuicTransports(t);
   const promise = localQuicTransport.getStats();
   localQuicTransport.transport.stop();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'getStats() promises rejected  with InvalidStateError if ' +
    'RTCIceTransport calls stop() before being fulfilled.');
 
@@ -276,7 +276,7 @@ promise_test(async t => {
       await makeTwoConnectedQuicTransports(t);
   localQuicTransport.transport.stop();
   const promise = localQuicTransport.getStats();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'getStats() promises immediately rejected if called after ' +
    `'closed' state.`);
 
@@ -348,7 +348,7 @@ promise_test(async t => {
 test(t => {
   const quicTransport = makeStandaloneQuicTransport(t);
   const promise = quicTransport.readyToSendDatagram();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'readyToSendDatagram() promise immediately rejected if called before ' +
     'connecting');
 
@@ -357,14 +357,14 @@ promise_test(async t => {
       await makeTwoConnectedQuicTransports(t);
   localQuicTransport.stop();
   const promise = localQuicTransport.readyToSendDatagram();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'readyToSendDatagram() promise immediately rejected if called after ' +
     `'closed' state.`);
 
 test(t => {
   const quicTransport = makeStandaloneQuicTransport(t);
   const promise = quicTransport.receiveDatagrams();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'receiveDatagrams() promise immediately rejected if called before ' +
     'connecting.');
 
@@ -373,7 +373,7 @@ promise_test(async t => {
       await makeTwoConnectedQuicTransports(t);
   localQuicTransport.stop();
   const promise = localQuicTransport.receiveDatagrams();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'receiveDatagrams() promise immediately rejected if called after ' +
     `'closed' state.`);
 
@@ -382,7 +382,7 @@ promise_test(async t => {
       await makeTwoConnectedQuicTransports(t);
   const promise = localQuicTransport.receiveDatagrams();
   localQuicTransport.stop();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'receiveDatagrams() promise rejected  with InvalidStateError if stop() ' +
     'is called before being fulfilled.');
 
@@ -391,7 +391,7 @@ promise_test(async t => {
       await makeTwoConnectedQuicTransports(t);
   const promise = localQuicTransport.receiveDatagrams();
   localQuicTransport.transport.stop();
-  promise_rejects(t, 'InvalidStateError', promise);
+  promise_rejects_dom(t, 'InvalidStateError', promise);
 }, 'receiveDatagrams() promises rejected  with InvalidStateError if ' +
    'RTCIceTransport calls stop() before being fulfilled.');
 

--- a/webrtc/RTCConfiguration-rtcpMuxPolicy.html
+++ b/webrtc/RTCConfiguration-rtcpMuxPolicy.html
@@ -166,7 +166,7 @@
     const pc = new RTCPeerConnection({rtcpMuxPolicy: 'require'});
     t.add_cleanup(() => pc.close());
 
-    return promise_rejects(t, 'InvalidAccessError', pc.setRemoteDescription({type: 'offer', sdp}));
+    return promise_rejects_dom(t, 'InvalidAccessError', pc.setRemoteDescription({type: 'offer', sdp}));
   }, 'setRemoteDescription throws InvalidAccessError when called with an offer without rtcp-mux and rtcpMuxPolicy is set to require');
 
   promise_test(async t => {
@@ -191,6 +191,6 @@
 
     const offer = await generateAudioReceiveOnlyOffer(pc);
     await pc.setLocalDescription(offer);
-    return promise_rejects(t, 'InvalidAccessError', pc.setRemoteDescription({type: 'answer', sdp}));
+    return promise_rejects_dom(t, 'InvalidAccessError', pc.setRemoteDescription({type: 'answer', sdp}));
   }, 'setRemoteDescription throws InvalidAccessError when called with an answer without rtcp-mux and rtcpMuxPolicy is set to require');
 </script>

--- a/webrtc/RTCPeerConnection-addIceCandidate.html
+++ b/webrtc/RTCPeerConnection-addIceCandidate.html
@@ -128,7 +128,7 @@ a=rtcp-rsize
 
     t.add_cleanup(() => pc.close());
 
-    return promise_rejects(t, 'InvalidStateError',
+    return promise_rejects_dom(t, 'InvalidStateError',
       pc.addIceCandidate({
         candidate: candidateStr1,
         sdpMid: sdpMid1,
@@ -220,7 +220,7 @@ a=rtcp-rsize
     t.add_cleanup(() => pc.close());
 
     await pc.setRemoteDescription(sessionDesc);
-    await promise_rejects(t, 'OperationError',
+    await promise_rejects_dom(t, 'OperationError',
       pc.addIceCandidate({usernameFragment: "no such ufrag"}));
   }, 'addIceCandidate({usernameFragment: "no such ufrag"}) should not work');
 
@@ -480,7 +480,7 @@ a=rtcp-rsize
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
-      promise_rejects(t, 'OperationError',
+      promise_rejects_dom(t, 'OperationError',
         pc.addIceCandidate({
           candidate: candidateStr1,
           sdpMid: 'invalid',
@@ -504,7 +504,7 @@ a=rtcp-rsize
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
-      promise_rejects(t, 'OperationError',
+      promise_rejects_dom(t, 'OperationError',
         pc.addIceCandidate({
           candidate: candidateStr1,
           sdpMLineIndex: 2,
@@ -560,7 +560,7 @@ a=rtcp-rsize
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
-      promise_rejects(t, 'OperationError',
+      promise_rejects_dom(t, 'OperationError',
         pc.addIceCandidate({
           candidate: candidateStr1,
           sdpMid: sdpMid1,
@@ -583,7 +583,7 @@ a=rtcp-rsize
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
-      promise_rejects(t, 'OperationError',
+      promise_rejects_dom(t, 'OperationError',
         pc.addIceCandidate({
           candidate: invalidCandidateStr,
           sdpMid: sdpMid1,
@@ -599,7 +599,7 @@ a=rtcp-rsize
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
-      promise_rejects(t, 'OperationError',
+      promise_rejects_dom(t, 'OperationError',
         pc.addIceCandidate({
           candidate: candidateStr2,
           sdpMid: sdpMid2,

--- a/webrtc/RTCPeerConnection-createAnswer.html
+++ b/webrtc/RTCPeerConnection-createAnswer.html
@@ -24,7 +24,7 @@
   promise_test(t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    return promise_rejects(t, 'InvalidStateError',
+    return promise_rejects_dom(t, 'InvalidStateError',
       pc.createAnswer());
   }, 'createAnswer() with null remoteDescription should reject with InvalidStateError');
 
@@ -59,7 +59,7 @@
     .then(offer => pc.setRemoteDescription(offer))
     .then(() => {
       pc.close();
-      return promise_rejects(t, 'InvalidStateError',
+      return promise_rejects_dom(t, 'InvalidStateError',
         pc.createAnswer());
     });
   }, 'createAnswer() when connection is closed reject with InvalidStateError');

--- a/webrtc/RTCPeerConnection-createOffer.html
+++ b/webrtc/RTCPeerConnection-createOffer.html
@@ -65,7 +65,7 @@
     t.add_cleanup(() => pc.close());
     pc.close();
 
-    return promise_rejects(t, 'InvalidStateError',
+    return promise_rejects_dom(t, 'InvalidStateError',
       pc.createOffer());
   }, 'createOffer() after connection is closed should reject with InvalidStateError');
 
@@ -108,7 +108,7 @@
        pc.setRemoteDescription(offer)
        .then(() => {
           assert_equals(pc.signalingState, 'have-remote-offer');
-          return promise_rejects(t, 'InvalidStateError',
+          return promise_rejects_dom(t, 'InvalidStateError',
              pc.createOffer());
        })
      )

--- a/webrtc/RTCPeerConnection-generateCertificate.html
+++ b/webrtc/RTCPeerConnection-generateCertificate.html
@@ -68,12 +68,12 @@
    *        will not use to generate a certificate for RTCPeerConnection.
    */
   promise_test(t =>
-    promise_rejects(t, 'NotSupportedError',
+    promise_rejects_dom(t, 'NotSupportedError',
       RTCPeerConnection.generateCertificate('invalid-algo')),
     'generateCertificate() with invalid string algorithm should reject with NotSupportedError');
 
   promise_test(t =>
-    promise_rejects(t, 'NotSupportedError',
+    promise_rejects_dom(t, 'NotSupportedError',
       RTCPeerConnection.generateCertificate({
         name: 'invalid-algo'
       })),

--- a/webrtc/RTCPeerConnection-getStats.https.html
+++ b/webrtc/RTCPeerConnection-getStats.https.html
@@ -64,7 +64,7 @@
     t.add_cleanup(() => pc.close());
     return getTrackFromUserMedia('audio')
     .then(([track, mediaStream]) => {
-      return promise_rejects(t, 'InvalidAccessError', pc.getStats(track));
+      return promise_rejects_dom(t, 'InvalidAccessError', pc.getStats(track));
     });
   }, 'getStats() with track not added to connection should reject with InvalidAccessError');
 
@@ -103,7 +103,7 @@
       assert_not_equals(transceiver1.sender, transceiver2.sender);
       assert_equals(transceiver1.sender.track, transceiver2.sender.track);
 
-      return promise_rejects(t, 'InvalidAccessError', pc.getStats(track));
+      return promise_rejects_dom(t, 'InvalidAccessError', pc.getStats(track));
     });
   }, `getStats() with track associated with more than one sender should reject with InvalidAccessError`);
 
@@ -117,7 +117,7 @@
     const transceiver2 = pc.addTransceiver(transceiver1.receiver.track);
     assert_equals(transceiver1.receiver.track, transceiver2.sender.track);
 
-    return promise_rejects(t, 'InvalidAccessError', pc.getStats(transceiver1.receiver.track));
+    return promise_rejects_dom(t, 'InvalidAccessError', pc.getStats(transceiver1.receiver.track));
   }, 'getStats() with track associated with both sender and receiver should reject with InvalidAccessError');
 
   /*

--- a/webrtc/RTCPeerConnection-setLocalDescription-answer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-answer.html
@@ -132,7 +132,7 @@
       pc.setRemoteDescription(offer)
       .then(() => generateAnswer(offer))
       .then(answer =>
-        promise_rejects(t, 'InvalidModificationError',
+        promise_rejects_dom(t, 'InvalidModificationError',
           pc.setLocalDescription(answer))));
   }, 'setLocalDescription() with answer not created by own createAnswer() should reject with InvalidModificationError');
 
@@ -153,7 +153,7 @@
 
     return pc.createOffer()
     .then(offer =>
-      promise_rejects(t, 'InvalidModificationError',
+      promise_rejects_dom(t, 'InvalidModificationError',
         pc.setLocalDescription({ type: 'answer', sdp: offer.sdp })));
   }, 'Calling setLocalDescription(answer) from stable state should reject with InvalidModificationError');
 
@@ -167,7 +167,7 @@
       pc.setLocalDescription(offer)
       .then(() => generateAnswer(offer)))
     .then(answer =>
-      promise_rejects(t, 'InvalidModificationError',
+      promise_rejects_dom(t, 'InvalidModificationError',
         pc.setLocalDescription(answer)));
   }, 'Calling setLocalDescription(answer) from have-local-offer state should reject with InvalidModificationError');
 

--- a/webrtc/RTCPeerConnection-setLocalDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-offer.html
@@ -111,7 +111,7 @@
 
     return generateDataChannelOffer(pc)
     .then(offer =>
-      promise_rejects(t, 'InvalidModificationError',
+      promise_rejects_dom(t, 'InvalidModificationError',
         pc2.setLocalDescription(offer)));
   }, 'setLocalDescription() with offer not created by own createOffer() should reject with InvalidModificationError');
 
@@ -127,7 +127,7 @@
       generateVideoReceiveOnlyOffer(pc)
       .then(offer2 => {
         assert_session_desc_not_similar(offer1, offer2);
-        return promise_rejects(t, 'InvalidModificationError',
+        return promise_rejects_dom(t, 'InvalidModificationError',
           pc.setLocalDescription(offer1));
       }));
   }, 'Set created offer other than last offer should reject with InvalidModificationError');

--- a/webrtc/RTCPeerConnection-setLocalDescription-pranswer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-pranswer.html
@@ -65,7 +65,7 @@
 
     return pc.createOffer()
     .then(offer =>
-      promise_rejects(t, 'InvalidStateError',
+      promise_rejects_dom(t, 'InvalidStateError',
         pc.setLocalDescription({ type: 'pranswer', sdp: offer.sdp })));
   }, 'setLocalDescription(pranswer) from stable state should reject with InvalidStateError');
 

--- a/webrtc/RTCPeerConnection-setLocalDescription-rollback.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-rollback.html
@@ -99,7 +99,7 @@
   promise_test(t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    return promise_rejects(t, 'InvalidStateError',
+    return promise_rejects_dom(t, 'InvalidStateError',
       pc.setLocalDescription({ type: 'rollback' }));
   }, `setLocalDescription(rollback) from stable state should reject with InvalidStateError`);
 
@@ -112,7 +112,7 @@
       .then(() => pc.createAnswer()))
     .then(answer => pc.setLocalDescription(answer))
     .then(() => {
-      return promise_rejects(t, 'InvalidStateError',
+      return promise_rejects_dom(t, 'InvalidStateError',
         pc.setLocalDescription({ type: 'rollback' }));
     });
   }, `setLocalDescription(rollback) after setting answer description should reject with InvalidStateError`);

--- a/webrtc/RTCPeerConnection-setRemoteDescription-answer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-answer.html
@@ -102,7 +102,7 @@
 
     return pc.createOffer()
     .then(offer =>
-      promise_rejects(t, 'InvalidStateError',
+      promise_rejects_dom(t, 'InvalidStateError',
         pc.setRemoteDescription({ type: 'answer', sdp: offer.sdp })));
   }, 'Calling setRemoteDescription(answer) from stable state should reject with InvalidStateError');
 
@@ -116,7 +116,7 @@
       pc.setRemoteDescription(offer)
       .then(() => generateAnswer(offer)))
     .then(answer =>
-      promise_rejects(t, 'InvalidStateError',
+      promise_rejects_dom(t, 'InvalidStateError',
         pc.setRemoteDescription(answer)));
   }, 'Calling setRemoteDescription(answer) from have-remote-offer state should reject with InvalidStateError');
 

--- a/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
@@ -274,7 +274,7 @@
     assert_equals(pc1.signalingState, 'stable');
     const p2 = pc1.addIceCandidate();
     const p3 = pc1.setRemoteDescription(offer);
-    await promise_rejects(t, 'InvalidStateError', p2);
+    await promise_rejects_dom(t, 'InvalidStateError', p2);
     await p1;
     await p3;
     assert_equals(pc1.signalingState, 'have-remote-offer');
@@ -305,6 +305,6 @@
     assert_equals(pc1.signalingState, 'stable');
     assert_equals(pc1.pendingLocalDescription, null);
     assert_equals(pc1.pendingRemoteDescription, null);
-    await promise_rejects(t, 'RTCError', p);
+    await promise_rejects_dom(t, 'RTCError', p);
   }, 'setRemoteDescription(invalidOffer) from have-local-offer does not undo rollback');
 </script>

--- a/webrtc/RTCPeerConnection-setRemoteDescription-pranswer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-pranswer.html
@@ -66,7 +66,7 @@
 
     return pc.createOffer()
     .then(offer =>
-      promise_rejects(t, 'InvalidStateError',
+      promise_rejects_dom(t, 'InvalidStateError',
         pc.setRemoteDescription({ type: 'pranswer', sdp: offer.sdp })));
   }, 'setRemoteDescription(pranswer) from stable state should reject with InvalidStateError');
 

--- a/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html
@@ -99,7 +99,7 @@
   promise_test(t => {
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
-    return promise_rejects(t, 'InvalidStateError',
+    return promise_rejects_dom(t, 'InvalidStateError',
       pc.setRemoteDescription({type: 'rollback'}));
   }, `setRemoteDescription(rollback) from stable state should reject with InvalidStateError`);
 

--- a/webrtc/RTCPeerConnection-track-stats.https.html
+++ b/webrtc/RTCPeerConnection-track-stats.https.html
@@ -574,7 +574,7 @@
     t.add_cleanup(() => pc.close());
     let [tracks, streams] = await getUserMediaTracksAndStreams(1);
     t.add_cleanup(() => tracks.forEach(track => track.stop()));
-    await promise_rejects(t, 'InvalidAccessError', pc.getStats(tracks[0]));
+    await promise_rejects_dom(t, 'InvalidAccessError', pc.getStats(tracks[0]));
   }, 'RTCPeerConnection.getStats(track) throws InvalidAccessError when there ' +
      'are zero senders or receivers for the track');
 
@@ -586,7 +586,7 @@
     let sender1 = pc.addTrack(tracks[0], streams[0]);
     let sender2 = pc.addTrack(tracks[1], streams[1]);
     await sender2.replaceTrack(sender1.track);
-    await promise_rejects(t, 'InvalidAccessError', pc.getStats(sender1.track));
+    await promise_rejects_dom(t, 'InvalidAccessError', pc.getStats(sender1.track));
   }, 'RTCPeerConnection.getStats(track) throws InvalidAccessError when there ' +
      'are multiple senders for the track');
 

--- a/webrtc/RTCRtpParameters-codecs.html
+++ b/webrtc/RTCRtpParameters-codecs.html
@@ -99,7 +99,7 @@
       codec.payloadType += 1;
     }
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, 'setParameters() with codec.payloadType modified should reject with InvalidModificationError');
 
@@ -119,7 +119,7 @@
       codec.mimeType = `${codec.mimeType}-modified`;
     }
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, 'setParameters() with codec.mimeType modified should reject with InvalidModificationError');
 
@@ -139,7 +139,7 @@
       codec.clockRate += 1;
     }
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, 'setParameters() with codec.clockRate modified should reject with InvalidModificationError');
 
@@ -159,7 +159,7 @@
       codec.channels += 1;
     }
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, 'setParameters() with codec.channels modified should reject with InvalidModificationError');
 
@@ -179,7 +179,7 @@
       codec.sdpFmtpLine = `${codec.sdpFmtpLine};foo=1`;
     }
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, 'setParameters() with codec.sdpFmtpLine modified should reject with InvalidModificationError');
 
@@ -200,7 +200,7 @@
       channels: 2
     });
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, 'setParameters() with new codecs inserted should reject with InvalidModificationError');
 

--- a/webrtc/RTCRtpParameters-encodings.html
+++ b/webrtc/RTCRtpParameters-encodings.html
@@ -177,7 +177,7 @@
     encodings.push({});
     assert_equals(param.encodings.length, 2);
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, `sender.setParameters() with mismatch number of encodings should reject with InvalidModificationError`);
 
@@ -211,7 +211,7 @@
     assert_equals(encoding.rid, 'foo');
 
     encoding.rid = 'bar';
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, `setParameters() with modified encoding.rid field should reject with InvalidModificationError`);
 

--- a/webrtc/RTCRtpParameters-headerExtensions.html
+++ b/webrtc/RTCRtpParameters-headerExtensions.html
@@ -68,7 +68,7 @@
       encrypted: false
     }];
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, `setParameters() with modified headerExtensions should reject with InvalidModificationError`);
 

--- a/webrtc/RTCRtpParameters-rtcp.html
+++ b/webrtc/RTCRtpParameters-rtcp.html
@@ -74,7 +74,7 @@
       rtcp.cname = `${rtcp.cname}-modified`;
     }
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, `setParameters() with modified rtcp.cname should reject with InvalidModificationError`);
 
@@ -98,7 +98,7 @@
       rtcp.reducedSize = !rtcp.reducedSize;
     }
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, `setParameters() with modified rtcp.reducedSize should reject with InvalidModificationError`);
 

--- a/webrtc/RTCRtpParameters-transactionId.html
+++ b/webrtc/RTCRtpParameters-transactionId.html
@@ -97,7 +97,7 @@
     const { transactionId } = param;
     param.transactionId = `${transactionId}-modified`;
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param));
   }, `sender.setParameters() with transaction ID different from last getParameters() should reject with InvalidModificationError`);
 
@@ -127,7 +127,7 @@
 
     return sender.setParameters(param)
     .then(() =>
-      promise_rejects(t, 'InvalidStateError',
+      promise_rejects_dom(t, 'InvalidStateError',
         sender.setParameters(param)));
   }, `setParameters() twice with the same parameters should reject with InvalidStateError`);
 
@@ -145,7 +145,7 @@
 
     assert_not_equals(param1.transactionId, param2.transactionId);
 
-    return promise_rejects(t, 'InvalidModificationError',
+    return promise_rejects_dom(t, 'InvalidModificationError',
       sender.setParameters(param1));
   }, `setParameters() with parameters older than last getParameters() should reject with InvalidModificationError`);
 

--- a/webrtc/RTCRtpSender-replaceTrack.https.html
+++ b/webrtc/RTCRtpSender-replaceTrack.https.html
@@ -39,7 +39,7 @@
     const { sender } = transceiver;
     pc.close();
 
-    return promise_rejects(t, 'InvalidStateError',
+    return promise_rejects_dom(t, 'InvalidStateError',
       sender.replaceTrack(track));
   }, 'Calling replaceTrack on closed connection should reject with InvalidStateError');
 
@@ -79,7 +79,7 @@
     const { sender } = transceiver;
     transceiver.stop();
 
-    return promise_rejects(t, 'InvalidStateError',
+    return promise_rejects_dom(t, 'InvalidStateError',
       sender.replaceTrack(track));
   }, 'Calling replaceTrack on stopped sender should reject with InvalidStateError');
 

--- a/webrtc/RTCRtpSender-setParameters.html
+++ b/webrtc/RTCRtpSender-setParameters.html
@@ -23,7 +23,7 @@
     const param = sender.getParameters();
     transceiver.stop();
 
-    return promise_rejects(t, 'InvalidStateError',
+    return promise_rejects_dom(t, 'InvalidStateError',
       sender.setParameters(param));
   }, `setParameters() when transceiver is stopped should reject with InvalidStateError`);
 

--- a/websockets/stream-tentative/abort.any.js
+++ b/websockets/stream-tentative/abort.any.js
@@ -14,9 +14,9 @@ promise_test(async t => {
   // We intentionally use the port for the HTTP server, not the WebSocket
   // server, because we don't expect the connection to be performed.
   const wss = new WebSocketStream(wsUrl, { signal: controller.signal });
-  await promise_rejects(t, 'AbortError', wss.connection,
+  await promise_rejects_dom(t, 'AbortError', wss.connection,
                         'connection should reject');
-  await promise_rejects(t, 'AbortError', wss.closed, 'closed should reject');
+  await promise_rejects_dom(t, 'AbortError', wss.closed, 'closed should reject');
   // An incorrect implementation could pass this test due a race condition,
   // but it is hard to completely eliminate the possibility.
   const response = await fetch(`/fetch/api/resources/stash-take.py?key=${key}`);
@@ -30,9 +30,9 @@ promise_test(async t => {
   // Give the connection a chance to start.
   await new Promise(resolve => t.step_timeout(resolve, 0));
   controller.abort();
-  await promise_rejects(t, 'AbortError', wss.connection,
+  await promise_rejects_dom(t, 'AbortError', wss.connection,
                         'connection should reject');
-  await promise_rejects(t, 'AbortError', wss.closed, 'closed should reject');
+  await promise_rejects_dom(t, 'AbortError', wss.closed, 'closed should reject');
 }, 'abort during handshake should work');
 
 promise_test(async t => {

--- a/websockets/stream-tentative/close.any.js
+++ b/websockets/stream-tentative/close.any.js
@@ -66,9 +66,9 @@ promise_test(t => {
   const wss = new WebSocketStream(ECHOURL);
   wss.close();
   return Promise.all([
-    promise_rejects(t, 'NetworkError', wss.connection,
+    promise_rejects_dom(t, 'NetworkError', wss.connection,
                     'connection promise should reject'),
-    promise_rejects(t, 'NetworkError', wss.closed,
+    promise_rejects_dom(t, 'NetworkError', wss.closed,
                     'closed promise should reject')]);
 }, 'close during handshake should work');
 

--- a/websockets/stream-tentative/constructor.any.js
+++ b/websockets/stream-tentative/constructor.any.js
@@ -45,9 +45,9 @@ promise_test(async () => {
 promise_test(t => {
   const wss = new WebSocketStream(`${BASEURL}/404`);
   return Promise.all([
-    promise_rejects(t, 'NetworkError', wss.connection,
+    promise_rejects_dom(t, 'NetworkError', wss.connection,
                     'connection should reject'),
-    promise_rejects(t, 'NetworkError', wss.closed, 'closed should reject')
+    promise_rejects_dom(t, 'NetworkError', wss.closed, 'closed should reject')
   ]);
 }, 'connection failure should reject the promises');
 

--- a/webxr/ar-module/xrDevice_requestSession_immersive-ar.https.html
+++ b/webxr/ar-module/xrDevice_requestSession_immersive-ar.https.html
@@ -18,7 +18,7 @@
         return navigator.xr.test.simulateDeviceConnection(TRACKED_IMMERSIVE_DEVICE)
           .then((controller) => new Promise((resolve) => {
             navigator.xr.test.simulateUserActivation(() => {
-              resolve(promise_rejects(
+              resolve(promise_rejects_dom(
                 t, "NotSupportedError",
                 navigator.xr.requestSession('immersive-ar', {})));
             });

--- a/webxr/webGLCanvasContext_makecompatible_contextlost.https.html
+++ b/webxr/webGLCanvasContext_makecompatible_contextlost.https.html
@@ -15,7 +15,7 @@
           webglCanvas = document.getElementById('webgl-canvas');
           gl = webglCanvas.getContext('webgl', {xrCompatible: true});
           gl.getExtension('WEBGL_lose_context').loseContext();
-          return promise_rejects(t, 'InvalidStateError', gl.makeXRCompatible());
+          return promise_rejects_dom(t, 'InvalidStateError', gl.makeXRCompatible());
         });
     });
 

--- a/webxr/webxr_feature_policy.https.html
+++ b/webxr/webxr_feature_policy.https.html
@@ -18,7 +18,7 @@ xr_promise_test(
 
     // It shouldn't matter that there's no device connected, the SecurityError
     // should reject first.
-    return promise_rejects(t, "SecurityError",
+    return promise_rejects_dom(t, "SecurityError",
       navigator.xr.isSessionSupported("immersive-vr"),
       "Immersive isSessionSupported should reject");
   });
@@ -40,11 +40,11 @@ xr_promise_test(
         resolve(Promise.all([
           navigator.xr.requestSession("inline").then(session => session.end()),
 
-          promise_rejects(t, "NotSupportedError",
+          promise_rejects_dom(t, "NotSupportedError",
             navigator.xr.requestSession("inline", { requiredFeatures: ["local"] }),
             "Inline with features should reject without feature policy"),
 
-          promise_rejects(t, "NotSupportedError",
+          promise_rejects_dom(t, "NotSupportedError",
             navigator.xr.requestSession("immersive-vr"),
             "Immersive-vr should reject without feature policy")
           ]));

--- a/webxr/xrDevice_requestSession_immersive_no_gesture.https.html
+++ b/webxr/xrDevice_requestSession_immersive_no_gesture.https.html
@@ -9,7 +9,7 @@
       "Requesting immersive session outside of a user gesture rejects",
       (t) => {
         return navigator.xr.test.simulateDeviceConnection(TRACKED_IMMERSIVE_DEVICE)
-          .then( (controller) => promise_rejects(
+          .then( (controller) => promise_rejects_dom(
             t, 'SecurityError', navigator.xr.requestSession('immersive-vr')));
       });
   </script>

--- a/webxr/xrDevice_requestSession_immersive_unsupported.https.html
+++ b/webxr/xrDevice_requestSession_immersive_unsupported.https.html
@@ -11,7 +11,7 @@
         return navigator.xr.test.simulateDeviceConnection(VALID_NON_IMMERSIVE_DEVICE)
           .then( (controller) => new Promise((resolve) => {
             navigator.xr.test.simulateUserActivation( () => {
-              resolve(promise_rejects(
+              resolve(promise_rejects_dom(
                 t,
                 "NotSupportedError",
                 navigator.xr.requestSession('immersive-vr')

--- a/webxr/xrDevice_requestSession_requiredFeatures_unknown.https.html
+++ b/webxr/xrDevice_requestSession_requiredFeatures_unknown.https.html
@@ -12,14 +12,14 @@
         return navigator.xr.test.simulateDeviceConnection(TRACKED_IMMERSIVE_DEVICE)
           .then( (controller) => new Promise((resolve) => {
             navigator.xr.test.simulateUserActivation( () => {
-              resolve(promise_rejects(
+              resolve(promise_rejects_dom(
                 t,
                 "NotSupportedError",
                 navigator.xr.requestSession('immersive-vr',
                                             {requiredFeatures: ['undefined-unicorns']}),
                 "unexpected requestSession success"
               ).then(() => {
-                return promise_rejects(
+                return promise_rejects_dom(
                   t,
                   "NotSupportedError",
                   navigator.xr.requestSession('immersive-vr',

--- a/webxr/xrSession_features_deviceSupport.https.html
+++ b/webxr/xrSession_features_deviceSupport.https.html
@@ -37,7 +37,7 @@
           // Attempting to request required features that aren't supported by
           // the device should reject.
 
-          return promise_rejects(t, "NotSupportedError",
+          return promise_rejects_dom(t, "NotSupportedError",
             navigator.xr.requestSession("immersive-vr", {
               requiredFeatures: ['bounded-floor']
             }))

--- a/webxr/xrSession_prevent_multiple_exclusive.https.html
+++ b/webxr/xrSession_prevent_multiple_exclusive.https.html
@@ -20,7 +20,7 @@
                   // session is active should fail. Immersive sessions
                   // should take up the users entire view, and therefore it should
                   // be impossible for a user to be engaged with more than one.
-                  resolve(promise_rejects(
+                  resolve(promise_rejects_dom(
                     t,
                     "InvalidStateError",
                     navigator.xr.requestSession('immersive-vr')

--- a/webxr/xrSession_requestReferenceSpace.https.html
+++ b/webxr/xrSession_requestReferenceSpace.https.html
@@ -45,13 +45,13 @@
         .then(() => {
           if (session.mode == 'inline') {
             // Bounded reference spaces are not allowed in inline sessions.
-            return promise_rejects(t, "NotSupportedError", session.requestReferenceSpace('bounded-floor'))
+            return promise_rejects_dom(t, "NotSupportedError", session.requestReferenceSpace('bounded-floor'))
           }
         })
         .then(() => {
           if (session.mode == 'inline') {
             // Unbounded reference spaces are not allowed in inline sessions.
-            return promise_rejects(t, "NotSupportedError", session.requestReferenceSpace('unbounded'))
+            return promise_rejects_dom(t, "NotSupportedError", session.requestReferenceSpace('unbounded'))
           }
         })
     };

--- a/webxr/xrSession_requestReferenceSpace_features.https.html
+++ b/webxr/xrSession_requestReferenceSpace_features.https.html
@@ -20,7 +20,7 @@
 
     let makeInvalidSpaceTest = (space_type) => {
       return (session, fakeDeviceController, t) => {
-          return  promise_rejects(t, "NotSupportedError",
+          return  promise_rejects_dom(t, "NotSupportedError",
                                   session.requestReferenceSpace(space_type),
                                   "requestReferenceSpace('" + space_type + "')");
       };


### PR DESCRIPTION
…romise_rejects_dom.

This diff was generated by running:

  find . -type f -print0 | xargs -0 perl -pi -e "BEGIN { \$/ = undef; } s/promise_rejects\(([ \n]*[a-zA-Z_]+[ \n]*,[ \n]*)([\"'][A-Za-z_]*[\"']) *(, *.)/promise_rejects_dom(\1\2\3/gs"

in bash (doesn't work in tcsh, due to the $ inside "").