### PR TITLE
Convert returned binary data from gitfunc() to string

### DIFF
--- a/tools/manifest/utils.py
+++ b/tools/manifest/utils.py
@@ -60,11 +60,13 @@ def git(path):
         # type: (bytes, *bytes) -> bytes
         full_cmd = ["git", cmd] + list(args)
         try:
-            return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT)
+            return subprocess.check_output(
+                full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf-8')
         except Exception as e:
             if platform.uname()[0] == "Windows" and isinstance(e, WindowsError):
                 full_cmd[0] = "git.bat"
-                return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT)
+                return subprocess.check_output(
+                    full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf-8')
             else:
                 raise
 


### PR DESCRIPTION
This changes is based on the same cause as
commit 9ce6f138bb56ac6941cd58366808f16f9c4a53cd

subprocess.check_output() returns binary data as output. In python2,
binary is basically an alias of str so it can be directly used as a
normal string. However in python3 the binary data is different to a
string. Inserting binary data into a string in python3 generates
strings like '/some/path/with/b'binary'/data/inserted' which are not
correct tags.