### PR TITLE
Refactor: Make user-interaction-editing-contenteditable tests atomic

### DIFF
--- a/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
+++ b/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
@@ -1,54 +1,114 @@
 <!DOCTYPE html>
 <html>
- <head>
-  <title>Editing: contentEditable attribute test</title>
-  <link rel="author" title="Baidu" href="mailto: guopengcheng@baidu.com"/>
-  <link rel="help" href="https://html.spec.whatwg.org/multipage/#contenteditable"/>
-  <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
-  <div id="log"></div>
- </head>
- <body>
-  <script type="text/javascript">
-   var testElement = document.createElement("testElement");
-   test(function() {
-    assert_equals(testElement.contentEditable,"inherit", "check for testElement.contentEditable value");
-   }, "no contentEditable attribute");
-   testElement.setAttribute("contentEditable", "");
-   test(function() {
-    assert_true(testElement.isContentEditable, "check for testElement.isContentEditable value");
-    assert_equals(testElement.contentEditable,"true", "check for testElement.contentEditable value");
-   }, "empty contentEditable attribute");
-   testElement.contentEditable="true";
-   test(function() {
-    assert_true(testElement.isContentEditable, "check for testElement.isContentEditable value");
-    assert_equals(testElement.contentEditable,"true", "check for testElement.contentEditable value");
-   }, "set contentEditable = \"true\"");
-   testElement.contentEditable="false";
-   test(function() {
-    assert_false(testElement.isContentEditable, "check for testElement.isContentEditable value");
-    assert_equals(testElement.contentEditable,"false", "check for testElement.contentEditable value");
-   }, "set contentEditable = \"false\"");
-   testElement.contentEditable="inherit";
-   test(function() {
-    assert_equals(testElement.contentEditable,"inherit", "check for testElement.contentEditable value");
-   }, "set contentEditable = \"inherit\"");
-   var childElement = document.createElement("childElement");
-   testElement.appendChild(childElement);
-   testElement.contentEditable="true";
-   test(function() {
-    assert_true(testElement.isContentEditable, "check for testElement.isContentEditable value");
-    assert_equals(testElement.contentEditable,"true", "check for testElement.contentEditable value");
-    assert_true(childElement.isContentEditable, "check for childElement.isContentEditable value");
-    assert_equals(childElement.contentEditable,"inherit", "check for childElement.contentEditable value");
-   }, "set parent element contentEditable = \"true\"");
-   testElement.contentEditable="false";
-   test(function() {
-    assert_false(testElement.isContentEditable, "check for testElement.isContentEditable value");
-    assert_equals(testElement.contentEditable,"false", "check for testElement.contentEditable value");
-    assert_false(childElement.isContentEditable, "check for childElement.isContentEditable value");
-    assert_equals(childElement.contentEditable,"inherit", "check for childElement.contentEditable value");
-   }, "set parent element contentEditable = \"false\"");
-  </script>
- </body>
+  <head>
+    <title>Editing: contentEditable attribute test</title>
+    <link rel="author" title="Baidu" href="mailto: guopengcheng@baidu.com" />
+    <link
+      rel="help"
+      href="https://html.spec.whatwg.org/multipage/#contenteditable"
+    />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <div id="log"></div>
+  </head>
+  <body>
+    <script type="text/javascript">
+      var testElement = document.createElement("testElement");
+      test(function() {
+        assert_equals(
+          testElement.contentEditable,
+          "inherit",
+          "check for testElement.contentEditable value"
+        );
+      }, "no contentEditable attribute");
+      testElement.setAttribute("contentEditable", "");
+      test(function() {
+        assert_true(
+          testElement.isContentEditable,
+          "check for testElement.isContentEditable value"
+        );
+        assert_equals(
+          testElement.contentEditable,
+          "true",
+          "check for testElement.contentEditable value"
+        );
+      }, "empty contentEditable attribute");
+      testElement.contentEditable = "true";
+      test(function() {
+        assert_true(
+          testElement.isContentEditable,
+          "check for testElement.isContentEditable value"
+        );
+        assert_equals(
+          testElement.contentEditable,
+          "true",
+          "check for testElement.contentEditable value"
+        );
+      }, 'set contentEditable = "true"');
+      testElement.contentEditable = "false";
+      test(function() {
+        assert_false(
+          testElement.isContentEditable,
+          "check for testElement.isContentEditable value"
+        );
+        assert_equals(
+          testElement.contentEditable,
+          "false",
+          "check for testElement.contentEditable value"
+        );
+      }, 'set contentEditable = "false"');
+      testElement.contentEditable = "inherit";
+      test(function() {
+        assert_equals(
+          testElement.contentEditable,
+          "inherit",
+          "check for testElement.contentEditable value"
+        );
+      }, 'set contentEditable = "inherit"');
+      var childElement = document.createElement("childElement");
+      testElement.appendChild(childElement);
+      testElement.contentEditable = "true";
+      test(function() {
+        assert_true(
+          testElement.isContentEditable,
+          "check for testElement.isContentEditable value"
+        );
+        assert_equals(
+          testElement.contentEditable,
+          "true",
+          "check for testElement.contentEditable value"
+        );
+        assert_true(
+          childElement.isContentEditable,
+          "check for childElement.isContentEditable value"
+        );
+        assert_equals(
+          childElement.contentEditable,
+          "inherit",
+          "check for childElement.contentEditable value"
+        );
+      }, 'set parent element contentEditable = "true"');
+      testElement.contentEditable = "false";
+      test(function() {
+        assert_false(
+          testElement.isContentEditable,
+          "check for testElement.isContentEditable value"
+        );
+        assert_equals(
+          testElement.contentEditable,
+          "false",
+          "check for testElement.contentEditable value"
+        );
+        assert_false(
+          childElement.isContentEditable,
+          "check for childElement.isContentEditable value"
+        );
+        assert_equals(
+          childElement.contentEditable,
+          "inherit",
+          "check for childElement.contentEditable value"
+        );
+      }, 'set parent element contentEditable = "false"');
+    </script>
+  </body>
 </html>

--- a/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
+++ b/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
@@ -31,6 +31,7 @@
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"
         );
+
         assert_equals(
           testElement.contentEditable,
           "true",
@@ -46,6 +47,7 @@
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"
         );
+
         assert_equals(
           testElement.contentEditable,
           "true",
@@ -61,6 +63,7 @@
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"
         );
+
         assert_equals(
           testElement.contentEditable,
           "false",
@@ -89,15 +92,18 @@
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"
         );
+
         assert_equals(
           testElement.contentEditable,
           "true",
           "check for testElement.contentEditable value"
         );
+
         assert_true(
           childElement.isContentEditable,
           "check for childElement.isContentEditable value"
         );
+
         assert_equals(
           childElement.contentEditable,
           "inherit",
@@ -115,15 +121,18 @@
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"
         );
+
         assert_equals(
           testElement.contentEditable,
           "false",
           "check for testElement.contentEditable value"
         );
+
         assert_false(
           childElement.isContentEditable,
           "check for childElement.isContentEditable value"
         );
+
         assert_equals(
           childElement.contentEditable,
           "inherit",

--- a/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
+++ b/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
@@ -13,16 +13,20 @@
   </head>
   <body>
     <script type="text/javascript">
-      var testElement = document.createElement("testElement");
       test(function() {
+        const testElement = document.createElement("testElement");
+
         assert_equals(
           testElement.contentEditable,
           "inherit",
           "check for testElement.contentEditable value"
         );
       }, "no contentEditable attribute");
-      testElement.setAttribute("contentEditable", "");
+
       test(function() {
+        const testElement = document.createElement("testElement");
+        testElement.setAttribute("contentEditable", "");
+
         assert_true(
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"
@@ -33,8 +37,11 @@
           "check for testElement.contentEditable value"
         );
       }, "empty contentEditable attribute");
-      testElement.contentEditable = "true";
+
       test(function() {
+        const testElement = document.createElement("testElement");
+        testElement.contentEditable = "true";
+
         assert_true(
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"
@@ -45,8 +52,11 @@
           "check for testElement.contentEditable value"
         );
       }, 'set contentEditable = "true"');
-      testElement.contentEditable = "false";
+
       test(function() {
+        const testElement = document.createElement("testElement");
+        testElement.contentEditable = "false";
+
         assert_false(
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"
@@ -57,18 +67,24 @@
           "check for testElement.contentEditable value"
         );
       }, 'set contentEditable = "false"');
-      testElement.contentEditable = "inherit";
+
       test(function() {
+        const testElement = document.createElement("testElement");
+        testElement.contentEditable = "inherit";
+
         assert_equals(
           testElement.contentEditable,
           "inherit",
           "check for testElement.contentEditable value"
         );
       }, 'set contentEditable = "inherit"');
-      var childElement = document.createElement("childElement");
-      testElement.appendChild(childElement);
-      testElement.contentEditable = "true";
+
       test(function() {
+        const testElement = document.createElement("testElement");
+        const childElement = document.createElement("childElement");
+        testElement.appendChild(childElement);
+        testElement.contentEditable = "true";
+
         assert_true(
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"
@@ -88,8 +104,13 @@
           "check for childElement.contentEditable value"
         );
       }, 'set parent element contentEditable = "true"');
-      testElement.contentEditable = "false";
+
       test(function() {
+        const testElement = document.createElement("testElement");
+        const childElement = document.createElement("childElement");
+        testElement.appendChild(childElement);
+        testElement.contentEditable = "false";
+
         assert_false(
           testElement.isContentEditable,
           "check for testElement.isContentEditable value"

--- a/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
+++ b/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
@@ -139,6 +139,90 @@
           "check for childElement.contentEditable value"
         );
       }, 'set parent element contentEditable = "false"');
+      
+      test(function() {
+        var testElement = document.createElement("testElement");
+
+        assert_equals(
+          testElement.contentEditable,
+          "inherit",
+          "no contentEditable attribute, so inherit"
+        );
+        testElement.setAttribute("contentEditable", "");
+
+        assert_true(
+          testElement.isContentEditable,
+          "check for testElement.isContentEditable value"
+        );
+        assert_equals(
+          testElement.contentEditable,
+          "true",
+          "empty contentEditable attribute is 'true'"
+        );
+
+        testElement.contentEditable = "true";
+        assert_true(
+          testElement.isContentEditable,
+          "check for testElement.isContentEditable value"
+        );
+        assert_equals(
+          testElement.contentEditable,
+          "true",
+          "contentEditable='true' is 'true'"
+        );
+
+        testElement.contentEditable = "false";
+        assert_false(
+          testElement.isContentEditable,
+          "check for testElement.isContentEditable value"
+        );
+        assert_equals(
+          testElement.contentEditable,
+          "false",
+          "contentEditable = 'false' is 'false'"
+        );
+
+        testElement.contentEditable = "inherit";
+        assert_equals(
+          testElement.contentEditable,
+          "inherit",
+          "contentEditable='inherit' is 'inherit'"
+        );
+
+        var childElement = document.createElement("childElement");
+        testElement.appendChild(childElement);
+        testElement.contentEditable = "true";
+        assert_true(
+          testElement.isContentEditable,
+          'parent element contentEditable = "true"'
+        );
+        assert_equals(testElement.contentEditable, "true");
+        assert_true(
+          childElement.isContentEditable,
+          'parent element contentEditable = "true", so childElement must be editable'
+        );
+        assert_equals(
+          childElement.contentEditable,
+          "inherit",
+          'parent element contentEditable = "true", so child inherits'
+        );
+
+        testElement.contentEditable = "false";
+        assert_false(
+          testElement.isContentEditable,
+          'parent element contentEditable = "false"'
+        );
+        assert_equals(testElement.contentEditable, "false");
+        assert_false(
+          childElement.isContentEditable,
+          'parent element contentEditable = "false"'
+        );
+        assert_equals(
+          childElement.contentEditable,
+          "inherit",
+          'parent element contentEditable = "false"'
+        );
+      }, "Dynamically changing contentEditable values");
     </script>
   </body>
 </html>

--- a/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
+++ b/html/editing/editing-0/contenteditable/user-interaction-editing-contenteditable.html
@@ -139,7 +139,7 @@
           "check for childElement.contentEditable value"
         );
       }, 'set parent element contentEditable = "false"');
-      
+
       test(function() {
         var testElement = document.createElement("testElement");
 


### PR DESCRIPTION
Hi! 
I noticed that the tests in this file used variables that are not scoped to individual tests, and that these variables are modified outside tests. eg:

`var testElement = document.createElement("testElement");`
`testElement.contentEditable="true";`

I refactored the tests to have variables scoped to individual tests, thus making tests atomic and not dependent on the order in which they are run.

I also ran the file through `prettier` to format it.

cc @marcoscaceres - thank you for your help!