### PR TITLE
Enable xfailed test in wptserve's test_response

### DIFF
--- a/tools/wptserve/tests/functional/test_response.py
+++ b/tools/wptserve/tests/functional/test_response.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import unittest
 import json

--- a/tools/wptserve/tests/functional/test_response.py
+++ b/tools/wptserve/tests/functional/test_response.py
@@ -5,11 +5,7 @@ from io import BytesIO
 
 import pytest
 from six import create_bound_method, PY3
-
-try:
-    from httplib import BadStatusLine
-except ImportError:
-    from http.client import BadStatusLine
+from six.moves.http_client import BadStatusLine
 
 wptserve = pytest.importorskip("wptserve")
 from .base import TestUsingServer, TestUsingH2Server, doc_root


### PR DESCRIPTION
python2 and python3 do not handle invalid HTTP responses. In the case of python3 we're getting an http.client.BadStatusLine whereas python2 does not trigger any exception at all.