### PR TITLE
Remove leftover code in tools/ci/pr_preview.py

### DIFF
--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -308,9 +308,6 @@ def synchronize(host, github_project, window):
                 project.create_deployment(
                     pull_request, revision_latest
                 )
-                # Temporarily bail after creating one deployment, to verify the
-                # end-to-end flow without spamming many PRs.
-                logger.info('Created one deployment, returning for testing purposes')
         else:
             logger.info('Pull Request should not be mirrored')
 


### PR DESCRIPTION
This was meant to bail after a single deployment on any given run, but I failed to actually write 'return' so it never had any effect -_-. As it turns out, we do very few deploys/run anyway.