### PR TITLE
Convert returned binary data from call() to string

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -1087,11 +1087,11 @@ class Safari(Browser):
         except subprocess.CalledProcessError:
             self.logger.warning("Failed to call %s --version" % webdriver_binary)
             return None
-        m = re.match(br"Included with Safari (.*)", version_string)
+        m = re.match(r"Included with Safari (.*)", version_string)
         if not m:
             self.logger.warning("Failed to extract version from: %s" % version_string)
             return None
-        return m.group(1).decode()
+        return m.group(1)
 
 
 class Servo(Browser):
@@ -1234,7 +1234,7 @@ class WebKitGTKMiniBrowser(WebKit):
         gcc = find_executable("gcc")
         if gcc:
             try:
-                triplet = call(gcc, "-dumpmachine").decode().strip()
+                triplet = call(gcc, "-dumpmachine").strip()
             except subprocess.CalledProcessError:
                 pass
         # Add Debian/Ubuntu path
@@ -1253,7 +1253,7 @@ class WebKitGTKMiniBrowser(WebKit):
         if binary is None:
             return None
         try:  # WebKitGTK MiniBrowser before 2.26.0 doesn't support --version
-            output = call(binary, "--version").decode().strip()
+            output = call(binary, "--version").strip()
         except subprocess.CalledProcessError:
             return None
         # Example output: "WebKitGTK 2.26.1"

--- a/tools/wpt/utils.py
+++ b/tools/wpt/utils.py
@@ -46,7 +46,7 @@ def call(*args):
     """
     logger.debug(" ".join(args))
     try:
-        return subprocess.check_output(args)
+        return subprocess.check_output(args).decode('utf8')
     except subprocess.CalledProcessError as e:
         logger.critical("%s exited with return code %i" %
                         (e.cmd, e.returncode))


### PR DESCRIPTION
This changes is based on the same cause as
commit 6ea4b6f95f85e8a425e827ddddc5f2caa06755c3

subprocess.check_output() returns binary data as output. In python2,
binary is basically an alias of str so it can be directly used as a
normal string. However in python3 the binary data is different to a
string. Inserting binary data into a string in python3 generates
strings like '/some/path/with/b'binary'/data/inserted' which are not
correct file paths. We must decode() the returned data in order to use
it as a string.