### PR TITLE
Create different _venv directories per python major version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .pytest_cache/
 .tox/
 .virtualenv/
-_venv/
+_venv*/
 _virtualenv/
 
 # Node

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -240,9 +240,9 @@ def test_run_verify_unstable(temp_test):
 @pytest.mark.remote_network
 def test_install_chromedriver():
     if sys.platform == "win32":
-        chromedriver_path = os.path.join(wpt.localpaths.repo_root, "_venv", "Scripts", "chromedriver.exe")
+        chromedriver_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "Scripts", "chromedriver.exe")
     else:
-        chromedriver_path = os.path.join(wpt.localpaths.repo_root, "_venv", "bin", "chromedriver")
+        chromedriver_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "bin", "chromedriver")
     if os.path.exists(chromedriver_path):
         os.unlink(chromedriver_path)
     with pytest.raises(SystemExit) as excinfo:
@@ -258,9 +258,9 @@ def test_install_chromedriver():
                    reason="https://github.com/web-platform-tests/wpt/issues/17074")
 def test_install_firefox():
     if sys.platform == "darwin":
-        fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "nightly", "Firefox Nightly.app")
+        fx_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", "nightly", "Firefox Nightly.app")
     else:
-        fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "nightly", "firefox")
+        fx_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", "nightly", "firefox")
     if os.path.exists(fx_path):
         shutil.rmtree(fx_path)
     with pytest.raises(SystemExit) as excinfo:

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -108,13 +108,15 @@ def create_complete_parser():
 
     return parser
 
+def venv_dir():
+    return "_venv" + str(sys.version_info[0])
 
 def setup_virtualenv(path, skip_venv_setup, props):
     if skip_venv_setup and path is None:
         raise ValueError("Must set --venv when --skip-venv-setup is used")
     should_skip_setup = path is not None and skip_venv_setup
     if path is None:
-        path = os.path.join(wpt_root, "_venv")
+        path = os.path.join(wpt_root, venv_dir())
     venv = virtualenv.Virtualenv(path, should_skip_setup)
     if not should_skip_setup:
         venv.start()


### PR DESCRIPTION
On #22057 we added support for `_venv` generation for different python versions. The whole virtual environment is recreated for each python version (even minor) change though. However we'd like the option to have multiple virtual environments per python major version at least while we support py27 and py3.x.

Fixes #22069 