### PR TITLE
New tests for letter-spacing in a bidi context

### DIFF
--- a/css/css-text/letter-spacing/letter-spacing-bidi-003.xht
+++ b/css/css-text/letter-spacing/letter-spacing-bidi-003.xht
@@ -1,0 +1,48 @@
+﻿<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8"/>
+    <title>CSS Text level 3 Test: letter spacing, justified text and bidi</title>
+    <link rel="author" title="Mike Bremford" href="http://bfo.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-text-3/#letter-spacing-property" />
+    <link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#bidi-fragmentation" />
+    <link rel="match" href="reference/letter-spacing-bidi-003-ref.xht" />
+    <meta name="assert" content="text-align: justify will stretch the space between words, which should be applied after bidi processing."/>
+    <style>
+      .test, .control {
+          font: 50px/1 monospace;
+          margin: 0;
+          width: 14ch;
+          font-kerning: none;
+          border: 1px solid black;
+      }
+      .control {
+          position: absolute;
+          color: red;
+          z-index: -1;
+          white-space: pre;
+      }
+      .rtl {
+          direction: rtl;
+      }
+      .justify {
+          text-align-last: justify;
+      }
+      span {
+          background-color: #eee;
+      }
+      .narrow {
+          letter-spacing: 1ch;
+      }
+    </style>
+ </head>
+ <body>
+  <p>Test passes if no red is visible.</p>
+  <!-- bet <ls> alef <ls> <space stretched from justification> A <ls> B -->
+  <div class="control">&#x5d0; &#x5d1;<div style="float: right">A B</div></div>
+  <div class="test narrow justify">&#x5d0;&#x5d1; AB</div>
+
+  <!-- A <ls> B <ls> <space stretched from justification> alef <ls> bet -->
+  <div class="control">A B<div style="float: right">&#x5d0; &#x5d1;</div></div>
+  <div class="test narrow justify rtl">&#x5d0;&#x5d1; AB</div>
+  </body>
+</html>

--- a/css/css-text/letter-spacing/letter-spacing-bidi-003.xht
+++ b/css/css-text/letter-spacing/letter-spacing-bidi-003.xht
@@ -10,7 +10,6 @@
     <style>
       .test, .control {
           font: 50px/1 monospace;
-          margin: 0;
           width: 14ch;
           font-kerning: none;
           border: 1px solid black;
@@ -21,14 +20,9 @@
           z-index: -1;
           white-space: pre;
       }
-      .rtl {
-          direction: rtl;
-      }
       .justify {
           text-align-last: justify;
-      }
-      span {
-          background-color: #eee;
+          text-justify: inter-word;
       }
       .narrow {
           letter-spacing: 1ch;
@@ -36,13 +30,13 @@
     </style>
  </head>
  <body>
-  <p>Test passes if no red is visible.</p>
+  <p>Test passes if no red is visible except for anti-aliasing differences.</p>
   <!-- bet <ls> alef <ls> <space stretched from justification> A <ls> B -->
   <div class="control">&#x5d0; &#x5d1;<div style="float: right">A B</div></div>
   <div class="test narrow justify">&#x5d0;&#x5d1; AB</div>
 
   <!-- A <ls> B <ls> <space stretched from justification> alef <ls> bet -->
   <div class="control">A B<div style="float: right">&#x5d0; &#x5d1;</div></div>
-  <div class="test narrow justify rtl">&#x5d0;&#x5d1; AB</div>
+  <div dir="rtl" class="test narrow justify">&#x5d0;&#x5d1; AB</div>
   </body>
 </html>

--- a/css/css-text/letter-spacing/letter-spacing-bidi-004.xht
+++ b/css/css-text/letter-spacing/letter-spacing-bidi-004.xht
@@ -1,0 +1,43 @@
+﻿<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8"/>
+    <title>CSS Text level 3 Test: letter spacing is between letters, with bidi</title>
+    <link rel="author" title="Mike Bremford" href="http://bfo.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-text-3/#letter-spacing-property" />
+    <link rel="match" href="reference/letter-spacing-bidi-004-ref.xht" />
+    <meta name="assert" content="letter spacing should be applied between letters, not after letters. The latter will cause the colored backgrounds of the span elements to expand."/>
+    <style>
+      .test, .control {
+          font: 50px/1 monospace;
+          margin: 0;
+          width: 14ch;
+          font-kerning: none;
+      }
+      .control {
+          position: absolute;
+          color: red;
+          z-index: -1;
+          white-space: pre;
+      }
+      .control span {
+          /* to ensure both background and text must overlay */
+          background: linear-gradient(to bottom, red 50%, green 50%, green 100%);
+      }
+      .test span {
+          background: linear-gradient(to bottom, green 50%, transparent 50%, transparent 100%);
+      }
+      .wide {
+          letter-spacing: 2ch;
+      }
+      .narrow {
+          letter-spacing: 1ch;
+      }
+    </style>
+ </head>
+ <body>
+  <p>Test passes if no red is visible and the green boxes are the width of a single letter.</p>
+  <!-- A <ls> B <ls> <bg>C</bg> <ls> gimel <ls> bet <ls> <bg>alef</bg> <gap> -->
+  <div class="control">A B <span>C</span> &#x5d1; &#x5d2; <span style="unicode-bidi:embed">&#x5d0;</span></div>
+  <div class="test narrow">AB<span class="wide">C&#x5d0;</span>&#x5d1;&#x5d2;</div>
+  </body>
+</html>

--- a/css/css-text/letter-spacing/letter-spacing-bidi-004.xht
+++ b/css/css-text/letter-spacing/letter-spacing-bidi-004.xht
@@ -9,8 +9,6 @@
     <style>
       .test, .control {
           font: 50px/1 monospace;
-          margin: 0;
-          width: 14ch;
           font-kerning: none;
       }
       .control {
@@ -35,7 +33,7 @@
     </style>
  </head>
  <body>
-  <p>Test passes if no red is visible and the green boxes are the width of a single letter.</p>
+  <p>Test passes if no red is visible except for anti-aliasing differences, and the green boxes are the width of a single letter.</p>
   <!-- A <ls> B <ls> <bg>C</bg> <ls> gimel <ls> bet <ls> <bg>alef</bg> <gap> -->
   <div class="control">A B <span>C</span> &#x5d1; &#x5d2; <span style="unicode-bidi:embed">&#x5d0;</span></div>
   <div class="test narrow">AB<span class="wide">C&#x5d0;</span>&#x5d1;&#x5d2;</div>

--- a/css/css-text/letter-spacing/letter-spacing-bidi-005.xht
+++ b/css/css-text/letter-spacing/letter-spacing-bidi-005.xht
@@ -4,7 +4,7 @@
     <title>CSS Text level 3 Test: letter spacing nested changes, with bidi</title>
     <link rel="author" title="Mike Bremford" href="http://bfo.com" />
     <link rel="help" href="https://drafts.csswg.org/css-text-3/#letter-spacing-property" />
-    <link rel="match" href="reference/letter-spacing-bidi-005-ref.html" />
+    <link rel="match" href="reference/letter-spacing-bidi-005-ref.xht" />
     <meta name="assert" content="Changes in letter spacing affect the spacing between letters within that element only" />
     <style>
       .test, .control {

--- a/css/css-text/letter-spacing/letter-spacing-bidi-005.xht
+++ b/css/css-text/letter-spacing/letter-spacing-bidi-005.xht
@@ -1,0 +1,43 @@
+﻿<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <title>CSS Text level 3 Test: letter spacing nested changes, with bidi</title>
+    <link rel="author" title="Mike Bremford" href="http://bfo.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-text-3/#letter-spacing-property" />
+    <link rel="match" href="reference/letter-spacing-bidi-005-ref.html" />
+    <meta name="assert" content="Changes in letter spacing affect the spacing between letters within that element only" />
+    <style>
+      .test, .control {
+          font: 50px/1 monospace;
+          margin: 0;
+          width: 14ch;
+          font-kerning: none;
+      }
+      .control {
+          position: absolute;
+          color: red;
+          z-index: -1;
+          white-space: pre;
+      }
+      .control span {
+          /* to ensure both background and text overlay correctly */
+          background: linear-gradient(to bottom, red 50%, green 50%, green 100%);
+      }
+      .test span {
+          background: linear-gradient(to bottom, green 50%, transparent 50%, transparent 100%);
+      }
+      .wide {
+          letter-spacing: 2ch;
+      }
+      .narrow {
+          letter-spacing: 1ch;
+      }
+    </style>
+ </head>
+ <body>
+  <p>Test passes if no red is visible and the green rectangle does not extend beyond B to C.</p>
+  <!-- A <ls> <ls> <bg>B <ls> bet <ls> alef <ls> C</bg> <ls> D <gap> -->
+  <div class="control">A  <span>B &#x5d0; &#x5d1; C</span>  D</div>
+  <div class="test wide">A<span class="narrow">B&#x5d0;&#x5d1;C</span>D</div>
+  </body>
+</html>

--- a/css/css-text/letter-spacing/letter-spacing-bidi-005.xht
+++ b/css/css-text/letter-spacing/letter-spacing-bidi-005.xht
@@ -9,8 +9,6 @@
     <style>
       .test, .control {
           font: 50px/1 monospace;
-          margin: 0;
-          width: 14ch;
           font-kerning: none;
       }
       .control {
@@ -35,7 +33,7 @@
     </style>
  </head>
  <body>
-  <p>Test passes if no red is visible and the green rectangle does not extend beyond B to C.</p>
+  <p>Test passes if no red is visible except for anti-aliasing differences, and the green rectangle does not extend beyond B to C.</p>
   <!-- A <ls> <ls> <bg>B <ls> bet <ls> alef <ls> C</bg> <ls> D <gap> -->
   <div class="control">A  <span>B &#x5d0; &#x5d1; C</span>  D</div>
   <div class="test wide">A<span class="narrow">B&#x5d0;&#x5d1;C</span>D</div>

--- a/css/css-text/letter-spacing/letter-spacing-nesting-003.xht
+++ b/css/css-text/letter-spacing/letter-spacing-nesting-003.xht
@@ -1,0 +1,43 @@
+﻿<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <title>CSS Text level 3 Test: letter spacing changes within element tree</title>
+    <link rel="author" title="Mike Bremford" href="http://bfo.com" />
+    <link rel="help" href="https://drafts.csswg.org/css-text-3/#letter-spacing-property" />
+    <link rel="match" href="reference/letter-spacing-nesting-003-ref.xht" />
+    <meta name="assert" content="Changes in letter spacing affect the spacing between letters within that element only" />
+    <style>
+      .test, .control {
+          font: 50px/1 monospace;
+          margin: 0;
+          width: 14ch;
+          font-kerning: none;
+      }
+      .control {
+          position: absolute;
+          color: red;
+          z-index: -1;
+          white-space: pre;
+      }
+      .control span {
+          /* to ensure both background and text overlay correctly */
+          background: linear-gradient(to bottom, red 50%, green 50%, green 100%);
+      }
+      .test span {
+          background: linear-gradient(to bottom, green 50%, transparent 50%, transparent 100%);
+      }
+      .wide {
+          letter-spacing: 2ch;
+      }
+      .narrow {
+          letter-spacing: 1ch;
+      }
+    </style>
+ </head>
+ <body>
+  <p>Test passes if no red is visible and the green rectangle does not extend beyond B to C.</p>
+  <!-- A <ls> <ls> <bg>B <ls> <ls> C</bg> <ls> D -->
+  <div class="control">A <span>B  C</span> D</div>
+  <div class="test narrow">A<span class="wide">BC</span>D</div>
+  </body>
+</html>

--- a/css/css-text/letter-spacing/letter-spacing-nesting-003.xht
+++ b/css/css-text/letter-spacing/letter-spacing-nesting-003.xht
@@ -10,7 +10,6 @@
       .test, .control {
           font: 50px/1 monospace;
           margin: 0;
-          width: 14ch;
           font-kerning: none;
       }
       .control {
@@ -35,7 +34,7 @@
     </style>
  </head>
  <body>
-  <p>Test passes if no red is visible and the green rectangle does not extend beyond B to C.</p>
+  <p>Test passes if no red is visible except for anti-aliasing differences, and the green rectangle does not extend beyond B to C.</p>
   <!-- A <ls> <ls> <bg>B <ls> <ls> C</bg> <ls> D -->
   <div class="control">A <span>B  C</span> D</div>
   <div class="test narrow">A<span class="wide">BC</span>D</div>

--- a/css/css-text/letter-spacing/letter-spacing-nesting-003.xht
+++ b/css/css-text/letter-spacing/letter-spacing-nesting-003.xht
@@ -9,7 +9,6 @@
     <style>
       .test, .control {
           font: 50px/1 monospace;
-          margin: 0;
           font-kerning: none;
       }
       .control {

--- a/css/css-text/letter-spacing/reference/letter-spacing-bidi-003-ref.xht
+++ b/css/css-text/letter-spacing/reference/letter-spacing-bidi-003-ref.xht
@@ -1,0 +1,24 @@
+﻿<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="author" title="Mike Bremford" href="http://bfo.com" />
+    <style>
+      .control {
+          font: 50px/1 monospace;
+          margin: 0;
+          width: 14ch;
+          font-kerning: none;
+          border: 1px solid black;
+          white-space: pre;
+      }
+    </style>
+ </head>
+ <body>
+  <p>Test passes if no red is visible.</p>
+  <!-- bet <ls> alef <ls> <space stretched from justification> A <ls> B -->
+  <div class="control">&#x5d0; &#x5d1;<div style="float: right">A B</div></div>
+
+  <!-- A <ls> B <ls> <space stretched from justification> alef <ls> bet -->
+  <div class="control">A B<div style="float: right">&#x5d0; &#x5d1;</div></div>
+  </body>
+</html>

--- a/css/css-text/letter-spacing/reference/letter-spacing-bidi-003-ref.xht
+++ b/css/css-text/letter-spacing/reference/letter-spacing-bidi-003-ref.xht
@@ -5,20 +5,26 @@
     <style>
       .control {
           font: 50px/1 monospace;
-          margin: 0;
           width: 14ch;
           font-kerning: none;
           border: 1px solid black;
           white-space: pre;
       }
+      .red {
+          color: red;
+          position: absolute;
+          z-index: -1;
+      }
     </style>
  </head>
  <body>
-  <p>Test passes if no red is visible.</p>
+  <p>Test passes if no red is visible except for anti-aliasing differences.</p>
   <!-- bet <ls> alef <ls> <space stretched from justification> A <ls> B -->
+  <div class="control red">&#x5d0; &#x5d1;<div style="float: right">A B</div></div>
   <div class="control">&#x5d0; &#x5d1;<div style="float: right">A B</div></div>
 
   <!-- A <ls> B <ls> <space stretched from justification> alef <ls> bet -->
+  <div class="control red">A B<div style="float: right">&#x5d0; &#x5d1;</div></div>
   <div class="control">A B<div style="float: right">&#x5d0; &#x5d1;</div></div>
   </body>
 </html>

--- a/css/css-text/letter-spacing/reference/letter-spacing-bidi-004-ref.xht
+++ b/css/css-text/letter-spacing/reference/letter-spacing-bidi-004-ref.xht
@@ -5,10 +5,13 @@
     <style>
       .control {
           font: 50px/1 monospace;
-          margin: 0;
-          width: 14ch;
           font-kerning: none;
           white-space: pre;
+      }
+      .red {
+          color: red;
+          position: absolute;
+          z-index: -1;
       }
       .control span {
           background: green;
@@ -16,8 +19,9 @@
     </style>
  </head>
  <body>
-  <p>Test passes if no red is visible and the green boxes are the width of a single letter.</p>
+  <p>Test passes if no red is visible except for anti-aliasing differences, and the green boxes are the width of a single letter.</p>
   <!-- A <ls> B <ls> <bg>C</bg> <ls> gimel <ls> bet <ls> <bg>alef</bg> <gap> -->
+  <div class="control red">A B <span>C</span> &#x5d1; &#x5d2; <span style="unicode-bidi:embed">&#x5d0;</span></div>
   <div class="control">A B <span>C</span> &#x5d1; &#x5d2; <span style="unicode-bidi:embed">&#x5d0;</span></div>
   </body>
 </html>

--- a/css/css-text/letter-spacing/reference/letter-spacing-bidi-004-ref.xht
+++ b/css/css-text/letter-spacing/reference/letter-spacing-bidi-004-ref.xht
@@ -1,0 +1,23 @@
+﻿<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="author" title="Mike Bremford" href="http://bfo.com" />
+    <style>
+      .control {
+          font: 50px/1 monospace;
+          margin: 0;
+          width: 14ch;
+          font-kerning: none;
+          white-space: pre;
+      }
+      .control span {
+          background: green;
+      }
+    </style>
+ </head>
+ <body>
+  <p>Test passes if no red is visible and the green boxes are the width of a single letter.</p>
+  <!-- A <ls> B <ls> <bg>C</bg> <ls> gimel <ls> bet <ls> <bg>alef</bg> <gap> -->
+  <div class="control">A B <span>C</span> &#x5d1; &#x5d2; <span style="unicode-bidi:embed">&#x5d0;</span></div>
+  </body>
+</html>

--- a/css/css-text/letter-spacing/reference/letter-spacing-bidi-005-ref.xht
+++ b/css/css-text/letter-spacing/reference/letter-spacing-bidi-005-ref.xht
@@ -1,0 +1,23 @@
+﻿<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="author" title="Mike Bremford" href="http://bfo.com" />
+    <style>
+      .control {
+          font: 50px/1 monospace;
+          margin: 0;
+          width: 14ch;
+          font-kerning: none;
+          white-space: pre;
+      }
+      .control span {
+          background: green;
+      }
+    </style>
+ </head>
+ <body>
+  <p>Test passes if no red is visible and the green rectangle does not extend beyond B to C.</p>
+  <!-- A <ls> <ls> <bg>B <ls> bet <ls> alef <ls> C</bg> <ls> D <gap> -->
+  <div class="control">A  <span>B &#x5d0; &#x5d1; C</span>  D</div>
+  </body>
+</html>

--- a/css/css-text/letter-spacing/reference/letter-spacing-bidi-005-ref.xht
+++ b/css/css-text/letter-spacing/reference/letter-spacing-bidi-005-ref.xht
@@ -5,10 +5,13 @@
     <style>
       .control {
           font: 50px/1 monospace;
-          margin: 0;
-          width: 14ch;
           font-kerning: none;
           white-space: pre;
+      }
+      .red {
+          color: red;
+          position: absolute;
+          z-index: -1;
       }
       .control span {
           background: green;
@@ -16,8 +19,9 @@
     </style>
  </head>
  <body>
-  <p>Test passes if no red is visible and the green rectangle does not extend beyond B to C.</p>
+  <p>Test passes if no red is visible except for anti-aliasing differences, and the green rectangle does not extend beyond B to C.</p>
   <!-- A <ls> <ls> <bg>B <ls> bet <ls> alef <ls> C</bg> <ls> D <gap> -->
+  <div class="control red">A  <span>B &#x5d0; &#x5d1; C</span>  D</div>
   <div class="control">A  <span>B &#x5d0; &#x5d1; C</span>  D</div>
   </body>
 </html>

--- a/css/css-text/letter-spacing/reference/letter-spacing-nesting-003-ref.xht
+++ b/css/css-text/letter-spacing/reference/letter-spacing-nesting-003-ref.xht
@@ -1,0 +1,23 @@
+﻿<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="author" title="Mike Bremford" href="http://bfo.com" />
+    <style>
+      .control {
+          font: 50px/1 monospace;
+          margin: 0;
+          width: 14ch;
+          font-kerning: none;
+          white-space: pre;
+      }
+      .control span {
+          background: green;
+      }
+    </style>
+ </head>
+ <body>
+  <p>Test passes if no red is visible and the green rectangle does not extend beyond B to C.</p>
+  <!-- A <ls> <ls> <bg>B <ls> <ls> C</bg> <ls> D -->
+  <div class="control">A <span>B  C</span> D</div>
+  </body>
+</html>

--- a/css/css-text/letter-spacing/reference/letter-spacing-nesting-003-ref.xht
+++ b/css/css-text/letter-spacing/reference/letter-spacing-nesting-003-ref.xht
@@ -5,10 +5,13 @@
     <style>
       .control {
           font: 50px/1 monospace;
-          margin: 0;
-          width: 14ch;
           font-kerning: none;
           white-space: pre;
+      }
+      .red {
+          color: red;
+          position: absolute;
+          z-index: -1;
       }
       .control span {
           background: green;
@@ -16,7 +19,7 @@
     </style>
  </head>
  <body>
-  <p>Test passes if no red is visible and the green rectangle does not extend beyond B to C.</p>
+  <p>Test passes if no red is visible except for anti-aliasing differences, and the green rectangle does not extend beyond B to C.</p>
   <!-- A <ls> <ls> <bg>B <ls> <ls> C</bg> <ls> D -->
   <div class="control">A <span>B  C</span> D</div>
   </body>


### PR DESCRIPTION
Some new tests for the follow assertions:

1. letter-spacing is between characters _within_ an element, not _after_ an element. Tested by applying a background to an element with letter-spacing and ensuring the background doesn't extend beyond the last letter

2. letter-spacing is applied between characters after the bidi algorithm has run.
