### PR TITLE
Fix resources path in lazy load tests

### DIFF
--- a/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-ifame-001.sub.html
+++ b/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-ifame-001.sub.html
@@ -13,7 +13,8 @@
 promise_test(async t => {
   iframe.src =
       get_host_info().HTTP_NOTSAMESITE_ORIGIN +
-      "/loading/lazyload/resources/image-loading-lazy-below-viewport-iframe.html";
+      new URL("resources/", self.location).pathname +
+      "image-loading-lazy-below-viewport-iframe.html";
 
   let image_loaded = false;
 

--- a/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-ifame-002.sub.html
+++ b/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-ifame-002.sub.html
@@ -14,7 +14,8 @@
 promise_test(async t => {
   iframe.src =
     get_host_info().HTTP_NOTSAMESITE_ORIGIN +
-    "/loading/lazyload/resources/image-loading-lazy-in-viewport-iframe.html";
+    new URL("resources/", self.location).pathname +
+    "image-loading-lazy-in-viewport-iframe.html";
 
   let image_loaded = false;
 

--- a/html/semantics/embedded-content/the-img-element/original-base-url-applied-2.html
+++ b/html/semantics/embedded-content/the-img-element/original-base-url-applied-2.html
@@ -6,7 +6,7 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="common.js"></script>
-  <base href='/loading/lazyload/resources/'>
+  <base href='/html/semantics/embedded-content/the-img-element/resources/'>
 </head>
 
 <script>

--- a/html/semantics/embedded-content/the-img-element/original-base-url-applied-iframe.html
+++ b/html/semantics/embedded-content/the-img-element/original-base-url-applied-iframe.html
@@ -6,7 +6,7 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="common.js"></script>
-  <base href='/loading/lazyload/resources/'>
+  <base href='/html/semantics/embedded-content/the-img-element/resources/'>
 </head>
 
 <script>

--- a/html/semantics/embedded-content/the-img-element/original-crossorigin-applied.sub.html
+++ b/html/semantics/embedded-content/the-img-element/original-crossorigin-applied.sub.html
@@ -37,6 +37,6 @@
 <body>
   <div style="height:10000px;"></div>
   <img id="crossorigin_img" loading="lazy"
-       src='http://{{hosts[alt][www]}}:{{ports[http][0]}}/loading/lazyload/resources/image.png'
+       src='http://{{hosts[alt][www]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-img-element/resources/image.png'
        onload="crossorigin_img.resolve();" onerror="crossorigin_img.reject();">
 </body>


### PR DESCRIPTION
When moving lazy load tests to html/semantics/embedded-content/the-img-element
the internal resources path was not adjusted, so do it in this change.