### PR TITLE
COEP: change cache.match() exception

### DIFF
--- a/html/cross-origin-embedder-policy/require-corp-load-from-cache-storage.https.html
+++ b/html/cross-origin-embedder-policy/require-corp-load-from-cache-storage.https.html
@@ -110,7 +110,7 @@ function test(
     const cache = await caches.open('v1');
 
     if (response_type === 'error') {
-      await promise_rejects_dom(t, 'InvalidAccessError', cache.match(url));
+      await promise_rejects_js(t, TypeError, cache.match(url));
       return;
     }
 


### PR DESCRIPTION
TypeError is more consistent with the overall API.

See https://github.com/w3c/ServiceWorker/issues/1490#issuecomment-572981138.

This reverts https://github.com/web-platform-tests/wpt/commit/615aa2a91ba7f496a17e9c4815280795ef265b4f.

cc @ArthurSonzogni @wanderview @asutherland @mikewest 