### PR TITLE
Fixed copy-paste issue in URL passed to hixie.ch/delayed-file

### DIFF
--- a/css/CSS2/cascade-import/cascade-import-009.xht
+++ b/css/CSS2/cascade-import/cascade-import-009.xht
@@ -14,7 +14,7 @@
   <link rel="stylesheet"
         href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=5&amp;mime=text%2Fcss&amp;text=.a+%7B+color%3A+blue%3B+%7D"/>
   <link rel="alternate stylesheet" title="Test"
-        href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=8&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D>"/>
+        href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=8&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D"/>
  </head>
  <body>
   <p class="a">Select the alternate stylesheet to run this test.</p>

--- a/css/CSS2/cascade-import/cascade-import-010.xht
+++ b/css/CSS2/cascade-import/cascade-import-010.xht
@@ -14,7 +14,7 @@
   <link rel="stylesheet"
         href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=5&amp;mime=text%2Fcss&amp;text=.a+%7B+color%3A+blue%3B+%7D"/>
   <link rel="alternate stylesheet" title="Test"
-        href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=2&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D>"/>
+        href="http://software.hixie.ch/utilities/cgi/test-tools/delayed-file?pause=2&amp;mime=text%2Fcss&amp;text=.b+%7B+color%3A+green%3B+%7D"/>
  </head>
  <body>
   <p class="a">Select the alternate stylesheet to run this test.</p>


### PR DESCRIPTION
These two tests imported a file from hixie.ch/delayed-file. It looks like they were cut/paste from tests 011 and 012, but the syntax in those tests wrapped the content in <...>. The leading angle bracket was removed, the trailing was not.