### PR TITLE
Add tests for navigation CORP

### DIFF
--- a/html/cross-origin-embedder-policy/none.https.html
+++ b/html/cross-origin-embedder-policy/none.https.html
@@ -4,8 +4,12 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/common/utils.js></script> <!-- Use token() to allow running tests in parallel -->
+<script src="/common/get-host-info.sub.js"></script>
 <div id=log></div>
 <script>
+const HOST = get_host_info();
+const BASE = new URL("resources", location).pathname;
+
 async_test(t => {
   const frame = document.createElement("iframe");
   t.add_cleanup(() => frame.remove());
@@ -79,4 +83,19 @@ async_test(t => {
   const win = window.open(`resources/navigate-require-corp.sub.html?channelName=${bc.name}&to=navigate-none.sub.html?channelName=${bc2.name}`, "_blank", "noopener");
   assert_equals(win, null);
 }, `"require-corp" top-level noopener popup: navigating to "none" should succeed`);
+
+async_test(t => {
+  const frame = document.createElement("iframe");
+  const id = token();
+  t.add_cleanup(() => frame.remove());
+  window.addEventListener('message', t.step_func((e) => {
+    if (e.data === id) {
+      // Loaded!
+      t.done();
+    }
+  }));
+  frame.src = `${HOST.HTTPS_NOTSAMESITE_ORIGIN}${BASE}/navigate-require-corp-same-site.sub.html?token=${id}`;
+  document.body.append(frame);
+}, 'CORP: same-site is not checked.');
+
 </script>

--- a/html/cross-origin-embedder-policy/require-corp.https.html
+++ b/html/cross-origin-embedder-policy/require-corp.https.html
@@ -7,6 +7,9 @@
 <script src="/common/utils.js"></script> <!-- Use token() to allow running tests in parallel -->
 <div id=log></div>
 <script>
+const HOST = get_host_info();
+const BASE = new URL("resources", location).pathname;
+
 async_test(t => {
   const frame = document.createElement("iframe");
   t.add_cleanup(() => frame.remove());
@@ -153,4 +156,80 @@ async_test(t => {
   document.body.append(frame);
   assert_equals(frame.contentDocument.body.localName, "body");
 }, `"require-corp" top-level: navigating an iframe to a page without CORP, through a WindowProxy, should fail`);
+
+async_test(t => {
+  const frame = document.createElement("iframe");
+  const id = token();
+  t.add_cleanup(() => frame.remove());
+  window.addEventListener('message', t.step_func((e) => {
+    if (e.data === id) {
+      // Loaded!
+      t.done();
+    }
+  }));
+  // REMOTE_ORIGIN is cross-origin, same-site.
+  frame.src = `${HOST.HTTPS_REMOTE_ORIGIN}${BASE}/navigate-require-corp-same-site.sub.html?token=${id}`;
+  document.body.append(frame);
+}, 'CORP: same-site is checked and allowed.');
+
+async_test(t => {
+  const frame = document.createElement("iframe");
+  const id = token();
+  t.add_cleanup(() => frame.remove());
+  let loaded = false;
+  window.addEventListener('message', t.step_func((e) => {
+    if (e.data === id) {
+        loaded = true;
+    }
+  }));
+  t.step_timeout(() => {
+    // Make sure the iframe didn't load. See https://github.com/whatwg/html/issues/125 for why a
+    // timeout is used here. Long term all network error handling should be similar and have a
+    // reliable event.
+    assert_false(loaded);
+    t.done();
+  }, 2000);
+
+  // NOTESAMESITE_ORIGIN is cross-origin, cross-site.
+  frame.src = `${HOST.HTTPS_NOTSAMESITE_ORIGIN}${BASE}/navigate-require-corp-same-site.sub.html?token=${id}`;
+  document.body.append(frame);
+}, 'CORP: same-site is checked and blocked.');
+
+async_test(t => {
+  const frame = document.createElement("iframe");
+  const bc = new BroadcastChannel(token());
+  t.add_cleanup(() => frame.remove());
+  bc.onmessage = t.step_func_done((event) => {
+    const payload = event.data;
+    assert_equals(payload, "loaded");
+  });
+
+  const dest = `${HOST.ORIGIN}${BASE}/navigate-require-corp.sub.html?channelName=${bc.name}`;
+  // REMOTE_ORIGIN is cross-origin, same-site.
+  frame.src = `${HOST.REMOTE_ORIGIN}${BASE}/navigate-require-corp-same-site.sub.html?to=${encodeURIComponent(dest)}`;
+  document.body.append(frame);
+}, 'navigation CORP is checked with the parent frame, not the navigation source - to be allowed');
+
+async_test(t => {
+  const frame = document.createElement("iframe");
+  const bc = new BroadcastChannel(token());
+  t.add_cleanup(() => frame.remove());
+  let loaded = false;
+  bc.onmessage = t.step_func((event) => {
+    loaded = true;
+  });
+  t.step_timeout(() => {
+    // Make sure the iframe didn't load. See https://github.com/whatwg/html/issues/125 for why a
+    // timeout is used here. Long term all network error handling should be similar and have a
+    // reliable event.
+    assert_false(loaded);
+    t.done();
+  }, 2000);
+
+  const dest = `${HOST.REMOTE_ORIGIN}${BASE}/navigate-require-corp.sub.html?channelName=${bc.name}`;
+  // REMOTE_ORIGIN is cross-origin, same-site.
+  frame.src = `${HOST.REMOTE_ORIGIN}${BASE}/navigate-require-corp-same-site.sub.html?to=${encodeURIComponent(dest)}`;
+  document.body.append(frame);
+}, 'navigation CORP is checked with the parent frame, not the navigation source - to be blocked');
+
 </script>

--- a/html/cross-origin-embedder-policy/resources/navigate-require-corp-same-site.sub.html
+++ b/html/cross-origin-embedder-policy/resources/navigate-require-corp-same-site.sub.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<script>
+  const current = new URL(window.location.href);
+  const token = current.searchParams.get("token");
+  const navigateTo = current.searchParams.get("to");
+  const channelName = current.searchParams.get("channelName");
+  const clearOpener = current.searchParams.get("clearOpener");
+
+  if (clearOpener) {
+    window.opener = null;
+  }
+
+  current.search = "";
+  if (navigateTo) {
+    let next = new URL(navigateTo, current);
+    setTimeout(() => {
+      window.location = next.href;
+    }, 50);
+  }
+
+  if (channelName) {
+    let bc = new BroadcastChannel(channelName);
+    bc.postMessage("loaded");
+  }
+
+  if (parent !== window && token) {
+    parent.postMessage(token, "*");
+  }
+</script>

--- a/html/cross-origin-embedder-policy/resources/navigate-require-corp-same-site.sub.html.headers
+++ b/html/cross-origin-embedder-policy/resources/navigate-require-corp-same-site.sub.html.headers
@@ -1,0 +1,2 @@
+Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Resource-Policy: same-site

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -297,6 +297,7 @@ SET TIMEOUT: document-policy/font-display/font-display-document-policy-01.tentat
 SET TIMEOUT: html/browsers/windows/auxiliary-browsing-contexts/resources/close-opener.html
 SET TIMEOUT: html/cross-origin-embedder-policy/resources/navigate-none.sub.html
 SET TIMEOUT: html/cross-origin-embedder-policy/resources/navigate-require-corp.sub.html
+SET TIMEOUT: html/cross-origin-embedder-policy/resources/navigate-require-corp-same-site.sub.html
 SET TIMEOUT: html/dom/documents/dom-tree-accessors/Document.currentScript.html
 SET TIMEOUT: html/webappapis/timers/*
 SET TIMEOUT: portals/history/resources/portal-harness.js


### PR DESCRIPTION
We are planning to check CORP for requests whose modes are 'navigate'
when cross-origin-embedder-policy is enabled.