### PR TITLE
Use errno attribute to handle socket.error for PY2 and PY3 compatibility

### DIFF
--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -273,7 +273,7 @@ def wait_for_service(addr, timeout=60):
         except socket.timeout:
             pass
         except socket.error as e:
-            if e[0] != errno.ECONNREFUSED:
+            if e.errno != errno.ECONNREFUSED:
                 raise
         else:
             return True


### PR DESCRIPTION
Python 3 has introduced Built-in Exception class 'ConnectionRefusedError'
as a subclass of ConnectionError for connection-related issue.