### PR TITLE
Fix Queue module import for PY2/PY3 compatibility

### DIFF
--- a/tools/wptrunner/wptrunner/instruments.py
+++ b/tools/wptrunner/wptrunner/instruments.py
@@ -1,6 +1,6 @@
 import time
 import threading
-from Queue import Queue
+from six.moves.queue import Queue
 
 """Instrumentation for measuring high-level time spent on various tasks inside the runner.
 


### PR DESCRIPTION
The Queue module has been renamed to queue in Python 3.