### PR TITLE
Correct some calls on format_exc() in wptrunner

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -260,8 +260,9 @@ class TestExecutor(object):
         try:
             result = self.do_test(test)
         except Exception as e:
-            self.logger.warning(traceback.format_exc(e))
-            result = self.result_from_exception(test, e)
+            exception_string = traceback.format_exc()
+            self.logger.warning(exception_string)
+            result = self.result_from_exception(test, e, exception_string)
 
         if result is Stop:
             return result
@@ -294,7 +295,7 @@ class TestExecutor(object):
     def on_environment_change(self, new_environment):
         pass
 
-    def result_from_exception(self, test, e):
+    def result_from_exception(self, test, e, exception_string):
         if hasattr(e, "status") and e.status in test.result_cls.statuses:
             status = e.status
         else:
@@ -302,7 +303,7 @@ class TestExecutor(object):
         message = text_type(getattr(e, "message", ""))
         if message:
             message += "\n"
-        message += traceback.format_exc(e)
+        message += exception_string
         return test.result_cls(status, message), []
 
     def wait(self):
@@ -579,7 +580,7 @@ class WdspecRun(object):
             message = getattr(e, "message")
             if message:
                 message += "\n"
-            message += traceback.format_exc(e)
+            message += traceback.format_exc()
             self.result = False, ("INTERNAL-ERROR", message)
         finally:
             self.result_flag.set()

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -115,8 +115,8 @@ class MarionetteBaseProtocolPart(BaseProtocolPart):
             except IOError:
                 self.logger.debug("Socket closed")
                 break
-            except Exception as e:
-                self.logger.warning(traceback.format_exc(e))
+            except Exception:
+                self.logger.warning(traceback.format_exc())
                 break
 
 
@@ -138,12 +138,12 @@ class MarionetteTestharnessProtocolPart(TestharnessProtocolPart):
         self.logger.debug("Loading %s" % url)
         try:
             self.dismiss_alert(lambda: self.marionette.navigate(url))
-        except Exception as e:
+        except Exception:
             self.logger.critical(
                 "Loading initial page %s failed. Ensure that the "
                 "there are no other programs bound to this port and "
                 "that your firewall rules or network setup does not "
-                r"prevent access.\e%s" % (url, traceback.format_exc(e)))
+                r"prevent access.\e%s" % (url, traceback.format_exc()))
             raise
         self.runner_handle = self.marionette.current_window_handle
         format_map = {"title": threading.current_thread().name.replace("'", '"')}
@@ -659,7 +659,7 @@ class ExecuteAsyncScriptRun(TimedRunner):
                 message = getattr(e, "message", "")
                 if message:
                     message += "\n"
-                message += traceback.format_exc(e)
+                message += traceback.format_exc()
                 self.logger.warning(traceback.format_exc())
             self.result = False, ("INTERNAL-ERROR", message)
         finally:
@@ -809,10 +809,10 @@ class MarionetteRefTestExecutor(RefTestExecutor):
                 if handles:
                     self.protocol.marionette.switch_to_window(handles[0])
             super(self.__class__, self).teardown()
-        except Exception as e:
+        except Exception:
             # Ignore errors during teardown
             self.logger.warning("Exception during reftest teardown:\n%s" %
-                                traceback.format_exc(e))
+                                traceback.format_exc())
 
     def reset(self):
         self.implementation.reset(**self.implementation_kwargs)
@@ -935,9 +935,9 @@ class InternalRefTestImplementation(RefTestImplementation):
                 handles = self.executor.protocol.marionette.window_handles
                 if handles:
                     self.executor.protocol.marionette.switch_to_window(handles[0])
-        except Exception as e:
+        except Exception:
             # Ignore errors during teardown
-            self.logger.warning(traceback.format_exc(e))
+            self.logger.warning(traceback.format_exc())
 
 
 class GeckoDriverProtocol(WebDriverProtocol):

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -73,8 +73,8 @@ class SeleniumBaseProtocolPart(BaseProtocolPart):
             except (socket.timeout, exceptions.NoSuchWindowException,
                     exceptions.ErrorInResponseException, IOError):
                 break
-            except Exception as e:
-                self.logger.error(traceback.format_exc(e))
+            except Exception:
+                self.logger.error(traceback.format_exc())
                 break
 
 
@@ -262,7 +262,7 @@ class SeleniumRun(TimedRunner):
             message = str(getattr(e, "message", ""))
             if message:
                 message += "\n"
-            message += traceback.format_exc(e)
+            message += traceback.format_exc()
             self.result = False, ("INTERNAL-ERROR", message)
         finally:
             self.result_flag.set()

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -126,8 +126,8 @@ class ServoWebDriverProtocol(Protocol):
                 pass
             except (socket.timeout, IOError):
                 break
-            except Exception as e:
-                self.logger.error(traceback.format_exc(e))
+            except Exception:
+                self.logger.error(traceback.format_exc())
                 break
 
 
@@ -146,7 +146,7 @@ class ServoWebDriverRun(TimedRunner):
             message = getattr(e, "message", "")
             if message:
                 message += "\n"
-            message += traceback.format_exc(e)
+            message += traceback.format_exc()
             self.result = False, ("INTERNAL-ERROR", e)
         finally:
             self.result_flag.set()
@@ -256,7 +256,7 @@ class ServoWebDriverRefTestExecutor(RefTestExecutor):
             message = getattr(e, "message", "")
             if message:
                 message += "\n"
-            message += traceback.format_exc(e)
+            message += traceback.format_exc()
             return test.result_cls("INTERNAL-ERROR", message), []
 
     def screenshot(self, test, viewport_size, dpi):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -79,8 +79,8 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
                     client.UnknownErrorException,
                     IOError):
                 break
-            except Exception as e:
-                self.logger.error(traceback.format_exc(e))
+            except Exception:
+                self.logger.error(traceback.format_exc())
                 break
 
 
@@ -296,7 +296,7 @@ class WebDriverProtocol(Protocol):
             message = str(getattr(e, "message", ""))
             if message:
                 message += "\n"
-            message += traceback.format_exc(e)
+            message += traceback.format_exc()
             self.logger.debug(message)
         self.webdriver = None
 
@@ -345,7 +345,7 @@ class WebDriverRun(TimedRunner):
                 message = str(getattr(e, "message", ""))
                 if message:
                     message += "\n"
-                message += traceback.format_exc(e)
+                message += traceback.format_exc()
                 self.result = False, ("INTERNAL-ERROR", message)
         finally:
             self.result_flag.set()

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -393,8 +393,8 @@ class TestRunnerManager(threading.Thread):
                             return
                     self.state = new_state
                     self.logger.debug("new state: %s" % self.state.__class__.__name__)
-            except Exception as e:
-                self.logger.error(traceback.format_exc(e))
+            except Exception:
+                self.logger.error(traceback.format_exc())
                 raise
             finally:
                 self.logger.debug("TestRunnerManager main loop terminating, starting cleanup")


### PR DESCRIPTION
The first argument passed to format_exc() should not be an exception.
It is a limit of number of lines of trace back to print.