### PR TITLE
'currentColor' is now inherited as a keyword

### DIFF
--- a/css/CSS2/borders/border-color-011-ref.xht
+++ b/css/CSS2/borders/border-color-011-ref.xht
@@ -19,7 +19,7 @@
 
  <body>
 
-  <div>This should have a green border, because the computed value of 'border-color' set to its initial value is the computed value of 'color', which is then inherited as a color.</div>
+  <div>This should have a green border, because the computed value of 'border-color' set to its initial value is 'currentColor', which refers to the color on the current element.</div>
 
  </body>
 </html>

--- a/css/CSS2/borders/border-color-011.xht
+++ b/css/CSS2/borders/border-color-011.xht
@@ -12,7 +12,6 @@
   <style type="text/css">
    .test { display: block; color: red; border: none; }
    .test .inner { border-color: inherit; border-style: solid; color: green; }
-   .test .inner .text { color: green; }
   </style>
  </head>
  <body>

--- a/css/CSS2/borders/border-color-011.xht
+++ b/css/CSS2/borders/border-color-011.xht
@@ -6,11 +6,12 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/inheritance/border-color/001.html" type="text/html"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/inheritance/border-color/001.xml" type="application/xhtml+xml"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
+  <link rel="help" href="https://drafts.csswg.org/css-color/#resolving-color-values" />
   <link rel="match" href="border-color-011-ref.xht" />
-
+  <meta name="assert" content="The initial value of border-color is 'currentColor', which (as of css-color-3) is inherited as a keyword." />
   <style type="text/css">
-   .test { display: block; color: green; border: none; }
-   .test .inner { border-color: inherit; border-style: solid; color: red; }
+   .test { display: block; color: red; border: none; }
+   .test .inner { border-color: inherit; border-style: solid; color: green; }
    .test .inner .text { color: green; }
   </style>
  </head>
@@ -19,8 +20,8 @@
    <div class="inner">
     <div class="text">
      This should have a green border, because the computed value of
-     'border-color' set to its initial value is the computed value
-     of 'color', which is then inherited as a color.
+     'border-color' set to its initial value is 'currentColor', which
+     refers to the color on the current element.
     </div>
    </div>
   </div>

--- a/css/CSS2/borders/border-color-012-ref.xht
+++ b/css/CSS2/borders/border-color-012-ref.xht
@@ -17,7 +17,7 @@
 
  <body>
 
-  <div><span>This should have a green border, because the computed value of 'border-color' set to its initial value is the computed value of 'color', which is then inherited as a color.</span></div>
+  <div><span>This should have a green border, because the computed value of 'border-color' set to its initial value is 'currentColor'.</span></div>
 
  </body>
 </html>

--- a/css/CSS2/borders/border-color-012.xht
+++ b/css/CSS2/borders/border-color-012.xht
@@ -10,7 +10,6 @@
   <style type="text/css">
    .test { display: block; color: red; border: none; }
    .test > .inner { border-color: inherit; border-style: solid; color: green; }
-   .test > .inner > .text { color: green; }
   </style>
  </head>
  <body>

--- a/css/CSS2/borders/border-color-012.xht
+++ b/css/CSS2/borders/border-color-012.xht
@@ -6,10 +6,10 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/inheritance/border/color/001.xml" type="application/xhtml+xml"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
   <link rel="match" href="border-color-012-ref.xht" />
-
+  <meta name="assert" content="The initial value of border-color is 'currentColor', which (as of css-color-3) is inherited as a keyword." />
   <style type="text/css">
-   .test { display: block; color: green; border: none; }
-   .test > .inner { border-color: inherit; border-style: solid; color: red; }
+   .test { display: block; color: red; border: none; }
+   .test > .inner { border-color: inherit; border-style: solid; color: green; }
    .test > .inner > .text { color: green; }
   </style>
  </head>
@@ -18,8 +18,7 @@
    <span class="inner">
     <span class="text">
      This should have a green border, because the computed value of
-     'border-color' set to its initial value is the computed value
-     of 'color', which is then inherited as a color.
+     'border-color' set to its initial value is 'currentColor'.
     </span>
    </span>
   </div>


### PR DESCRIPTION
currentColor now inherits as a keyword, but border-color-11 and 12 did not reflect this (note this will cause a failure in Webkit, which still inherits as a color value)

See comment from @svgeesus from the first time I tried to apply this: https://github.com/web-platform-tests/wpt/pull/10755#pullrequestreview-190356109