### PR TITLE
Detect WebKitGTK crashes and WebDriver hangs

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -373,10 +373,8 @@ class Session(object):
                  port,
                  url_prefix="/",
                  capabilities=None,
-                 timeout=None,
                  extension=None):
-        self.transport = transport.HTTPWireProtocol(
-            host, port, url_prefix, timeout=timeout)
+        self.transport = transport.HTTPWireProtocol(host, port, url_prefix)
         self.requested_capabilities = capabilities
         self.capabilities = None
         self.session_id = None

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -163,10 +163,14 @@ class TimedRunner(object):
                 self.result = False, ("INTERNAL-ERROR", "%s.run_func didn't set a result" %
                                       self.__class__.__name__)
             else:
-                message = "Executor hit external timeout (this may indicate a hang)\n"
-                # get a traceback for the current stack of the executor thread
-                message += "".join(traceback.format_stack(sys._current_frames()[executor.ident]))
-                self.result = False, ("EXTERNAL-TIMEOUT", message)
+                if self.protocol.is_alive():
+                    message = "Executor hit external timeout (this may indicate a hang)\n"
+                    # get a traceback for the current stack of the executor thread
+                    message += "".join(traceback.format_stack(sys._current_frames()[executor.ident]))
+                    self.result = False, ("EXTERNAL-TIMEOUT", message)
+                else:
+                    self.logger.info("Browser not responding, setting status to CRASH")
+                    self.result = False, ("CRASH", None)
         elif self.result[1] is None:
             # We didn't get any data back from the test, so check if the
             # browser is still responsive

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -301,11 +301,19 @@ class WebDriverProtocol(Protocol):
         self.webdriver = None
 
     def is_alive(self):
+        socket_previous_timeout = socket.getdefaulttimeout()
         try:
-            # Get a simple property over the connection
+            # Get a simple property over the connection, with 2 seconds of timeout
+            # that should be more than enough to check if the WebDriver its
+            # still alive, and allows to complete the check within the testrunner
+            # 5 seconds of extra_timeout we have as maximum to end the test before
+            # the external timeout from testrunner triggers.
+            socket.setdefaulttimeout(2)
             self.webdriver.window_handle
-        except (socket.timeout, client.UnknownErrorException):
+        except (socket.timeout, client.UnknownErrorException, client.InvalidSessionIdException):
             return False
+        finally:
+            socket.setdefaulttimeout(socket_previous_timeout)
         return True
 
     def after_connect(self):


### PR DESCRIPTION
This PR allows WPT to detect when WebKitGTK crashes.
It also improves detecting hangs of WebDriver, that now should be reported as crashes as it seems it was intended on the current code (but not working)

This PR contains 2 commits, description below:

* Commit 1
```
 Avoid raising httplib.CannotSendRequest exception if the WebDriver hangs.
    
    * When the WebDriver hangs the httplib request will not return until the
    HTTP timeout triggers, but we were using the default HTTP timeout which
    is much bigger than the test timeout since 2cc0e750cb.
    
    * Then when the external timeout triggers, the next request to the
    WebDriver will cause an httplib.CannotSendRequest exception because
    we didn't waited for the httplib request.
    
    * To fix that we set a boolean and restart the connection with the
    WebDriver if the previous one didn't finished.
    
    * This patch also removes the timeout setting from the class
    HTTPWireProtocol() which was unused (it passed a value of None
    always)
```

* Commit 2
```
    Improve detection of crashes and hangs with WebDriver.
    
    This makes crash report work with WebKitWebDriver:
     * When the WebKitWebProcess crashes, WebKitWebDriver will raise an
       InvalidSessionIdException <https://webkit.org/b/207565> like the
       Chrome WebDriver does. So we make WebDriverProtocol::is_alive()
       check for that exception.
    
    It also fixes detecting when the WebDriver has hanged:
     * The call to is_alive() can hang if WebDriver itself has hanged
       or its unresponsive. If this call takes more than 5 seconds then
       the external timeout from the testrunner will be fired and testrunner
       will force a termination of the test marking it as external-timeout
       instead of crash.
     * The current logic tried to mark the test as crashing if socket
       timeout fired, but that timeout value was much higher than the
       grace period of 5 seconds, so this didn't worked.
     * We modify the socket timeout to 2 seconds, which should be more
       than enough to check if the WebDriver its still alive and allows
       to complete the check during the testrunner 5 seconds of
       extra_timeout.
```