### PR TITLE
Migrate affected_testfiles() to python3

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 import six
+from builtins import map
 from collections import OrderedDict
 from six import iteritems
 
@@ -279,7 +280,7 @@ def affected_testfiles(files_changed,  # type: Iterable[Text]
         nontest_changed_paths.add((full_path, repo_path))
 
     interface_name = lambda x: os.path.splitext(os.path.basename(x))[0]
-    interfaces_changed_names = map(interface_name, interfaces_changed)
+    interfaces_changed_names = list(map(interface_name, interfaces_changed))
 
     def affected_by_wdspec(test):
         # type: (str) -> bool
@@ -299,7 +300,7 @@ def affected_testfiles(files_changed,  # type: Iterable[Text]
 
     def affected_by_interfaces(file_contents):
         # type: (Union[bytes, Text]) -> bool
-        if len(interfaces_changed) > 0:
+        if len(interfaces_changed_names) > 0:
             if 'idlharness.js' in file_contents:
                 for interface in interfaces_changed_names:
                     regex = '[\'"]' + interface + '(\\.idl)?[\'"]'


### PR DESCRIPTION
The problem is that the `affected_by_interfaces()` method expects `interfaces_changed_names` to be a list because `map()` returns a list in python2. That is not true for python3, so the same code that is supposed to iterate over a list does not work at all for a map object.