### PR TITLE
Various small fixes

### DIFF
--- a/css/CSS2/bidi-text/bidi-003.xht
+++ b/css/CSS2/bidi-text/bidi-003.xht
@@ -41,7 +41,7 @@
     <span class="control b end">   mmm nnn ooo </span>
    </p>
    <p>
-    <span class="test a"> aaa bbb ccc &#x202E; lll kkk jjj </span> iii hhh ggg <span class="test b"> fff eee ddd &#x202C; mmm nnn ooo </span>
+    <span class="test a"> aaa bbb ccc &#x202E; lll kkk jjj</span> iii hhh ggg<span class="test b"> fff eee ddd&#x202C;mmm nnn ooo </span>
    </p>
   </div>
  </body>

--- a/css/CSS2/bidi-text/bidi-004-ref.xht
+++ b/css/CSS2/bidi-text/bidi-004-ref.xht
@@ -24,14 +24,14 @@
   <p> The following two blocks should be identical, including overflow. (Force bidi: &#x05D0;) </p>
   <div>
    <p>
-    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp</span><br
+    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp&nbsp;</span><br
    /><span class="control b start">pXpX</span>&nbsp;pXXp&nbsp;pXXX&nbsp;Xppp<span class="control a end">&nbsp;XppX</span><br
-   /><span class="control b end">XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
+   /><span class="control b end">&nbsp;XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
    </p>
    <p>
-    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp</span><br
+    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp&nbsp;</span><br
    /><span class="control b start">pXpX</span>&nbsp;pXXp&nbsp;pXXX&nbsp;Xppp<span class="control a end">&nbsp;XppX</span><br
-   /><span class="control b end">XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
+   /><span class="control b end">&nbsp;XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
    </p>
   </div>
 

--- a/css/CSS2/bidi-text/bidi-004.xht
+++ b/css/CSS2/bidi-text/bidi-004.xht
@@ -33,9 +33,9 @@
   <p> The following two blocks should be identical, including overflow. (Force bidi: &#x05D0;) </p>
   <div>
    <p>
-    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp</span><br
+    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp&nbsp;</span><br
    /><span class="control b start">pXpX</span>&nbsp;pXXp&nbsp;pXXX&nbsp;Xppp<span class="control a end">&nbsp;XppX</span><br
-   /><span class="control b end">XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
+   /><span class="control b end">&nbsp;XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
    </p>
    <p>
     <!-- (note that everything between the RLO to the PDF is backwards) -->

--- a/css/CSS2/borders/border-color-011-ref.xht
+++ b/css/CSS2/borders/border-color-011-ref.xht
@@ -19,7 +19,7 @@
 
  <body>
 
-  <div>This should have a green border, because the computed value of 'border-color' set to its initial value is the computed value of 'color', which is then inherited as a color.</div>
+  <div>This should have a green border, because the computed value of 'border-color' set to its initial value is 'currentColor', which refers to the color on the current element.</div>
 
  </body>
 </html>

--- a/css/CSS2/borders/border-color-011.xht
+++ b/css/CSS2/borders/border-color-011.xht
@@ -6,11 +6,12 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/inheritance/border-color/001.html" type="text/html"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/inheritance/border-color/001.xml" type="application/xhtml+xml"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
+  <link rel="help" href="https://drafts.csswg.org/css-color/#resolving-color-values" />
   <link rel="match" href="border-color-011-ref.xht" />
-
+  <meta name="assert" content="The initial value of border-color is 'currentColor', which (as of css-color-3) is inherited as a keyword." />
   <style type="text/css">
-   .test { display: block; color: green; border: none; }
-   .test .inner { border-color: inherit; border-style: solid; color: red; }
+   .test { display: block; color: red; border: none; }
+   .test .inner { border-color: inherit; border-style: solid; color: green; }
    .test .inner .text { color: green; }
   </style>
  </head>
@@ -19,8 +20,8 @@
    <div class="inner">
     <div class="text">
      This should have a green border, because the computed value of
-     'border-color' set to its initial value is the computed value
-     of 'color', which is then inherited as a color.
+     'border-color' set to its initial value is 'currentColor', which
+     refers to the color on the current element.
     </div>
    </div>
   </div>

--- a/css/CSS2/borders/border-color-012-ref.xht
+++ b/css/CSS2/borders/border-color-012-ref.xht
@@ -17,7 +17,7 @@
 
  <body>
 
-  <div><span>This should have a green border, because the computed value of 'border-color' set to its initial value is the computed value of 'color', which is then inherited as a color.</span></div>
+  <div><span>This should have a green border, because the computed value of 'border-color' set to its initial value is 'currentColor'.</span></div>
 
  </body>
 </html>

--- a/css/CSS2/borders/border-color-012.xht
+++ b/css/CSS2/borders/border-color-012.xht
@@ -6,10 +6,10 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/inheritance/border/color/001.xml" type="application/xhtml+xml"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
   <link rel="match" href="border-color-012-ref.xht" />
-
+  <meta name="assert" content="The initial value of border-color is 'currentColor', which (as of css-color-3) is inherited as a keyword." />
   <style type="text/css">
-   .test { display: block; color: green; border: none; }
-   .test > .inner { border-color: inherit; border-style: solid; color: red; }
+   .test { display: block; color: red; border: none; }
+   .test > .inner { border-color: inherit; border-style: solid; color: green; }
    .test > .inner > .text { color: green; }
   </style>
  </head>
@@ -18,8 +18,7 @@
    <span class="inner">
     <span class="text">
      This should have a green border, because the computed value of
-     'border-color' set to its initial value is the computed value
-     of 'color', which is then inherited as a color.
+     'border-color' set to its initial value is 'currentColor'.
     </span>
    </span>
   </div>

--- a/css/CSS2/cascade-import/cascade-import-009.xht
+++ b/css/CSS2/cascade-import/cascade-import-009.xht
@@ -14,7 +14,7 @@
   <link rel="stylesheet"
         href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=5&amp;mime=text%2Fcss&amp;text=.a+%7B+color%3A+blue%3B+%7D"/>
   <link rel="alternate stylesheet" title="Test"
-        href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=8&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D>"/>
+        href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=8&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D"/>
  </head>
  <body>
   <p class="a">Select the alternate stylesheet to run this test.</p>

--- a/css/CSS2/cascade-import/cascade-import-010.xht
+++ b/css/CSS2/cascade-import/cascade-import-010.xht
@@ -14,7 +14,7 @@
   <link rel="stylesheet"
         href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=5&amp;mime=text%2Fcss&amp;text=.a+%7B+color%3A+blue%3B+%7D"/>
   <link rel="alternate stylesheet" title="Test"
-        href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=2&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D>"/>
+        href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=2&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D"/>
  </head>
  <body>
   <p class="a">Select the alternate stylesheet to run this test.</p>

--- a/css/CSS2/cascade-import/cascade-import-011.xht
+++ b/css/CSS2/cascade-import/cascade-import-011.xht
@@ -14,7 +14,7 @@
   <link rel="stylesheet"
         href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=5&amp;mime=text%2Fcss&amp;text=.a+%7B+color%3A+blue%3B+%7D"/>
   <meta http-equiv="Link"
-        content='&lt;http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=8&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D>; rel="alternate stylesheet"; title="Test"'/>
+        content='&lt;http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=8&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D; rel="alternate stylesheet"; title="Test"'/>
  </head>
  <body>
   <p class="a">Select the alternate stylesheet to run this test.</p>

--- a/css/CSS2/cascade-import/cascade-import-012.xht
+++ b/css/CSS2/cascade-import/cascade-import-012.xht
@@ -14,7 +14,7 @@
   <link rel="stylesheet"
         href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=5&amp;mime=text%2Fcss&amp;text=.a+%7B+color%3A+blue%3B+%7D"/>
   <meta http-equiv="Link"
-        content='&lt;http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=2&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D>; rel="alternate stylesheet"; title="Test"' />
+        content='&lt;http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=2&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D; rel="alternate stylesheet"; title="Test"' />
  </head>
  <body>
   <p class="a">Select the alternate stylesheet to run this test.</p>

--- a/css/css-masking/clip-path/clip-path-element-userSpaceOnUse-003.html
+++ b/css/css-masking/clip-path/clip-path-element-userSpaceOnUse-003.html
@@ -9,7 +9,7 @@
     <link rel="match" href="reference/clip-path-ref-right-green-ref.html">
     <meta name="assert" content="The clip-path property takes a reference to a clipPath element for clipping. Percentage values
         are relative to the viewport for userSpaceOnUse on clipPathUnits.
-        On pass the left half of the site is white and the right half of the site is blue.">
+        On pass the left half of the site is white and the right half of the site is green.">
 
     <style>
         html, body {
@@ -21,7 +21,7 @@
 </head>
 <body>
     <div style="width: 100%; height: 100%; background-color: green; clip-path: url(#clip); position: absolute;"></div>
-    <p style="position: absolute;">The test passes if the left half of the site is white and the right half of the site is blue.</p>
+    <p style="position: absolute;">The test passes if the left half of the site is white and the right half of the site is green.</p>
 
     <svg>
         <clipPath id="clip">

--- a/css/css-text/hanging-punctuation/hanging-punctuation-allow-end-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-allow-end-001.xht
@@ -16,6 +16,7 @@
 				/* the CSS below is not part of the test */
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/hanging-punctuation-first-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-first-001.xht
@@ -16,6 +16,7 @@
 				/* the CSS below is not part of the test */
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.hanging {
 					left: -1em;

--- a/css/css-text/hanging-punctuation/hanging-punctuation-force-end-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-force-end-001.xht
@@ -16,6 +16,7 @@
 				/* the CSS below is not part of the test */
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/hanging-punctuation-last-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-last-001.xht
@@ -16,6 +16,7 @@
 				/* the CSS below is not part of the test */
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-allow-end-001-ref.xht
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-allow-end-001-ref.xht
@@ -8,6 +8,7 @@
 			<![CDATA[
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-first-001-ref.xht
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-first-001-ref.xht
@@ -8,6 +8,7 @@
 			<![CDATA[
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.hanging {
 					left: -1em;

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-force-end-001-ref.xht
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-force-end-001-ref.xht
@@ -8,6 +8,7 @@
 			<![CDATA[
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-last-001-ref.xht
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-last-001-ref.xht
@@ -8,6 +8,7 @@
 			<![CDATA[
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/svg/render/reftests/blending-svg-foreign-object-ref.html
+++ b/svg/render/reftests/blending-svg-foreign-object-ref.html
@@ -2,7 +2,7 @@
 <div style="background: green">
   <div>Expected: a black square on green background.</div>
   <svg style="height: 200px">
-    <foreignObject>
+    <foreignObject width="200" height="200">
       <div style="width: 200px; height: 200px; background: black"></div>
     </foreignObject>
   </svg>

--- a/svg/render/reftests/blending-svg-foreign-object.html
+++ b/svg/render/reftests/blending-svg-foreign-object.html
@@ -5,7 +5,7 @@
 <div style="background: green">
   <div>Expected: a black square on green background.</div>
   <svg style="width: 200px; height: 200px">
-    <foreignObject style="mix-blend-mode: multiply">
+    <foreignObject width="200" height="200" style="mix-blend-mode: multiply">
       <div style="width: 200px; height: 200px; background: red"></div>
     </foreignObject>
   </svg>

--- a/svg/text/reftests/textpath-shape-001.svg
+++ b/svg/text/reftests/textpath-shape-001.svg
@@ -11,7 +11,7 @@
           href="mailto:tavmjong@free.fr"/>
     <html:link rel="help"
           href="https://svgwg.org/svg2-draft/text.html#TextPathAttributes"/>
-    <html:link rel="match"  href="textpath-side-001-ref.svg" />
+    <html:link rel="match"  href="textpath-shape-001-ref.svg" />
   </g>
 
   <style id="test-font" type="text/css">


### PR DESCRIPTION
These are most of the small patches we have been applying to some older reftests to make them correct. All of these were failing in all browsers (except webkit for test 2).

1. The whitespace in bidi-003 and bidi-004 were out by a single character due to collapsing. No browsers were rendering these correctly - it's possible the tests are right and everything else was wrong, but I think in this case the tests were the ones that were wrong.

2. currentColor now inherits as a keyword, but border-color-11 and 12 did not reflect this (note this will cause a failure in Webkit, which still inherits as a color value)

3. There was a junk characters in the "cascade-import" tests, which I don't think anyone noticed because no-one tests HTTP link headers. Still, they should be correct.

4. The hanging-punctuation tests relied on characters having an exact width and wrapping at a certain point. kerning could break this, so set "font-kerning: none"

5. The SVG "foreignObject" tests presumed that foreignObject would somehow size to fit the content. That's not the case, the default width/height is zero so these tests weren't working. Set the width and height.

6. The SVG textpath test was referring to the wrong reftest.