### PR TITLE
Add WPTs for parse error handling in SharedWorkers

### DIFF
--- a/workers/modules/shared-worker-parse-error-failure.html
+++ b/workers/modules/shared-worker-parse-error-failure.html
@@ -2,6 +2,7 @@
 <title>SharedWorker: parse error failure</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="../support/check-error-arguments.js"></script>
 <script>
 
 // Check if module shared worker is supported.
@@ -27,23 +28,12 @@ promise_setup(async () => {
   );
 });
 
-const checkArguments = (args) => {
-  assert_equals(args.a.constructor, Event);
-  assert_true('message' in args.a, 'Event.message');
-  assert_equals(typeof args.a.message, 'string', 'Event.message');
-  assert_equals(args.a.filename, location.href + '/resources/syntax-error.js'),
-                'Event.filename');
-  assert_equals(args.a.lineno, 1, 'Event.lineno');
-  assert_equals(args.b, undefined, 'unexpected second argument to onerror');
-  assert_equals(args.c, undefined, 'unexpected third argument to onerror');
-};
-
 promise_test(async () => {
   const scriptURL = 'resources/syntax-error.js';
   const worker = new SharedWorker(scriptURL, { type: 'module' });
   const args = await new Promise(resolve =>
-      worker.onerror = (a, b, c) => resolve({a, b, c}));
-  checkArguments(args);
+      worker.onerror = (...args) => resolve(args));
+  window.checkErrorArguments(args);
 }, 'Module shared worker construction for script with syntax error should ' +
    'dispatch an event named error.');
 
@@ -51,8 +41,8 @@ promise_test(async () => {
   const scriptURL = 'resources/static-import-syntax-error.js';
   const worker = new SharedWorker(scriptURL, { type: 'module' });
   const args = await new Promise(resolve =>
-      worker.onerror = (a, b, c) => resolve({a, b, c}));
-  checkArguments(args);
+      worker.onerror = (...args) => resolve(args));
+  window.checkErrorArguments(args);
 }, 'Static import on module shared worker for script with syntax error ' +
    'should dispatch an event named error.');
 

--- a/workers/modules/shared-worker-parse-error-failure.html
+++ b/workers/modules/shared-worker-parse-error-failure.html
@@ -20,7 +20,7 @@ promise_setup(async () => {
     worker.port.onmessage = e => {
       resolve(e.data.length == 1 && e.data[0] == 'export-on-load-script.js');
     };
-    worker.onerror = () => reject(false);
+    worker.onerror = () => resolve(false);
   });
   assert_precondition(
     supportsModuleWorkers,

--- a/workers/modules/shared-worker-parse-error-failure.html
+++ b/workers/modules/shared-worker-parse-error-failure.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>SharedWorker: parse error failure</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+// Check if module shared worker is supported.
+// In this test scope, we only use simple non-nested static import as a feature
+// of module shared worker, so we only check if static import is supported.
+//
+// This check is necessary to appropriately test parse error handling because
+// we need to distingusih the parse error invoked by unsupported "import" in
+// the top-level script from the parse error invoked by the statically imported
+// script which is the one we want to check in this test.
+promise_setup(async () => {
+  const scriptURL = 'resources/static-import-worker.js';
+  const worker = new SharedWorker(scriptURL, { type: 'module' });
+  const supportsModuleWorkers = await new Promise((resolve, reject) => {
+    worker.port.onmessage = e => {
+      resolve(e.data.length == 1 && e.data[0] == 'export-on-load-script.js');
+    };
+    worker.onerror = () => reject(false);
+  });
+  assert_precondition(
+    supportsModuleWorkers,
+    "Static import must be supported on module shared worker to run this test."
+  );
+});
+
+const checkArguments = (args) => {
+  assert_equals(args.a.constructor, Event);
+  assert_true('message' in args.a, 'Event.message');
+  assert_equals(typeof args.a.message, 'string', 'Event.message');
+  assert_equals(args.a.filename, location.href + '/resources/syntax-error.js'),
+                'Event.filename');
+  assert_equals(args.a.lineno, 1, 'Event.lineno');
+  assert_equals(args.b, undefined, 'unexpected second argument to onerror');
+  assert_equals(args.c, undefined, 'unexpected third argument to onerror');
+};
+
+promise_test(async () => {
+  const scriptURL = 'resources/syntax-error.js';
+  const worker = new SharedWorker(scriptURL, { type: 'module' });
+  const args = await new Promise(resolve =>
+      worker.onerror = (a, b, c) => resolve({a, b, c}));
+  checkArguments(args);
+}, 'Module shared worker construction for script with syntax error should ' +
+   'dispatch an event named error.');
+
+promise_test(async () => {
+  const scriptURL = 'resources/static-import-syntax-error.js';
+  const worker = new SharedWorker(scriptURL, { type: 'module' });
+  const args = await new Promise(resolve =>
+      worker.onerror = (a, b, c) => resolve({a, b, c}));
+  checkArguments(args);
+}, 'Static import on module shared worker for script with syntax error ' +
+   'should dispatch an event named error.');
+
+</script>

--- a/workers/shared-worker-parse-error-failure.html
+++ b/workers/shared-worker-parse-error-failure.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<title>SharedWorker: parse error failure</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+promise_test(async () => {
+  const scriptURL = 'modules/resources/syntax-error.js';
+  const worker = new SharedWorker(scriptURL, { name: 'classic',
+                                               type: 'classic' });
+  return new Promise(resolve => worker.onerror = resolve);
+}, 'Classic shared worker construction for script with syntax error should ' +
+   'dispatch an ErrorEvent.');
+
+promise_test(async () => {
+  const scriptURL = 'modules/resources/syntax-error.js';
+  const worker = new SharedWorker(scriptURL, { name: 'module',
+                                               type: 'module' });
+  return new Promise(resolve => worker.onerror = resolve);
+}, 'Module shared worker construction for script with syntax error should ' +
+   'dispatch an ErrorEvent.');
+
+promise_test(async () => {
+  const scriptURL = 'modules/resources/static-import-syntax-error.js';
+  const worker = new SharedWorker(scriptURL, { type: 'module' });
+  return new Promise(resolve => worker.onerror = resolve);
+}, 'Static import on module shared worker for script with syntax error ' +
+   'should dispatch an ErrorEvent.');
+
+promise_test(async () => {
+  const scriptURL = 'modules/resources/static-import-worker.js';
+  const worker = new SharedWorker(scriptURL, { type: 'classic' });
+  return new Promise(resolve => worker.onerror = resolve);
+}, 'Static import on classic shared worker should dispatch an ErrorEvent.');
+
+</script>

--- a/workers/shared-worker-parse-error-failure.html
+++ b/workers/shared-worker-parse-error-failure.html
@@ -2,25 +2,15 @@
 <title>SharedWorker: parse error failure</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="./support/check-error-arguments.js"></script>
 <script>
-
-const checkArguments = (args) => {
-  assert_equals(args.a.constructor, Event);
-  assert_true('message' in args.a, 'Event.message');
-  assert_equals(typeof args.a.message, 'string', 'Event.message');
-  assert_equals(args.a.filename, location.href + '/resources/syntax-error.js',
-                'Event.filename');
-  assert_equals(args.a.lineno, 1, 'Event.lineno');
-  assert_equals(args.b, undefined, 'unexpected second argument to onerror');
-  assert_equals(args.c, undefined, 'unexpected third argument to onerror');
-};
 
 promise_test(async () => {
   const scriptURL = 'modules/resources/syntax-error.js';
   const worker = new SharedWorker(scriptURL, { type: 'classic' });
   const args = await new Promise(resolve =>
-      worker.onerror = (a, b, c) => resolve({a, b, c}));
-  checkArguments(args);
+      worker.onerror = (...args) => resolve(args));
+  window.checkErrorArguments(args);
 }, 'Classic shared worker construction for script with syntax error should ' +
    'dispatch an event named error.');
 
@@ -28,8 +18,8 @@ promise_test(async () => {
   const scriptURL = 'modules/resources/static-import-worker.js';
   const worker = new SharedWorker(scriptURL, { type: 'classic' });
   const args = await new Promise(resolve =>
-      worker.onerror = (a, b, c) => resolve({a, b, c}));
-  checkArguments(args);
+      worker.onerror = (...args) => resolve(args));
+  window.checkErrorArguments(args);
 }, 'Static import on classic shared worker should dispatch an event named ' +
    'error.');
 

--- a/workers/shared-worker-parse-error-failure.html
+++ b/workers/shared-worker-parse-error-failure.html
@@ -4,33 +4,33 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 
+const checkArguments = (args) => {
+  assert_equals(args.a.constructor, Event);
+  assert_true('message' in args.a, 'Event.message');
+  assert_equals(typeof args.a.message, 'string', 'Event.message');
+  assert_equals(args.a.filename, location.href + '/resources/syntax-error.js',
+                'Event.filename');
+  assert_equals(args.a.lineno, 1, 'Event.lineno');
+  assert_equals(args.b, undefined, 'unexpected second argument to onerror');
+  assert_equals(args.c, undefined, 'unexpected third argument to onerror');
+};
+
 promise_test(async () => {
   const scriptURL = 'modules/resources/syntax-error.js';
-  const worker = new SharedWorker(scriptURL, { name: 'classic',
-                                               type: 'classic' });
-  return new Promise(resolve => worker.onerror = resolve);
+  const worker = new SharedWorker(scriptURL, { type: 'classic' });
+  const args = await new Promise(resolve =>
+      worker.onerror = (a, b, c) => resolve({a, b, c}));
+  checkArguments(args);
 }, 'Classic shared worker construction for script with syntax error should ' +
-   'dispatch an ErrorEvent.');
-
-promise_test(async () => {
-  const scriptURL = 'modules/resources/syntax-error.js';
-  const worker = new SharedWorker(scriptURL, { name: 'module',
-                                               type: 'module' });
-  return new Promise(resolve => worker.onerror = resolve);
-}, 'Module shared worker construction for script with syntax error should ' +
-   'dispatch an ErrorEvent.');
-
-promise_test(async () => {
-  const scriptURL = 'modules/resources/static-import-syntax-error.js';
-  const worker = new SharedWorker(scriptURL, { type: 'module' });
-  return new Promise(resolve => worker.onerror = resolve);
-}, 'Static import on module shared worker for script with syntax error ' +
-   'should dispatch an ErrorEvent.');
+   'dispatch an event named error.');
 
 promise_test(async () => {
   const scriptURL = 'modules/resources/static-import-worker.js';
   const worker = new SharedWorker(scriptURL, { type: 'classic' });
-  return new Promise(resolve => worker.onerror = resolve);
-}, 'Static import on classic shared worker should dispatch an ErrorEvent.');
+  const args = await new Promise(resolve =>
+      worker.onerror = (a, b, c) => resolve({a, b, c}));
+  checkArguments(args);
+}, 'Static import on classic shared worker should dispatch an event named ' +
+   'error.');
 
 </script>

--- a/workers/support/check-error-arguments.js
+++ b/workers/support/check-error-arguments.js
@@ -1,0 +1,4 @@
+window.checkErrorArguments = args => {
+  assert_equals(args.length, 1);
+  assert_equals(args[0].constructor, Event);
+}

--- a/workers/support/check-error-arguments.js
+++ b/workers/support/check-error-arguments.js
@@ -1,4 +1,4 @@
 window.checkErrorArguments = args => {
   assert_equals(args.length, 1);
   assert_equals(args[0].constructor, Event);
-}
+};


### PR DESCRIPTION
Corresponds to [#5347](https://github.com/whatwg/html/pull/5347)

This pull request adds web-platform-tests to check if parse error events invoked by shared workers are successfully caught from the constructor.