### PR TITLE
Convert string to binary to be able to concatenate with request headers

### DIFF
--- a/fetch/api/resources/inspect-headers.py
+++ b/fetch/api/resources/inspect-headers.py
@@ -18,7 +18,7 @@ def main(request, response):
         if "allow_headers" in request.GET:
             headers.append(("Access-Control-Allow-Headers", request.GET['allow_headers']))
         else:
-            headers.append(("Access-Control-Allow-Headers", ", ".join(request.headers)))
+            headers.append(("Access-Control-Allow-Headers", b", ".join(request.headers)))
 
     headers.append(("content-type", "text/plain"))
     return headers, ""


### PR DESCRIPTION
This is due to all keys and values have binary type in
wptserve.request.RequestHeaders

Reference commit: 8b09eceee87d1001d261536e20901290c7c1b6d1