### PR TITLE
[webauthn] Better virtual authenticator setup

### DIFF
--- a/webauthn/helpers.js
+++ b/webauthn/helpers.js
@@ -537,28 +537,22 @@ function validateAuthenticatorAssertionResponse(assert) {
 
 function standardSetup(cb) {
     // Setup an automated testing environment if available.
-    let authenticator;
-    promise_test(async t => {
-        try {
-            authenticator = await window.test_driver.add_virtual_authenticator({
-                protocol: "ctap1/u2f",
-                transport: "usb"
-            });
-        } catch (error) {
-            if (error !== "error: Action add_virtual_authenticator not implemented") {
-                throw error;
-            }
-            // The protocol is not available. Continue manually.
+    window.test_driver.add_virtual_authenticator({
+        protocol: "ctap1/u2f",
+        transport: "usb"
+    }).then(authenticator => {
+        cb();
+        // XXX add a subtest to clean up the virtual authenticator since
+        // testharness does not support waiting for promises on cleanup.
+        promise_test(() => window.test_driver.remove_virtual_authenticator(authenticator),
+                     "Clean up the test environment");
+    }).catch(error => {
+        if (error !== "error: Action add_virtual_authenticator not implemented") {
+            throw error;
         }
-    }, "Set up the test environment");
-
-    cb();
-
-    promise_test(t => {
-        if (authenticator) {
-            return window.test_driver.remove_virtual_authenticator(authenticator);
-        }
-    }, "Clean up the test environment");
+        // The protocol is not available. Continue manually.
+        cb();
+    });
 }
 
 /* JSHINT */


### PR DESCRIPTION
If available, wait until the virtual authenticator environment is set up
before running the setup callback. Clean up the environment with a
promise test that runs after everything else. This should allow tests to
call createCredential() & other webauthn methods from outside promise
tests.