### PR TITLE
Fix is_alive() usage and always call it as a function.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/android_weblayer.py
+++ b/tools/wptrunner/wptrunner/browsers/android_weblayer.py
@@ -124,7 +124,7 @@ class WeblayerShell(Browser):
         # TODO(ato): This only indicates the driver is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/android_webview.py
+++ b/tools/wptrunner/wptrunner/browsers/android_webview.py
@@ -123,7 +123,7 @@ class SystemWebViewShell(Browser):
         # TODO(ato): This only indicates the driver is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -125,7 +125,7 @@ class ChromeBrowser(Browser):
         # TODO(ato): This only indicates the driver is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -114,7 +114,7 @@ class ChromeAndroidBrowser(Browser):
         # TODO(ato): This only indicates the driver is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/chrome_ios.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_ios.py
@@ -71,7 +71,7 @@ class ChromeiOSBrowser(Browser):
         # TODO(ato): This only indicates the driver is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -108,7 +108,7 @@ class EdgeBrowser(Browser):
         # TODO(ato): This only indicates the server is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/edgechromium.py
+++ b/tools/wptrunner/wptrunner/browsers/edgechromium.py
@@ -107,7 +107,7 @@ class EdgeChromiumBrowser(Browser):
         # TODO(ato): This only indicates the driver is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/ie.py
+++ b/tools/wptrunner/wptrunner/browsers/ie.py
@@ -64,7 +64,7 @@ class InternetExplorerBrowser(Browser):
         # TODO(ato): This only indicates the server is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/opera.py
+++ b/tools/wptrunner/wptrunner/browsers/opera.py
@@ -93,7 +93,7 @@ class OperaBrowser(Browser):
         # TODO(ato): This only indicates the driver is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/safari.py
+++ b/tools/wptrunner/wptrunner/browsers/safari.py
@@ -79,7 +79,7 @@ class SafariBrowser(Browser):
         # TODO(ato): This only indicates the driver is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -101,7 +101,7 @@ class WebKitBrowser(Browser):
         # TODO(ato): This only indicates the driver is alive,
         # and doesn't say anything about whether a browser session
         # is active.
-        return self.server.is_alive
+        return self.server.is_alive()
 
     def cleanup(self):
         self.stop()

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -170,7 +170,7 @@ class TimedRunner(object):
         elif self.result[1] is None:
             # We didn't get any data back from the test, so check if the
             # browser is still responsive
-            if self.protocol.is_alive:
+            if self.protocol.is_alive():
                 self.result = False, ("INTERNAL-ERROR", None)
             else:
                 self.logger.info("Browser not responding, setting status to CRASH")
@@ -512,7 +512,7 @@ class WdspecExecutor(TestExecutor):
         self.protocol = self.protocol_cls(self, browser)
 
     def is_alive(self):
-        return self.protocol.is_alive
+        return self.protocol.is_alive()
 
     def on_environment_change(self, new_environment):
         pass
@@ -638,10 +638,9 @@ class WebDriverProtocol(Protocol):
         pass
 
     def teardown(self):
-        if self.server is not None and self.server.is_alive:
+        if self.server is not None and self.server.is_alive():
             self.server.stop()
 
-    @property
     def is_alive(self):
         """Test that the connection is still alive.
 

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -592,7 +592,6 @@ class MarionetteProtocol(Protocol):
             del self.marionette
         super(MarionetteProtocol, self).teardown()
 
-    @property
     def is_alive(self):
         try:
             self.marionette.current_window_handle
@@ -698,7 +697,7 @@ class MarionetteTestharnessExecutor(TestharnessExecutor):
         self.protocol.testharness.load_runner(self.last_environment["protocol"])
 
     def is_alive(self):
-        return self.protocol.is_alive
+        return self.protocol.is_alive()
 
     def on_environment_change(self, new_environment):
         self.protocol.on_environment_change(self.last_environment, new_environment)
@@ -818,7 +817,7 @@ class MarionetteRefTestExecutor(RefTestExecutor):
         self.implementation.reset(**self.implementation_kwargs)
 
     def is_alive(self):
-        return self.protocol.is_alive
+        return self.protocol.is_alive()
 
     def on_environment_change(self, new_environment):
         self.protocol.on_environment_change(self.last_environment, new_environment)
@@ -972,7 +971,7 @@ class MarionetteCrashtestExecutor(CrashtestExecutor):
             do_delayed_imports()
 
     def is_alive(self):
-        return self.protocol.is_alive
+        return self.protocol.is_alive()
 
     def on_environment_change(self, new_environment):
         self.protocol.on_environment_change(self.last_environment, new_environment)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -32,7 +32,6 @@ class Protocol(object):
         """:returns: Current logger"""
         return self.executor.logger
 
-    @property
     def is_alive(self):
         """Is the browser connection still active
 

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -84,14 +84,13 @@ class WebDriverServer(object):
 
     def stop(self, force=False):
         self.logger.debug("Stopping WebDriver")
-        if self.is_alive:
+        if self.is_alive():
             kill_result = self._proc.kill()
             if force and kill_result != 0:
                 return self._proc.kill(9)
             return kill_result
-        return not self.is_alive
+        return not self.is_alive()
 
-    @property
     def is_alive(self):
         return hasattr(self._proc, "proc") and self._proc.poll() is None
 


### PR DESCRIPTION
There is some confusion in the way the method is_alive is used:
 * The code seems to assume that this method is accessed like a variable for Protocol and WebDriverServer classes (by using the `@property` decorator in the is_alive() definition).
* But then some class that inherit from those and re-declare is_alive() forget to declare the decorator. For example, the base class Protocol declares is_alive as a property, but some of the classes that inherit from it like WebDriverProtocol from executorwebdriver.py, ServoWebDriverProtocol or SeleniumProtocol.
* This caused the code that checks for is_alive to be broken for those classes because `if is_alive` its always true.

To add to the confusion about how this should be used, the browser classes have also a method named `is_alive()`, where the current code assumes it is used as a function.
This has already caused previously confusion (see 8be26a07bc).

Fix this by ensuring is_alive() its always used as a function and remove the `@property` decorators from the classes that were declaring it.