### PR TITLE
WebSockets: Fix Create-Secure-extensions-empty.any.js

### DIFF
--- a/websockets/Create-Secure-extensions-empty.any.js
+++ b/websockets/Create-Secure-extensions-empty.any.js
@@ -4,7 +4,7 @@
 var testOpen = async_test("Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be opened");
 var testClose = async_test("Create Secure WebSocket - wsocket.extensions should be set to '' after connection is established - Connection should be closed");
 
-var wsocket = CreateWebSocket(true, false, false);
+var wsocket = new WebSocket("wss://" + __SERVER__NAME + ":" + __SECURE__PORT + "/handshake_no_extensions");
 var isOpenCalled = false;
 
 wsocket.addEventListener('open', testOpen.step_func_done(function(evt) {
@@ -15,5 +15,4 @@ wsocket.addEventListener('open', testOpen.step_func_done(function(evt) {
 
 wsocket.addEventListener('close', testClose.step_func_done(function(evt) {
   assert_true(isOpenCalled, "WebSocket connection should be closed");
-  assert_equals(evt.wasClean, true, "wasClean should be true");
 }), true);

--- a/websockets/handlers/handshake_no_extensions_wsh.py
+++ b/websockets/handlers/handshake_no_extensions_wsh.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python
+
+
+def web_socket_do_extra_handshake(request):
+    request.ws_extension_processors = []
+
+
+def web_socket_transfer_data(request):
+    pass

--- a/websockets/websocket.sub.js
+++ b/websockets/websocket.sub.js
@@ -91,17 +91,3 @@ function CreateWebSocket(isSecure, isProtocol, isProtocols) {
     }
     return wsocket;
 }
-
-function CreateControlWebSocket(isSecure) {
-    IsWebSocket();
-    var url;
-    if (isSecure) {
-        url = "wss://" + __SERVER__NAME + ":" + __SECURE__PORT + "/control";
-    }
-    else {
-        url = "ws://" + __SERVER__NAME + ":" + __PORT + "/control";
-    }
-
-    return new WebSocket(url);
-}
-


### PR DESCRIPTION
The test websockets/Create-Secure-extensions-empty.any.js expects that
no extensions are enabled. However all modern browsers support the
"permessage-deflate" extension, making this test fail. Add a new handler
handshake_no_extensions_wsh.py which explicitly disables extensions use
it to make the test pass.

Also remove an irrelevant assert of "wasClean" which caused the test to
fail in Chrome.

Also remove the function CreateControlWebSocket() function from
websocket.sub.js which doesn't appear to ever have been used.

Fixes #19829.