### PR TITLE
Fix module script descendant referrer tests to match spec PR

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html
@@ -29,14 +29,15 @@ const remoteOrigin = "http://{{domains[www1]}}:{{ports[http][0]}}/";
 test(t => {
   assert_equals(
       referrerSame, location.href,
-      "Referrer should be sent for the same-origin top-level script.");
+      "Full referrer should be sent for the same-origin top-level script.");
 }, "Importing a same-origin top-level script with the " +
    "origin-when-cross-origin policy.");
 
 test(t => {
   assert_equals(
       referrerRemote, origin,
-      "Referrer should be sent for the remote-origin top-level script.");
+      "Referrer should be stripped to the origin when importing " +
+      "remote-origin top-level script.");
 }, "Importing a remote-origin top-level script with the " +
    "origin-when-cross-origin policy.");
 
@@ -45,31 +46,34 @@ test(t => {
       new URL("resources/import-referrer-checker.sub.js", location.href)
   assert_equals(
       referrerSameSame, scriptURL + "?name=same_same",
-      "Referrer should be sent for the same-origin descendant script.");
+      "Full referrer should be sent for same-origin descendant script" +
+      "imported by same-origin top-level script.");
 }, "Importing a same-origin descendant script from a same-origin top-level " +
    "script with the origin-when-cross-origin policy.");
 
 test(t => {
   assert_equals(
       referrerSameRemote, origin,
-      "Referrer should be sent for the remote-origin descendant script.");
+      "Referrer should be stripped to the origin for the remote-origin " +
+      "descendant script imported from same-origin top-level script.");
 }, "Importing a remote-origin descendant script from a same-origin top-level " +
    "script with the origin-when-cross-origin policy.");
 
 test(t => {
-  assert_equals(
-      referrerRemoteRemote, remoteOrigin,
-      "Referrer should be sent for the remote-origin descendant script.");
+  const scriptURL = new URL(
+    "html/semantics/scripting-1/the-script-element/module/resources/" +
+    "import-referrer-checker.sub.js",
+    remoteOrigin);
+  assert_equals(referrerRemoteRemote, scriptURL + "?name=remote_remote",
+      "Full referrer should be sent for the remote-origin descendant script " +
+      "imported from a remote-origin top-level script.");
 }, "Importing a remote-origin descendant script from a remote-origin " +
    "top-level script with the origin-when-cross-origin policy.");
 
 test(t => {
-  const scriptURL = new URL(
-    "html/semantics/scripting-1/the-script-element/module/resources/" +
-    "import-same-origin-referrer-checker-from-remote-origin.sub.js",
-    remoteOrigin);
-  assert_equals(referrerRemoteSame, scriptURL + "?name=remote_same",
-      "Referrer should be sent for the same-origin descendant script.");
+  assert_equals(referrerRemoteSame, remoteOrigin,
+      "Referrer should be stripped to the origin for the same-origin " +
+      "descendant script imported by remote-origin top-level script.");
 }, "Importing a same-origin descendant script from a remote-origin " +
    "top-level script with the origin-when-cross-origin policy.");
 

--- a/html/semantics/scripting-1/the-script-element/module/referrer-same-origin.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/referrer-same-origin.sub.html
@@ -54,22 +54,21 @@ test(t => {
    "script with the same-origin policy.");
 
 test(t => {
+  const scriptURL = new URL(
+    "html/semantics/scripting-1/the-script-element/module/resources/" +
+    "import-referrer-checker.sub.js", remoteOrigin);
   assert_equals(
-      referrerRemoteRemote, "",
-      "Referrer should not be sent for the remote-origin descendant script " +
-      "even if it is imported from the script in the same remote-origin.");
+      referrerRemoteRemote, scriptURL + "?name=remote_remote",
+      "Referrer should be sent for the remote-origin descendant script " +
+      "when it is imported from a top-level script in the same remote-origin.");
 }, "Importing a remote-origin descendant script from a remote-origin " +
    "top-level script with the same-origin policy.");
 
 test(t => {
-  const scriptURL = new URL(
-    "html/semantics/scripting-1/the-script-element/module/resources/" +
-    "import-same-origin-referrer-checker-from-remote-origin.sub.js",
-    remoteOrigin);
   assert_equals(
-      referrerRemoteSame, scriptURL + "?name=remote_same",
-      "Referrer should be sent for the same-origin descendant script " +
-      "even if it is imported from the script in the remote-origin.");
+      referrerRemoteSame, "",
+      "Referrer should not be sent for the same-origin descendant script " +
+      "when it is imported from a top-level remote-origin script.");
 }, "Importing a same-origin descendant script from a remote-origin " +
    "top-level script with the same-origin policy.");
 


### PR DESCRIPTION
This PR fixes module script descendent referrer tests that I originally added in https://crrev.com/c/1809205. The tests I added match the spec, and we were going to change Chromium's implementation accordingly, however after more discussion in https://github.com/w3c/webappsec-referrer-policy/issues/123, we're aiming to change the spec to be more sane.

This PR makes the module script descendant scripts tests assert that a descendant script's referrer string is used in determining if the request is same-origin or not. Currently the spec computes [same-origin-ness by comparing](https://w3c.github.io/webappsec-referrer-policy/#same-origin-request) request's currently URL and request's origin (which can be its client's origin). It does not consider the referrer string, which may be different than its client's origin, via module scripts. Consider:

 - A.com/page.html fetches top-level module script B.com/x.js
 - B.com/x.js fetches a descendant script A.com/x.js

In this case, the request for A.com/x.js's referrer string is B.com/x.js, but it's client's origin is A.com. The point of the HTML Standard setting the descendant's referrer string to its parent's URL is to make the parent behave as the referrer in this case, but the Referrer Policy spec didn't respect this. https://github.com/w3c/webappsec-referrer-policy/issues/123 changes the Referrer Policy spec accordingly, and this PR considers the above request to be cross-origin (the descendant request is cross-origin relative its parent).