### PR TITLE
Fetch HTTP(S) scheme/data url scripts from data url iframe/dedicated worker/shared worker

### DIFF
--- a/fetch/api/cors/data-url-iframe.html
+++ b/fetch/api/cors/data-url-iframe.html
@@ -38,9 +38,9 @@ const fetch_from_data_url_iframe_test =
 
 fetch_from_data_url_iframe_test(
   '../resources/top.txt',
-  'same-origin',
+  'acao-omitted',
   'rejected',
-  'fetching "top.txt" should be rejected.'
+  'fetching "top.txt" without ACAO should be rejected.'
 );
 fetch_from_data_url_iframe_test(
   '../resources/top.txt',
@@ -50,7 +50,7 @@ fetch_from_data_url_iframe_test(
 );
 fetch_from_data_url_iframe_test(
   'data:text/plain, top',
-  'same-origin',
+  'acao-omitted',
   'allowed',
   'fetching data url script should be allowed.'
 );

--- a/fetch/api/cors/data-url-iframe.html
+++ b/fetch/api/cors/data-url-iframe.html
@@ -36,29 +36,23 @@ const fetch_from_data_url_iframe_test =
   }, description);
 };
 
-fetch_from_data_url_worker_test(
+fetch_from_data_url_iframe_test(
   '../resources/top.txt',
   'no-cors',
   'rejected',
   'fetching "top.txt" with no CORS should be rejected.'
 );
-fetch_from_data_url_worker_test(
+fetch_from_data_url_iframe_test(
   '../resources/top.txt',
   'null-origin',
   'allowed',
   'fetching "top.txt" with CORS allowing null origin should be allowed.'
 );
-fetch_from_data_url_worker_test(
+fetch_from_data_url_iframe_test(
   'data:text/plain, top',
   'no-cors',
   'allowed',
-  'fetching data url script with no CORS should be allowed.'
-);
-fetch_from_data_url_worker_test(
-  'data:text/plain, top',
-  'null-origin',
-  'allowed',
-  'fetching data url script with CORS allowing null origin should be allowed.'
+  'fetching data url script should be allowed.'
 );
 
 </script>

--- a/fetch/api/cors/data-url-iframe.html
+++ b/fetch/api/cors/data-url-iframe.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+
+const createDataUrlIframe = (url, cors) => {
+  const iframe = document.createElement("iframe");
+  const fetchURL = new URL(url, location.href) +
+      `${cors === 'null-origin'
+           ? '?pipe=header(Access-Control-Allow-Origin, null)' : ''}`;
+  const tag_name = 'script';
+  iframe.src =
+      `data:text/html, <${tag_name}>` +
+      `async function test() {` +
+      `  let allowed = true;` +
+      `  try {` +
+      `    await fetch('${fetchURL}');` +
+      `  } catch (e) {` +
+      `    allowed = false;` +
+      `  }` +
+      `  parent.postMessage({allowed}, '*');` +
+      `}` +
+      `test(); </${tag_name}>`;
+  return iframe;
+};
+
+const fetch_from_data_url_iframe_test =
+    (url, cors, expectation, description) => {
+  promise_test(async () => {
+    const iframe = createDataUrlIframe(url, cors);
+    document.body.appendChild(iframe);
+    const msgEvent = await new Promise(resolve => window.onmessage = resolve);
+    assert_equals(msgEvent.data.allowed ? 'allowed' : 'rejected', expectation);
+  }, description);
+};
+
+fetch_from_data_url_worker_test(
+  '../resources/top.txt',
+  'no-cors',
+  'rejected',
+  'fetching "top.txt" with no CORS should be rejected.'
+);
+fetch_from_data_url_worker_test(
+  '../resources/top.txt',
+  'null-origin',
+  'allowed',
+  'fetching "top.txt" with CORS allowing null origin should be rejected.'
+);
+fetch_from_data_url_worker_test(
+  'data:text/plain, top',
+  'no-cors',
+  'allowed',
+  'fetching data url script with no CORS should be allowed.'
+);
+fetch_from_data_url_worker_test(
+  'data:text/plain, top',
+  'null-origin',
+  'allowed',
+  'fetching data url script with CORS allowing null origin should be allowed.'
+);
+
+</script>

--- a/fetch/api/cors/data-url-iframe.html
+++ b/fetch/api/cors/data-url-iframe.html
@@ -46,7 +46,7 @@ fetch_from_data_url_worker_test(
   '../resources/top.txt',
   'null-origin',
   'allowed',
-  'fetching "top.txt" with CORS allowing null origin should be rejected.'
+  'fetching "top.txt" with CORS allowing null origin should be allowed.'
 );
 fetch_from_data_url_worker_test(
   'data:text/plain, top',

--- a/fetch/api/cors/data-url-iframe.html
+++ b/fetch/api/cors/data-url-iframe.html
@@ -38,9 +38,9 @@ const fetch_from_data_url_iframe_test =
 
 fetch_from_data_url_iframe_test(
   '../resources/top.txt',
-  'no-cors',
+  'same-origin',
   'rejected',
-  'fetching "top.txt" with no CORS should be rejected.'
+  'fetching "top.txt" should be rejected.'
 );
 fetch_from_data_url_iframe_test(
   '../resources/top.txt',
@@ -50,7 +50,7 @@ fetch_from_data_url_iframe_test(
 );
 fetch_from_data_url_iframe_test(
   'data:text/plain, top',
-  'no-cors',
+  'same-origin',
   'allowed',
   'fetching data url script should be allowed.'
 );

--- a/fetch/api/cors/data-url-shared-worker.html
+++ b/fetch/api/cors/data-url-shared-worker.html
@@ -41,7 +41,7 @@ fetch_from_data_url_worker_test(
   '../resources/top.txt',
   'null-origin',
   'allowed',
-  'fetching "top.txt" with CORS allowing null origin should be rejected.'
+  'fetching "top.txt" with CORS allowing null origin should be allowed.'
 );
 fetch_from_data_url_worker_test(
   'data:text/plain, top',

--- a/fetch/api/cors/data-url-shared-worker.html
+++ b/fetch/api/cors/data-url-shared-worker.html
@@ -33,9 +33,9 @@ const fetch_from_data_url_worker_test =
 
 fetch_from_data_url_worker_test(
   '../resources/top.txt',
-  'no-cors',
+  'same-origin',
   'rejected',
-  'fetching "top.txt" with no CORS should be rejected.'
+  'fetching "top.txt" with should be rejected.'
 );
 fetch_from_data_url_worker_test(
   '../resources/top.txt',
@@ -45,7 +45,7 @@ fetch_from_data_url_worker_test(
 );
 fetch_from_data_url_worker_test(
   'data:text/plain, top',
-  'no-cors',
+  'same-origin',
   'allowed',
   'fetching data url script should be allowed.'
 );

--- a/fetch/api/cors/data-url-shared-worker.html
+++ b/fetch/api/cors/data-url-shared-worker.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+const fetch_from_data_url_worker_test =
+    (url, cors, expectation, description) => {
+  promise_test(async () => {
+    const fetchURL = new URL(url, location.href) +
+        `${cors === 'null-origin'
+             ? '?pipe=header(Access-Control-Allow-Origin, null)' : ''}`;
+    const scriptURL =
+      `data:text/javascript,` +
+      `async function test(port) {` +
+      `  let allowed = true;` +
+      `  try {` +
+      `    await fetch('${fetchURL}');` +
+      `  } catch (e) {` +
+      `    allowed = false;` +
+      `  }` +
+      `  port.postMessage({allowed});` +
+      `}` +
+      `onconnect = e => {` +
+      `  test(e.ports[0]);` +
+      `};`;
+    const worker = new SharedWorker(scriptURL);
+    const msgEvent =
+        await new Promise(resolve => worker.port.onmessage = resolve);
+    assert_equals(msgEvent.data.allowed ? 'allowed' : 'rejected', expectation);
+  }, description);
+};
+
+fetch_from_data_url_worker_test(
+  '../resources/top.txt',
+  'no-cors',
+  'rejected',
+  'fetching "top.txt" with no CORS should be rejected.'
+);
+fetch_from_data_url_worker_test(
+  '../resources/top.txt',
+  'null-origin',
+  'allowed',
+  'fetching "top.txt" with CORS allowing null origin should be rejected.'
+);
+fetch_from_data_url_worker_test(
+  'data:text/plain, top',
+  'no-cors',
+  'allowed',
+  'fetching data url script with no CORS should be allowed.'
+);
+fetch_from_data_url_worker_test(
+  'data:text/plain, top',
+  'null-origin',
+  'allowed',
+  'fetching data url script with CORS allowing null origin should be allowed.'
+);
+
+</script>

--- a/fetch/api/cors/data-url-shared-worker.html
+++ b/fetch/api/cors/data-url-shared-worker.html
@@ -47,13 +47,7 @@ fetch_from_data_url_worker_test(
   'data:text/plain, top',
   'no-cors',
   'allowed',
-  'fetching data url script with no CORS should be allowed.'
-);
-fetch_from_data_url_worker_test(
-  'data:text/plain, top',
-  'null-origin',
-  'allowed',
-  'fetching data url script with CORS allowing null origin should be allowed.'
+  'fetching data url script should be allowed.'
 );
 
 </script>

--- a/fetch/api/cors/data-url-shared-worker.html
+++ b/fetch/api/cors/data-url-shared-worker.html
@@ -33,9 +33,9 @@ const fetch_from_data_url_worker_test =
 
 fetch_from_data_url_worker_test(
   '../resources/top.txt',
-  'same-origin',
+  'acao-omitted',
   'rejected',
-  'fetching "top.txt" with should be rejected.'
+  'fetching "top.txt" without ACAO should be rejected.'
 );
 fetch_from_data_url_worker_test(
   '../resources/top.txt',
@@ -45,7 +45,7 @@ fetch_from_data_url_worker_test(
 );
 fetch_from_data_url_worker_test(
   'data:text/plain, top',
-  'same-origin',
+  'acao-omitted',
   'allowed',
   'fetching data url script should be allowed.'
 );

--- a/fetch/api/cors/data-url-worker.html
+++ b/fetch/api/cors/data-url-worker.html
@@ -44,13 +44,7 @@ fetch_from_data_url_shared_worker_test(
   'data:text/plain, top',
   'no-cors',
   'allowed',
-  'fetching data url script with no CORS should be allowed.'
-);
-fetch_from_data_url_shared_worker_test(
-  'data:text/plain, top',
-  'null-origin',
-  'allowed',
-  'fetching data url script with CORS allowing null origin should be allowed.'
+  'fetching data url script should be allowed.'
 );
 
 </script>

--- a/fetch/api/cors/data-url-worker.html
+++ b/fetch/api/cors/data-url-worker.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+const fetch_from_data_url_shared_worker_test =
+    (url, cors, expectation, description) => {
+  promise_test(async () => {
+    const fetchURL = new URL(url, location.href) +
+        `${cors === 'null-origin'
+             ? '?pipe=header(Access-Control-Allow-Origin, null)' : ''}`;
+    const scriptURL =
+      `data:text/javascript,` +
+      `async function test() {` +
+      `  let allowed = true;` +
+      `  try {` +
+      `    await fetch('${fetchURL}');` +
+      `  } catch (e) {` +
+      `    allowed = false;` +
+      `  }` +
+      `  postMessage({allowed});` +
+      `}` +
+      `test();`;
+    const worker = new Worker(scriptURL);
+    const msgEvent = await new Promise(resolve => worker.onmessage = resolve);
+    assert_equals(msgEvent.data.allowed ? 'allowed' : 'rejected', expectation);
+  }, description);
+};
+
+fetch_from_data_url_shared_worker_test(
+  '../resources/top.txt',
+  'no-cors',
+  'rejected',
+  'fetching "top.txt" with no CORS should be rejected.'
+);
+fetch_from_data_url_shared_worker_test(
+  '../resources/top.txt',
+  'null-origin',
+  'allowed',
+  'fetching "top.txt" with CORS allowing null origin should be rejected.'
+);
+fetch_from_data_url_shared_worker_test(
+  'data:text/plain, top',
+  'no-cors',
+  'allowed',
+  'fetching data url script with no CORS should be allowed.'
+);
+fetch_from_data_url_shared_worker_test(
+  'data:text/plain, top',
+  'null-origin',
+  'allowed',
+  'fetching data url script with CORS allowing null origin should be allowed.'
+);
+
+</script>

--- a/fetch/api/cors/data-url-worker.html
+++ b/fetch/api/cors/data-url-worker.html
@@ -30,9 +30,9 @@ const fetch_from_data_url_shared_worker_test =
 
 fetch_from_data_url_shared_worker_test(
   '../resources/top.txt',
-  'no-cors',
+  'same-origin',
   'rejected',
-  'fetching "top.txt" with no CORS should be rejected.'
+  'fetching "top.txt" should be rejected.'
 );
 fetch_from_data_url_shared_worker_test(
   '../resources/top.txt',
@@ -42,7 +42,7 @@ fetch_from_data_url_shared_worker_test(
 );
 fetch_from_data_url_shared_worker_test(
   'data:text/plain, top',
-  'no-cors',
+  'same-origin',
   'allowed',
   'fetching data url script should be allowed.'
 );

--- a/fetch/api/cors/data-url-worker.html
+++ b/fetch/api/cors/data-url-worker.html
@@ -38,7 +38,7 @@ fetch_from_data_url_shared_worker_test(
   '../resources/top.txt',
   'null-origin',
   'allowed',
-  'fetching "top.txt" with CORS allowing null origin should be rejected.'
+  'fetching "top.txt" with CORS allowing null origin should be allowed.'
 );
 fetch_from_data_url_shared_worker_test(
   'data:text/plain, top',

--- a/fetch/api/cors/data-url-worker.html
+++ b/fetch/api/cors/data-url-worker.html
@@ -30,9 +30,9 @@ const fetch_from_data_url_shared_worker_test =
 
 fetch_from_data_url_shared_worker_test(
   '../resources/top.txt',
-  'same-origin',
+  'acao-omitted',
   'rejected',
-  'fetching "top.txt" should be rejected.'
+  'fetching "top.txt" without ACAO should be rejected.'
 );
 fetch_from_data_url_shared_worker_test(
   '../resources/top.txt',
@@ -42,7 +42,7 @@ fetch_from_data_url_shared_worker_test(
 );
 fetch_from_data_url_shared_worker_test(
   'data:text/plain, top',
-  'same-origin',
+  'acao-omitted',
   'allowed',
   'fetching data url script should be allowed.'
 );


### PR DESCRIPTION
This pull request adds web-platform-tests to check if fetching scripts from data url iframe, dedicated worker or shared worker is appropriately allowed or rejected with Access-Control-Allow-Origin cors.