### PR TITLE
Remove py38 env as mozbase does not properly support it

### DIFF
--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38
+envlist = py27,py35,py36,py37
 skipsdist=True
 skip_missing_interpreters = False
 

--- a/tools/wptrunner/tox.ini
+++ b/tools/wptrunner/tox.ini
@@ -2,7 +2,7 @@
 xfail_strict=true
 
 [tox]
-envlist = py27-{base,chrome,edge,firefox,ie,opera,safari,sauce,servo,webkit,webkitgtk_minibrowser,epiphany},{py35,py36,py37,py38}-base
+envlist = py27-{base,chrome,edge,firefox,ie,opera,safari,sauce,servo,webkit,webkitgtk_minibrowser,epiphany},{py35,py36,py37}-base
 skip_missing_interpreters = False
 
 [testenv]


### PR DESCRIPTION
Among others the `mozinfo` module is using `platform.dist()` and `platform.linux_distribution()` who were deprecated in python3.5 and effectively removed in python3.8. Reported https://bugzilla.mozilla.org/show_bug.cgi?id=1621226 to track the issue although is already well known by mozbase maintainers who plan to remove that code block once python2.7/python3.5 support is removed from mozbase.