### PR TITLE
Updated to intentionally include a blank page test

### DIFF
--- a/html/semantics/embedded-content/the-object-element/object-attributes.html
+++ b/html/semantics/embedded-content/the-object-element/object-attributes.html
@@ -7,25 +7,35 @@
 <body onload="on_load()">
 <div id="log"></div>
 <form>
-  <object id="obj1" data="blue.html" name="o" height="50" width="100"></object>
+  <object id="obj1" data="/common/blank.html" name="o" height="50" width="100"></object>
   <object id="obj2" name="p" type="image/png"></object>
+  <object id="obj3" data="missing.html" name="o3" height="50" width="100"></object>
 </form>
 <script>
   var obj1;
   var obj2;
+  var obj3;
   var t1 = async_test("object.contentWindow");
+  var t2 = async_test("object.contentWindow.name");
   var t3 = async_test("object.width");
   var t4 = async_test("object.height");
 
   setup(function() {
     obj1 = document.getElementById("obj1");
     obj2 = document.getElementById("obj2");
+    obj3 = document.getElementById("obj3");
   });
 
   function on_load () {
     t1.step(function() {
-      assert_equals(obj1.contentWindow.name, "o", "The contentWindow's name of the object element should be 'o'.");
+      assert_not_equals(obj1.contentWindow, null, "The contentWindow of the object element should not be null.");
       assert_equals(obj2.contentWindow, null, "The contentWindow of the object element should be null when it type attribute starts with 'image/'.");
+      assert_equals(obj3.contentWindow, null, "The contentWindow of the object element should be null as it is showing fallback content.");
+    });
+    t1.done()
+
+    t2.step(function() {
+      assert_equals(obj1.contentWindow.name, "o", "The contentWindow's name of the object element should be 'o'.");
       obj1.setAttribute("name", "o1");
       assert_equals(obj1.name, "o1", "The name of the object element should be 'o1'.");
       assert_equals(obj1.contentWindow.name, "o", "The contentWindow's name of the object element should still be 'o'.");
@@ -33,7 +43,7 @@
       assert_equals(obj1.name, "", "The name of the object element should be empty string.");
       assert_equals(obj1.contentWindow.name, "o", "The contentWindow's name of the object element should still be 'o'.");
     });
-    t1.done()
+    t2.done()
 
     t3.step(function() {
       assert_equals(getComputedStyle(obj1, null)["width"], "100px", "The width should be 100px.");


### PR DESCRIPTION
Added new subtest to check contentWindow against an object with an empty page, an image and fallback content.

Updated existing test that was unintentionally testing with a missing page, to use a valid empty page.