### PR TITLE
Pass a constructor to assert_throws_dom and promise_rejects_dom.

### DIFF
--- a/css/cssom/CSSStyleSheet-constructable.html
+++ b/css/cssom/CSSStyleSheet-constructable.html
@@ -344,7 +344,11 @@ promise_test(() => {
   const plainSheet = new CSSStyleSheet();
   const redStyleSheetPromise = plainSheet.replace(redStyleTexts[0]);
   return redStyleSheetPromise.then(function(redStyleSheet) {
-    assert_throws_dom('NotAllowedError', () => { iframe.contentDocument.adoptedStyleSheets = [redStyleSheet]; });
+    assert_throws_dom(
+      'NotAllowedError',
+      iframe.contentWindow.DOMException,
+      () => { iframe.contentDocument.adoptedStyleSheets = [redStyleSheet]; }
+    );
     assert_equals(getComputedStyle(greenIframeSpan).color, "rgb(0, 0, 0)");
     assert_equals(getComputedStyle(redIframeSpan).color, "rgb(0, 0, 0)");
     assert_equals(getComputedStyle(blueIframeSpan).color, "rgb(0, 0, 0)");
@@ -444,7 +448,9 @@ test(() => {
   iframe.contentDocument.body.appendChild(iframeDiv);
 
   assert_equals(getComputedStyle(iframeDiv).color, "rgb(0, 0, 0)");
-  assert_throws_dom('NotAllowedError', () => { iframe.contentDocument.adoptedStyleSheets = [nonConstructedStyleSheet]; });
+  assert_throws_dom('NotAllowedError', iframe.contentWindow.DOMException, () => {
+    iframe.contentDocument.adoptedStyleSheets = [nonConstructedStyleSheet];
+  });
   assert_equals(getComputedStyle(iframeDiv).color, "rgb(0, 0, 0)");
 
   iframeStyle = iframe.contentDocument.createElement("style");

--- a/css/selectors/attribute-selectors/attribute-case/syntax.html
+++ b/css/selectors/attribute-selectors/attribute-case/syntax.html
@@ -135,7 +135,7 @@ onload = function() {
         assert_equals(global.getComputedStyle(elm).visibility, 'visible', 'invalid selector matched');
       }, s + ' in ' + global.mode);
       test(function() {
-        assert_throws_dom("SyntaxError", function() {
+        assert_throws_dom("SyntaxError", global.DOMException, function() {
           global.document.querySelector(s);
         }, 'invalid selector');
       }, s + ' with querySelector in ' + global.mode);

--- a/custom-elements/custom-element-registry/define.html
+++ b/custom-elements/custom-element-registry/define.html
@@ -105,7 +105,7 @@
   });
   invalidCustomElementNames.forEach(name =>  {
     test(() =>  {
-      assert_throws_dom(expectSyntaxError, () =>  {
+      assert_throws_dom(expectSyntaxError, testWindow.DOMException, () =>  {
         customElements.define(name, class {});
       });
     }, `Element names: defining an element named ${name} should throw a SyntaxError`);
@@ -115,7 +115,7 @@
   // then throw a NotSupportedError and abort these steps.
   test(() =>  {
     customElements.define('test-define-dup-name', class {});
-    assert_throws_dom(expectNotSupportedError, () =>  {
+    assert_throws_dom(expectNotSupportedError, testWindow.DOMException, () =>  {
       customElements.define('test-define-dup-name', class {});
     });
   }, 'If the name is already defined, should throw a NotSupportedError');
@@ -125,7 +125,7 @@
   test(() =>  {
     class TestDupConstructor {};
     customElements.define('test-define-dup-constructor', TestDupConstructor);
-    assert_throws_dom(expectNotSupportedError, () =>  {
+    assert_throws_dom(expectNotSupportedError, testWindow.DOMException, () =>  {
       customElements.define('test-define-dup-ctor2', TestDupConstructor);
     });
   }, 'If the constructor is already defined, should throw a NotSupportedError');
@@ -134,7 +134,7 @@
   // then throw a NotSupportedError.
   validCustomElementNames.forEach(name =>  {
     test(() =>  {
-      assert_throws_dom(expectNotSupportedError, () =>  {
+      assert_throws_dom(expectNotSupportedError, testWindow.DOMException, () =>  {
         customElements.define('test-define-extend-valid-name', class {}, { extends: name });
       });
     }, `If extends is ${name}, should throw a NotSupportedError`);
@@ -154,7 +154,7 @@
     'elementnametobeunknownelement',
   ].forEach(name =>  {
     test(() =>  {
-      assert_throws_dom(expectNotSupportedError, () =>  {
+      assert_throws_dom(expectNotSupportedError, testWindow.DOMException, () =>  {
         customElements.define('test-define-extend-' + name, class {}, { extends: name });
       });
     }, `If extends is ${name}, should throw a NotSupportedError`);

--- a/custom-elements/reactions/with-exceptions.html
+++ b/custom-elements/reactions/with-exceptions.html
@@ -25,7 +25,11 @@ test_with_window((contentWindow, contentDocument) => {
   contentDocument.documentElement.appendChild(text);
   const element = contentDocument.createElement("custom-element");
   contentDocument.documentElement.appendChild(element);
-  assert_throws_dom("HierarchyRequestError", () => text.before("", contentDocument.documentElement));
+  assert_throws_dom(
+    "HierarchyRequestError",
+    contentWindow.DOMException,
+    () => text.before("", contentDocument.documentElement)
+  );
   assert_true(reactionRan);
 }, "Reaction must run even after the exception is thrown");
 </script>

--- a/custom-elements/throw-on-dynamic-markup-insertion-counter-construct.html
+++ b/custom-elements/throw-on-dynamic-markup-insertion-counter-construct.html
@@ -45,12 +45,12 @@
 
  promise_test(async function () {
      const result = await construct_custom_element_in_parser(this, (document) => document.open());
-     assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+     assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
  }, 'document.open() must throw an InvalidStateError when synchronously constructing a custom element');
 
  promise_test(async function () {
      const result = await construct_custom_element_in_parser(this, (document) => document.open('text/html'));
-     assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+     assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
  }, 'document.open("text/html") must throw an InvalidStateError when synchronously constructing a custom element');
 
  // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-open-window
@@ -63,19 +63,19 @@
 
  promise_test(async function () {
      const result = await construct_custom_element_in_parser(this, (document) => document.close());
-     assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+     assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
  }, 'document.close() must throw an InvalidStateError when synchronously constructing a custom element');
 
  promise_test(async function () {
      const result = await construct_custom_element_in_parser(this, (document) => document.write('<b>some text</b>'));
-     assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+     assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
      assert_equals(result.document.querySelector('b'), null, 'Must not insert new content');
      assert_false(result.document.documentElement.innerHTML.includes('some text'), 'Must not insert new content');
  }, 'document.write must throw an InvalidStateError when synchronously constructing a custom element');
 
  promise_test(async function () {
      const result = await construct_custom_element_in_parser(this, (document) => document.writeln('<b>some text</b>'));
-     assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+     assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
      assert_equals(result.document.querySelector('b'), null, 'Must not insert new content');
      assert_false(result.document.documentElement.innerHTML.includes('some text'), 'Must not insert new content');
  }, 'document.writeln must throw an InvalidStateError when synchronously constructing a custom element');

--- a/custom-elements/throw-on-dynamic-markup-insertion-counter-reactions.html
+++ b/custom-elements/throw-on-dynamic-markup-insertion-counter-reactions.html
@@ -45,12 +45,12 @@ async function custom_element_reactions_in_parser(test, call_function)
 
 promise_test(async function () {
     const result = await custom_element_reactions_in_parser(this, (document) => document.open());
-    assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+    assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
 }, 'document.open() must throw an InvalidStateError when processing custom element reactions for a synchronous constructed custom element');
 
 promise_test(async function () {
     const result = await custom_element_reactions_in_parser(this, (document) => document.open('text/html'));
-    assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+    assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
 }, 'document.open("text/html") must throw an InvalidStateError when processing custom element reactions for a synchronous constructed custom element');
 
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-open-window
@@ -63,19 +63,19 @@ promise_test(async function () {
 
 promise_test(async function () {
     const result = await custom_element_reactions_in_parser(this, (document) => document.close());
-    assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+    assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
 }, 'document.close() must throw an InvalidStateError when processing custom element reactions for a synchronous constructed custom element');
 
 promise_test(async function () {
     const result = await custom_element_reactions_in_parser(this, (document) => document.write('<b>some text</b>'));
-    assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+    assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
     assert_equals(result.document.querySelector('b'), null, 'Must not insert new content');
     assert_false(result.document.documentElement.innerHTML.includes('some text'), 'Must not insert new content');
 }, 'document.write must throw an InvalidStateError when processing custom element reactions for a synchronous constructed custom element');
 
 promise_test(async function () {
     const result = await custom_element_reactions_in_parser(this, (document) => document.writeln('<b>some text</b>'));
-    assert_throws_dom('InvalidStateError', () => { throw result.exception; }, 'Must throw an InvalidStateError');
+    assert_throws_dom('InvalidStateError', result.window.DOMException, () => { throw result.exception; }, 'Must throw an InvalidStateError');
     assert_equals(result.document.querySelector('b'), null, 'Must not insert new content');
     assert_false(result.document.documentElement.innerHTML.includes('some text'), 'Must not insert new content');
 }, 'document.writeln must throw an InvalidStateError when processing custom element reactions for a synchronous constructed custom element');

--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -206,7 +206,7 @@ promise_rejects_exactly(test_object, value, promise, description)
 
 The `code`, `constructor`, and `value` arguments are equivalent to the same
 argument to the `assert_throws_dom`, `assert_throws_js`, and
-`assert_throws_exactly` functions.
+`assert_throws_exactly` functions.  The `promise_rejects_dom` function can also be called with a DOMException constructor argument between the `code` and `promise` arguments, just like `assert_throws_dom`, when we want to assert that the DOMException comes from a non-default global.
 
 Here's an example where the `bar()` function returns a Promise that rejects
 with a TypeError:
@@ -858,7 +858,7 @@ attribute attribute_name following the conditions specified by WebIDL
 ### `assert_readonly(object, property_name, description)`
 assert that property `property_name` on object is readonly
 
-### `assert_throws_dom(code, func, description)`
+### `assert_throws_dom(code, func, description)` or `assert_throws_dom(code, constructor, func, description)`
 `code` - the expected exception. This can take several forms:
 
   * string - asserts that the thrown exception must be a DOMException
@@ -870,6 +870,8 @@ assert that property `property_name` on object is readonly
              with the fiven code value (e.g. DOMException.TIMEOUT_ERR).
 
 `func` - a function that should throw
+
+`constructor` - The DOMException constructor that the resulting DOMException should have as its `.constructor`.  This should be used when a DOMException from a non-default global is expected to be thrown.
 
 ### `assert_throws_js(constructor, func, description)`
 `constructor` - the expected exception. This is the constructor object

--- a/dom/nodes/Document-createElement.html
+++ b/dom/nodes/Document-createElement.html
@@ -145,8 +145,9 @@ invalid.forEach(function(arg) {
     async_test(function(testObj) {
       window.addEventListener("load", function() {
         testObj.step(function() {
-          var doc = getWin(desc).document;
-          assert_throws_dom("InvalidCharacterError",
+          let win = getWin(desc);
+          let doc = win.document;
+          assert_throws_dom("InvalidCharacterError", win.DOMException,
                             function() { doc.createElement(arg) })
         });
         testObj.done();

--- a/dom/nodes/Document-createElementNS.html
+++ b/dom/nodes/Document-createElementNS.html
@@ -50,7 +50,7 @@ function runTest(t, i, desc) {
         }
         var namespace = t[0], qualifiedName = t[1], expected = t[2]
         if (expected != null) {
-          assert_throws_dom(expected, function() { doc.createElementNS(namespace, qualifiedName) })
+          assert_throws_dom(expected, doc.defaultView.DOMException, function() {doc.createElementNS(namespace, qualifiedName) });
         } else {
           var element = doc.createElementNS(namespace, qualifiedName)
           assert_not_equals(element, null)

--- a/dom/nodes/Element-matches.js
+++ b/dom/nodes/Element-matches.js
@@ -49,9 +49,13 @@ function runInvalidSelectorTestMatches(method, type, root, selectors) {
       var q = s["selector"];
 
       test(function() {
-        assert_throws_dom("SyntaxError", function() {
-          root[method](q)
-        })
+        assert_throws_dom(
+          "SyntaxError",
+          root.ownerDocument.defaultView.DOMException,
+          function() {
+            root[method](q)
+          }
+        );
       }, type + "." + method + ": " + n + ": " + q);
     }
   }

--- a/dom/nodes/Node-removeChild.html
+++ b/dom/nodes/Node-removeChild.html
@@ -41,7 +41,11 @@ documents.forEach(function(d) {
       var s = doc[creator]("test")
       doc.body.appendChild(s)
       assert_equals(s.ownerDocument, doc)
-      assert_throws_dom("NOT_FOUND_ERR", function() { s.removeChild(doc) })
+      assert_throws_dom(
+        "NOT_FOUND_ERR",
+        (doc.defaultView || self).DOMException,
+        function() { s.removeChild(doc) }
+      );
     }, "Calling removeChild on a " + p + " from " + description +
        " with no children should throw NOT_FOUND_ERR.")
   }

--- a/dom/nodes/ParentNode-querySelector-All.js
+++ b/dom/nodes/ParentNode-querySelector-All.js
@@ -207,6 +207,10 @@ function runValidSelectorTest(type, root, selectors, testType, docType) {
   }
 }
 
+function windowFor(root) {
+  return root.defaultView || root.ownerDocument.defaultView;
+}
+
 /*
  * Execute queries with the specified invalid selectors for both querySelector() and querySelectorAll()
  * Only run these tests when errors are expected. Don't run for valid selector tests.
@@ -218,15 +222,15 @@ function runInvalidSelectorTest(type, root, selectors) {
     var q = s["selector"];
 
     test(function() {
-      assert_throws_dom("SyntaxError", function() {
+      assert_throws_dom("SyntaxError", windowFor(root).DOMException, function() {
         root.querySelector(q)
-      })
+      });
     }, type + ".querySelector: " + n + ": " + q);
 
     test(function() {
-      assert_throws_dom("SyntaxError", function() {
+      assert_throws_dom("SyntaxError", windowFor(root).DOMException, function() {
         root.querySelectorAll(q)
-      })
+      });
     }, type + ".querySelectorAll: " + n + ": " + q);
   }
 }

--- a/dom/ranges/Range-cloneContents.html
+++ b/dom/ranges/Range-cloneContents.html
@@ -312,9 +312,13 @@ function testCloneContents(i) {
 
     expectedFrag = myCloneContents(expectedRange);
     if (typeof expectedFrag == "string") {
-      assert_throws_dom(expectedFrag, function() {
-        actualRange.cloneContents();
-      });
+      assert_throws_dom(
+        expectedFrag,
+        actualIframe.contentWindow.DOMException,
+        function() {
+          actualRange.cloneContents();
+        }
+      );
     } else {
       actualFrag = actualRange.cloneContents();
     }

--- a/dom/ranges/Range-extractContents.html
+++ b/dom/ranges/Range-extractContents.html
@@ -95,9 +95,13 @@ function testExtractContents(i) {
 
     expectedFrag = myExtractContents(expectedRange);
     if (typeof expectedFrag == "string") {
-      assert_throws_dom(expectedFrag, function() {
-        actualRange.extractContents();
-      });
+      assert_throws_dom(
+        expectedFrag,
+        actualIframe.contentWindow.DOMException,
+        function() {
+          actualRange.extractContents();
+        }
+      );
     } else {
       actualFrag = actualRange.extractContents();
     }

--- a/dom/ranges/Range-insertNode.html
+++ b/dom/ranges/Range-insertNode.html
@@ -138,7 +138,7 @@ function testInsertNode(i, j) {
             throw e;
         }
         if (typeof result == "string") {
-            assert_throws_dom(result, function() {
+            assert_throws_dom(result, actualIframe.contentWindow.DOMException, function() {
                 try {
                     actualRange.insertNode(actualNode);
                 } catch (e) {

--- a/dom/ranges/Range-surroundContents.html
+++ b/dom/ranges/Range-surroundContents.html
@@ -181,7 +181,7 @@ function testSurroundContents(i, j) {
       throw e;
     }
     if (typeof result == "string") {
-      assert_throws_dom(result, function() {
+      assert_throws_dom(result, actualIframe.contentWindow.DOMException, function() {
         try {
           actualRange.surroundContents(actualNode);
         } catch (e) {

--- a/fetch/api/abort/serviceworker-intercepted.https.html
+++ b/fetch/api/abort/serviceworker-intercepted.https.html
@@ -46,7 +46,7 @@
 
     const fetchPromise = w.fetch('data.json', { signal });
 
-    await promise_rejects_dom(t, "AbortError", fetchPromise);
+    await promise_rejects_dom(t, "AbortError", w.DOMException, fetchPromise);
 
     await w.fetch('data.json?no-abort');
 
@@ -76,7 +76,7 @@
         Promise.resolve().then(() => log.push('next-microtask'))
       ]);
 
-      await promise_rejects_dom(t, "AbortError", bodyPromise);
+      await promise_rejects_dom(t, "AbortError", w.DOMException, bodyPromise);
 
       assert_array_equals(log, [`${bodyMethod}-reject`, 'next-microtask']);
     }, `response.${bodyMethod}() rejects if already aborted`);
@@ -97,8 +97,8 @@
 
     controller.abort();
 
-    await promise_rejects_dom(t, "AbortError", reader.read());
-    await promise_rejects_dom(t, "AbortError", reader.closed);
+    await promise_rejects_dom(t, "AbortError", w.DOMException, reader.read());
+    await promise_rejects_dom(t, "AbortError", w.DOMException, reader.closed);
   }, "Stream errors once aborted.");
 </script>
 </body>

--- a/html/browsers/history/the-history-interface/001.html
+++ b/html/browsers/history/the-history-interface/001.html
@@ -94,7 +94,7 @@ function reportload() {
             assert_throws_dom('SECURITY_ERR',function () { history.pushState('','','data:text/html,'); });
         }, 'pushState must not be allowed to create cross-origin URLs (data:URI)');
         test(function () {
-            assert_throws_dom('SECURITY_ERR',function () { iframe.contentWindow.history.pushState('','','http://www.example.com/'); },iframe.contentWindow);
+            assert_throws_dom('SECURITY_ERR', iframe.contentWindow.DOMException, function () { iframe.contentWindow.history.pushState('','','http://www.example.com/'); });
         }, 'security errors are expected to be thrown in the context of the document that owns the history object');
         test(function () {
             iframe.contentWindow.location.hash = 'test2';
@@ -180,9 +180,9 @@ function reportload() {
             }
         }, 'pushState must be able to use an error object as data');
         test(function () {
-            assert_throws_dom( 'DATA_CLONE_ERR', function () {
+            assert_throws_dom('DATA_CLONE_ERR', iframe.contentWindow.DOMException, function () {
                 iframe.contentWindow.history.pushState(document,'');
-            }, iframe.contentWindow );
+            });
         }, 'security errors are expected to be thrown in the context of the document that owns the history object (2)');
         cloneobj = {
             nulldata: null,

--- a/html/browsers/history/the-history-interface/002.html
+++ b/html/browsers/history/the-history-interface/002.html
@@ -99,7 +99,7 @@ function reportload() {
             assert_throws_dom('SECURITY_ERR',function () { history.replaceState('','','data:text/html,'); });
         }, 'replaceState must not be allowed to create cross-origin URLs (data:URI)');
         test(function () {
-            assert_throws_dom('SECURITY_ERR',function () { iframe.contentWindow.history.replaceState('','','http://www.example.com/'); },iframe.contentWindow);
+            assert_throws_dom('SECURITY_ERR',iframe.contentWindow.DOMException,function () { iframe.contentWindow.history.replaceState('','','http://www.example.com/'); });
         }, 'security errors are expected to be thrown in the context of the document that owns the history object');
         test(function () {
             //avoids browsers running .go synchronously when only a hash change is involved
@@ -161,9 +161,9 @@ function reportload() {
             }
         }, 'replaceState must be able to use an error object as data');
         test(function () {
-            assert_throws_dom( 'DATA_CLONE_ERR', function () {
+            assert_throws_dom('DATA_CLONE_ERR', iframe.contentWindow.DOMException, function () {
                 iframe.contentWindow.history.replaceState(document,'');
-            }, iframe.contentWindow );
+            });
         }, 'security errors are expected to be thrown in the context of the document that owns the history object (2)');
         cloneobj = {
             nulldata: null,

--- a/html/browsers/origin/relaxing-the-same-origin-restriction/document_domain_setter.html
+++ b/html/browsers/origin/relaxing-the-same-origin-restriction/document_domain_setter.html
@@ -61,7 +61,8 @@
           assert_equals(iframe.contentWindow.location.toString(), iframe_url.toString());
           // document.open checks for same-origin, not same-origin-domain,
           // https://github.com/whatwg/html/issues/2282
-          assert_throws_dom("SecurityError", function() { iframe.contentDocument.open(); });
+          assert_throws_dom("SecurityError", iframe.contentWindow.DOMException,
+                            function() { iframe.contentDocument.open(); });
         }));
       }, "same-origin-domain iframe");
 

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-origin.sub.window.js
@@ -14,9 +14,14 @@ async_test(t => {
   iframe.onload = t.step_func_done(() => {
     // Since this is called as an event handler on an element of this window,
     // the entry settings object is that of this browsing context.
-    assert_throws_dom("InvalidStateError", () => {
-      iframe.contentDocument.open();
-    }, "opening an XML document should throw an InvalidStateError");
+    assert_throws_dom(
+      "InvalidStateError",
+      iframe.contentWindow.DOMException,
+      () => {
+        iframe.contentDocument.open();
+      },
+      "opening an XML document should throw an InvalidStateError"
+    );
   });
   const frameURL = new URL("resources/bailout-order-xml-with-domain-frame.sub.xhtml", document.URL);
   frameURL.port = "{{ports[http][1]}}";
@@ -39,9 +44,14 @@ async_test(t => {
     // IDL algorithm in "create an element", called by "create an element for a
     // token" in the parser.
     setEntryToTopLevel(t.step_func_done(() => {
-      assert_throws_dom("InvalidStateError", () => {
-        iframe.contentDocument.open();
-      }, "opening a document when the throw-on-dynamic-markup-insertion counter is incremented should throw an InvalidStateError");
+      assert_throws_dom(
+        "InvalidStateError",
+        iframe.contentWindow.DOMException,
+        () => {
+          iframe.contentDocument.open();
+        },
+        "opening a document when the throw-on-dynamic-markup-insertion counter is incremented should throw an InvalidStateError"
+      );
     }));
   });
   const frameURL = new URL("resources/bailout-order-custom-element-with-domain-frame.sub.html", document.URL);
@@ -60,9 +70,14 @@ async_test(t => {
     // "Clean up after running script" is executed when the </script> tag is
     // seen by the HTML parser.
     setEntryToTopLevel(t.step_func_done(() => {
-      assert_throws_dom("SecurityError", () => {
-        iframe.contentDocument.open();
-      }, "opening a same origin-domain (but not same origin) document should throw a SecurityError");
+      assert_throws_dom(
+        "SecurityError",
+        iframe.contentWindow.DOMException,
+        () => {
+          iframe.contentDocument.open();
+        },
+        "opening a same origin-domain (but not same origin) document should throw a SecurityError"
+      );
     }));
   });
   const frameURL = new URL("resources/bailout-order-synchronous-script-with-domain-frame.sub.html", document.URL);
@@ -85,9 +100,14 @@ for (const ev of ["beforeunload", "pagehide", "unload"]) {
         // "Clean up after running script" is called in the task that
         // navigates.
         setEntryToTopLevel(t.step_func_done(() => {
-          assert_throws_dom("SecurityError", () => {
-            iframe.contentDocument.open();
-          }, "opening a same origin-domain (but not same origin) document should throw a SecurityError");
+          assert_throws_dom(
+            "SecurityError",
+            iframe.contentWindow.DOMException,
+            () => {
+              iframe.contentDocument.open();
+            },
+            "opening a same origin-domain (but not same origin) document should throw a SecurityError"
+          );
         }));
       }));
       iframe.src = "about:blank";

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-xml.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-xml.window.js
@@ -2,7 +2,7 @@ async_test(t => {
   const iframe = document.body.appendChild(document.createElement("iframe"));
   t.add_cleanup(() => { iframe.remove(); });
   self.testSynchronousScript = t.step_func_done(() => {
-    assert_throws_dom("InvalidStateError", () => {
+    assert_throws_dom("InvalidStateError", iframe.contentWindow.DOMException, () => {
       iframe.contentDocument.open();
     }, "opening an XML document should throw");
   });
@@ -15,7 +15,7 @@ for (const ev of ["beforeunload", "pagehide", "unload"]) {
     t.add_cleanup(() => { iframe.remove(); });
     iframe.addEventListener("load", t.step_func(() => {
       iframe.contentWindow.addEventListener(ev, t.step_func_done(() => {
-        assert_throws_dom("InvalidStateError", () => {
+        assert_throws_dom("InvalidStateError", iframe.contentWindow.DOMException, () => {
           iframe.contentDocument.open();
         }, "opening an XML document should throw");
       }));

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-same-origin-domain.sub.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-same-origin-domain.sub.window.js
@@ -7,7 +7,7 @@ testInIFrame("http://{{host}}:{{ports[http][1]}}/common/domain-setter.sub.html",
   const iframe = ctx.iframes[0];
   const origURL = iframe.contentDocument.URL;
   assertDocumentIsReadyForSideEffectsTest(iframe.contentDocument, "same origin-domain (but not same origin) document");
-  assert_throws_dom("SecurityError", () => {
+  assert_throws_dom("SecurityError", iframe.contentWindow.DOMException, () => {
     ctx.iframes[0].contentDocument.open();
   }, "document.open() should throw a SecurityError on a same origin-domain (but not same origin) document");
   assertOpenHasNoSideEffects(iframe.contentDocument, origURL, "same origin-domain (but not same origin) document");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-xml.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-xml.window.js
@@ -7,9 +7,14 @@ async_test(t => {
   iframe.onload = t.step_func_done(() => {
     const origURL = iframe.contentDocument.URL;
     assertDocumentIsReadyForSideEffectsTest(iframe.contentDocument, "XML document");
-    assert_throws_dom("InvalidStateError", () => {
-      iframe.contentDocument.open();
-    }, "document.open() should throw on XML documents");
+    assert_throws_dom(
+      "InvalidStateError",
+      iframe.contentWindow.DOMException,
+      () => {
+        iframe.contentDocument.open();
+      },
+      "document.open() should throw on XML documents"
+    );
     assertOpenHasNoSideEffects(iframe.contentDocument, origURL, "XML document");
   });
 }, "document.open bailout should not have any side effects (XML document)");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/origin-check-in-document-open-same-origin-domain.sub.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/origin-check-in-document-open-same-origin-domain.sub.html
@@ -9,14 +9,16 @@
 <script>
 testInIFrame("http://{{host}}:{{ports[http][1]}}/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/set-document-domain.html", (ctx) => {
   document.domain = document.domain;
-  var doc = ctx.iframes[0].contentDocument;
-  assert_throws_dom("SecurityError", doc.open.bind(doc), "Opening a same origin-domain (but not same origin) document doesn't throw.");
+  let doc = ctx.iframes[0].contentDocument;
+  let constructor = ctx.iframes[0].contentWindow.DOMException;
+  assert_throws_dom("SecurityError", constructor, doc.open.bind(doc), "Opening a same origin-domain (but not same origin) document doesn't throw.");
 }, "It should not be possible to open same origin-domain (but not same origin) documents.");
 
 testInIFrame("http://{{host}}:{{ports[http][1]}}/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/set-document-domain.html", (ctx) => {
   document.domain = document.domain;
-  var doc = ctx.iframes[0].contentDocument;
-  assert_throws_dom("SecurityError", doc.write.bind(doc, ""), "Implicitly opening a same origin-domain (but not same origin) document doesn't throw.");
+  let doc = ctx.iframes[0].contentDocument;
+  let constructor = ctx.iframes[0].contentWindow.DOMException;
+  assert_throws_dom("SecurityError", constructor, doc.write.bind(doc, ""), "Implicitly opening a same origin-domain (but not same origin) document doesn't throw.");
 }, "It should not be possible to implicitly open same origin-domain (but not same origin) documents.");
 </script>
 </body>

--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -196,6 +196,33 @@
 
     test(function()
     {
+        var ifr = document.createElement("iframe");
+        document.body.appendChild(ifr);
+        this.add_cleanup(() => ifr.remove());
+        assert_throws_dom("SyntaxError", ifr.contentWindow.DOMException,
+                          function () {ifr.contentDocument.querySelector("")});
+    }, "Test throw DOM SyntaxError from subframe");
+
+    test(function()
+    {
+        var ifr = document.createElement("iframe");
+        document.body.appendChild(ifr);
+        this.add_cleanup(() => ifr.remove());
+        assert_throws_dom("SyntaxError",
+                          function () {ifr.contentDocument.querySelector("")});
+    }, "Test throw DOM SyntaxError from subframe with incorrect global expectation; expected to fail");
+
+    test(function()
+    {
+        var ifr = document.createElement("iframe");
+        document.body.appendChild(ifr);
+        this.add_cleanup(() => ifr.remove());
+        assert_throws_dom("SyntaxError", ifr.contentWindow.DOMException,
+                          function () {document.querySelector("")});
+    }, "Test throw DOM SyntaxError with incorrect expectation; expected to fail");
+
+    test(function()
+    {
         assert_throws_dom("SyntaxError", function () {JSON.parse("{")});
     }, "Test throw JS SyntaxError where SyntaxError DOMException expected; expected to fail")
 
@@ -214,13 +241,15 @@
 
     test(function()
     {
-        var e = {code:0, name:"TEST_ERR", TEST_ERR:0}
+        var e = {code:0, name:"TEST_ERR", TEST_ERR:0};
+        e.constructor = DOMException;
         assert_throws_dom("TEST_ERR", function() {throw e});
     }, "Test assert_throws_dom with non-DOM-exception expected to Fail");
 
     test(function()
     {
-        var e = {code: DOMException.SYNTAX_ERR, name:"SyntaxError"}
+        var e = {code: DOMException.SYNTAX_ERR, name:"SyntaxError"};
+        e.constructor = DOMException;
         assert_throws_dom(DOMException.SYNTAX_ERR, function() {throw e});
     }, "Test assert_throws_dom with number code value expected to Pass");
 
@@ -356,6 +385,24 @@
       "status_string": "PASS",
       "name": "Test throw DOM SyntaxError",
       "message": null,
+      "properties": {}
+    },
+    {
+      "status_string": "PASS",
+      "name": "Test throw DOM SyntaxError from subframe",
+      "message": null,
+      "properties": {}
+    },
+    {
+      "status_string": "FAIL",
+      "name": "Test throw DOM SyntaxError from subframe with incorrect global expectation; expected to fail",
+      "message": "assert_throws_dom: function \"function () {ifr.contentDocument.querySelector(\"\")}\" threw an exception from the wrong global",
+      "properties": {}
+    },
+    {
+      "status_string": "FAIL",
+      "name": "Test throw DOM SyntaxError with incorrect expectation; expected to fail",
+      "message": "assert_throws_dom: function \"function () {document.querySelector(\"\")}\" threw an exception from the wrong global",
       "properties": {}
     },
     {

--- a/service-workers/service-worker/detached-context.https.html
+++ b/service-workers/service-worker/detached-context.https.html
@@ -75,12 +75,14 @@ promise_test(t => {
       .then(() => { return with_iframe(scope); })
       .then(frame => {
           const worker = frame.contentWindow.navigator.serviceWorker.controller;
+          const ctor = frame.contentWindow.DOMException;
           frame.remove();
           assert_equals(worker.scriptURL, normalizeURL(script));
           assert_equals(worker.state, 'activated');
           worker.onstatechange = () => { /* empty */ };
           assert_throws_dom(
               'InvalidStateError',
+               ctor,
               () => { worker.postMessage(''); },
               'postMessage on a detached client should throw an exception.');
         });

--- a/service-workers/service-worker/multipart-image.https.html
+++ b/service-workers/service-worker/multipart-image.https.html
@@ -56,12 +56,13 @@ promise_test(t => {
 promise_test(t => {
     return frame.contentWindow.load_multipart_image('cross-origin-multipart-image-with-no-cors')
       .then(img => {
-        assert_throws_dom('SecurityError', () => frame.contentWindow.get_image_data(img));
+        assert_throws_dom('SecurityError', frame.contentWindow.DOMException,
+                          () => frame.contentWindow.get_image_data(img));
       });
   }, 'cross-origin multipart image with no-cors via SW should not be readable');
 
 promise_test(t => {
     const promise = frame.contentWindow.load_multipart_image('cross-origin-multipart-image-with-cors-rejected');
-    return promise_rejects_dom(t, 'NetworkError', promise);
+    return promise_rejects_dom(t, 'NetworkError', frame.contentWindow.DOMException, promise);
   }, 'cross-origin multipart image via SW with rejected CORS should fail to load');
 </script>

--- a/webmessaging/postMessage_Document.htm
+++ b/webmessaging/postMessage_Document.htm
@@ -25,7 +25,7 @@
     {
         test(function()
         {
-            assert_throws_dom("DATA_CLONE_ERR", function()
+            assert_throws_dom("DATA_CLONE_ERR", TARGET.contentWindow.DOMException, function()
             {
                 TARGET.contentWindow.postMessage(DATA, "*");
             });

--- a/webmessaging/postMessage_Function.htm
+++ b/webmessaging/postMessage_Function.htm
@@ -25,7 +25,7 @@
     {
         test(function()
         {
-            assert_throws_dom("DATA_CLONE_ERR", function()
+            assert_throws_dom("DATA_CLONE_ERR", TARGET.contentWindow.DOMException, function()
             {
                 TARGET.contentWindow.postMessage(DATA, "*");
             });

--- a/webmessaging/postMessage_dup_transfer_objects.htm
+++ b/webmessaging/postMessage_dup_transfer_objects.htm
@@ -25,7 +25,7 @@
     {
         test(function()
         {
-            assert_throws_dom("DATA_CLONE_ERR", function()
+            assert_throws_dom("DATA_CLONE_ERR", TARGET.contentWindow.DOMException, function()
             {
                 assert_own_property(window, "MessageChannel", "window");
                 var channel = new MessageChannel();

--- a/webmessaging/postMessage_invalid_targetOrigin.htm
+++ b/webmessaging/postMessage_invalid_targetOrigin.htm
@@ -27,7 +27,7 @@
     {
         test(function()
         {
-            assert_throws_dom("SYNTAX_ERR", function()
+            assert_throws_dom("SYNTAX_ERR", TARGET.contentWindow.DOMException, function()
             {
                 TARGET.contentWindow.postMessage(DATA, DATA);
             });

--- a/xhr/open-url-multi-window-2.htm
+++ b/xhr/open-url-multi-window-2.htm
@@ -11,12 +11,13 @@
     <script>
     function init(){ // called from page inside IFRAME
         test(function() {
-          var client = new self[0].XMLHttpRequest()
+          var client = new self[0].XMLHttpRequest();
+          let exceptionCtor = self[0].DOMException;
           document.body.removeChild(document.getElementsByTagName("iframe")[0])
-          assert_throws_dom("InvalidStateError", function() {
+          assert_throws_dom("InvalidStateError", exceptionCtor, function() {
             client.open("GET", "folder.txt")
-          }, "open() when associated document's IFRAME is removed")
-          })
+          }, "open() when associated document's IFRAME is removed");
+        });
       }
     </script>
     <iframe src="resources/init.htm"></iframe>

--- a/xhr/open-url-multi-window-3.htm
+++ b/xhr/open-url-multi-window-3.htm
@@ -10,12 +10,13 @@
     <script>
       function init() {
         test(function() {
-          var client = new self[0].XMLHttpRequest()
+          var client = new self[0].XMLHttpRequest();
+          let exceptionCtor = self[0].DOMException;
           client.open("GET", "folder.txt")
           document.body.removeChild(document.getElementsByTagName("iframe")[0])
-          assert_throws_dom("InvalidStateError", function() {
+          assert_throws_dom("InvalidStateError", exceptionCtor, function() {
             client.send(null)
-          }, "send() when associated document's IFRAME is removed")
+          }, "send() when associated document's IFRAME is removed");
         })
       }
     </script>

--- a/xhr/open-url-multi-window-5.htm
+++ b/xhr/open-url-multi-window-5.htm
@@ -11,15 +11,17 @@
     <script>
       var test = async_test(),
           client,
-          count = 0
+          exceptionCtor,
+          count = 0;
       function init() {
         test.step(function() {
           if(0 == count) {
-            client = new self[0].XMLHttpRequest()
+            client = new self[0].XMLHttpRequest();
+            exceptionCtor = self[0].DOMException;
             count++
             self[0].location.reload()
           } else if(1 == count) {
-            assert_throws_dom("InvalidStateError", function() { client.open("GET", "...") })
+            assert_throws_dom("InvalidStateError", exceptionCtor, function() {client.open("GET", "...") });
             test.done()
           }
         })


### PR DESCRIPTION
Then we can verify that the DOMExceptions come from the right global.

Fixes https://github.com/web-platform-tests/wpt/issues/21809