### PR TITLE
Ensure manifest url base is a string.

### DIFF
--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -545,7 +545,7 @@ def create_test_tree(metadata_path, test_manifest):
             if dir_id in id_test_map:
                 break
 
-            test_file_data = TestFileData(intern(test_manifest.url_base),
+            test_file_data = TestFileData(intern(ensure_str(test_manifest.url_base)),
                                           None,
                                           metadata_path,
                                           dir_meta_path,


### PR DESCRIPTION
This was lost as part of the changes in 31c0f5efba38b7d1d7f45ac449bcbc892e8771ce. Fixes #21713.