### PR TITLE
Migrated wpt test_run to Python3

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -290,7 +290,7 @@ class Firefox(Browser):
 
     def get_version_and_channel(self, binary):
         version_string = call(binary, "--version").strip()
-        m = re.match(r"Mozilla Firefox (\d+\.\d+(?:\.\d+)?)(a|b)?", version_string.decode('utf-8'))
+        m = re.match(r"Mozilla Firefox (\d+\.\d+(?:\.\d+)?)(a|b)?", version_string)
         if not m:
             return None, "nightly"
         version, status = m.groups()
@@ -445,7 +445,7 @@ class Firefox(Browser):
     def version(self, binary=None, webdriver_binary=None):
         """Retrieve the release version of the installed browser."""
         version_string = call(binary, "--version").strip()
-        m = re.match(r"Mozilla Firefox (.*)", version_string.decode('utf-8'))
+        m = re.match(r"Mozilla Firefox (.*)", version_string)
         if not m:
             return None
         return m.group(1)
@@ -656,7 +656,7 @@ class Chrome(Browser):
         except subprocess.CalledProcessError:
             self.logger.warning("Failed to call %s" % binary)
             return None
-        m = re.match(r"(?:Google Chrome|Chromium) (.*)", version_string.decode('utf-8'))
+        m = re.match(r"(?:Google Chrome|Chromium) (.*)", version_string)
         if not m:
             self.logger.warning("Failed to extract version from: %s" % version_string)
             return None
@@ -877,7 +877,7 @@ class Opera(Browser):
         except subprocess.CalledProcessError:
             self.logger.warning("Failed to call %s" % binary)
             return None
-        m = re.search(r"[0-9\.]+( [a-z]+)?$", output.decode('utf-8').strip())
+        m = re.search(r"[0-9\.]+( [a-z]+)?$", output.strip())
         if m:
             return m.group(0)
 
@@ -976,7 +976,7 @@ class EdgeChromium(Browser):
             except subprocess.CalledProcessError:
                 self.logger.warning("Failed to call %s" % binary)
                 return None
-            m = re.match(r"Microsoft Edge (.*) ", version_string.decode('utf-8'))
+            m = re.match(r"Microsoft Edge (.*) ", version_string)
             if not m:
                 self.logger.warning("Failed to extract version from: %s" % version_string)
                 return None
@@ -1166,7 +1166,7 @@ class Servo(Browser):
     def version(self, binary=None, webdriver_binary=None):
         """Retrieve the release version of the installed browser."""
         output = call(binary, "--version")
-        m = re.search(r"Servo ([0-9\.]+-[a-f0-9]+)?(-dirty)?$", output.decode('utf-8').strip())
+        m = re.search(r"Servo ([0-9\.]+-[a-f0-9]+)?(-dirty)?$", output.strip())
         if m:
             return m.group(0)
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -290,7 +290,7 @@ class Firefox(Browser):
 
     def get_version_and_channel(self, binary):
         version_string = call(binary, "--version").strip()
-        m = re.match(r"Mozilla Firefox (\d+\.\d+(?:\.\d+)?)(a|b)?", version_string)
+        m = re.match(r"Mozilla Firefox (\d+\.\d+(?:\.\d+)?)(a|b)?", version_string.decode('utf-8'))
         if not m:
             return None, "nightly"
         version, status = m.groups()
@@ -445,7 +445,7 @@ class Firefox(Browser):
     def version(self, binary=None, webdriver_binary=None):
         """Retrieve the release version of the installed browser."""
         version_string = call(binary, "--version").strip()
-        m = re.match(r"Mozilla Firefox (.*)", version_string)
+        m = re.match(r"Mozilla Firefox (.*)", version_string.decode('utf-8'))
         if not m:
             return None
         return m.group(1)
@@ -656,7 +656,7 @@ class Chrome(Browser):
         except subprocess.CalledProcessError:
             self.logger.warning("Failed to call %s" % binary)
             return None
-        m = re.match(r"(?:Google Chrome|Chromium) (.*)", version_string)
+        m = re.match(r"(?:Google Chrome|Chromium) (.*)", version_string.decode('utf-8'))
         if not m:
             self.logger.warning("Failed to extract version from: %s" % version_string)
             return None
@@ -877,7 +877,7 @@ class Opera(Browser):
         except subprocess.CalledProcessError:
             self.logger.warning("Failed to call %s" % binary)
             return None
-        m = re.search(r"[0-9\.]+( [a-z]+)?$", output.strip())
+        m = re.search(r"[0-9\.]+( [a-z]+)?$", output.decode('utf-8').strip())
         if m:
             return m.group(0)
 
@@ -976,7 +976,7 @@ class EdgeChromium(Browser):
             except subprocess.CalledProcessError:
                 self.logger.warning("Failed to call %s" % binary)
                 return None
-            m = re.match(r"Microsoft Edge (.*) ", version_string)
+            m = re.match(r"Microsoft Edge (.*) ", version_string.decode('utf-8'))
             if not m:
                 self.logger.warning("Failed to extract version from: %s" % version_string)
                 return None
@@ -1166,7 +1166,7 @@ class Servo(Browser):
     def version(self, binary=None, webdriver_binary=None):
         """Retrieve the release version of the installed browser."""
         output = call(binary, "--version")
-        m = re.search(r"Servo ([0-9\.]+-[a-f0-9]+)?(-dirty)?$", output.strip())
+        m = re.search(r"Servo ([0-9\.]+-[a-f0-9]+)?(-dirty)?$", output.decode('utf-8').strip())
         if m:
             return m.group(0)
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -191,7 +191,7 @@ def safe_unsetenv(env_var):
     """
     try:
         del os.environ[env_var]
-    except AttributeError:
+    except KeyError:
         pass
 
 class Firefox(BrowserSetup):

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -192,8 +192,11 @@ def safe_unsetenv(env_var):
     try:
         os.unsetenv(env_var)
     except AttributeError:
-        if env_var in os.environ:
-            del os.environ[env_var]
+        try:
+            os.putenv(env_var,"")
+        except AttributeError:
+            if env_var in os.environ:
+                del os.environ[env_var]
 
 class Firefox(BrowserSetup):
     name = "firefox"

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -183,21 +183,6 @@ class BrowserSetup(object):
     def setup(self, kwargs):
         self.setup_kwargs(kwargs)
 
-def safe_unsetenv(env_var):
-    """Safely remove an environment variable.
-
-    Python3 does not support os.unsetenv in Windows, so we better remove the
-    variable directly from os.environ
-    """
-    try:
-        os.unsetenv(env_var)
-    except AttributeError:
-        try:
-            os.putenv(env_var,"")
-        except AttributeError:
-            if env_var in os.environ:
-                del os.environ[env_var]
-
 class Firefox(BrowserSetup):
     name = "firefox"
     browser_cls = browser.Firefox
@@ -257,9 +242,9 @@ Consider installing certutil via your OS package manager or directly.""")
             logger.info("Running in headless mode, pass --no-headless to disable")
 
         # Turn off Firefox WebRTC ICE logging on WPT (turned on by mozrunner)
-        safe_unsetenv('R_LOG_LEVEL')
-        safe_unsetenv('R_LOG_DESTINATION')
-        safe_unsetenv('R_LOG_VERBOSE')
+        del os.environ['R_LOG_LEVEL']
+        del os.environ['R_LOG_DESTINATION']
+        del os.environ['R_LOG_VERBOSE']
 
         # Allow WebRTC tests to call getUserMedia.
         kwargs["extra_prefs"].append("media.navigator.streams.fake=true")

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -183,6 +183,17 @@ class BrowserSetup(object):
     def setup(self, kwargs):
         self.setup_kwargs(kwargs)
 
+def safe_unsetenv(env_var):
+    """Safely remove an environment variable.
+
+    Python3 does not support os.unsetenv in Windows, so we better remove the
+    variable directly from os.environ
+    """
+    try:
+        os.unsetenv(env_var)
+    except AttributeError:
+        if env_var in os.environ:
+            del os.environ[env_var]
 
 class Firefox(BrowserSetup):
     name = "firefox"
@@ -243,9 +254,9 @@ Consider installing certutil via your OS package manager or directly.""")
             logger.info("Running in headless mode, pass --no-headless to disable")
 
         # Turn off Firefox WebRTC ICE logging on WPT (turned on by mozrunner)
-        os.unsetenv('R_LOG_LEVEL')
-        os.unsetenv('R_LOG_DESTINATION')
-        os.unsetenv('R_LOG_VERBOSE')
+        safe_unsetenv('R_LOG_LEVEL')
+        safe_unsetenv('R_LOG_DESTINATION')
+        safe_unsetenv('R_LOG_VERBOSE')
 
         # Allow WebRTC tests to call getUserMedia.
         kwargs["extra_prefs"].append("media.navigator.streams.fake=true")

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -183,6 +183,17 @@ class BrowserSetup(object):
     def setup(self, kwargs):
         self.setup_kwargs(kwargs)
 
+def safe_unsetenv(env_var):
+    """Safely remove an environment variable.
+
+    Python3 does not support os.unsetenv in Windows for python<3.9, so we better
+    remove the variable directly from os.environ.
+    """
+    try:
+        del os.environ[env_var]
+    except AttributeError:
+        pass
+
 class Firefox(BrowserSetup):
     name = "firefox"
     browser_cls = browser.Firefox
@@ -242,9 +253,9 @@ Consider installing certutil via your OS package manager or directly.""")
             logger.info("Running in headless mode, pass --no-headless to disable")
 
         # Turn off Firefox WebRTC ICE logging on WPT (turned on by mozrunner)
-        del os.environ['R_LOG_LEVEL']
-        del os.environ['R_LOG_DESTINATION']
-        del os.environ['R_LOG_VERBOSE']
+        safe_unsetenv('R_LOG_LEVEL')
+        safe_unsetenv('R_LOG_DESTINATION')
+        safe_unsetenv('R_LOG_VERBOSE')
 
         # Allow WebRTC tests to call getUserMedia.
         kwargs["extra_prefs"].append("media.navigator.streams.fake=true")

--- a/tools/wpt/tests/test_run.py
+++ b/tools/wpt/tests/test_run.py
@@ -42,8 +42,6 @@ def venv():
 
 @pytest.fixture(scope="module")
 def logger():
-    if sys.version_info >= (3,):
-        pytest.xfail(reason="broken on Py3")
     run.setup_logging({})
 
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -539,7 +539,8 @@ def check_args(kwargs):
 
     if kwargs['extra_prefs']:
         # If a single pref is passed in as a string, make it a list
-        if type(kwargs['extra_prefs']) in (str, unicode):
+        from six import text_type
+        if isinstance(kwargs['extra_prefs'], text_type):
             kwargs['extra_prefs'] = [kwargs['extra_prefs']]
         missing = any('=' not in prefarg for prefarg in kwargs['extra_prefs'])
         if missing:

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -5,7 +5,7 @@ import sys
 from collections import OrderedDict
 from distutils.spawn import find_executable
 from datetime import timedelta
-from six import iterkeys, itervalues, iteritems
+from six import iterkeys, itervalues, iteritems, string_types
 
 from . import config
 from . import wpttest
@@ -539,8 +539,7 @@ def check_args(kwargs):
 
     if kwargs['extra_prefs']:
         # If a single pref is passed in as a string, make it a list
-        from six import text_type
-        if isinstance(kwargs['extra_prefs'], text_type):
+        if isinstance(kwargs['extra_prefs'], string_types):
             kwargs['extra_prefs'] = [kwargs['extra_prefs']]
         missing = any('=' not in prefarg for prefarg in kwargs['extra_prefs'])
         if missing:


### PR DESCRIPTION
Most of the issues was that in python3 subprocess.call() returns a binary object instead of a string. We had to add several decode() to make it python3 compatible. Apart from that isinstance() is now used to check whether an argument is text or not.