### PR TITLE
Use test() correctly in css-page tests

### DIFF
--- a/css/css-page/page-rule-declarations-000.html
+++ b/css/css-page/page-rule-declarations-000.html
@@ -80,41 +80,43 @@
 </style>
 <script type="text/javascript">
 
-    test(function(){
-        let expectedForSelector = {
-            "" : "margin-top: 5cm; margin-bottom: 10cm;",
-            ":left" : "margin-right: 3cm;",
-            ":right" : "margin-left: 3cm;",
-            ":first" : "border-width: 1px;",
-            "hello" : "color: green;",
-            "world:right" : "background-color: green;",
-            "auto_page" : "size: auto;",
-            "square_page" : "size: 4in;",
-            "letter_page" : "size: letter;",
-            "page_width_height" : "size: 10cm 15cm;",
-            "page_size_orientation" : "size: ledger landscape;",
-            "page_orientation_size" : "size: a4 portrait;",
-            "page_jis_size_orientation" : "size: jis-b5 portrait;",
-            "page_orientation_jis_size" : "size: jis-b4 landscape;",
-            "err_empty_size" : "",
-            "err_unknow_page_size" : "",
-            "err_length_and_page_size" : "",
-            "err_length_and_orientation" : "",
-            "err_orientations" : "",
-            "err_too_many_params" : ""
-        };
-        let styleSheets = document.styleSheets;
-        for (let i = 0; i < styleSheets.length; i++) {
-            let rules = styleSheets[i].cssRules;
-            for (let rule of rules) {
-                if (rule.type == CSSRule.PAGE_RULE) {
-                    let expected = expectedForSelector[rule.selectorText];
+    let expectedForSelector = {
+        "" : "margin-top: 5cm; margin-bottom: 10cm;",
+        ":left" : "margin-right: 3cm;",
+        ":right" : "margin-left: 3cm;",
+        ":first" : "border-width: 1px;",
+        "hello" : "color: green;",
+        "world:right" : "background-color: green;",
+        "auto_page" : "size: auto;",
+        "square_page" : "size: 4in;",
+        "letter_page" : "size: letter;",
+        "page_width_height" : "size: 10cm 15cm;",
+        "page_size_orientation" : "size: ledger landscape;",
+        "page_orientation_size" : "size: a4 portrait;",
+        "page_jis_size_orientation" : "size: jis-b5 portrait;",
+        "page_orientation_jis_size" : "size: jis-b4 landscape;",
+        "err_empty_size" : "",
+        "err_unknow_page_size" : "",
+        "err_length_and_page_size" : "",
+        "err_length_and_orientation" : "",
+        "err_orientations" : "",
+        "err_too_many_params" : ""
+    };
+    let styleSheets = document.styleSheets;
+    for (let i = 0; i < styleSheets.length; i++) {
+        let rules = styleSheets[i].cssRules;
+        for (let rule of rules) {
+            if (rule.type == CSSRule.PAGE_RULE) {
+                let expected = expectedForSelector[rule.selectorText];
+                test(function(){
                     assert_equals(rule.style.cssText, expected, "unexpected @page contents");
-                    delete expectedForSelector[rule.selectorText];
-                }
+                }, "unexpected contents for selector ['" + rule.selectorText + "']");
+                delete expectedForSelector[rule.selectorText];
             }
         }
+    }
+    test(function() {
         assert_equals(Object.keys(expectedForSelector).length, 0, "missing @page selectors");
-    }, "test CSS @page declarations");
+    });
 
 </script>

--- a/css/css-page/page-rule-declarations-001.html
+++ b/css/css-page/page-rule-declarations-001.html
@@ -27,29 +27,31 @@
 </style>
 <script type="text/javascript">
 
-    test(function(){
-        let expectedForSelector = {
-            "" : "margin: 3cm;",
-            ":first" : "margin-top: 6cm;",
-            ":left" : "color: red;",
-            ":right" : "color: blue;"
-        };
-        let styleSheets = document.styleSheets;
-        for (let i = 0; i < styleSheets.length; i++) {
-            let rules = styleSheets[i].cssRules;
-            for (let rule of rules) {
-                if (rule.type == CSSRule.MEDIA_RULE && rule.conditionText == 'print') {
-                    for (let mediaRule of rule.cssRules) {
-                        if (mediaRule.type == CSSRule.PAGE_RULE) {
-                            let expected = expectedForSelector[mediaRule.selectorText];
+    let expectedForSelector = {
+        "" : "margin: 3cm;",
+        ":first" : "margin-top: 6cm;",
+        ":left" : "color: red;",
+        ":right" : "color: blue;"
+    };
+    let styleSheets = document.styleSheets;
+    for (let i = 0; i < styleSheets.length; i++) {
+        let rules = styleSheets[i].cssRules;
+        for (let rule of rules) {
+            if (rule.type == CSSRule.MEDIA_RULE && rule.conditionText == 'print') {
+                for (let mediaRule of rule.cssRules) {
+                    if (mediaRule.type == CSSRule.PAGE_RULE) {
+                        let expected = expectedForSelector[mediaRule.selectorText];
+                        test(function(){
                             assert_equals(mediaRule.style.cssText, expected, "unexpected @page contents");
-                            delete expectedForSelector[mediaRule.selectorText];
-                        }
+                        }, "unexpected contents for selector ['" + mediaRule.selectorText + "']");
+                        delete expectedForSelector[mediaRule.selectorText];
                     }
                 }
             }
         }
+    }
+    test(function() {
         assert_equals(Object.keys(expectedForSelector).length, 0, "missing @page selectors in @media");
-    }, "test @page inside a @media print rule");
+    });
 
 </script>

--- a/css/css-page/page-rule-declarations-002.html
+++ b/css/css-page/page-rule-declarations-002.html
@@ -23,14 +23,12 @@
 </style>
 <script type="text/javascript">
 
-    test(function(){
-        test_valid_value("page", "auto");
-        test_valid_value("page", "small_page");
-        test_valid_value("page", "large_page");
-        test_invalid_value("page", "auto small_page");
-        test_invalid_value("page", "large_page auto");
-        test_invalid_value("page", "small_page large_page");
-        test_invalid_value("page", "1cm");
-    }, "test page properties in HTML elements");
+    test_valid_value("page", "auto");
+    test_valid_value("page", "small_page");
+    test_valid_value("page", "large_page");
+    test_invalid_value("page", "auto small_page");
+    test_invalid_value("page", "large_page auto");
+    test_invalid_value("page", "small_page large_page");
+    test_invalid_value("page", "1cm");
 
 </script>


### PR DESCRIPTION
Update `css/css-page/page-rule-declarations-*` to use the `test()` method properly to test one feature at a time.

- `page-rule-declarations-000.html` and `page-rule-declarations-001.html` were testing for an excessively large number of features within one `test()` call

- `page-rule-declarations-002.html` was wrapping several tests inside an unnecessary `test()` call.