### PR TITLE
[Azure Pipelines] Consistently use the "Use Python Version" task

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -34,6 +34,9 @@ jobs:
   pool:
     vmImage: 'macOS-10.14'
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7.x'
   - template: tools/ci/azure/affected_tests.yml
     parameters:
       artifactName: 'safari-preview-affected-tests'
@@ -48,6 +51,9 @@ jobs:
   pool:
     vmImage: 'macOS-10.14'
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7.x'
   - template: tools/ci/azure/affected_tests.yml
     parameters:
       checkoutCommit: 'HEAD^1'
@@ -82,6 +88,9 @@ jobs:
   pool:
     vmImage: 'macOS-10.14'
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7.x'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/pip_install.yml
     parameters:
@@ -114,6 +123,9 @@ jobs:
   variables:
     HYPOTHESIS_PROFILE: ci
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7.x'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
@@ -161,6 +173,9 @@ jobs:
   variables:
     HYPOTHESIS_PROFILE: ci
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7.x'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/tox_pytest.yml
     parameters:
@@ -209,6 +224,9 @@ jobs:
     HYPOTHESIS_PROFILE: ci
   steps:
   # full checkout required
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7.x'
   - template: tools/ci/azure/install_chrome.yml
   - template: tools/ci/azure/install_firefox.yml
   - template: tools/ci/azure/update_hosts.yml
@@ -594,6 +612,9 @@ jobs:
   pool:
     vmImage: 'macOS-10.14'
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7.x'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/pip_install.yml
     parameters:
@@ -628,6 +649,9 @@ jobs:
   pool:
     vmImage: 'macOS-10.14'
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7.x'
   - template: tools/ci/azure/checkout.yml
   - template: tools/ci/azure/pip_install.yml
     parameters:

--- a/tools/ci/azure/pip_install.yml
+++ b/tools/ci/azure/pip_install.yml
@@ -2,18 +2,5 @@ parameters:
   packages: ''
 
 steps:
-- script: |
-    if [ `which pip` = '/usr/bin/pip' ]; then
-      # `sudo pip install` is not used because some packages (e.g. tox) depend on
-      # system packages (e.g. setuptools) which cannot be upgraded due to System
-      # Integrity Protection, see https://stackoverflow.com/a/33004920.
-      pip install --user ${{ parameters.packages }}
-      echo "##vso[task.prependpath]$HOME/Library/Python/2.7/bin"
-    else
-      pip --disable-pip-version-check install --upgrade ${{ parameters.packages }}
-    fi
-  displayName: 'Install Python packages (macOS)'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 - script: pip --disable-pip-version-check install --upgrade ${{ parameters.packages }}
-  displayName: 'Install Python packages (Windows)'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+  displayName: 'Install Python packages'


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/use-python-version?view=azure-devops

The default python/pip on the macOS VMs don't any longer. It may be
possible to fix this, but to fix the urgent issue use the method
that's supported by Azure Pipelines.

The python version will remain unchanged at 2.7.17, but pip will
change from 19.3.1 to 20.0.2.

pip_install.yml can be simplified because the remaining code path is
the same for macOS and Windows.

Fixes https://github.com/web-platform-tests/wpt/issues/21691.