### PR TITLE
Convert binary data to string for JSON functions

### DIFF
--- a/fetch/api/request/resources/cache.py
+++ b/fetch/api/request/resources/cache.py
@@ -3,7 +3,7 @@ def main(request, response):
     if "querystate" in request.GET:
         from json import JSONEncoder
         response.headers.set("Content-Type", "text/plain")
-        return JSONEncoder().encode(request.server.stash.take(token))
+        return JSONEncoder().encode(request.server.stash.take(token).decode('utf-8'))
     content = request.GET.first("content", None)
     tag = request.GET.first("tag", None)
     date = request.GET.first("date", None)

--- a/fetch/http-cache/resources/http-cache.py
+++ b/fetch/http-cache/resources/http-cache.py
@@ -38,7 +38,7 @@ def handle_preflight(uuid, request, response):
 
 def handle_state(uuid, request, response):
     response.headers.set("Content-Type", "text/plain")
-    return json.dumps(request.server.stash.take(uuid))
+    return json.dumps(request.server.stash.take(uuid).decode('utf-8'))
 
 def handle_test(uuid, request, response):
     server_state = request.server.stash.take(uuid) or []

--- a/fetch/origin/resources/redirect-and-stash.py
+++ b/fetch/origin/resources/redirect-and-stash.py
@@ -1,5 +1,15 @@
 import json
 
+from six import binary_type
+
+def ensure_str_list(l):
+    if isinstance(l, list):
+        return [ensure_str_list(value) for value in l]
+    elif isinstance(l, binary_type):
+        return l.decode('utf-8')
+    else:
+        return l
+
 def main(request, response):
     key = request.GET.first("stash")
     origin = request.headers.get("origin")
@@ -10,7 +20,7 @@ def main(request, response):
 
     if "dump" in request.GET:
         response.headers.set("Content-Type", "application/json")
-        response.content = json.dumps(origin_list)
+        response.content = json.dumps(ensure_str_list(origin_list))
         return
 
     if origin_list is None:


### PR DESCRIPTION
In python2, binary is basically an alias of str. In python3 the binary
data is different to a string. This change is to convert some binary data
to string type in order to be compatible for both Python 2 and Python 3.