### PR TITLE
Fix round(), abstract the tests

### DIFF
--- a/css/css-values/round-function.html
+++ b/css/css-values/round-function.html
@@ -78,13 +78,13 @@ testRound("round(-18px, -10px)", "-20px");
 // 0 step is NaN
 testRound("round(5px, 0px)", "calc(NaN * 1px)");
 // both infinite is NaN
-testRound("round(1px/0, 1px/0)", "calc(NaN * 1px)");
+testRound("round(infinity * 1px, infinity * 1px)", "calc(NaN * 1px)");
 
 // infinite value with finite step is the same infinity
-testRound("round(1px/0, 5px)", "calc(infinity * 1px)");
-testRound("round(1px/0, -5px)", "calc(infinity * 1px)");
-testRound("round(-1px/0, 5px)", "calc(-infinity * 1px)");
-testRound("round(-1px/0, -5px)", "calc(-infinity * 1px)");
+testRound("round(infinity * 1px, 5px)", "calc(infinity * 1px)");
+testRound("round(infinity * 1px, -5px)", "calc(infinity * 1px)");
+testRound("round(-infinity * 1px, 5px)", "calc(-infinity * 1px)");
+testRound("round(-infinity * 1px, -5px)", "calc(-infinity * 1px)");
 
 // finite value with infinite step is same-sign 0
 // Since I can't tell +0 and -0 apart normally,

--- a/css/css-values/round-function.html
+++ b/css/css-values/round-function.html
@@ -11,7 +11,7 @@
 <div></div>
 <script>
 const testEl = document.querySelector("div");
-function testRound(testString, expectedString, {base="123px", msg}={}) {
+function equalsValue(testString, expectedString, {base="123px", msg}={}) {
     test(()=>{
         testEl.style.left = base;
         testEl.style.left = testString;
@@ -24,74 +24,74 @@ function testRound(testString, expectedString, {base="123px", msg}={}) {
         assert_equal(usedValue, expectedValue);
     }, msg || `${testString} should round to ${expectedString}`);
 }
-
-// No-op round should be same as nearest
-testRound("round(23px, 10px)", "20px");
-testRound("round(18px, 10px)", "20px");
-testRound("round(15px, 10px)", "20px");
-testRound("round(13px, 10px)", "10px");
-testRound("round(-13px, 10px)", "-10px");
-testRound("round(-18px, 10px)", "-20px");
-
-// Test nearest
-testRound("round(nearest, 23px, 10px)", "20px");
-testRound("round(nearest, 18px, 10px)", "20px");
-testRound("round(nearest, 15px, 10px)", "20px");
-testRound("round(nearest, 13px, 10px)", "10px");
-testRound("round(nearest, -13px, 10px)", "-10px");
-testRound("round(nearest, -18px, 10px)", "-20px");
-
-// Test down
-testRound("round(down, 23px, 10px)", "20px");
-testRound("round(down, 18px, 10px)", "10px");
-testRound("round(down, 15px, 10px)", "10px");
-testRound("round(down, 13px, 10px)", "10px");
-testRound("round(down, -13px, 10px)", "-20px");
-testRound("round(down, -18px, 10px)", "-20px");
-
-// Test up
-testRound("round(up, 23px, 10px)", "30px");
-testRound("round(up, 18px, 10px)", "20px");
-testRound("round(up, 15px, 10px)", "20px");
-testRound("round(up, 13px, 10px)", "20px");
-testRound("round(up, -13px, 10px)", "-10px");
-testRound("round(up, -18px, 10px)", "-10px");
-
-// Test to-zero
-testRound("round(to-zero, 23px, 10px)", "20px");
-testRound("round(to-zero, 18px, 10px)", "10px");
-testRound("round(to-zero, 15px, 10px)", "10px");
-testRound("round(to-zero, 13px, 10px)", "10px");
-testRound("round(to-zero, -13px, 10px)", "-10px");
-testRound("round(to-zero, -18px, 10px)", "-10px");
-
-// Test a negative step
-testRound("round(23px, -10px)", "20px");
-testRound("round(18px, -10px)", "20px");
-testRound("round(15px, -10px)", "20px");
-testRound("round(13px, -10px)", "10px");
-testRound("round(-13px, -10px)", "-10px");
-testRound("round(-18px, -10px)", "-20px");
-
-// Extreme cases:
 function equalsPosInfinity(testString) {
-    testRound(`calc(1px * ${testString})`, "calc(infinity * 1px)");
+    equalsValue(`calc(1px * ${testString})`, "calc(infinity * 1px)");
 }
 function equalsNegInfinity(testString) {
-    testRound(`calc(1px * ${testString})`, "calc(-infinity * 1px)");
+    equalsValue(`calc(1px * ${testString})`, "calc(-infinity * 1px)");
 }
 function equalsPosZero(testString) {
-    testRound(`calc(1px / ${testString})`, "calc(infinity * 1px)");
+    equalsValue(`calc(1px / ${testString})`, "calc(infinity * 1px)");
 }
 function equalsNegZero(testString) {
-    testRound(`calc(1px / ${testString})`, "calc(-infinity * 1px)");
+    equalsValue(`calc(1px / ${testString})`, "calc(-infinity * 1px)");
 }
 function equalsNaN(testString) {
     // Make sure that it's NaN, not an infinity,
     // by making sure that it's the same value both pos and neg.
-    testRound(`calc(1px * ${testString})`, "calc(NaN * 1px)");
-    testRound(`calc(-1px * ${testString})`, "calc(NaN * 1px)");
+    equalsValue(`calc(1px * ${testString})`, "calc(NaN * 1px)");
+    equalsValue(`calc(-1px * ${testString})`, "calc(NaN * 1px)");
 }
+
+// No-op round should be same as nearest
+equalsValue("round(23px, 10px)", "20px");
+equalsValue("round(18px, 10px)", "20px");
+equalsValue("round(15px, 10px)", "20px");
+equalsValue("round(13px, 10px)", "10px");
+equalsValue("round(-13px, 10px)", "-10px");
+equalsValue("round(-18px, 10px)", "-20px");
+
+// Test nearest
+equalsValue("round(nearest, 23px, 10px)", "20px");
+equalsValue("round(nearest, 18px, 10px)", "20px");
+equalsValue("round(nearest, 15px, 10px)", "20px");
+equalsValue("round(nearest, 13px, 10px)", "10px");
+equalsValue("round(nearest, -13px, 10px)", "-10px");
+equalsValue("round(nearest, -18px, 10px)", "-20px");
+
+// Test down
+equalsValue("round(down, 23px, 10px)", "20px");
+equalsValue("round(down, 18px, 10px)", "10px");
+equalsValue("round(down, 15px, 10px)", "10px");
+equalsValue("round(down, 13px, 10px)", "10px");
+equalsValue("round(down, -13px, 10px)", "-20px");
+equalsValue("round(down, -18px, 10px)", "-20px");
+
+// Test up
+equalsValue("round(up, 23px, 10px)", "30px");
+equalsValue("round(up, 18px, 10px)", "20px");
+equalsValue("round(up, 15px, 10px)", "20px");
+equalsValue("round(up, 13px, 10px)", "20px");
+equalsValue("round(up, -13px, 10px)", "-10px");
+equalsValue("round(up, -18px, 10px)", "-10px");
+
+// Test to-zero
+equalsValue("round(to-zero, 23px, 10px)", "20px");
+equalsValue("round(to-zero, 18px, 10px)", "10px");
+equalsValue("round(to-zero, 15px, 10px)", "10px");
+equalsValue("round(to-zero, 13px, 10px)", "10px");
+equalsValue("round(to-zero, -13px, 10px)", "-10px");
+equalsValue("round(to-zero, -18px, 10px)", "-10px");
+
+// Test a negative step
+equalsValue("round(23px, -10px)", "20px");
+equalsValue("round(18px, -10px)", "20px");
+equalsValue("round(15px, -10px)", "20px");
+equalsValue("round(13px, -10px)", "10px");
+equalsValue("round(-13px, -10px)", "-10px");
+equalsValue("round(-18px, -10px)", "-20px");
+
+// Extreme cases:
 
 // 0 step is NaN
 equalsNaN("round(5, 0)");

--- a/css/css-values/round-function.html
+++ b/css/css-values/round-function.html
@@ -74,6 +74,18 @@ testRound("round(-13px, -10px)", "-10px");
 testRound("round(-18px, -10px)", "-20px");
 
 // Extreme cases:
+function equalsPosInfinity(testString) {
+    testRound(`calc(1px * ${testString})`, "calc(infinity * 1px)");
+}
+function equalsNegInfinity(testString) {
+    testRound(`calc(1px * ${testString})`, "calc(-infinity * 1px)");
+}
+function equalsPosZero(testString) {
+    testRound(`calc(1px / ${testString})`, "calc(infinity * 1px)");
+}
+function equalsNegZero(testString) {
+    testRound(`calc(1px / ${testString})`, "calc(-infinity * 1px)");
+}
 
 // 0 step is NaN
 testRound("round(5px, 0px)", "calc(NaN * 1px)");
@@ -81,16 +93,29 @@ testRound("round(5px, 0px)", "calc(NaN * 1px)");
 testRound("round(infinity * 1px, infinity * 1px)", "calc(NaN * 1px)");
 
 // infinite value with finite step is the same infinity
-testRound("round(infinity * 1px, 5px)", "calc(infinity * 1px)");
-testRound("round(infinity * 1px, -5px)", "calc(infinity * 1px)");
-testRound("round(-infinity * 1px, 5px)", "calc(-infinity * 1px)");
-testRound("round(-infinity * 1px, -5px)", "calc(-infinity * 1px)");
+equalsPosInfinity("round(infinity, 5)");
+equalsPosInfinity("round(infinity, -5)");
+equalsNegInfinity("round(-infinity, 5)");
+equalsNegInfinity("round(-infinity, -5)");
 
-// finite value with infinite step is same-sign 0
-// Since I can't tell +0 and -0 apart normally,
-// invert them so they become distinguishable infinities
-testRound("calc(1px / round(5, infinity))", "calc(infinity * 1px)");
-testRound("calc(1px / round(5, -infinity))", "calc(infinity * 1px)");
-testRound("calc(1px / round(-5, infinity))", "calc(-infinity * 1px)");
-testRound("calc(1px / round(-5, -infinity))", "calc(-infinity * 1px)");
+// Finite value with infinite step depends on rounding strategy.
+// 'nearest' and 'to-zero': pos and +0 go to +0, neg and -0 go to -0
+equalsPosZero("round(5, infinity)");
+equalsPosZero("round(5, -infinity)");
+equalsNegZero("round(-5, infinity)");
+equalsNegZero("round(-5, -infinity)");
+equalsPosZero("round(to-zero, 5, infinity)");
+equalsPosZero("round(to-zero, 5, -infinity)");
+equalsNegZero("round(to-zero, -5, infinity)");
+equalsNegZero("round(to-zero, -5, -infinity)");
+// 'up': pos goes to +inf, 0+ goes to 0+, else 0-
+equalsPosInfinity("round(up, 1, infinity)");
+equalsPosZero("round(up, 0, infinity)");
+equalsNegZero("round(up, -1 * 0, infinity");
+equalsNegZero("round(up, -1, infinity");
+// 'down': neg goes to -inf, -0 goes to -0, else 0+
+equalsNegInfinity("round(down, -1, infinity)");
+equalsNegZero("round(down, -1 * 0, infinity)");
+equalsPosZero("round(down, 0, infinity)");
+equalsPosZero("round(down, 1, infinity)");
 </script>

--- a/css/css-values/round-function.html
+++ b/css/css-values/round-function.html
@@ -86,11 +86,17 @@ function equalsPosZero(testString) {
 function equalsNegZero(testString) {
     testRound(`calc(1px / ${testString})`, "calc(-infinity * 1px)");
 }
+function equalsNaN(testString) {
+    // Make sure that it's NaN, not an infinity,
+    // by making sure that it's the same value both pos and neg.
+    testRound(`calc(1px * ${testString})`, "calc(NaN * 1px)");
+    testRound(`calc(-1px * ${testString})`, "calc(NaN * 1px)");
+}
 
 // 0 step is NaN
-testRound("round(5px, 0px)", "calc(NaN * 1px)");
+equalsNaN("round(5, 0)");
 // both infinite is NaN
-testRound("round(infinity * 1px, infinity * 1px)", "calc(NaN * 1px)");
+equalsNaN("round(infinity, infinity)");
 
 // infinite value with finite step is the same infinity
 equalsPosInfinity("round(infinity, 5)");

--- a/css/css-values/round-function.html
+++ b/css/css-values/round-function.html
@@ -2,126 +2,92 @@
 <title>round() function</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<style>
-</style>
+<script src="../support/numeric-testcommon.js"></script>
 
 <meta name=author content="Tab Atkins-Bittner">
 <link rel=help href="https://drafts.csswg.org/css-values-4/#round-func">
 
-<div></div>
+<div id=target></div>
 <script>
-const testEl = document.querySelector("div");
-function equalsValue(testString, expectedString, {base="123px", msg}={}) {
-    test(()=>{
-        testEl.style.left = base;
-        testEl.style.left = testString;
-        const usedValue = getComputedStyle(testEl).left;
-        assert_not_equals(usedValue, base);
-        testEl.style.left = base;
-        testEl.style.left = expectedString;
-        const expectedValue = getComputedStyle(testEl).left;
-        assert_not_equals(expectedValue, base)
-        assert_equal(usedValue, expectedValue);
-    }, msg || `${testString} should round to ${expectedString}`);
-}
-function equalsPosInfinity(testString) {
-    equalsValue(`calc(1px * ${testString})`, "calc(infinity * 1px)");
-}
-function equalsNegInfinity(testString) {
-    equalsValue(`calc(1px * ${testString})`, "calc(-infinity * 1px)");
-}
-function equalsPosZero(testString) {
-    equalsValue(`calc(1px / ${testString})`, "calc(infinity * 1px)");
-}
-function equalsNegZero(testString) {
-    equalsValue(`calc(1px / ${testString})`, "calc(-infinity * 1px)");
-}
-function equalsNaN(testString) {
-    // Make sure that it's NaN, not an infinity,
-    // by making sure that it's the same value both pos and neg.
-    equalsValue(`calc(1px * ${testString})`, "calc(NaN * 1px)");
-    equalsValue(`calc(-1px * ${testString})`, "calc(NaN * 1px)");
-}
-
 // No-op round should be same as nearest
-equalsValue("round(23px, 10px)", "20px");
-equalsValue("round(18px, 10px)", "20px");
-equalsValue("round(15px, 10px)", "20px");
-equalsValue("round(13px, 10px)", "10px");
-equalsValue("round(-13px, 10px)", "-10px");
-equalsValue("round(-18px, 10px)", "-20px");
+test_math_used("round(23px, 10px)", "20px");
+test_math_used("round(18px, 10px)", "20px");
+test_math_used("round(15px, 10px)", "20px");
+test_math_used("round(13px, 10px)", "10px");
+test_math_used("round(-13px, 10px)", "-10px");
+test_math_used("round(-18px, 10px)", "-20px");
 
 // Test nearest
-equalsValue("round(nearest, 23px, 10px)", "20px");
-equalsValue("round(nearest, 18px, 10px)", "20px");
-equalsValue("round(nearest, 15px, 10px)", "20px");
-equalsValue("round(nearest, 13px, 10px)", "10px");
-equalsValue("round(nearest, -13px, 10px)", "-10px");
-equalsValue("round(nearest, -18px, 10px)", "-20px");
+test_math_used("round(nearest, 23px, 10px)", "20px");
+test_math_used("round(nearest, 18px, 10px)", "20px");
+test_math_used("round(nearest, 15px, 10px)", "20px");
+test_math_used("round(nearest, 13px, 10px)", "10px");
+test_math_used("round(nearest, -13px, 10px)", "-10px");
+test_math_used("round(nearest, -18px, 10px)", "-20px");
 
 // Test down
-equalsValue("round(down, 23px, 10px)", "20px");
-equalsValue("round(down, 18px, 10px)", "10px");
-equalsValue("round(down, 15px, 10px)", "10px");
-equalsValue("round(down, 13px, 10px)", "10px");
-equalsValue("round(down, -13px, 10px)", "-20px");
-equalsValue("round(down, -18px, 10px)", "-20px");
+test_math_used("round(down, 23px, 10px)", "20px");
+test_math_used("round(down, 18px, 10px)", "10px");
+test_math_used("round(down, 15px, 10px)", "10px");
+test_math_used("round(down, 13px, 10px)", "10px");
+test_math_used("round(down, -13px, 10px)", "-20px");
+test_math_used("round(down, -18px, 10px)", "-20px");
 
 // Test up
-equalsValue("round(up, 23px, 10px)", "30px");
-equalsValue("round(up, 18px, 10px)", "20px");
-equalsValue("round(up, 15px, 10px)", "20px");
-equalsValue("round(up, 13px, 10px)", "20px");
-equalsValue("round(up, -13px, 10px)", "-10px");
-equalsValue("round(up, -18px, 10px)", "-10px");
+test_math_used("round(up, 23px, 10px)", "30px");
+test_math_used("round(up, 18px, 10px)", "20px");
+test_math_used("round(up, 15px, 10px)", "20px");
+test_math_used("round(up, 13px, 10px)", "20px");
+test_math_used("round(up, -13px, 10px)", "-10px");
+test_math_used("round(up, -18px, 10px)", "-10px");
 
 // Test to-zero
-equalsValue("round(to-zero, 23px, 10px)", "20px");
-equalsValue("round(to-zero, 18px, 10px)", "10px");
-equalsValue("round(to-zero, 15px, 10px)", "10px");
-equalsValue("round(to-zero, 13px, 10px)", "10px");
-equalsValue("round(to-zero, -13px, 10px)", "-10px");
-equalsValue("round(to-zero, -18px, 10px)", "-10px");
+test_math_used("round(to-zero, 23px, 10px)", "20px");
+test_math_used("round(to-zero, 18px, 10px)", "10px");
+test_math_used("round(to-zero, 15px, 10px)", "10px");
+test_math_used("round(to-zero, 13px, 10px)", "10px");
+test_math_used("round(to-zero, -13px, 10px)", "-10px");
+test_math_used("round(to-zero, -18px, 10px)", "-10px");
 
 // Test a negative step
-equalsValue("round(23px, -10px)", "20px");
-equalsValue("round(18px, -10px)", "20px");
-equalsValue("round(15px, -10px)", "20px");
-equalsValue("round(13px, -10px)", "10px");
-equalsValue("round(-13px, -10px)", "-10px");
-equalsValue("round(-18px, -10px)", "-20px");
+test_math_used("round(23px, -10px)", "20px");
+test_math_used("round(18px, -10px)", "20px");
+test_math_used("round(15px, -10px)", "20px");
+test_math_used("round(13px, -10px)", "10px");
+test_math_used("round(-13px, -10px)", "-10px");
+test_math_used("round(-18px, -10px)", "-20px");
 
 // Extreme cases:
 
 // 0 step is NaN
-equalsNaN("round(5, 0)");
+test_nan("round(5, 0)");
 // both infinite is NaN
-equalsNaN("round(infinity, infinity)");
+test_nan("round(infinity, infinity)");
 
 // infinite value with finite step is the same infinity
-equalsPosInfinity("round(infinity, 5)");
-equalsPosInfinity("round(infinity, -5)");
-equalsNegInfinity("round(-infinity, 5)");
-equalsNegInfinity("round(-infinity, -5)");
+test_plus_infinity("round(infinity, 5)");
+test_plus_infinity("round(infinity, -5)");
+test_minus_infinity("round(-infinity, 5)");
+test_minus_infinity("round(-infinity, -5)");
 
 // Finite value with infinite step depends on rounding strategy.
 // 'nearest' and 'to-zero': pos and +0 go to +0, neg and -0 go to -0
-equalsPosZero("round(5, infinity)");
-equalsPosZero("round(5, -infinity)");
-equalsNegZero("round(-5, infinity)");
-equalsNegZero("round(-5, -infinity)");
-equalsPosZero("round(to-zero, 5, infinity)");
-equalsPosZero("round(to-zero, 5, -infinity)");
-equalsNegZero("round(to-zero, -5, infinity)");
-equalsNegZero("round(to-zero, -5, -infinity)");
+test_plus_zero("round(5, infinity)");
+test_plus_zero("round(5, -infinity)");
+test_minus_zero("round(-5, infinity)");
+test_minus_zero("round(-5, -infinity)");
+test_plus_zero("round(to-zero, 5, infinity)");
+test_plus_zero("round(to-zero, 5, -infinity)");
+test_minus_zero("round(to-zero, -5, infinity)");
+test_minus_zero("round(to-zero, -5, -infinity)");
 // 'up': pos goes to +inf, 0+ goes to 0+, else 0-
-equalsPosInfinity("round(up, 1, infinity)");
-equalsPosZero("round(up, 0, infinity)");
-equalsNegZero("round(up, -1 * 0, infinity");
-equalsNegZero("round(up, -1, infinity");
+test_plus_infinity("round(up, 1, infinity)");
+test_plus_zero("round(up, 0, infinity)");
+test_minus_zero("round(up, -1 * 0, infinity");
+test_minus_zero("round(up, -1, infinity");
 // 'down': neg goes to -inf, -0 goes to -0, else 0+
-equalsNegInfinity("round(down, -1, infinity)");
-equalsNegZero("round(down, -1 * 0, infinity)");
-equalsPosZero("round(down, 0, infinity)");
-equalsPosZero("round(down, 1, infinity)");
+test_minus_infinity("round(down, -1, infinity)");
+test_minus_zero("round(down, -1 * 0, infinity)");
+test_plus_zero("round(down, 0, infinity)");
+test_plus_zero("round(down, 1, infinity)");
 </script>

--- a/css/css-values/round-function.html
+++ b/css/css-values/round-function.html
@@ -11,15 +11,15 @@
 <div></div>
 <script>
 const testEl = document.querySelector("div");
-function testRound(testString, expectedString, {base="0px", msg}={}) {
+function testRound(testString, expectedString, {base="123px", msg}={}) {
     test(()=>{
-        testEl.style.width = base;
-        testEl.style.width = testString;
-        const usedValue = getComputedStyle(testEl).width;
+        testEl.style.left = base;
+        testEl.style.left = testString;
+        const usedValue = getComputedStyle(testEl).left;
         assert_not_equals(usedValue, base);
-        testEl.style.width = base;
-        testEl.style.width = expectedString;
-        const expectedValue = getComputedStyle(testEl).width;
+        testEl.style.left = base;
+        testEl.style.left = expectedString;
+        const expectedValue = getComputedStyle(testEl).left;
         assert_not_equals(expectedValue, base)
         assert_equal(usedValue, expectedValue);
     }, msg || `${testString} should round to ${expectedString}`);

--- a/css/css-values/round-function.html
+++ b/css/css-values/round-function.html
@@ -63,6 +63,9 @@ test_math_used("round(-18px, -10px)", "-20px");
 test_nan("round(5, 0)");
 // both infinite is NaN
 test_nan("round(infinity, infinity)");
+test_nan("round(infinity, -infinity)");
+test_nan("round(-infinity, infinity)");
+test_nan("round(-infinity, -infinity)");
 
 // infinite value with finite step is the same infinity
 test_plus_infinity("round(infinity, 5)");

--- a/css/css-values/round-function.html
+++ b/css/css-values/round-function.html
@@ -76,17 +76,21 @@ testRound("round(-18px, -10px)", "-20px");
 // Extreme cases:
 
 // 0 step is NaN
-testRound("round(5px, 0px)", "calc(NaN)");
+testRound("round(5px, 0px)", "calc(NaN * 1px)");
 // both infinite is NaN
-testRound("round(1px/0, 1px/0)", "calc(NaN)");
+testRound("round(1px/0, 1px/0)", "calc(NaN * 1px)");
+
 // infinite value with finite step is the same infinity
 testRound("round(1px/0, 5px)", "calc(infinity * 1px)");
 testRound("round(1px/0, -5px)", "calc(infinity * 1px)");
 testRound("round(-1px/0, 5px)", "calc(-infinity * 1px)");
 testRound("round(-1px/0, -5px)", "calc(-infinity * 1px)");
+
 // finite value with infinite step is same-sign 0
-testRound("calc(1/round(5px, 1px/0))", "calc(infinity * 1px)");
-testRound("calc(1/round(5px, -1px/0))", "calc(infinity * 1px)");
-testRound("calc(1/round(-5px, 1px/0))", "calc(-infinity * 1px)");
-testRound("calc(1/round(-5px, -1px/0))", "calc(-infinity * 1px)");
+// Since I can't tell +0 and -0 apart normally,
+// invert them so they become distinguishable infinities
+testRound("calc(1px / round(5, infinity))", "calc(infinity * 1px)");
+testRound("calc(1px / round(5, -infinity))", "calc(infinity * 1px)");
+testRound("calc(1px / round(-5, infinity))", "calc(-infinity * 1px)");
+testRound("calc(1px / round(-5, -infinity))", "calc(-infinity * 1px)");
 </script>

--- a/css/support/numeric-testcommon.js
+++ b/css/support/numeric-testcommon.js
@@ -22,12 +22,12 @@ function test_math_used(testString, expectedString, {base="123px", msg, prop="le
         testEl.style[prop] = base;
         testEl.style[prop] = testString;
         const usedValue = getComputedStyle(testEl)[prop];
-        assert_not_equals(usedValue, base);
+        assert_not_equals(usedValue, base, `${testString} isn't valid in '${prop}'; got the default value instead.`);
         testEl.style[prop] = base;
         testEl.style[prop] = expectedString;
         const expectedValue = getComputedStyle(testEl)[prop];
-        assert_not_equals(expectedValue, base)
-        assert_equal(usedValue, expectedValue);
+        assert_not_equals(expectedValue, base, `${testString} isn't valid in '${prop}'; got the default value instead.`)
+        assert_equals(usedValue, expectedValue, `${testString} and ${expectedString} serialize to the same thing in used values.`);
     }, msg || `${testString} should be used-value-equivalent to ${expectedString}`);
 }
 

--- a/css/support/numeric-testcommon.js
+++ b/css/support/numeric-testcommon.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/*
+Tests to verify that numeric values
+(math functions, generally),
+are handled correctly.
+
+Relies on a #target element existing in the document,
+as this might rely on layout to resolve styles,
+and so it needs to be in the document.
+*/
+
+
+/*
+By default, assumes testString evaluates to a <length>.
+If this isn't true, override {base, prop} accordingly.
+*/
+function test_math_used(testString, expectedString, {base="123px", msg, prop="left"}={}) {
+    const testEl = document.getElementById('target');
+    if(testEl == null) throw "Couldn't find #target element to run tests on."
+    test(()=>{
+        testEl.style[prop] = base;
+        testEl.style[prop] = testString;
+        const usedValue = getComputedStyle(testEl)[prop];
+        assert_not_equals(usedValue, base);
+        testEl.style[prop] = base;
+        testEl.style[prop] = expectedString;
+        const expectedValue = getComputedStyle(testEl)[prop];
+        assert_not_equals(expectedValue, base)
+        assert_equal(usedValue, expectedValue);
+    }, msg || `${testString} should be used-value-equivalent to ${expectedString}`);
+}
+
+/*
+All of these expect the testString to evaluate to a <number>.
+*/
+function test_plus_infinity(testString) {
+    test_math_used(`calc(1px * ${testString})`, "calc(infinity * 1px)");
+}
+function test_minus_infinity(testString) {
+    test_math_used(`calc(1px * ${testString})`, "calc(-infinity * 1px)");
+}
+function test_plus_zero(testString) {
+    test_math_used(`calc(1px / ${testString})`, "calc(infinity * 1px)");
+}
+function test_minus_zero(testString) {
+    test_math_used(`calc(1px / ${testString})`, "calc(-infinity * 1px)");
+}
+function test_nan(testString) {
+    // Make sure that it's NaN, not an infinity,
+    // by making sure that it's the same value both pos and neg.
+    test_math_used(`calc(1px * ${testString})`, "calc(NaN * 1px)");
+    test_math_used(`calc(-1px * ${testString})`, "calc(NaN * 1px)");
+}


### PR DESCRIPTION
Fix the rounding tests due to changes in the spec, and generally abstract the testing framework in preparation more math function tests using them.