### PR TITLE
foreignObject default size is 0, we must set it

### DIFF
--- a/svg/render/reftests/blending-svg-foreign-object-ref.html
+++ b/svg/render/reftests/blending-svg-foreign-object-ref.html
@@ -2,7 +2,7 @@
 <div style="background: green">
   <div>Expected: a black square on green background.</div>
   <svg style="height: 200px">
-    <foreignObject>
+    <foreignObject width="200" height="200">
       <div style="width: 200px; height: 200px; background: black"></div>
     </foreignObject>
   </svg>

--- a/svg/render/reftests/blending-svg-foreign-object.html
+++ b/svg/render/reftests/blending-svg-foreign-object.html
@@ -5,7 +5,7 @@
 <div style="background: green">
   <div>Expected: a black square on green background.</div>
   <svg style="width: 200px; height: 200px">
-    <foreignObject style="mix-blend-mode: multiply">
+    <foreignObject width="200" height="200" style="mix-blend-mode: multiply">
       <div style="width: 200px; height: 200px; background: red"></div>
     </foreignObject>
   </svg>


### PR DESCRIPTION
SVG foreignObject has a default width/height of zero. If we want them to contain a 200x200 object, we have to set width/height explicitly.

Quote from https://svgwg.org/svg2-draft/geometry.html#Sizing
> This means that, for example, a ‘foreignObject’ object element will not shrink-wrap to its contents if auto is used.


