### PR TITLE
Sync Mozilla CSS tests as of 2020-02-21

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/check-for-references.sh
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/check-for-references.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 find . -name reftest.list | sed 's,/reftest.list$,,' | while read DIRNAME
 do
-    cat "$DIRNAME/reftest.list" | grep -v -e "^default-preferences" -e "include " | sed 's/ #.*//;s/^#.*//;s/.* == /== /;s/.* != /!= /' | grep -v "^ *$" | while read TYPE TEST REF
+    cat "$DIRNAME/reftest.list" | grep -v -e "^defaults" -e "include " | sed 's/ #.*//;s/^#.*//;s/.* == /== /;s/.* != /!= /' | grep -v "^ *$" | while read TYPE TEST REF
     do
         REFTYPE=""
         if [ "$TYPE" == "==" ]

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
@@ -53,10 +53,3 @@
 == contain-layout-ignored-cases-no-principal-box-003.html contain-layout-ignored-cases-no-principal-box-003-ref.html
 == contain-layout-suppress-baseline-001.html contain-layout-suppress-baseline-001-ref.html
 == contain-layout-suppress-baseline-002.html contain-layout-suppress-baseline-002-ref.html
-
-# The following lines are duplicates of other lines from further up in this
-# manifest. They're listed again here so we can re-run these tests with
-# column-span enabled. These lines can be removed once the pref becomes
-# default-enabled (Bug 1426010).
-== contain-size-multicol-002.html contain-size-multicol-002-ref.html
-== contain-size-multicol-003.html contain-size-multicol-003-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/reftest.list
@@ -1,9 +1,3 @@
 == broken-column-rule-1.html broken-column-rule-1-ref.html
 == moz-multicol3-column-balancing-break-inside-avoid-1.html moz-multicol3-column-balancing-break-inside-avoid-1-ref.html
 == multicol-height-002.xht reference/multicol-height-002.xht
-
-# The following lines are duplicates of other lines from further up in this
-# manifest. They're listed again here so we can re-run these tests with
-# column-span enabled. These lines can be removed once the pref becomes
-# default-enabled (Bug 1426010).
-== broken-column-rule-1.html broken-column-rule-1-ref.html


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/793e3b87db82871f182046db439391d86d47cb67 .

This contains changes from:
* [bug 1616368](https://bugzilla.mozilla.org/show_bug.cgi?id=1616368) by @ahal, reviewed by me.
* [bug 1499281](https://bugzilla.mozilla.org/show_bug.cgi?id=1499281) by @aethanyc, reviewed by me.