### PR TITLE
Use error instead of critical for logging the traceback (#21594)

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -125,7 +125,7 @@ class TestRunner(object):
         try:
             return self.executor.run_test(test)
         except Exception:
-            self.logger.critical(traceback.format_exc())
+            self.logger.error(traceback.format_exc())
             raise
 
     def wait(self):


### PR DESCRIPTION
If critical its used, then the test step will return non-zero status,
even when the step has finished completing the run.
This causes issues on the CI, as the whole run its marked as failed
even when it completed.
This fixes issue #21594