### PR TITLE
Update worklet referrer tests to match spec PR

### DIFF
--- a/worklets/resources/referrer-tests.js
+++ b/worklets/resources/referrer-tests.js
@@ -188,7 +188,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'remote',
                                               descendant: 'same' } });
   }, 'Importing a same-origin script from a remote-origin worklet script ' +
-     'that has "same-origin" referrer policy should send referrer.');
+     'that has "same-origin" referrer policy should not send referrer.');
 
   promise_test(() => {
     return runReferrerTest({ workletType: workletType,
@@ -197,7 +197,7 @@ function runReferrerTests(workletType) {
                              scriptOrigins: { topLevel: 'remote',
                                               descendant: 'remote' } });
   }, 'Importing a remote-origin script from a remote-origin worklet script ' +
-     'that has "same-origin" referrer policy should not send referrer.');
+     'that has "same-origin" referrer policy should send referrer.');
 
   // TODO(domfarolino): Add tests for more referrer policies.
 }

--- a/worklets/resources/referrer-window.html
+++ b/worklets/resources/referrer-window.html
@@ -51,8 +51,10 @@ function createScriptURLForDecendant(scriptOrigins) {
 function isDestinationCrossOrigin(fetchType, scriptOrigins) {
   if (fetchType === 'top-level')
     return scriptOrigins.topLevel === 'remote';
+
+  // Compute a descendant's cross-origin-ness relative to the top-level script.
   if (fetchType === 'descendant')
-    return scriptOrigins.descendant === 'remote';
+    return scriptOrigins.descendant !== scriptOrigins.topLevel;
   assert_unreached('fetchType has an invalid value.');
 }
 


### PR DESCRIPTION
The same thing as https://github.com/web-platform-tests/wpt/pull/22038, but for worklets. Since `addModule()` ultimately invokes the https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree algorithm, the request for an "added" module's descendant, should use its parent's URL as the referrer string. Therefore, an "added" module's descendant is considered cross-origin, if it's is cross-origin with its parent's URL, not its client's origin. This PR fixes the tests to assert that.

(Sorry if that is confusing, let me know if I can clarify).

Related: https://github.com/w3c/webappsec-referrer-policy/issues/123