### PR TITLE
Unskip linting unit test by making it work with python3

### DIFF
--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -633,9 +633,8 @@ def test_late_timeout():
             ]
 
 
-@pytest.mark.skipif(six.PY3, reason="Cannot parse print statements from python 3")
 def test_print_statement():
-    error_map = check_with_files(b"def foo():\n  print 'statement'\n  print\n")
+    error_map = check_with_files(b"def foo():\n  print('statement')\n  print\n")
 
     for (filename, (errors, kind)) in error_map.items():
         check_errors(errors)


### PR DESCRIPTION
The problem was that it was using the `print 'something'` syntax which is not valid in python3 and thus, it was detecting more parsing issues than it should. Replaced by the more compatible `print()` version