### PR TITLE
Use exception's errno as the parameter for traceback.format_exc() whe…

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -296,7 +296,10 @@ class WebDriverProtocol(Protocol):
             message = str(getattr(e, "message", ""))
             if message:
                 message += "\n"
-            message += traceback.format_exc(e)
+            if getattr(e, 'errno', None) != None:
+                message += traceback.format_exc(e.errno)
+            else:
+                message += traceback.format_exc(e)
             self.logger.debug(message)
         self.webdriver = None
 
@@ -337,7 +340,10 @@ class WebDriverRun(TimedRunner):
                 message = str(getattr(e, "message", ""))
                 if message:
                     message += "\n"
-                message += traceback.format_exc(e)
+                if getattr(e, 'errno', None) != None:
+                    message += traceback.format_exc(e.errno)
+                else:    
+                    message += traceback.format_exc(e)
                 self.result = False, ("INTERNAL-ERROR", message)
         finally:
             self.result_flag.set()


### PR DESCRIPTION
…n exists.

Python 3 has introduced some new OS exception classes, such as ConnectionResetError
used in this instance. We need to pass the errno (integer) to traceback.format_exc()
rather than a class.