### PR TITLE
[wptpr.live] Mirror vendor-exported PRs if labeled

### DIFF
--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -268,10 +268,11 @@ def has_mirroring_label(pull_request):
 
 def should_be_mirrored(project, pull_request):
     return (
-        is_open(pull_request) and
-        pull_request['user']['login'] not in AUTOMATION_GITHUB_USERS and (
-            pull_request['author_association'] in TRUSTED_AUTHOR_ASSOCIATIONS or
-            has_mirroring_label(pull_request)
+        is_open(pull_request) and (
+            has_mirroring_label(pull_request) or (
+                pull_request['user']['login'] not in AUTOMATION_GITHUB_USERS and
+                pull_request['author_association'] in TRUSTED_AUTHOR_ASSOCIATIONS
+            )
         ) and
         # Query this last as it requires another API call to verify
         not project.pull_request_is_from_fork(pull_request)

--- a/tools/ci/tests/test_pr_preview.py
+++ b/tools/ci/tests/test_pr_preview.py
@@ -512,10 +512,57 @@ def test_synchronize_sync_trusted_contributor():
                 'items': [
                     {
                         'number': 23,
+                        # user here is a contributor (untrusted), but the issue
+                        # has been labelled as safe.
                         'labels': [{'name': 'safe for preview'}],
                         'closed_at': None,
                         'user': {'login': 'Hexcles'},
                         'author_association': 'CONTRIBUTOR'
+                    }
+                ],
+                'incomplete_results': False
+            }
+        )),
+        (Requests.pr_details, (200,
+            {
+                'head': {
+                    'repo': {
+                        'full_name': 'test-org/test-repo'
+                    }
+                }
+            }
+        )),
+        (Requests.ref_create_open, (200, {})),
+        (Requests.ref_create_trusted, (200, {})),
+        (Requests.deployment_get, (200, [])),
+        (Requests.deployment_create, (200, {}))
+    ]
+
+    returncode, actual_traffic, remote_refs = synchronize(expected_traffic)
+
+    assert returncode == 0
+    assert same_members(expected_traffic, actual_traffic)
+
+def test_synchronize_sync_bot_with_label():
+    expected_traffic = [
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.search, (
+            200,
+            {
+                'items': [
+                    {
+                        'number': 23,
+                        # user here is a bot which is normally not mirrored,
+                        # but the issue has been labelled as safe.
+                        'labels': [{'name': 'safe for preview'}],
+                        'closed_at': None,
+                        'user': {'login': 'chromium-wpt-export-bot'},
+                        'author_association': 'COLLABORATOR'
                     }
                 ],
                 'incomplete_results': False


### PR DESCRIPTION
Although most vendor-exported PRs are reviewed entirely upstream and so
mirroring them would be pointless (and potentially a security issue),
some reviewers do like to check the changes on GitHub so it seems
reasonable to support.

Fixes https://github.com/web-platform-tests/wpt.live/issues/28