### PR TITLE
Fix WPT test redirect-mode.any.html

### DIFF
--- a/fetch/api/redirect/redirect-mode.any.js
+++ b/fetch/api/redirect/redirect-mode.any.js
@@ -6,6 +6,7 @@ function testRedirect(origin, redirectStatus, redirectMode, corsMode) {
   var url = new URL("../resources/redirect.py", self.location);
   if (origin === "cross-origin") {
     url.host = get_host_info().REMOTE_HOST;
+    url.port = get_host_info().HTTP_PORT;
   }
 
   var urlParameters = "?redirect_status=" + redirectStatus;


### PR DESCRIPTION
Fix WPT test redirect-mode.any.html by also specifying the server port, this
is needed for WebKit local test runs.