### PR TITLE
Two tests, primarily for "content: contents"

### DIFF
--- a/css/css-content/content-contents-001.html
+++ b/css/css-content/content-contents-001.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+ <head>
+  <title>Test several aspects of generated content and lists</title>
+  <link rel="author" title="Mike Bremford" href="http://bfo.com">
+  <link rel="match" href="reference/content-contents-001-ref.html">
+  <link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property">
+  <link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+  <link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-item-counter">
+  <link rel="help" href="https://drafts.csswg.org/css-display/#the-display-properties">
+  <style>
+  body {
+      counter-reset: cite;
+  }
+  q[cite]::before {
+      content: open-quote contents close-quote;
+  }
+  q {
+      content: none;
+  }
+  q[cite]::after {
+      display: inline list-item;
+      list-style-position: inside;
+      counter-increment: list-item 0 cite 1;
+      content: "(" attr(cite) ")";
+  }
+  q[cite]::after::marker {
+      content: " [" counter(cite) "]";
+      background-color: #ddd;
+  }
+  </style>
+ </head>
+ <body>
+ <ol>
+  <li>
+   Item one contains two quotes:
+   <q cite="A">this</q>
+   and
+   <q cite="B">that</q>
+  </li>
+  <li>
+   Item two contains one quote:
+   <q cite="C">the other</q>
+  </li>
+ </ol>
+
+ <!--
+ This test works as follows:
+
+ 1. The ::before pseudo-element on Q is genreated, and contains
+    the content of the DOM element, surrounded by open and close quotes.
+
+ 2. The <q> element itself has no content between the ::before and ::after
+    pseudo-elements - the DOM textNode has been moved to the ::before.
+
+ 3. The ::after pseudo-element on Q is a list-item, however it does not
+    increment the normal "list-item" counter - it increments the "cite"
+    counter instead, which is in-scope as it was reset on the body. The
+    display is "inline list-item", so it generates an inline box.
+
+ 4. A ::marker is generated inside the ::after pseudo-element, containing
+    the "cite" counter value in its own style. It's list-position is inside,
+    so the ::marker is generated as an inline box.
+
+ 5. Following the marker, the cite attribute is included inside brackets.
+
+ The hypothetical box tree for the second list item looks like this:
+
+ <li>
+  <li::marker>
+   <text>2.</text>
+  </li::marker>
+  <::linebox>
+   <text>Item two contains one quote: </text>
+   <q>
+    <q::before>
+     <text>&lquot;text>
+     <text>the other</text>
+     <text>&rquot;</text>
+    </q::before>
+    <q::after>
+     <q::after::marker>
+      <text>[3]</txt>
+     </q::after::marker>
+     <text>(source 3)</text>
+    </q::after>
+   </q>
+  </::linebox>
+ </li>
+
+ -->
+</body>
+</html>

--- a/css/css-content/content-contents-002.html
+++ b/css/css-content/content-contents-002.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <title>Test the "contents" value of content can be interleaved with generated content</title>
+  <link rel="author" title="Mike Bremford" href="http://bfo.com">
+  <link rel="help" href="https://drafts.csswg.org/css-content-3/#element-content">
+  <meta name="flags" content="Ahem">
+  <meta name="assert" content="The 'contents' value of content can be interleaved with generated content">
+  <link rel="match" href="reference/content-contents-002-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <style>
+  span::before {
+      content: "X" contents "X";
+      color: green;
+  }
+  span {
+      font: 100px Ahem;
+      content: none;
+      color: red;
+  }
+  </style>
+ </head>
+ <body>
+ <p>Test passes if you see a green rectangle and no red.</p>
+ <span>X</span>
+</body>
+</html>

--- a/css/css-content/reference/content-contents-001-ref.html
+++ b/css/css-content/reference/content-contents-001-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <link rel="author" title="Mike Bremford" href="http://bfo.com">
+  <style>
+  span {
+    background-color: #ddd;
+  }
+  </style>
+ </head>
+ <body>
+ <ol>
+  <li>Item one contains two quotes: &ldquo;this&rdquo;<span> [1]</span>(A) and &ldquo;that&rdquo;<span> [2]</span>(B)</li>
+  <li>Item two contains one quote: &ldquo;the other&rdquo;<span> [3]</span>(C)</li>
+ </ol>
+</body>
+</html>

--- a/css/css-content/reference/content-contents-002-ref.html
+++ b/css/css-content/reference/content-contents-002-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Mike Bremford" href="http://bfo.com">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <style>
+  span {
+      font: 100px Ahem;
+      color: green;
+  }
+  </style>
+ </head>
+ <body>
+ <p>Test passes if you see a green rectangle and no red.</p>
+ <span>XXX</span>
+</body>
+</html>


### PR DESCRIPTION
Two tests for the "contents" value of the `content` property.  One testing this in isolation, another when combined with a few other features of generated content and lists in a realistic use-case (which is something that's been requested in the spec, see https://drafts.csswg.org/css-content-3/#issue-bfc60bbc)
