### PR TITLE
Enable test_wpt.py to be run with python3

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -926,7 +926,7 @@ def lint(repo_root, paths, output_format, ignore_glob=str()):
         last = process_errors(errors) or last
 
         if not os.path.isdir(abs_path):
-            with open(abs_path, 'r') as f:
+            with open(abs_path, 'rb') as f:
                 errors = check_file_contents(repo_root, path, f)
                 last = process_errors(errors) or last
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -610,12 +610,12 @@ def check_global_metadata(value):
     global_values = {item.strip() for item in value.split(b",") if item.strip()}
 
     included_variants = set.union(get_default_any_variants(),
-                                  *(get_any_variants(ensure_str(v)) for v in global_values if not v.startswith(b"!")))
+                                  *(get_any_variants(v) for v in global_values if not v.startswith(b"!")))
 
     for global_value in global_values:
         if global_value.startswith(b"!"):
             excluded_value = global_value[1:]
-            if not get_any_variants(ensure_str(excluded_value)):
+            if not get_any_variants(excluded_value):
                 yield (rules.UnknownGlobalMetadata, ())
 
             elif excluded_value in global_values:
@@ -623,13 +623,13 @@ def check_global_metadata(value):
                        (("Cannot specify both %s and %s" % (global_value, excluded_value)),))
 
             else:
-                excluded_variants = get_any_variants(ensure_str(excluded_value))
+                excluded_variants = get_any_variants(excluded_value)
                 if not (excluded_variants & included_variants):
                     yield (rules.BrokenGlobalMetadata,
                            (("Cannot exclude %s if it is not included" % (excluded_value,)),))
 
         else:
-            if not get_any_variants(ensure_str(global_value)):
+            if not get_any_variants(global_value):
                 yield (rules.UnknownGlobalMetadata, ())
 
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -21,7 +21,7 @@ from ..wpt import testfiles
 from ..manifest.vcs import walk
 
 from ..manifest.sourcefile import SourceFile, js_meta_re, python_meta_re, space_chars, get_any_variants, get_default_any_variants
-from six import binary_type, ensure_str, iteritems, itervalues, with_metaclass
+from six import binary_type, iteritems, itervalues, with_metaclass
 from six.moves import range
 from six.moves.urllib.parse import urlsplit, urljoin
 

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -391,7 +391,7 @@ def write(manifest, manifest_path):
     dir_name = os.path.dirname(manifest_path)
     if not os.path.exists(dir_name):
         os.makedirs(dir_name)
-    with open(manifest_path, "wb") as f:
+    with open(manifest_path, "w") as f:
         # Use ',' instead of the default ', ' separator to prevent trailing
         # spaces: https://docs.python.org/2/library/json.html#json.dump
         json.dump(manifest.to_json(caller_owns_obj=True), f,

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -85,9 +85,9 @@ _any_variants = {
 
 
 def get_any_variants(item):
-    # type: (bytes) -> Set[bytes]
+    # type: (str) -> Set[str]
     """
-    Returns a set of variants (bytestrings) defined by the given keyword.
+    Returns a set of variants (strings) defined by the given keyword.
     """
     assert isinstance(item, text_type), item
     assert not item.startswith("!"), item

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -2,7 +2,7 @@ import hashlib
 import re
 import os
 from collections import deque
-from six import binary_type, text_type, iteritems, ensure_str
+from six import binary_type, ensure_str, iteritems, string_types
 from six.moves.urllib.parse import urljoin
 from fnmatch import fnmatch
 
@@ -89,7 +89,7 @@ def get_any_variants(item):
     """
     Returns a set of variants (strings) defined by the given keyword.
     """
-    assert isinstance(item, text_type), item
+    assert isinstance(item, string_types), item
     assert not item.startswith("!"), item
 
     variant = _any_variants.get(item, None)
@@ -112,7 +112,7 @@ def parse_variants(value):
     """
     Returns a set of variants (bytestrings) defined by a comma-separated value.
     """
-    assert isinstance(value, text_type), value
+    assert isinstance(value, string_types), value
 
     globals = get_default_any_variants()
 
@@ -133,7 +133,7 @@ def global_suffixes(value):
     variant is intended to run in a JS shell, for the variants defined by the
     given comma-separated value.
     """
-    assert isinstance(value, text_type), value
+    assert isinstance(value, string_types), value
 
     rv = set()
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -108,7 +108,7 @@ def get_default_any_variants():
 
 
 def parse_variants(value):
-    # type: (bytes) -> Set[bytes]
+    # type: (str) -> Set[str]
     """
     Returns a set of variants (bytestrings) defined by a comma-separated value.
     """

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -74,29 +74,29 @@ def read_script_metadata(f, regexp):
 
 
 _any_variants = {
-    "default": {"longhand": {"window", "dedicatedworker"}},
-    "window": {"suffix": ".any.html"},
-    "serviceworker": {"force_https": True},
-    "sharedworker": {},
-    "dedicatedworker": {"suffix": ".any.worker.html"},
-    "worker": {"longhand": {"dedicatedworker", "sharedworker", "serviceworker"}},
-    "jsshell": {"suffix": ".any.js"},
+    b"default": {"longhand": {"window", "dedicatedworker"}},
+    b"window": {"suffix": ".any.html"},
+    b"serviceworker": {"force_https": True},
+    b"sharedworker": {},
+    b"dedicatedworker": {"suffix": ".any.worker.html"},
+    b"worker": {"longhand": {"dedicatedworker", "sharedworker", "serviceworker"}},
+    b"jsshell": {"suffix": ".any.js"},
 }  # type: Dict[bytes, Dict[str, Any]]
 
 
 def get_any_variants(item):
-    # type: (str) -> Set[str]
+    # type: (bytes) -> Set[bytes]
     """
-    Returns a set of variants (strings) defined by the given keyword.
+    Returns a set of variants (bytestrings) defined by the given keyword.
     """
-    assert isinstance(item, string_types), item
-    assert not item.startswith("!"), item
+    assert isinstance(item, binary_type), item
+    assert not item.startswith(b"!"), item
 
     variant = _any_variants.get(item, None)
     if variant is None:
         return set()
 
-    return variant.get("longhand", {item})
+    return variant.get(b"longhand", {item})
 
 
 def get_default_any_variants():
@@ -104,7 +104,7 @@ def get_default_any_variants():
     """
     Returns a set of variants (bytestrings) that will be used by default.
     """
-    return set(_any_variants["default"]["longhand"])
+    return set(_any_variants[b"default"]["longhand"])
 
 
 def parse_variants(value):
@@ -233,7 +233,9 @@ class SourceFile(object):
         self.url_base = url_base
         self.contents = contents
         self.items_cache = None  # type: Optional[Tuple[Text, List[ManifestItem]]]
-        self._hash = ensure_str(hash, encoding='ascii') if hash else None
+        if hash:
+            assert(isinstance(hash, string_types))
+        self._hash = hash
 
     def __getstate__(self):
         # type: () -> Dict[str, Any]

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -178,9 +178,9 @@ class HtmlWrapperHandler(WrapperHandler):
 
     def check_exposure(self, request):
         if self.global_type:
-            globals = b""
+            globals = ""
             for (key, value) in self._get_metadata(request):
-                if key == b"global":
+                if key == "global":
                     globals = value
                     break
 

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -43,8 +43,6 @@ def get_persistent_manifest_path():
 
 @pytest.fixture(scope="module", autouse=True)
 def init_manifest():
-    if sys.version_info >= (3,):
-        pytest.xfail(reason="broken on Py3")
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["manifest", "--no-download",
                        "--path", get_persistent_manifest_path()])


### PR DESCRIPTION
The main issue while making it py2/py3 compatible was the writing of the manifest. All the code was based on handing bytes. However the json module does only generate str output not bytes. That was fine for python2 (bytes==str) but invalid for python3.

Most of the work was related to switch code to use str instead of bytes as required. The manifest file is also no open in binary mode for writting since we are not longer providing bytes.