### PR TITLE
CSP nonce: correct some SVG assertions

### DIFF
--- a/content-security-policy/nonce-hiding/script-nonces-hidden.html
+++ b/content-security-policy/nonce-hiding/script-nonces-hidden.html
@@ -149,10 +149,10 @@
 <nonce-element nonce="abc"></nonce-element>
 <script nonce="abc">
   test(t => {
+    assert_object_equals(eventList[0], { type: "AttributeChanged", name: "nonce", oldValue: null, newValue: "abc" }, "AttributeChanged 1");
+    assert_object_equals(eventList[1], { type: "Connected" }, "Connected");
+    assert_object_equals(eventList[2], { type: "AttributeChanged", name: "nonce", oldValue: "abc", newValue: "" }, "AttributeChanged 2");
     assert_equals(eventList.length, 3);
-    assert_object_equals(eventList[0], { type: "AttributeChanged", name: "nonce", oldValue: null, newValue: "abc" });
-    assert_object_equals(eventList[1], { type: "Connected" });
-    assert_object_equals(eventList[2], { type: "AttributeChanged", name: "nonce", oldValue: "abc", newValue: "" });
   }, "Custom elements expose the correct events.");
 </script>
 

--- a/content-security-policy/nonce-hiding/svgscript-nonces-hidden-meta.sub.html
+++ b/content-security-policy/nonce-hiding/svgscript-nonces-hidden-meta.sub.html
@@ -49,7 +49,7 @@
     test(t => {
       script.setAttribute('nonce', 'foo');
       assert_equals(script.getAttribute('nonce'), 'foo');
-      assert_equals(script.nonce, 'abc');
+      assert_equals(script.nonce, 'foo');
     }, "Writing 'nonce' content attribute.");
 
     // Set the IDL attribute to 'bar'
@@ -77,6 +77,8 @@
       innerScript.innerText = script.innerText;
       innerScript.nonce = 'abc';
       s.appendChild(innerScript);
+      assert_equals(innerScript.nonce, 'abc');
+      assert_equals(innerScript.getAttribute('nonce'), null, 'innerScript.getAttribute nonce');
       document.body.appendChild(s);
       assert_equals(innerScript.nonce, 'abc');
       assert_equals(innerScript.getAttribute('nonce'), null, 'innerScript.getAttribute nonce');

--- a/content-security-policy/nonce-hiding/svgscript-nonces-hidden.html
+++ b/content-security-policy/nonce-hiding/svgscript-nonces-hidden.html
@@ -49,7 +49,7 @@
     test(t => {
       script.setAttribute('nonce', 'foo');
       assert_equals(script.getAttribute('nonce'), 'foo');
-      assert_equals(script.nonce, 'abc');
+      assert_equals(script.nonce, 'foo');
     }, "Writing 'nonce' content attribute.");
 
     // Set the IDL attribute to 'bar'


### PR DESCRIPTION
Chrome implements nonce reflection incorrectly for SVG and the tests (used to) reflect that...

Also change assertion order of a custom element test to be more useful.