### PR TITLE
Enable xfailed test in wptrunner's test_sauce

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -179,7 +179,7 @@ class SauceConnect():
 
         tot_wait = 0
         while not os.path.exists('./sauce_is_ready') and self.sc_process.poll() is None:
-            if tot_wait >= self.sauce_init_timeout:
+            if not self.sauce_init_timeout or (tot_wait >= self.sauce_init_timeout):
                 self.quit()
 
                 raise SauceException("Sauce Connect Proxy was not ready after %d seconds" % tot_wait)

--- a/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
@@ -96,7 +96,6 @@ def test_sauceconnect_cleanup():
 
         sleep.assert_called()
 
-@pytest.mark.xfail(sys.version_info >= (3,), reason="fails on Py3")
 def test_sauceconnect_failure_never_ready():
     with mock.patch.object(sauce.SauceConnect, "upload_prerun_exec"),\
             mock.patch.object(sauce.subprocess, "Popen") as Popen,\


### PR DESCRIPTION
It was failing because comparing ints and None objects is valid in Python2 (returns True) but raises a type missmatch exception in Python3.