### PR TITLE
Bidi whitespace collapse was preventing reftest match

### DIFF
--- a/css/CSS2/bidi-text/bidi-003.xht
+++ b/css/CSS2/bidi-text/bidi-003.xht
@@ -41,7 +41,7 @@
     <span class="control b end">   mmm nnn ooo </span>
    </p>
    <p>
-    <span class="test a"> aaa bbb ccc &#x202E; lll kkk jjj </span> iii hhh ggg <span class="test b"> fff eee ddd &#x202C; mmm nnn ooo </span>
+    <span class="test a"> aaa bbb ccc &#x202E; lll kkk jjj</span> iii hhh ggg<span class="test b"> fff eee ddd&#x202C;mmm nnn ooo </span>
    </p>
   </div>
  </body>

--- a/css/CSS2/bidi-text/bidi-004-ref.xht
+++ b/css/CSS2/bidi-text/bidi-004-ref.xht
@@ -9,7 +9,7 @@
   <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact" />
   <meta name="flags" content="ahem"/>
 
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="../../../fonts/ahem.css" />
   <style type="text/css">
    div p { width: 28em; border: solid; margin: 1em; padding: 0.5em; background: #FFFFCC; color: black; font: 1em/1 Ahem; }
    .control { line-height: 3em; }
@@ -24,14 +24,14 @@
   <p> The following two blocks should be identical, including overflow. (Force bidi: &#x05D0;) </p>
   <div>
    <p>
-    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp</span><br
+    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp&nbsp;</span><br
    /><span class="control b start">pXpX</span>&nbsp;pXXp&nbsp;pXXX&nbsp;Xppp<span class="control a end">&nbsp;XppX</span><br
-   /><span class="control b end">XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
+   /><span class="control b end">&nbsp;XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
    </p>
    <p>
-    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp</span><br
+    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp&nbsp;</span><br
    /><span class="control b start">pXpX</span>&nbsp;pXXp&nbsp;pXXX&nbsp;Xppp<span class="control a end">&nbsp;XppX</span><br
-   /><span class="control b end">XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
+   /><span class="control b end">&nbsp;XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
    </p>
   </div>
 

--- a/css/CSS2/bidi-text/bidi-004.xht
+++ b/css/CSS2/bidi-text/bidi-004.xht
@@ -17,7 +17,7 @@
   <link rel="match" href="bidi-004-ref.xht" />
 
   <meta name="flags" content="may21 ahem"/>
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="../../../fonts/ahem.css" />
   <style type="text/css">
    div p { width: 28em; border: solid; margin: 1em; padding: 0.5em; background: #FFFFCC; color: black; font: 1em/1 Ahem; }
    .test { border: solid; padding: 0.4em 1em; line-height: 3em; }
@@ -33,9 +33,9 @@
   <p> The following two blocks should be identical, including overflow. (Force bidi: &#x05D0;) </p>
   <div>
    <p>
-    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp</span><br
+    <span class="control a start">pppp&nbsp;pppX&nbsp;ppXp&nbsp;ppXX&nbsp;pXpp&nbsp;</span><br
    /><span class="control b start">pXpX</span>&nbsp;pXXp&nbsp;pXXX&nbsp;Xppp<span class="control a end">&nbsp;XppX</span><br
-   /><span class="control b end">XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
+   /><span class="control b end">&nbsp;XpXp&nbsp;XpXX&nbsp;XXpp&nbsp;XXpX&nbsp;XXXp</span>
    </p>
    <p>
     <!-- (note that everything between the RLO to the PDF is backwards) -->


### PR DESCRIPTION
The whitespace in bidi-003 and bidi-004 were out by a single whitespace character due to collapsing. No browsers were rendering these correctly - it's possible the tests are right and everything else was wrong, but I think in this case the tests were the ones that were wrong.