### PR TITLE
Eliminate last uses of assert_throws.

### DIFF
--- a/content-security-policy/reporting/report-clips-sample.html
+++ b/content-security-policy/reporting/report-clips-sample.html
@@ -11,7 +11,7 @@
   <script>
   promise_test(t => {
     let evil = false;
-    assert_throws(new EvalError(), _ => {
+    assert_throws_js(EvalError, _ => {
       eval("evil = '1234567890123456789012345678901234567890';");
     });
     assert_false(evil);
@@ -21,7 +21,7 @@
   }, "Unsafe eval violation sample is clipped to 40 characters.");
 
   promise_test(t => {
-    assert_throws(new EvalError(), _ => {
+    assert_throws_js(EvalError, _ => {
       new Function("a", "b", "return '1234567890123456789012345678901234567890';");
     });
     return waitUntilCSPEventForTrustedTypes(t).then(t.step_func_done(e => {
@@ -32,7 +32,7 @@
 
   promise_test(t => {
     const a = document.createElement("a");
-    assert_throws(new TypeError(), _ => {
+    assert_throws_js(TypeError, _ => {
       a.innerHTML = "1234567890123456789012345678901234567890xxxx";
     });
     assert_equals(a.innerHTML, "");

--- a/cors/support.js
+++ b/cors/support.js
@@ -1,16 +1,3 @@
-// For ignoring exception names (just for testing)
-/*
-_real_assert_throws = assert_throws;
-function assert_throws(d, func, desc) {
-    try {
-        func();
-    } catch(e) {
-        return true;
-    }
-    assert_unreached("Didn't throw!");
-}
-*/
-
 function dirname(path) {
     return path.replace(/\/[^\/]*$/, '/')
 }

--- a/custom-elements/state.tentative/ElementInternals-states.html
+++ b/custom-elements/state.tentative/ElementInternals-states.html
@@ -26,9 +26,9 @@ test(() => {
 
 test(() => {
   let i = (new TestElement()).internals;
-  assert_throws(new TypeError(), () => { i.states.supports('foo'); });
-  assert_throws(new SyntaxError(), () => { i.states.add(''); });
-  assert_throws('InvalidCharacterError', () => { i.states.add('a\tb'); });
+  assert_throws_js(TypeError, () => { i.states.supports('foo'); });
+  assert_throws_dom('SyntaxError', () => { i.states.add(''); });
+  assert_throws_dom('InvalidCharacterError', () => { i.states.add('a\tb'); });
 }, 'DOMTokenList behavior of ElementInternals.states: Exceptions');
 
 test(() => {

--- a/custom-elements/state.tentative/state-pseudo-class.html
+++ b/custom-elements/state.tentative/state-pseudo-class.html
@@ -54,13 +54,13 @@ class ContainerElement extends HTMLElement {
 customElements.define('container-element', ContainerElement);
 
 test(() => {
-  assert_throws(new SyntaxError(), () => { document.querySelector(':state'); });
-  assert_throws(new SyntaxError(), () => { document.querySelector(':state('); });
-  assert_throws(new SyntaxError(), () => { document.querySelector(':state()'); });
-  assert_throws(new SyntaxError(), () => { document.querySelector(':state(=)'); });
-  assert_throws(new SyntaxError(), () => { document.querySelector(':state(name=value)'); });
-  assert_throws(new SyntaxError(), () => { document.querySelector(':state( foo bar)'); });
-  assert_throws(new SyntaxError(), () => { document.querySelector(':state(16px)'); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state'); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state('); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state()'); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state(=)'); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state(name=value)'); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state( foo bar)'); });
+  assert_throws_dom('SyntaxError', () => { document.querySelector(':state(16px)'); });
 }, ':state() parsing failures');
 
 test(() => {

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -195,14 +195,18 @@ test may begin to execute before the returned promise has settled. Use
 resetting global state that need to happen consistently before the next test
 starts.
 
-`promise_rejects` can be used to test Promises that need to reject:
+`promise_rejects_dom`, `promise_rejects_js`, and `promise_rejects_exactly` can
+be used to test Promises that need to reject:
 
 ```js
-promise_rejects(test_object, code, promise, description)
+promise_rejects_dom(test_object, code, promise, description)
+promise_rejects_js(test_object, constructor, promise, description)
+promise_rejects_exactly(test_object, value, promise, description)
 ```
 
-The `code` argument is equivalent to the same argument to the `assert_throws`
-function.
+The `code`, `constructor`, and `value` arguments are equivalent to the same
+argument to the `assert_throws_dom`, `assert_throws_js`, and
+`assert_throws_exactly` functions.
 
 Here's an example where the `bar()` function returns a Promise that rejects
 with a TypeError:
@@ -854,7 +858,7 @@ attribute attribute_name following the conditions specified by WebIDL
 ### `assert_readonly(object, property_name, description)`
 assert that property `property_name` on object is readonly
 
-### `assert_throws(code, func, description)`
+### `assert_throws_dom(code, func, description)`
 `code` - the expected exception. This can take several forms:
 
   * string - asserts that the thrown exception must be a DOMException
@@ -862,9 +866,20 @@ assert that property `property_name` on object is readonly
              compatibility with existing tests, the name of a
              DOMException constant can also be given, e.g.,
              "TIMEOUT_ERR")
-  * object - asserts that the thrown exception must be any other kind
-             of exception, with a property called "name" that matches
-             `code.name`.
+  * number - asserts that the thrown exception must be a DOMException
+             with the fiven code value (e.g. DOMException.TIMEOUT_ERR).
+
+`func` - a function that should throw
+
+### `assert_throws_js(constructor, func, description)`
+`constructor` - the expected exception. This is the constructor object
+that the exception should have as its .constructor.  For example,
+`TypeError` or `someOtherWindow.RangeError`.
+
+`func` - a function that should throw
+
+### `assert_throws_exactly(value, func, description)`
+`valie` - the exact value that `func` is expected to throw if called.
 
 `func` - a function that should throw
 

--- a/fetch/http-cache/http-cache.js
+++ b/fetch/http-cache/http-cache.js
@@ -1,5 +1,5 @@
 /* global btoa fetch token promise_test step_timeout */
-/* global assert_equals assert_true assert_own_property assert_throws assert_less_than */
+/* global assert_equals assert_true assert_own_property assert_throws_js assert_less_than */
 
 const templates = {
   'fresh': {

--- a/html/dom/new-harness.js
+++ b/html/dom/new-harness.js
@@ -8,4 +8,4 @@ ReflectionHarness.test = function(fun, description) {
 
 ReflectionHarness.assertEquals = assert_equals;
 
-ReflectionHarness.assertThrows = assert_throws;
+ReflectionHarness.assertThrows = assert_throws_dom;

--- a/import-maps/builtin-support.tentative/imported/resources/helpers/parsing.js
+++ b/import-maps/builtin-support.tentative/imported/resources/helpers/parsing.js
@@ -26,7 +26,7 @@ exports.expectScopes = (inputArray, baseURL, outputArray, warnings = []) => {
 
 exports.expectBad = (input, baseURL, warnings = []) => {
   const checkWarnings = testWarningHandler(warnings);
-  expect(() => parseFromString(input, baseURL)).toThrow(TypeError);
+  expect(parseFromString(input, baseURL)).toThrow('TypeError');
   checkWarnings();
 };
 

--- a/import-maps/builtin-support.tentative/imported/resources/parsing-schema.js
+++ b/import-maps/builtin-support.tentative/imported/resources/parsing-schema.js
@@ -5,7 +5,7 @@ const { expectBad, expectWarnings, expectSpecifierMap } = require('./helpers/par
 const nonObjectStrings = ['null', 'true', '1', '"foo"', '[]'];
 
 test('Invalid JSON', () => {
-  expect(() => parseFromString('{ imports: {} }', 'https://base.example/')).toThrow(SyntaxError);
+  expect(parseFromString('{ imports: {} }', 'https://base.example/')).toThrow('SyntaxError');
 });
 
 describe('Mismatching the top-level schema', () => {

--- a/import-maps/resources/jest-test-helper.js
+++ b/import-maps/resources/jest-test-helper.js
@@ -35,11 +35,15 @@ function expect(v) {
   return {
     toMatchURL: expected => assert_equals(v, expected),
     toThrow: expected => {
-      if (expected.test && expected.test('not yet implemented')) {
+      if (v.localName === 'iframe') {
+        // `v` is the result of parseFromString(), and thus toThrow()
+        // should be examining the error in that iframe.
+        assert_throws_js(v.contentWindow[expected], () => { throw v.contentWindow.windowError });
+      } else if (expected.test && expected.test('not yet implemented')) {
         // We override /not yet implemented/ expectation.
         assert_throws_js(TypeError, v);
       } else {
-        assert_throws(expected(), v);
+        assert_throws_js(expected, v);
       }
     },
     toEqual: expected => {
@@ -115,11 +119,6 @@ function parseFromString(mapString, mapBaseURL) {
     </sc` + `ript>
   `);
   iframe.contentDocument.close();
-
-  // Rethrow window's error event.
-  if (iframe.contentWindow.windowError) {
-    throw iframe.contentWindow.windowError;
-  }
 
   return iframe;
 }

--- a/resource-timing/resources/webperftestharnessextension.js
+++ b/resource-timing/resources/webperftestharnessextension.js
@@ -30,13 +30,6 @@ function test_method_exists(method, method_name, properties)
     wp_test(function() { assert_true(typeof method === 'function', msg); }, msg, properties);
 }
 
-function test_method_throw_exception(func_str, exception, msg)
-{
-    var exception_name = typeof exception === "object" ? exception.name : exception;
-    var msg = 'Invocation of ' + func_str + ' should throw ' + exception_name  + ' Exception.';
-    wp_test(function() { assert_throws(exception, function() {eval(func_str)}, msg); }, msg);
-}
-
 function test_noless_than(value, greater_than, msg, properties)
 {
     wp_test(function () { assert_true(value >= greater_than, msg); }, msg, properties);

--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -343,7 +343,7 @@
     {
       "status_string": "FAIL",
       "name": "Test throw SyntaxError DOMException where JS SyntaxError expected; expected to fail",
-      "message": "assert_throws_js: function \"function () {document.querySelector(\"\")}\" threw object \"SyntaxError: '' is not a valid selector\" (\"SyntaxError\") expected instance of function \"function SyntaxError() {\n    [native code]\n}\" (\"SyntaxError\")",
+      "message": "assert_throws_js: function \"function () {document.querySelector(\"\")}\" threw object \"SyntaxError: Document.querySelector: '' is not a valid selector\" (\"SyntaxError\") expected instance of function \"function SyntaxError() {\n    [native code]\n}\" (\"SyntaxError\")",
       "properties": {}
     },
     {

--- a/resources/test/tests/unit/IdlInterface/do_member_unscopable_asserts.html
+++ b/resources/test/tests/unit/IdlInterface/do_member_unscopable_asserts.html
@@ -30,7 +30,7 @@
         const member = i.members[0];
         assert_true(member.isUnscopable);
         mock_interface_A({});
-        // assert_throws can't be used because it rethrows AssertionErrors.
+        // assert_throws_* can't be used because they rethrow AssertionErrors.
         try {
             i.do_member_unscopable_asserts(member);
         } catch(e) {

--- a/resources/test/tests/unit/assert_object_equals.html
+++ b/resources/test/tests/unit/assert_object_equals.html
@@ -7,7 +7,7 @@
 <script>
 'use strict';
 
-// Neither the `assert_throws` function  nor its variants may be used for this
+// The `assert_throws_*` functions cannot be used for this
 // purpose because they fail in response to AssertionError exceptions, even
 // when this is expressed as the expected error.
 function test_failure(fn, name) {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -640,7 +640,7 @@ policies and contribution forms [3].
 
     function promise_rejects(test, expected, promise, description) {
         return promise.then(test.unreached_func("Should have rejected: " + description)).catch(function(e) {
-            assert_throws(expected, function() { throw e }, description);
+            assert_throws_DO_NOT_USE(expected, function() { throw e }, description);
         });
     }
 
@@ -1474,7 +1474,7 @@ policies and contribution forms [3].
      * @param {Function} func Function which should throw.
      * @param {string} description Error description for the case that the error is not thrown.
      */
-    function assert_throws(code, func, description)
+    function assert_throws_DO_NOT_USE(code, func, description)
     {
         try {
             func.call(this);
@@ -1615,7 +1615,6 @@ policies and contribution forms [3].
             }
         }
     }
-    expose(assert_throws, "assert_throws");
 
     /**
      * Assert a JS Error with the expected constructor is thrown.

--- a/service-workers/service-worker/fetch-event-redirect.https.html
+++ b/service-workers/service-worker/fetch-event-redirect.https.html
@@ -47,9 +47,10 @@ function redirect_fetch_test(t, test) {
   const request = new Request(url, test.request_init);
 
   if (test.should_reject) {
-    return assert_promise_rejects(
+    return promise_rejects_js(
+      t,
+      frame.contentWindow.TypeError,
       frame.contentWindow.fetch(request),
-      new TypeError(),
       'Must fail to fetch: url=' + url);
   }
   return frame.contentWindow.fetch(request).then((response) => {

--- a/service-workers/service-worker/resources/testharness-helpers.js
+++ b/service-workers/service-worker/resources/testharness-helpers.js
@@ -5,33 +5,6 @@
  * environments, so code should for example not rely on the DOM.
  */
 
-// Returns a promise that fulfills after the provided |promise| is fulfilled.
-// The |test| succeeds only if |promise| rejects with an exception matching
-// |code|. Accepted values for |code| follow those accepted for assert_throws().
-// The optional |description| describes the test being performed.
-//
-// E.g.:
-//   assert_promise_rejects(
-//       new Promise(...), // something that should throw an exception.
-//       'NotFoundError',
-//       'Should throw NotFoundError.');
-//
-//   assert_promise_rejects(
-//       new Promise(...),
-//       new TypeError(),
-//       'Should throw TypeError');
-function assert_promise_rejects(promise, code, description) {
-  return promise.then(
-    function() {
-      throw 'assert_promise_rejects: ' + description + ' Promise did not reject.';
-    },
-    function(e) {
-      if (code !== undefined) {
-        assert_throws(code, function() { throw e; }, description);
-      }
-    });
-}
-
 // Asserts that two objects |actual| and |expected| are weakly equal under the
 // following definition:
 //

--- a/speech-api/SpeechSynthesis-speak-ownership.html
+++ b/speech-api/SpeechSynthesis-speak-ownership.html
@@ -15,9 +15,13 @@ async_test(t => {
     speechSynthesis.speak(utter);
     // the spec doesn't say what exception to throw:
     // https://github.com/w3c/speech-api/issues/8
-    assert_throws(null, () => {
+    let threw = false;
+    try {
       iframe.contentWindow.speechSynthesis.speak(utter);
-    });
+    } catch (e) {
+      threw = true;
+    }
+    assert_true(threw);
   }));
 }, 'Using the same SpeechSynthesisUtterance with two SpeechSynthesis instances');
 </script>

--- a/trusted-types/block-text-node-insertion-into-script-element.tentative.html
+++ b/trusted-types/block-text-node-insertion-into-script-element.tentative.html
@@ -176,7 +176,7 @@
     container.appendChild(new_script);
     assert_equals(inserted_script.textContent, "3*4");
 
-    // We expect 3 SPV events: two for the two assert_throws cases, and one
+    // We expect 3 SPV events: two for the two assert_throws_js cases, and one
     // for script element, which will be rejected at the time of execution.
     return checkSecurityPolicyViolationEvent(3);
   }, "Spot tests around script + innerHTML interaction.");

--- a/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.tentative.https.html
+++ b/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.tentative.https.html
@@ -42,7 +42,7 @@
     });
   }
 
-  // Like assert_throws, but we don't care about the exact error. We just want
+  // Like assert_throws_*, but we don't care about the exact error. We just want
   // to run the code and continue.
   function expect_throws(fn) {
     try { fn(); assert_unreached(); } catch (err) { /* ignore */ }

--- a/trusted-types/trusted-types-eval-reporting-report-only.tentative.https.html
+++ b/trusted-types/trusted-types-eval-reporting-report-only.tentative.https.html
@@ -42,7 +42,7 @@
     });
   }
 
-  // Like assert_throws, but we don't care about the exact error. We just want
+  // Like assert_throws_*, but we don't care about the exact error. We just want
   // to run the code and continue.
   function expect_throws(fn) {
     try { fn(); assert_unreached(); } catch (err) { /* ignore */ }

--- a/trusted-types/trusted-types-eval-reporting.tentative.https.html
+++ b/trusted-types/trusted-types-eval-reporting.tentative.https.html
@@ -36,7 +36,7 @@
     });
   }
 
-  // Like assert_throws, but we don't care about the exact error. We just want
+  // Like assert_throws_*, but we don't care about the exact error. We just want
   // to run the code and continue.
   function expect_throws(fn) {
     try { fn(); assert_unreached(); } catch (err) { /* ignore */ }

--- a/trusted-types/trusted-types-reporting.tentative.https.html
+++ b/trusted-types/trusted-types-reporting.tentative.https.html
@@ -48,7 +48,7 @@
     });
   }
 
-  // Like assert_throws, but we don't care about the exact error. We just want
+  // Like assert_throws_*, but we don't care about the exact error. We just want
   // to run the code and continue.
   function expect_throws(fn) {
     try { fn(); assert_unreached(); } catch (err) { /* ignore */ }

--- a/user-timing/measure_exception.html
+++ b/user-timing/measure_exception.html
@@ -19,7 +19,7 @@
 <div id="log"></div>
 <script>
 performance.mark('ExistMark');
-test_method_throw_exception('performance.measure()', TypeError());
+test_method_throw_exception('performance.measure()', TypeError);
 test_method_throw_exception('performance.measure("Exception1", "NonExistMark1")', 'SYNTAX_ERR');
 test_method_throw_exception('performance.measure("Exception2", "NonExistMark1", "navigationStart")', 'SYNTAX_ERR');
 test_method_throw_exception('performance.measure("Exception3", "navigationStart", "NonExistMark1")', 'SYNTAX_ERR');
@@ -27,8 +27,8 @@ test_method_throw_exception('performance.measure("Exception4", "NonExistMark1", 
 test_method_throw_exception('performance.measure("Exception5", "ExistMark", "NonExistMark1")', 'SYNTAX_ERR');
 test_method_throw_exception('performance.measure("Exception6", "NonExistMark1", "NonExistMark2")', 'SYNTAX_ERR');
 test_method_throw_exception('performance.measure("Exception7", "redirectStart")', 'INVALID_ACCESS_ERR');
-test_method_throw_exception('performance.measure("Exception8", {"detail": "non-empty"})', TypeError());
-test_method_throw_exception('performance.measure("Exception9", {"start": 1, "duration": 2, "end": 3})', TypeError());
+test_method_throw_exception('performance.measure("Exception8", {"detail": "non-empty"})', TypeError);
+test_method_throw_exception('performance.measure("Exception9", {"start": 1, "duration": 2, "end": 3})', TypeError);
 </script>
 </body>
 </html>

--- a/user-timing/resources/webperftestharnessextension.js
+++ b/user-timing/resources/webperftestharnessextension.js
@@ -32,9 +32,17 @@ function test_method_exists(method, method_name, properties)
 
 function test_method_throw_exception(func_str, exception, msg)
 {
-    var exception_name = typeof exception === "object" ? exception.name : exception;
+    let exception_name;
+    let test_func;
+    if (typeof exception == "function") {
+        exception_name = exception.name;
+        test_func = assert_throws_js;
+    } else {
+        exception_name = exception;
+        test_func = assert_throws_dom;
+    }
     var msg = 'Invocation of ' + func_str + ' should throw ' + exception_name  + ' Exception.';
-    wp_test(function() { assert_throws(exception, function() {eval(func_str)}, msg); }, msg);
+    wp_test(function() { test_func(exception, function() {eval(func_str)}, msg); }, msg);
 }
 
 function test_noless_than(value, greater_than, msg, properties)

--- a/video-raf/video-request-animation-frame.html
+++ b/video-raf/video-request-animation-frame.html
@@ -58,12 +58,12 @@ test(function(t) {
     let video = document.createElement('video');
 
     // requestAnimationFrame() expects 1 function as a parameter.
-    assert_throws(new TypeError(), _ => { video.requestAnimationFrame() } );
-    assert_throws(new TypeError(), _ => { video.requestAnimationFrame(0) });
-    assert_throws(new TypeError(), _ => { video.requestAnimationFrame("foo") });
+    assert_throws_js(TypeError, _ => { video.requestAnimationFrame() } );
+    assert_throws_js(TypeError, _ => { video.requestAnimationFrame(0) });
+    assert_throws_js(TypeError, _ => { video.requestAnimationFrame("foo") });
 
     // cancelAnimationFrame() expects 1 number as a parameter
-    assert_throws(new TypeError(), _ => { video.cancelAnimationFrame() } );
+    assert_throws_js(TypeError, _ => { video.cancelAnimationFrame() } );
 
     // Invalid calls are just noops
     video.cancelAnimationFrame(_ => {});

--- a/wasm/jsapi/bad-imports.js
+++ b/wasm/jsapi/bad-imports.js
@@ -2,7 +2,7 @@
  * `t` should be a function that takes at least three arguments:
  *
  * - the name of the test;
- * - the expected error (to be passed to `assert_throws` or similar);
+ * - the expected error (to be passed to `assert_throws_js`);
  * - a function that takes a `WasmModuleBuilder` and initializes it;
  * - (optionally) an options object.
  *

--- a/webrtc-extensions/RTCRtpParameters-maxFramerate.html
+++ b/webrtc-extensions/RTCRtpParameters-maxFramerate.html
@@ -11,7 +11,7 @@
 test(function(t) {
   const pc = new RTCPeerConnection();
   t.add_cleanup(() => pc.close());
-  assert_throws(new RangeError(), () => pc.addTransceiver('video', {
+  assert_throws_js(RangeError, () => pc.addTransceiver('video', {
     sendEncodings: [{
       maxFramerate: -10
     }]

--- a/webrtc/RTCConfiguration-iceCandidatePoolSize.html
+++ b/webrtc/RTCConfiguration-iceCandidatePoolSize.html
@@ -89,7 +89,7 @@ test(() => {
 
 /*
 The following tests include an explicit assertion for the existence of a
-setConfiguration function to prevent the assert_throws from catching the
+setConfiguration function to prevent the assert_throws_js from catching the
 TypeError object that will be thrown when attempting to call the
 non-existent setConfiguration method (in cases where it has not yet
 been implemented). Without this check, these tests will pass incorrectly.

--- a/webrtc/RTCPeerConnection-constructor.html
+++ b/webrtc/RTCPeerConnection-constructor.html
@@ -14,7 +14,7 @@ const toStringThrows = { toString: function() { throw new Error; } };
 const toNumberThrows = Symbol();
 
 // Test the first argument of the constructor. The key is the argument itself,
-// and the value is the first argument for assert_throws, or false if no
+// and the value is the first argument for assert_throws_js, or false if no
 // exception should be thrown.
 const testArgs = {
   // No argument or equivalent.

--- a/webrtc/RTCPeerConnection-track-stats.https.html
+++ b/webrtc/RTCPeerConnection-track-stats.https.html
@@ -648,15 +648,4 @@
       }
     }
   }
-
-  async function async_assert_throws(exceptionName, promise, description) {
-    try {
-      await promise;
-    } catch (e) {
-      assert_equals(e.name, exceptionName);
-      return;
-    }
-    assert_unreached('No exception was thrown.');
-  }
-
 </script>

--- a/webrtc/tools/.eslintrc.js
+++ b/webrtc/tools/.eslintrc.js
@@ -24,7 +24,6 @@ module.exports = {
     assert_array_equals: true,
     assert_in_array: true,
     assert_unreached: true,
-    assert_throws: true,
     assert_idl_attribute: true,
     assert_own_property: true,
     assert_greater_than: true,


### PR DESCRIPTION
The one remaining use inside promise_rejects will go away soon when
promise_rejects goes away.