### PR TITLE
5 new ::selection tests and 2 refs

### DIFF
--- a/css/css-pseudo/active-selection-051-ref.html
+++ b/css/css-pseudo/active-selection-051-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+   <style>
+  div
+    {
+      font-size: 300%;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>Test passes if "Selected Text" appears selected using the OS selection colors.
+
+  <div id="test">Selected Text</div>

--- a/css/css-pseudo/active-selection-051.html
+++ b/css/css-pseudo/active-selection-051.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: active selection and invalid declaration block</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-cascade">
+  <link rel="match" href="active-selection-051-ref.html">
+
+  <meta content="invalid" name="flags">
+  <meta name="assert" content="In this test, the selector div::selection has an invalid declaration block. Therefore, it is ignored. In such case, the UA must use the OS-default highlight colors for div::selection.">
+
+  <style>
+  div
+    {
+      color: transparent;
+      font-size: 300%;
+    }
+
+  div::selection
+    {
+      foo: bar;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>Test passes if "Selected Text" appears selected using the OS selection colors.
+
+  <div id="test">Selected Text</div>

--- a/css/css-pseudo/active-selection-051.html
+++ b/css/css-pseudo/active-selection-051.html
@@ -8,8 +8,8 @@
   <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-cascade">
   <link rel="match" href="active-selection-051-ref.html">
 
-  <meta content="invalid" name="flags">
-  <meta name="assert" content="In this test, the selector div::selection has an invalid declaration block. Therefore, it is ignored. In such case, the UA must use the OS-default highlight colors for div::selection.">
+  <meta content="invalid should" name="flags">
+  <meta name="assert" content="In this test, the selector div::selection has an invalid declaration block. Therefore, it is ignored. In such case, the UA should use the OS-default highlight colors for div::selection.">
 
   <style>
   div

--- a/css/css-pseudo/active-selection-052.html
+++ b/css/css-pseudo/active-selection-052.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: active selection and empty declaration block</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-cascade">
+  <link rel="match" href="active-selection-051-ref.html">
+
+  <meta content="" name="flags">
+  <meta name="assert" content="In this test, neither color nor background-color have been specified for the selector div::selection. In such case, the UA must use the OS-default highlight colors for div::selection.">
+
+  <style>
+  div
+    {
+      color: transparent;
+      font-size: 300%;
+    }
+
+  div::selection
+    {
+
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>Test passes if "Selected Text" appears selected using the OS selection colors.
+
+  <div id="test">Selected Text</div>

--- a/css/css-pseudo/active-selection-052.html
+++ b/css/css-pseudo/active-selection-052.html
@@ -8,8 +8,8 @@
   <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-cascade">
   <link rel="match" href="active-selection-051-ref.html">
 
-  <meta content="" name="flags">
-  <meta name="assert" content="In this test, neither color nor background-color have been specified for the selector div::selection. In such case, the UA must use the OS-default highlight colors for div::selection.">
+  <meta content="should" name="flags">
+  <meta name="assert" content="In this test, neither color nor background-color have been specified for the selector div::selection. In such case, the UA should use the OS-default highlight colors for div::selection.">
 
   <style>
   div

--- a/css/css-pseudo/active-selection-053.html
+++ b/css/css-pseudo/active-selection-053.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: active selection and invalid color value</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-cascade">
+  <link rel="match" href="active-selection-051-ref.html">
+
+  <meta content="invalid" name="flags">
+  <meta name="assert" content="In this test, 'color' has an invalid value which makes the declaration invalid; therefore, it is ignored. Therefore, the div::selection selector has neither color nor background-color specified. In such case, the UA must use the OS-default highlight colors for div::selection.">
+
+  <style>
+  div
+    {
+      color: transparent;
+      font-size: 300%;
+    }
+
+  div::selection
+    {
+      color: foo;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>Test passes if "Selected Text" appears selected using the OS selection colors.
+
+  <div id="test">Selected Text</div>

--- a/css/css-pseudo/active-selection-053.html
+++ b/css/css-pseudo/active-selection-053.html
@@ -8,8 +8,8 @@
   <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-cascade">
   <link rel="match" href="active-selection-051-ref.html">
 
-  <meta content="invalid" name="flags">
-  <meta name="assert" content="In this test, 'color' has an invalid value which makes the declaration invalid; therefore, it is ignored. Therefore, the div::selection selector has neither color nor background-color specified. In such case, the UA must use the OS-default highlight colors for div::selection.">
+  <meta content="invalid should" name="flags">
+  <meta name="assert" content="In this test, 'color' has an invalid value which makes the declaration invalid; therefore, it is ignored. Therefore, the div::selection selector has neither color nor background-color specified. In such case, the UA should use the OS-default highlight colors for div::selection.">
 
   <style>
   div

--- a/css/css-pseudo/active-selection-054.html
+++ b/css/css-pseudo/active-selection-054.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: active selection and invalid background-color value</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-cascade">
+  <link rel="match" href="active-selection-051-ref.html">
+
+  <meta content="invalid" name="flags">
+  <meta name="assert" content="In this test, 'background-color' has an invalid value which makes the declaration invalid; therefore, it is ignored. Therefore, the div::selection selector has neither color nor background-color specified. In such case, the UA must use the OS-default highlight colors for div::selection.">
+
+  <style>
+  div
+    {
+      color: transparent;
+      font-size: 300%;
+    }
+
+  div::selection
+    {
+      background-color: bar;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>Test passes if "Selected Text" appears selected using the OS selection colors.
+
+  <div id="test">Selected Text</div>

--- a/css/css-pseudo/active-selection-054.html
+++ b/css/css-pseudo/active-selection-054.html
@@ -8,8 +8,8 @@
   <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-cascade">
   <link rel="match" href="active-selection-051-ref.html">
 
-  <meta content="invalid" name="flags">
-  <meta name="assert" content="In this test, 'background-color' has an invalid value which makes the declaration invalid; therefore, it is ignored. Therefore, the div::selection selector has neither color nor background-color specified. In such case, the UA must use the OS-default highlight colors for div::selection.">
+  <meta content="invalid should" name="flags">
+  <meta name="assert" content="In this test, 'background-color' has an invalid value which makes the declaration invalid; therefore, it is ignored. Therefore, the div::selection selector has neither color nor background-color specified. In such case, the UA should use the OS-default highlight colors for div::selection.">
 
   <style>
   div

--- a/css/css-pseudo/active-selection-056.html
+++ b/css/css-pseudo/active-selection-056.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: active selection and 3 consecutive &lt;br&gt; elements</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-selectors">
+  <link rel="match" href="reference/ref-nothing-below.xht">
+
+  <!--
+
+  Issue 1018465: [CSS4-Pseudo] Active selection and hard wrap (or hard return)
+  line break: ::selection should not select <br>
+  https://bugs.chromium.org/p/chromium/issues/detail?id=1018465
+
+  -->
+
+  <meta content="" name="flags">
+  <meta name="assert" content="The &lt;br&gt; element is an empty element. Its background color can be painted but specifying its color should generate no rendering effect of any kind. Since the 'background-color' has been specified as 'transparent', then nothing should be painted or viewable in this test.">
+
+  <style>
+  div
+    {
+      font-size: 100px;
+    }
+
+  div::selection
+    {
+      background-color: transparent;
+      color: red;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>Test passes if there is nothing below.
+
+  <div id="test">&nbsp;<br><br><br>&nbsp;</div>

--- a/css/css-pseudo/reference/ref-nothing-below.xht
+++ b/css/css-pseudo/reference/ref-nothing-below.xht
@@ -1,0 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+ <head>
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+
+ </head>
+
+ <body>
+
+  <p>Test passes if there is nothing below.</p>
+
+ </body>
+</html>


### PR DESCRIPTION
This is a followup of
https://github.com/web-platform-tests/wpt/pull/21449
with improvements or corrections to:
active-selection-051: active selection and invalid declaration block
active-selection-052: active selection and empty declaration block
active-selection-053: active selection and invalid color value
active-selection-054: active selection and invalid background-color value
active-selection-056: active selection and 3 `<br>` elements
