### PR TITLE
Added font-kerning: none for interop when font is missing

### DIFF
--- a/css/css-text/hanging-punctuation/hanging-punctuation-allow-end-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-allow-end-001.xht
@@ -16,6 +16,7 @@
 				/* the CSS below is not part of the test */
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/hanging-punctuation-first-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-first-001.xht
@@ -16,6 +16,7 @@
 				/* the CSS below is not part of the test */
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.hanging {
 					left: -1em;

--- a/css/css-text/hanging-punctuation/hanging-punctuation-force-end-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-force-end-001.xht
@@ -16,6 +16,7 @@
 				/* the CSS below is not part of the test */
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/hanging-punctuation-last-001.xht
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-last-001.xht
@@ -16,6 +16,7 @@
 				/* the CSS below is not part of the test */
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-allow-end-001-ref.xht
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-allow-end-001-ref.xht
@@ -8,6 +8,7 @@
 			<![CDATA[
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-first-001-ref.xht
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-first-001-ref.xht
@@ -8,6 +8,7 @@
 			<![CDATA[
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.hanging {
 					left: -1em;

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-force-end-001-ref.xht
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-force-end-001-ref.xht
@@ -8,6 +8,7 @@
 			<![CDATA[
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-last-001-ref.xht
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-last-001-ref.xht
@@ -8,6 +8,7 @@
 			<![CDATA[
 				body {
 					font-family: "IPAMincho", "IPAGothic", "IPA明朝", "IPAゴシック";
+                                        font-kerning: none;
 				}
 				.no-wrap {
 					white-space: nowrap;


### PR DESCRIPTION
These tests specify the IPAMincho or IPAGothic font, which are not on every platform. The tests can still pass with other fonts, but the font-kerning tends to through them out. Add font-kerning none to remove this variability.