### PR TITLE
Ignore JavascriptErrorException during wait() in executorwebdriver

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -67,10 +67,17 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
         while True:
             try:
                 self.webdriver.execute_async_script("")
-            except (client.TimeoutException, client.ScriptTimeoutException):
+            except (client.TimeoutException,
+                    client.ScriptTimeoutException,
+                    client.JavascriptErrorException):
+                # A JavascriptErrorException will happen when we navigate;
+                # by ignoring it it's possible to reload the test whilst the
+                # harness remains paused
                 pass
-            except (socket.timeout, client.NoSuchWindowException,
-                    client.UnknownErrorException, IOError):
+            except (socket.timeout,
+                    client.NoSuchWindowException,
+                    client.UnknownErrorException,
+                    IOError):
                 break
             except Exception as e:
                 self.logger.error(traceback.format_exc(e))


### PR DESCRIPTION
This is the exception produced when the script is interrupted e.g.
by navigation. By ignoring it we end up waiting in the newly-loaded
document, which means we can do things like run a single test, pause,
and hit reload. This doesn't always work, but in cases where it does
is the expected/useful behaviour.