### PR TITLE
Make more robust the timeout check WebDriverProtocol.is_alive()

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -444,7 +444,7 @@ class Session(object):
         finally:
             self.session_id = None
 
-    def send_command(self, method, url, body=None):
+    def send_command(self, method, url, body=None, timeout=None):
         """
         Send a command to the remote end and validate its success.
 
@@ -465,7 +465,7 @@ class Session(object):
         response = self.transport.send(
             method, url, body,
             encoder=protocol.Encoder, decoder=protocol.Decoder,
-            session=self)
+            session=self, timeout=timeout)
 
         if response.status != 200:
             err = error.from_response(response)
@@ -493,7 +493,7 @@ class Session(object):
 
         return value
 
-    def send_session_command(self, method, uri, body=None):
+    def send_session_command(self, method, uri, body=None, timeout=None):
         """
         Send a command to an established session and validate its success.
 
@@ -510,7 +510,7 @@ class Session(object):
             an error.
         """
         url = urlparse.urljoin("session/%s/" % self.session_id, uri)
-        return self.send_command(method, url, body)
+        return self.send_command(method, url, body, timeout)
 
     @property
     @command

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -301,19 +301,15 @@ class WebDriverProtocol(Protocol):
         self.webdriver = None
 
     def is_alive(self):
-        socket_previous_timeout = socket.getdefaulttimeout()
         try:
             # Get a simple property over the connection, with 2 seconds of timeout
             # that should be more than enough to check if the WebDriver its
             # still alive, and allows to complete the check within the testrunner
             # 5 seconds of extra_timeout we have as maximum to end the test before
             # the external timeout from testrunner triggers.
-            socket.setdefaulttimeout(2)
-            self.webdriver.window_handle
+            self.webdriver.send_session_command("GET", "window", timeout=2)
         except (socket.timeout, client.UnknownErrorException, client.InvalidSessionIdException):
             return False
-        finally:
-            socket.setdefaulttimeout(socket_previous_timeout)
         return True
 
     def after_connect(self):


### PR DESCRIPTION
In 58988ab31a (#21889) the WebDriverProtocol.is_alive() check was modified
to use a 2 second timeout, but this only works when the connection with
the webdriver has been lost and a new one will be made for the is_alive()
check because calling socket.getdefaulttimeout() doesn't affect the ongoing
httplib connection with the WebDriver.

To fix this we introduce the timeout value as an optional parameter of the
WebDriver send_command() function. When timeout its specified, then the
socket timeout of the current httplib connection its modified just only
for this request (and restored after). This works both when the connection
with the WebDriver is lost (and a new one its made) as when the connection
it is working as expected.