### PR TITLE
Fix timeouts in the WindowClient.navigate() tests

### DIFF
--- a/service-workers/service-worker/windowclient-navigate.https.html
+++ b/service-workers/service-worker/windowclient-navigate.https.html
@@ -106,7 +106,9 @@ function navigate_test(override_parameters) {
       script_url += '?' + parameters.wait_state;
 
       navigator.serviceWorker.addEventListener('message', function(event) {
-          pausedLifecyclePort = event.data.port;
+          if (event.data.port) {
+            pausedLifecyclePort = event.data.port;
+          }
         });
     }
 


### PR DESCRIPTION
It seems like at some point after these tests were written, the Worker has started sending unrelated messages without an `event.data.port`, which would overwrite the `pausedLifecyclePort` variable, which we need later for the tests to progress. This patch ignores those messages.

This PR makes the tests pass again in Chrome. The "in scope but not controlled" and "out of scope" failures in Firefox are known bugs.