### PR TITLE
Added some missing reftests

### DIFF
--- a/css/css-gcpm/reference/string-set-001-ref.html
+++ b/css/css-gcpm/reference/string-set-001-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style type="text/css">
   @page {
+   margin: 72px;
    @top-center {
    content: "hello, world";
    }

--- a/css/css-gcpm/reference/string-set-001-ref.html
+++ b/css/css-gcpm/reference/string-set-001-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM string-set with string</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style type="text/css">
+  @page {
+   @top-center {
+   content: "hello, world";
+   }
+  }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “hello, world” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-002-ref.html
+++ b/css/css-gcpm/reference/string-set-002-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM String-set with content()</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "Chapter Title";
+   }
+  }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “Chapter Title” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-002-ref.html
+++ b/css/css-gcpm/reference/string-set-002-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "Chapter Title";
    }

--- a/css/css-gcpm/reference/string-set-003-ref.html
+++ b/css/css-gcpm/reference/string-set-003-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM String-set with content(text)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style type="text/css">
+  @page {
+   @top-center {
+   content: "Chapter Title";
+   }
+  }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if the text “Chapter Title” appears in the running head at the top of the page.</p>
+<!--AH errors out with content(text) rather than content()-->
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-003-ref.html
+++ b/css/css-gcpm/reference/string-set-003-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style type="text/css">
   @page {
+   margin: 72px;
    @top-center {
    content: "Chapter Title";
    }

--- a/css/css-gcpm/reference/string-set-004-ref.html
+++ b/css/css-gcpm/reference/string-set-004-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "C";
    }

--- a/css/css-gcpm/reference/string-set-004-ref.html
+++ b/css/css-gcpm/reference/string-set-004-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM String-set with content(first-letter)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "C";
+   }
+  }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “C” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-005-ref.html
+++ b/css/css-gcpm/reference/string-set-005-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM String-set with counter(page)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "1";
+   }
+  }
+</style>
+</head>
+<body>
+<h1>A</h1>
+<p>Test passes if “1” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-005-ref.html
+++ b/css/css-gcpm/reference/string-set-005-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "1";
    }

--- a/css/css-gcpm/reference/string-set-006-ref.html
+++ b/css/css-gcpm/reference/string-set-006-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM string-set with content(before)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "before-";
+   }
+  }
+</style>
+</head>
+<body>
+<h1>before-Chapter Title</h1>
+<p>Test passes if “before-” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-006-ref.html
+++ b/css/css-gcpm/reference/string-set-006-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "before-";
    }

--- a/css/css-gcpm/reference/string-set-007-ref.html
+++ b/css/css-gcpm/reference/string-set-007-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "-after";
    }

--- a/css/css-gcpm/reference/string-set-007-ref.html
+++ b/css/css-gcpm/reference/string-set-007-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM string-set with content(after)</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "-after";
+   }
+  }
+</style>
+</head>
+<body>
+<h1>Chapter Title-after</h1>
+<p>Test passes if “-after” appears in the running head at the top of the page.</p>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-008-ref.html
+++ b/css/css-gcpm/reference/string-set-008-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "C";
    }

--- a/css/css-gcpm/reference/string-set-008-ref.html
+++ b/css/css-gcpm/reference/string-set-008-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM string-set with multiple assignments</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "C";
+   }
+   @top-left {
+   content: "Chapter Title";
+   }
+   @top-right {
+   content: "Chapter Title";
+   }
+  }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “Chapter Title” appears in both the left and right running heads, and “C” appears in the center running head.</p>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-009-ref.html
+++ b/css/css-gcpm/reference/string-set-009-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "1 of 1"
    }

--- a/css/css-gcpm/reference/string-set-009-ref.html
+++ b/css/css-gcpm/reference/string-set-009-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM string-set with page and pages counters</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "1 of 1"
+   }
+  }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “1 of 1” appears in the running head.</p>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-010-ref.html
+++ b/css/css-gcpm/reference/string-set-010-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "Chapter Title";
    }
@@ -15,7 +16,6 @@
 </style>
 </head>
 <body>
-<h1>Chapter Title</h1>
 <p>Test passes if “Chapter Title” appears in the running head.</p>
 </body>
 </html>

--- a/css/css-gcpm/reference/string-set-010-ref.html
+++ b/css/css-gcpm/reference/string-set-010-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM string-set on element with display: none</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "Chapter Title";
+   }
+  }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if “Chapter Title” appears in the running head.</p>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-011-ref.html
+++ b/css/css-gcpm/reference/string-set-011-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM string-set on element with display: none</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page :right {
+   @top-center {
+   content: "Chapter One Title";
+   }
+  }
+  @page :left {
+   @top-center {
+   content: "Chapter Two Title";
+   }
+  }
+  #d2 { page-break-before: always; }
+</style>
+</head>
+<body>
+<p>Note: test has two pages</p>
+<p>Test passes if:</p>
+<ol>
+<li>
+“Chapter One Title” appears in the running head on page one.
+</li>
+<li>
+“Chapter Two Title” appears in the running head on page two.
+</li>
+</ol>
+
+<div id="d2">
+<p>Second Page</p>
+</div>
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-011-ref.html
+++ b/css/css-gcpm/reference/string-set-011-ref.html
@@ -8,11 +8,13 @@
 <meta name="flags" content="paged">
 <style>
   @page :right {
+   margin: 72px;
    @top-center {
    content: "Chapter One Title";
    }
   }
   @page :left {
+   margin: 72px;
    @top-center {
    content: "Chapter Two Title";
    }

--- a/css/css-gcpm/reference/string-set-012-ref.html
+++ b/css/css-gcpm/reference/string-set-012-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: GCPM string-set to attribute value</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "Hello, World"
+   }
+  }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if running head text reads “Hello, World”.
+</body>
+</html>

--- a/css/css-gcpm/reference/string-set-012-ref.html
+++ b/css/css-gcpm/reference/string-set-012-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "Hello, World"
    }

--- a/css/css-gcpm/reference/using-strings-001-ref.html
+++ b/css/css-gcpm/reference/using-strings-001-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: using 'first' property of named strings</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "Section One";
+   }
+  }
+</style>
+</head>
+<body>
+<p>Test passes if “Section One” is in the running head at the top of the page.</p>
+<h2 id="s1">Section One</h2>
+<h2 id="s2">Section Two</h2>
+<h2 id="s3">Section Three</h2>
+<h2 id="s4">Section Four</h2>
+<h2 id="s5">Section Five</h2>
+<h2 id="s6">Section Six</h2>
+</body>
+</html>

--- a/css/css-gcpm/reference/using-strings-001-ref.html
+++ b/css/css-gcpm/reference/using-strings-001-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "Section One";
    }

--- a/css/css-gcpm/reference/using-strings-002-ref.html
+++ b/css/css-gcpm/reference/using-strings-002-ref.html
@@ -8,6 +8,7 @@
 <meta name="flags" content="paged">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: "Section Six";
    }

--- a/css/css-gcpm/reference/using-strings-002-ref.html
+++ b/css/css-gcpm/reference/using-strings-002-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: using the 'last' property of named strings</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page {
+   @top-center {
+   content: "Section Six";
+   }
+  }
+</style>
+</head>
+<body>
+<p>Test passes if the text "Section Six" is in the running head at the top of the page.</p>
+<h2 id="s1">Section One</h2>
+<h2 id="s2">Section Two</h2>
+<h2 id="s3">Section Three</h2>
+<h2 id="s4">Section Four</h2>
+<h2 id="s5">Section Five</h2>
+<h2 id="s6">Section Six</h2>
+</body>
+</html>

--- a/css/css-gcpm/reference/using-strings-004-ref.html
+++ b/css/css-gcpm/reference/using-strings-004-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: using 'first-except' property of named strings</title>
+<link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
+<meta name="flags" content="paged">
+<style>
+  @page :first {
+   @top-center {
+   content: none;
+   }
+  }
+  @page {
+   @top-center {
+   content: "Chapter Title";
+   }
+  }
+#s2, #s3, #s4 { page-break-before: always; }
+</style>
+</head>
+<body>
+<h1>Chapter Title</h1>
+<p>Test passes if the running head is omitted on page one, and is “Chapter Title” on all other pages.</p>
+<h2 id="s1">Section One</h2>
+<h2 id="s2">Section Two</h2>
+<h2 id="s3">Section Three</h2>
+<h2 id="s4">Section Four</h2>
+<h2 id="s5">Section Five</h2>
+<h2 id="s6">Section Six</h2>
+</body>
+</html>

--- a/css/css-gcpm/reference/using-strings-004-ref.html
+++ b/css/css-gcpm/reference/using-strings-004-ref.html
@@ -8,11 +8,13 @@
 <meta name="flags" content="paged">
 <style>
   @page :first {
+   margin: 72px;
    @top-center {
    content: none;
    }
   }
   @page {
+   margin: 72px;
    @top-center {
    content: "Chapter Title";
    }

--- a/css/css-gcpm/string-set-001.html
+++ b/css/css-gcpm/string-set-001.html
@@ -5,11 +5,13 @@
 <title>CSS Test: GCPM string-set with string</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-001-ref.html"/>
 
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a named string can be set to a string value.">
 <style type="text/css">
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-002.html
+++ b/css/css-gcpm/string-set-002.html
@@ -5,11 +5,13 @@
 <title>CSS Test: GCPM String-set with content()</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-002-ref.html"/>
 
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a string can be set to the text value of an element, using the default content() syntax">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-003.html
+++ b/css/css-gcpm/string-set-003.html
@@ -5,11 +5,13 @@
 <title>CSS Test: GCPM String-set with content(text)</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-003-ref.html"/>
 
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a string can be set to the text value of an element, using the explicit content(text) syntax">
 <style type="text/css">
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-004.html
+++ b/css/css-gcpm/string-set-004.html
@@ -5,11 +5,13 @@
 <title>CSS Test: GCPM String-set with content(first-letter)</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-004-ref.html"/>
 
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a string can be set to the first letter of the text value of an element">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-005.html
+++ b/css/css-gcpm/string-set-005.html
@@ -5,11 +5,13 @@
 <title>CSS Test: GCPM String-set with counter(page)</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-005-ref.html"/>
 
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a named string can be set to the value of the page counter">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-006.html
+++ b/css/css-gcpm/string-set-006.html
@@ -5,10 +5,12 @@
 <title>CSS Test: GCPM string-set with content(before)</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-006-ref.html"/>
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a named string can be set to the content of the before pseudo-element">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-007.html
+++ b/css/css-gcpm/string-set-007.html
@@ -5,10 +5,12 @@
 <title>CSS Test: GCPM string-set with content(after)</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-007-ref.html"/>
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a named string can be set to the content of the after pseudo-element">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-008.html
+++ b/css/css-gcpm/string-set-008.html
@@ -5,10 +5,12 @@
 <title>CSS Test: GCPM string-set with multiple assignments</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-008-ref.html"/>
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that several named string can be set on a single element">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(center);
    }

--- a/css/css-gcpm/string-set-009.html
+++ b/css/css-gcpm/string-set-009.html
@@ -5,10 +5,12 @@
 <title>CSS Test: GCPM string-set with page and pages counters</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-009-ref.html"/>
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a string can be set to the page and pages counters">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-010.html
+++ b/css/css-gcpm/string-set-010.html
@@ -5,10 +5,12 @@
 <title>CSS Test: GCPM string-set on element with display: none</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-010-ref.html"/>
 <!--WD of this spec is out of date; referencing the ED--><meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a string can be set to the value of an element even if display is set to none">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-011.html
+++ b/css/css-gcpm/string-set-011.html
@@ -5,6 +5,7 @@
 <title>CSS Test: GCPM string-set on element with display: none</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-011-ref.html"/>
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a string can be set to the value of an element even if display is set to none">
 <!--
@@ -12,6 +13,7 @@ Note this test exposes a known bug in PrinceXML 9.0 rev 2 (and all previous vers
 -->
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title);
    }

--- a/css/css-gcpm/string-set-012.html
+++ b/css/css-gcpm/string-set-012.html
@@ -5,11 +5,13 @@
 <title>CSS Test: GCPM string-set to attribute value</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#setting-named-strings-the-string-set-pro">
+<link rel="match" href="reference/string-set-012-ref.html"/>
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that a string can be set to the value of an attribute ">
 
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(header);
    }

--- a/css/css-gcpm/using-strings-001.html
+++ b/css/css-gcpm/using-strings-001.html
@@ -5,10 +5,12 @@
 <title>CSS Test: using 'first' property of named strings</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#string-first">
+<link rel="match" href="reference/using-strings-001-ref.html"/>
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that the default value of the string property is first, so that the first instance of a named string on the page is used.">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(section);
    }

--- a/css/css-gcpm/using-strings-002.html
+++ b/css/css-gcpm/using-strings-002.html
@@ -5,10 +5,12 @@
 <title>CSS Test: using the 'last' property of named strings</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#string-last">
+<link rel="match" href="reference/using-strings-002-ref.html"/>
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that the last instance of a named string is used, when the 'last' property is applied to the string.">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(section, last);
    }

--- a/css/css-gcpm/using-strings-003.html
+++ b/css/css-gcpm/using-strings-003.html
@@ -9,6 +9,7 @@
 <meta name="assert" content="Test checks that the string set at the beginning of a page is used when the start property is applied">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(section, start);
    }

--- a/css/css-gcpm/using-strings-004.html
+++ b/css/css-gcpm/using-strings-004.html
@@ -5,10 +5,12 @@
 <title>CSS Test: using 'first-except' property of named strings</title>
 <link rel="author" title="Dave Cramer" href="mailto:dauwhe@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/css-gcpm-3/#string-first-except">
+<link rel="match" href="reference/using-strings-004-ref.html"/>
 <meta name="flags" content="paged">
 <meta name="assert" content="Test checks that if string is set to first-except, it is omitted on the page where the string is set, but appears on subsequent pages">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title, first-except);
    }

--- a/css/css-gcpm/using-strings-005.html
+++ b/css/css-gcpm/using-strings-005.html
@@ -9,6 +9,7 @@
 <meta name="assert" content="Test checks that if string is set to last, the last appearance of that element determines the content of the string">
 <style>
   @page {
+   margin: 72px;
    @top-center {
    content: string(title, last);
    }

--- a/css/css-page/reference/page-counters-000-ref.xht
+++ b/css/css-page/reference/page-counters-000-ref.xht
@@ -4,18 +4,17 @@
   <title>CSS Test: margin box referencing document counters</title>
   <link rel="author" title="Tom Clancy" href="mailto:tclancy@revenution.com"/>
   <link rel="author" title="Hewlett-Packard Company" href="http://www.hp.com/"/>
-  <link rel="help" href="http://www.w3.org/TR/css3-page/#populating-margin-boxes"/>
-  <link rel="match" href="reference/page-counters-000-ref.xht"/>
+  <link rel="author" title="Mike Bremford" href="http://bfo.com" />
   <meta name="flags" content="paged" />
-  <meta name="assert" content="The value of the counter at the beginning of page processing must be used by default. "/>
-  <style type="text/css"><![CDATA[
-   	body {counter-reset: chapter;}
-	div.chapter {counter-increment: chapter;}
-	@page {
-	  @top-center { content: "Chapter " counter(chapter); }
+  <style type="text/css">
+	@page :right {
+	  @top-center { content: "Chapter 0"; }
+	}
+	@page :left {
+	  @top-center { content: "Chapter 4"; }
 	}
 	div.section {page-break-before: always;}
-  ]]></style>
+  </style>
  </head>
  <body>
   	<div class="chapter">This paragaraph should appear on the first page, which should say &quot;Chapter 0&quot; at the top. A second page with &quot;Chapter 4&quot; at the top should also print.</div>


### PR DESCRIPTION
* Added new reftests

* Set the page margin for all css-gcpm tests to 72px. I suspect the tests were developed against Prince which uses 72px as a default - but this is specific to that user-agent. This will make the tests consistent across all user-agents, and ensure that where the UA default is 0, text does not overlap.