### PR TITLE
Improve python3 support of test_wpt

### DIFF
--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -26,6 +26,7 @@ if MYPY:
     from typing import Callable
     from typing import List
     from typing import Optional
+    from typing import Text
 
 here = os.path.dirname(__file__)
 
@@ -50,14 +51,14 @@ def should_download(manifest_path, rebuild_time=timedelta(days=5)):
 
 
 def merge_pr_tags(repo_root, max_count=50):
-    # type: (str, int) -> List[str]
+    # type: (str, int) -> List[Text]
     gitfunc = git(repo_root)
-    tags = []  # type: List[str]
+    tags = []  # type: List[Text]
     if gitfunc is None:
         return tags
-    for line in gitfunc("log", "--format=%D", "--max-count=%s" % max_count).split(b"\n"):
-        for ref in line.split(b", "):
-            if ref.startswith(b"tag: merge_pr_"):
+    for line in gitfunc("log", "--format=%D", "--max-count=%s" % max_count).split("\n"):
+        for ref in line.split(", "):
+            if ref.startswith("tag: merge_pr_"):
                 tags.append(ref[5:])
     return tags
 
@@ -79,7 +80,7 @@ def score_name(name):
 
 
 def github_url(tags):
-    # type: (List[str]) -> Optional[List[str]]
+    # type: (List[Text]) -> Optional[List[Text]]
     for tag in tags:
         url = "https://api.github.com/repos/web-platform-tests/wpt/releases/tags/%s" % tag
         try:
@@ -111,8 +112,8 @@ def github_url(tags):
 
 def download_manifest(
         manifest_path,  # type: str
-        tags_func,  # type: Callable[[], List[str]]
-        url_func,  # type: Callable[[List[str]], Optional[List[str]]]
+        tags_func,  # type: Callable[[], List[Text]]
+        url_func,  # type: Callable[[List[Text]], Optional[List[Text]]]
         force=False  # type: bool
 ):
     # type: (...) -> bool

--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -7,7 +7,6 @@ import json
 import io
 import os
 from datetime import datetime, timedelta
-from typing import Text
 
 from six.moves.urllib.request import urlopen
 
@@ -27,6 +26,7 @@ if MYPY:
     from typing import Callable
     from typing import List
     from typing import Optional
+    from typing import Text
 
 here = os.path.dirname(__file__)
 

--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -7,6 +7,7 @@ import json
 import io
 import os
 from datetime import datetime, timedelta
+from typing import Text
 
 from six.moves.urllib.request import urlopen
 
@@ -50,9 +51,9 @@ def should_download(manifest_path, rebuild_time=timedelta(days=5)):
 
 
 def merge_pr_tags(repo_root, max_count=50):
-    # type: (str, int) -> List[str]
+    # type: (str, int) -> List[Text]
     gitfunc = git(repo_root)
-    tags = []  # type: List[str]
+    tags = []  # type: List[Text]
     if gitfunc is None:
         return tags
     for line in gitfunc("log", "--format=%D", "--max-count=%s" % max_count).split("\n"):
@@ -79,7 +80,7 @@ def score_name(name):
 
 
 def github_url(tags):
-    # type: (List[str]) -> Optional[List[str]]
+    # type: (List[Text]) -> Optional[List[Text]]
     for tag in tags:
         url = "https://api.github.com/repos/web-platform-tests/wpt/releases/tags/%s" % tag
         try:
@@ -111,8 +112,8 @@ def github_url(tags):
 
 def download_manifest(
         manifest_path,  # type: str
-        tags_func,  # type: Callable[[], List[str]]
-        url_func,  # type: Callable[[List[str]], Optional[List[str]]]
+        tags_func,  # type: Callable[[], List[Text]]
+        url_func,  # type: Callable[[List[Text]], Optional[List[Text]]]
         force=False  # type: bool
 ):
     # type: (...) -> bool

--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -51,14 +51,14 @@ def should_download(manifest_path, rebuild_time=timedelta(days=5)):
 
 
 def merge_pr_tags(repo_root, max_count=50):
-    # type: (str, int) -> List[Text]
+    # type: (str, int) -> List[str]
     gitfunc = git(repo_root)
-    tags = []  # type: List[Text]
+    tags = []  # type: List[str]
     if gitfunc is None:
         return tags
-    for line in gitfunc("log", "--format=%D", "--max-count=%s" % max_count).split("\n"):
-        for ref in line.split(", "):
-            if ref.startswith("tag: merge_pr_"):
+    for line in gitfunc("log", "--format=%D", "--max-count=%s" % max_count).split(b"\n"):
+        for ref in line.split(b", "):
+            if ref.startswith(b"tag: merge_pr_"):
                 tags.append(ref[5:])
     return tags
 
@@ -80,7 +80,7 @@ def score_name(name):
 
 
 def github_url(tags):
-    # type: (List[Text]) -> Optional[List[Text]]
+    # type: (List[str]) -> Optional[List[str]]
     for tag in tags:
         url = "https://api.github.com/repos/web-platform-tests/wpt/releases/tags/%s" % tag
         try:
@@ -112,8 +112,8 @@ def github_url(tags):
 
 def download_manifest(
         manifest_path,  # type: str
-        tags_func,  # type: Callable[[], List[Text]]
-        url_func,  # type: Callable[[List[Text]], Optional[List[Text]]]
+        tags_func,  # type: Callable[[], List[str]]
+        url_func,  # type: Callable[[List[str]], Optional[List[str]]]
         force=False  # type: bool
 ):
     # type: (...) -> bool

--- a/tools/manifest/download.py
+++ b/tools/manifest/download.py
@@ -26,7 +26,6 @@ if MYPY:
     from typing import Callable
     from typing import List
     from typing import Optional
-    from typing import Text
 
 here = os.path.dirname(__file__)
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -195,7 +195,7 @@ class SourceFile(object):
                          ("css", "common")}  # type: Set[Tuple[bytes, ...]]
 
     def __init__(self, tests_root, rel_path, url_base, hash=None, contents=None):
-        # type: (AnyStr, AnyStr, Text, Optional[Text], Optional[bytes]) -> None
+        # type: (AnyStr, AnyStr, Text, Optional[bytes], Optional[bytes]) -> None
         """Object representing a file in a source tree.
 
         :param tests_root: Path to the root of the source tree
@@ -302,7 +302,7 @@ class SourceFile(object):
 
     @cached_property
     def hash(self):
-        # type: () -> Text
+        # type: () -> bytes
         if not self._hash:
             with self.open() as f:
                 content = f.read()

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -242,7 +242,7 @@ class SourceFile(object):
 
         if "__cached_properties__" in rv:
             cached_properties = rv["__cached_properties__"]
-            rv = { key:value for key, value in iteritems(rv) if not key in cached_properties }
+            rv = {key:value for key, value in iteritems(rv) if key not in cached_properties}
             del rv["__cached_properties__"]
         return rv
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -195,7 +195,7 @@ class SourceFile(object):
                          ("css", "common")}  # type: Set[Tuple[bytes, ...]]
 
     def __init__(self, tests_root, rel_path, url_base, hash=None, contents=None):
-        # type: (AnyStr, AnyStr, Text, Optional[bytes], Optional[bytes]) -> None
+        # type: (AnyStr, AnyStr, Text, Optional[Text], Optional[bytes]) -> None
         """Object representing a file in a source tree.
 
         :param tests_root: Path to the root of the source tree
@@ -302,7 +302,7 @@ class SourceFile(object):
 
     @cached_property
     def hash(self):
-        # type: () -> bytes
+        # type: () -> Text
         if not self._hash:
             with self.open() as f:
                 content = f.read()

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -2,7 +2,7 @@ import hashlib
 import re
 import os
 from collections import deque
-from six import binary_type, PY3
+from six import binary_type, PY3, iteritems
 from six.moves.urllib.parse import urljoin
 from fnmatch import fnmatch
 
@@ -242,9 +242,7 @@ class SourceFile(object):
 
         if "__cached_properties__" in rv:
             cached_properties = rv["__cached_properties__"]
-            for key in rv.keys():
-                if key in cached_properties:
-                    del rv[key]
+            rv = { key:value for key, value in iteritems(rv) if not key in cached_properties }
             del rv["__cached_properties__"]
         return rv
 

--- a/tools/manifest/utils.py
+++ b/tools/manifest/utils.py
@@ -55,16 +55,16 @@ def to_os_path(path):
 
 
 def git(path):
-    # type: (bytes) -> Optional[Callable[..., bytes]]
+    # type: (bytes) -> Optional[Callable[..., Text]]
     def gitfunc(cmd, *args):
-        # type: (bytes, *bytes) -> bytes
+        # type: (bytes, *bytes) -> Text
         full_cmd = ["git", cmd] + list(args)
         try:
-            return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT)
+            return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')
         except Exception as e:
             if platform.uname()[0] == "Windows" and isinstance(e, WindowsError):
                 full_cmd[0] = "git.bat"
-                return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT)
+                return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')
             else:
                 raise
 

--- a/tools/manifest/utils.py
+++ b/tools/manifest/utils.py
@@ -57,7 +57,7 @@ def to_os_path(path):
 def git(path):
     # type: (bytes) -> Optional[Callable[..., bytes]]
     def gitfunc(cmd, *args):
-        # type: (bytes, *bytes) -> AnyStr
+        # type: (bytes, *bytes) -> Text
         full_cmd = ["git", cmd] + list(args)
         try:
             return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')

--- a/tools/manifest/utils.py
+++ b/tools/manifest/utils.py
@@ -55,16 +55,16 @@ def to_os_path(path):
 
 
 def git(path):
-    # type: (bytes) -> Optional[Callable[..., Text]]
+    # type: (bytes) -> Optional[Callable[..., bytes]]
     def gitfunc(cmd, *args):
-        # type: (bytes, *bytes) -> Text
+        # type: (bytes, *bytes) -> bytes
         full_cmd = ["git", cmd] + list(args)
         try:
-            return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')
+            return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT)
         except Exception as e:
             if platform.uname()[0] == "Windows" and isinstance(e, WindowsError):
                 full_cmd[0] = "git.bat"
-                return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')
+                return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT)
             else:
                 raise
 

--- a/tools/manifest/utils.py
+++ b/tools/manifest/utils.py
@@ -60,11 +60,11 @@ def git(path):
         # type: (bytes, *bytes) -> bytes
         full_cmd = ["git", cmd] + list(args)
         try:
-            return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT)
+            return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')
         except Exception as e:
             if platform.uname()[0] == "Windows" and isinstance(e, WindowsError):
                 full_cmd[0] = "git.bat"
-                return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT)
+                return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')
             else:
                 raise
 

--- a/tools/manifest/utils.py
+++ b/tools/manifest/utils.py
@@ -57,7 +57,7 @@ def to_os_path(path):
 def git(path):
     # type: (bytes) -> Optional[Callable[..., bytes]]
     def gitfunc(cmd, *args):
-        # type: (bytes, *bytes) -> bytes
+        # type: (bytes, *bytes) -> str
         full_cmd = ["git", cmd] + list(args)
         try:
             return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')

--- a/tools/manifest/utils.py
+++ b/tools/manifest/utils.py
@@ -57,7 +57,7 @@ def to_os_path(path):
 def git(path):
     # type: (bytes) -> Optional[Callable[..., bytes]]
     def gitfunc(cmd, *args):
-        # type: (bytes, *bytes) -> str
+        # type: (bytes, *bytes) -> AnyStr
         full_cmd = ["git", cmd] + list(args)
         try:
             return subprocess.check_output(full_cmd, cwd=path, stderr=subprocess.STDOUT).decode('utf8')

--- a/tools/manifest/utils.py
+++ b/tools/manifest/utils.py
@@ -55,7 +55,7 @@ def to_os_path(path):
 
 
 def git(path):
-    # type: (bytes) -> Optional[Callable[..., bytes]]
+    # type: (bytes) -> Optional[Callable[..., Text]]
     def gitfunc(cmd, *args):
         # type: (bytes, *bytes) -> Text
         full_cmd = ["git", cmd] + list(args)

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -58,21 +58,21 @@ class GitHasher(object):
         self.git = git(path)
 
     def _local_changes(self):
-        # type: () -> Set[bytes]
+        # type: () -> Set[Text]
         """get a set of files which have changed between HEAD and working copy"""
         assert self.git is not None
         # note that git runs the command with tests_root as the cwd, which may
         # not be the root of the git repo (e.g., within a browser repo)
         cmd = [b"diff-index", b"--relative", b"--no-renames", b"--name-only", b"-z", b"HEAD"]
         data = self.git(*cmd)
-        return set(data.split(b"\0"))
+        return set(data.split("\0"))
 
     def hash_cache(self):
-        # type: () -> Dict[bytes, Optional[bytes]]
+        # type: () -> Dict[Text, Optional[Text]]
         """
         A dict of rel_path -> current git object id if the working tree matches HEAD else None
         """
-        hash_cache = {}  # type: Dict[bytes, Optional[bytes]]
+        hash_cache = {}  # type: Dict[Text, Optional[Text]]
 
         if self.git is None:
             return hash_cache
@@ -81,9 +81,9 @@ class GitHasher(object):
         # not be the root of the git repo (e.g., within a browser repo)
         cmd = ["ls-tree", "-r", "-z", "HEAD"]
         local_changes = self._local_changes()
-        for result in self.git(*cmd).split(b"\0")[:-1]:  # type: bytes
-            data, rel_path = result.rsplit(b"\t", 1)
-            hash_cache[rel_path] = None if rel_path in local_changes else data.split(b" ", 3)[2]
+        for result in self.git(*cmd).split("\0")[:-1]:  # type: Text
+            data, rel_path = result.rsplit("\t", 1)
+            hash_cache[rel_path] = None if rel_path in local_changes else data.split(" ", 3)[2]
 
         return hash_cache
 

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -33,7 +33,7 @@ def get_tree(tests_root, manifest, manifest_path, cache_root,
     # type: (bytes, Manifest, Optional[bytes], Optional[bytes], bool, bool) -> FileSystem
     tree = None
     if cache_root is None:
-        cache_root = os.path.join(tests_root, b".wptcache")
+        cache_root = os.path.join(tests_root, ".wptcache")
     if not os.path.exists(cache_root):
         try:
             os.makedirs(cache_root)
@@ -65,7 +65,7 @@ class GitHasher(object):
         # not be the root of the git repo (e.g., within a browser repo)
         cmd = [b"diff-index", b"--relative", b"--no-renames", b"--name-only", b"-z", b"HEAD"]
         data = self.git(*cmd)
-        return set(data.split(b"\0"))
+        return set(data.split("\0"))
 
     def hash_cache(self):
         # type: () -> Dict[bytes, Optional[bytes]]
@@ -81,9 +81,9 @@ class GitHasher(object):
         # not be the root of the git repo (e.g., within a browser repo)
         cmd = ["ls-tree", "-r", "-z", "HEAD"]
         local_changes = self._local_changes()
-        for result in self.git(*cmd).split(b"\0")[:-1]:  # type: bytes
-            data, rel_path = result.rsplit(b"\t", 1)
-            hash_cache[rel_path] = None if rel_path in local_changes else data.split(b" ", 3)[2]
+        for result in self.git(*cmd).split("\0")[:-1]:  # type: str
+            data, rel_path = result.rsplit("\t", 1)
+            hash_cache[rel_path] = None if rel_path in local_changes else data.split(" ", 3)[2]
 
         return hash_cache
 
@@ -174,7 +174,7 @@ class CacheFile(with_metaclass(abc.ABCMeta)):
 
 
 class MtimeCache(CacheFile):
-    file_name = b"mtime.json"
+    file_name = "mtime.json"
 
     def __init__(self, cache_root, tests_root, manifest_path, rebuild=False):
         # type: (bytes, bytes, bytes, bool) -> None
@@ -222,7 +222,7 @@ class MtimeCache(CacheFile):
 
 
 class GitIgnoreCache(CacheFile, MutableMapping):  # type: ignore
-    file_name = b"gitignore.json"
+    file_name = "gitignore.json"
 
     def check_valid(self, data):
         # type: (Dict[Any, Any]) -> Dict[Any, Any]
@@ -286,7 +286,7 @@ def walk(root):
     relpath = os.path.relpath
 
     root = os.path.abspath(root)
-    stack = deque([(root, b"")])
+    stack = deque([(root, "")])
 
     while stack:
         dir_path, rel_path = stack.popleft()

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -58,21 +58,21 @@ class GitHasher(object):
         self.git = git(path)
 
     def _local_changes(self):
-        # type: () -> Set[Text]
+        # type: () -> Set[bytes]
         """get a set of files which have changed between HEAD and working copy"""
         assert self.git is not None
         # note that git runs the command with tests_root as the cwd, which may
         # not be the root of the git repo (e.g., within a browser repo)
         cmd = [b"diff-index", b"--relative", b"--no-renames", b"--name-only", b"-z", b"HEAD"]
         data = self.git(*cmd)
-        return set(data.split("\0"))
+        return set(data.split(b"\0"))
 
     def hash_cache(self):
-        # type: () -> Dict[Text, Optional[Text]]
+        # type: () -> Dict[bytes, Optional[bytes]]
         """
         A dict of rel_path -> current git object id if the working tree matches HEAD else None
         """
-        hash_cache = {}  # type: Dict[Text, Optional[Text]]
+        hash_cache = {}  # type: Dict[bytes, Optional[bytes]]
 
         if self.git is None:
             return hash_cache
@@ -81,9 +81,9 @@ class GitHasher(object):
         # not be the root of the git repo (e.g., within a browser repo)
         cmd = ["ls-tree", "-r", "-z", "HEAD"]
         local_changes = self._local_changes()
-        for result in self.git(*cmd).split("\0")[:-1]:  # type: Text
-            data, rel_path = result.rsplit("\t", 1)
-            hash_cache[rel_path] = None if rel_path in local_changes else data.split(" ", 3)[2]
+        for result in self.git(*cmd).split(b"\0")[:-1]:  # type: bytes
+            data, rel_path = result.rsplit(b"\t", 1)
+            hash_cache[rel_path] = None if rel_path in local_changes else data.split(b" ", 3)[2]
 
         return hash_cache
 

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -58,7 +58,7 @@ class GitHasher(object):
         self.git = git(path)
 
     def _local_changes(self):
-        # type: () -> Set[bytes]
+        # type: () -> Set[Text]
         """get a set of files which have changed between HEAD and working copy"""
         assert self.git is not None
         # note that git runs the command with tests_root as the cwd, which may
@@ -68,11 +68,11 @@ class GitHasher(object):
         return set(data.split("\0"))
 
     def hash_cache(self):
-        # type: () -> Dict[bytes, Optional[bytes]]
+        # type: () -> Dict[Text, Optional[Text]]
         """
         A dict of rel_path -> current git object id if the working tree matches HEAD else None
         """
-        hash_cache = {}  # type: Dict[bytes, Optional[bytes]]
+        hash_cache = {}  # type: Dict[Text, Optional[Text]]
 
         if self.git is None:
             return hash_cache
@@ -81,7 +81,7 @@ class GitHasher(object):
         # not be the root of the git repo (e.g., within a browser repo)
         cmd = ["ls-tree", "-r", "-z", "HEAD"]
         local_changes = self._local_changes()
-        for result in self.git(*cmd).split("\0")[:-1]:  # type: str
+        for result in self.git(*cmd).split("\0")[:-1]:  # type: Text
             data, rel_path = result.rsplit("\t", 1)
             hash_cache[rel_path] = None if rel_path in local_changes else data.split(" ", 3)[2]
 

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -299,7 +299,7 @@ def affected_testfiles(files_changed,  # type: Iterable[Text]
 
     def affected_by_interfaces(file_contents):
         # type: (Union[bytes, Text]) -> bool
-        if len(interfaces_changed_names) > 0:
+        if interfaces_changed_names:
             if 'idlharness.js' in file_contents:
                 for interface in interfaces_changed_names:
                     regex = '[\'"]' + interface + '(\\.idl)?[\'"]'
@@ -324,9 +324,9 @@ def affected_testfiles(files_changed,  # type: Iterable[Text]
 
             with open(test_full_path, "rb") as fh:
                 raw_file_contents = fh.read()  # type: bytes
-                if raw_file_contents.startswith("\xfe\xff"):
+                if raw_file_contents.startswith(b"\xfe\xff"):
                     file_contents = raw_file_contents.decode("utf-16be", "replace")  # type: Text
-                elif raw_file_contents.startswith("\xff\xfe"):
+                elif raw_file_contents.startswith(b"\xff\xfe"):
                     file_contents = raw_file_contents.decode("utf-16le", "replace")
                 else:
                     file_contents = raw_file_contents.decode("utf8", "replace")

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -299,7 +299,7 @@ def affected_testfiles(files_changed,  # type: Iterable[Text]
 
     def affected_by_interfaces(file_contents):
         # type: (Union[bytes, Text]) -> bool
-        if interfaces_changed_names:
+        if len(interfaces_changed) > 0:
             if 'idlharness.js' in file_contents:
                 for interface in interfaces_changed_names:
                     regex = '[\'"]' + interface + '(\\.idl)?[\'"]'

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -5,7 +5,7 @@ import sys
 from collections import OrderedDict
 from distutils.spawn import find_executable
 from datetime import timedelta
-from six import iterkeys, itervalues, iteritems
+from six import iterkeys, itervalues, iteritems, string_types
 
 from . import config
 from . import wpttest
@@ -539,7 +539,7 @@ def check_args(kwargs):
 
     if kwargs['extra_prefs']:
         # If a single pref is passed in as a string, make it a list
-        if type(kwargs['extra_prefs']) in (str, unicode):
+        if isinstance(kwargs['extra_prefs'], string_types):
             kwargs['extra_prefs'] = [kwargs['extra_prefs']]
         missing = any('=' not in prefarg for prefarg in kwargs['extra_prefs'])
         if missing:


### PR DESCRIPTION
We are not there yet even with these changes, that's why I kept the xfail around. There are several issues with manifest file writting that need to be addressed first. However with these changes, tests pass in python3 as long as we don't update de manifest.