### PR TITLE
Fix lint.whitelist after 8636d91

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -111,7 +111,7 @@ CONSOLE: service-workers/service-worker/resources/navigation-redirect-other-orig
 CONSOLE: service-workers/service-worker/navigation-redirect.https.html
 CONSOLE: service-workers/service-worker/resources/clients-get-other-origin.html
 CONSOLE: webrtc/tools/*
-CONSOLE: webaudio/resources/audit.js:39
+CONSOLE: webaudio/resources/audit.js:41
 
 # use of console in a public library - annotation-model ensures
 # it is not actually used


### PR DESCRIPTION
The lint for audit.js is based on the exact line location, which changed when https://github.com/web-platform-tests/wpt/pull/21804 added two more lines to the file.