### PR TITLE
Font path was invalid - set to correct location

### DIFF
--- a/svg/text/reftests/text-complex-001-ref.svg
+++ b/svg/text/reftests/text-complex-001-ref.svg
@@ -23,7 +23,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-complex-001.svg
+++ b/svg/text/reftests/text-complex-001.svg
@@ -24,7 +24,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-complex-002-ref.svg
+++ b/svg/text/reftests/text-complex-002-ref.svg
@@ -23,7 +23,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-complex-002.svg
+++ b/svg/text/reftests/text-complex-002.svg
@@ -24,7 +24,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-001-ref.svg
+++ b/svg/text/reftests/text-inline-size-001-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-001.svg
+++ b/svg/text/reftests/text-inline-size-001.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-002-ref.svg
+++ b/svg/text/reftests/text-inline-size-002-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-002.svg
+++ b/svg/text/reftests/text-inline-size-002.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-003-ref.svg
+++ b/svg/text/reftests/text-inline-size-003-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-003.svg
+++ b/svg/text/reftests/text-inline-size-003.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-005-ref.svg
+++ b/svg/text/reftests/text-inline-size-005-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-005.svg
+++ b/svg/text/reftests/text-inline-size-005.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-006-ref.svg
+++ b/svg/text/reftests/text-inline-size-006-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-006.svg
+++ b/svg/text/reftests/text-inline-size-006.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-007-ref.svg
+++ b/svg/text/reftests/text-inline-size-007-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-007.svg
+++ b/svg/text/reftests/text-inline-size-007.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-101-ref.svg
+++ b/svg/text/reftests/text-inline-size-101-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-101.svg
+++ b/svg/text/reftests/text-inline-size-101.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-201-ref.svg
+++ b/svg/text/reftests/text-inline-size-201-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-inline-size-201.svg
+++ b/svg/text/reftests/text-inline-size-201.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-multiline-001-ref.svg
+++ b/svg/text/reftests/text-multiline-001-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-multiline-001.svg
+++ b/svg/text/reftests/text-multiline-001.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-multiline-002-ref.svg
+++ b/svg/text/reftests/text-multiline-002-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-multiline-002.svg
+++ b/svg/text/reftests/text-multiline-002.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-multiline-003-ref.svg
+++ b/svg/text/reftests/text-multiline-003-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-multiline-003.svg
+++ b/svg/text/reftests/text-multiline-003.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-shape-inside-001-ref.svg
+++ b/svg/text/reftests/text-shape-inside-001-ref.svg
@@ -23,7 +23,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-shape-inside-001.svg
+++ b/svg/text/reftests/text-shape-inside-001.svg
@@ -24,7 +24,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-shape-inside-002-ref.svg
+++ b/svg/text/reftests/text-shape-inside-002-ref.svg
@@ -23,7 +23,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-shape-inside-002.svg
+++ b/svg/text/reftests/text-shape-inside-002.svg
@@ -24,7 +24,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-001-ref.svg
+++ b/svg/text/reftests/text-text-anchor-001-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-001.svg
+++ b/svg/text/reftests/text-text-anchor-001.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-002-ref.svg
+++ b/svg/text/reftests/text-text-anchor-002-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-002.svg
+++ b/svg/text/reftests/text-text-anchor-002.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-003-ref.svg
+++ b/svg/text/reftests/text-text-anchor-003-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-003.svg
+++ b/svg/text/reftests/text-text-anchor-003.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-201-ref.svg
+++ b/svg/text/reftests/text-text-anchor-201-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-201.svg
+++ b/svg/text/reftests/text-text-anchor-201.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-202-ref.svg
+++ b/svg/text/reftests/text-text-anchor-202-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-202.svg
+++ b/svg/text/reftests/text-text-anchor-202.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-203-ref.svg
+++ b/svg/text/reftests/text-text-anchor-203-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/text-text-anchor-203.svg
+++ b/svg/text/reftests/text-text-anchor-203.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/textpath-shape-001-ref.svg
+++ b/svg/text/reftests/textpath-shape-001-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/textpath-shape-001.svg
+++ b/svg/text/reftests/textpath-shape-001.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/textpath-side-001-ref.svg
+++ b/svg/text/reftests/textpath-side-001-ref.svg
@@ -15,7 +15,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }

--- a/svg/text/reftests/textpath-side-001.svg
+++ b/svg/text/reftests/textpath-side-001.svg
@@ -18,7 +18,7 @@
     /* Standard Font (if needed). */
     @font-face {
       font-family: FreeSans;
-      src: url("fonts/FreeSans.woff") format("woff"),
+      src: url("../../import/woffs/FreeSans.woff") format("woff"),
            local("FreeSans");
     }
     text { font-family: FreeSans, sans-serif }


### PR DESCRIPTION
These tests all referred to a "fonts/FreeSans.woff" - there is no "fonts" directory here. The same font exists elsewhere in the svg testsuite, so point to the lowest-impact change that will get this working.

Note font metrics are potentially important for these tests, so the font is required.