### PR TITLE
Use assert_implements in test the-input-element/type-change-state.html

### DIFF
--- a/html/semantics/forms/the-input-element/type-change-state.html
+++ b/html/semantics/forms/the-input-element/type-change-state.html
@@ -53,6 +53,11 @@
     // We have no test cases using valid colors other than "#000000".
     return "#000000";
   }
+  function browserSupportsInputTypeOf(inputType) {
+    var inputTest = document.createElement("input");
+    inputTest.type = inputType;
+    return (inputTest.type === inputType);
+  }
 
 
   var types = [
@@ -99,6 +104,8 @@
     for (var j = 0; j < types.length; j++) {
       if (types[i] != types[j]) {
         test(function() {
+          assert_implements(browserSupportsInputTypeOf(types[i].type), "Support for input type " + types[i].type + " is required for this test.");
+          assert_implements(browserSupportsInputTypeOf(types[j].type), "Support for input type " + types[j].type + " is required for this test.");
           var input = document.createElement("input");
           var expected = INITIAL_VALUE;
           input.type = types[i].type;


### PR DESCRIPTION
Use assert_precondition to check if the browser supports both input element types before trying to change the state from one to other.

For example, WebKitGTK and Safari doesn't support several of the input types tested here (like those related to dates). The output of the test its clearer if the precondition its checked before.