### PR TITLE
COOP: with COOP "same-origin" opener/name should be aligned

### DIFF
--- a/html/cross-origin-opener-policy/iframe-popup-same-origin-to-same-origin.https.html
+++ b/html/cross-origin-opener-policy/iframe-popup-same-origin-to-same-origin.https.html
@@ -8,18 +8,21 @@
 
 <div id=log></div>
 <script>
+// This document has COOP "same-origin". The popup has COOP "same-origin". Therefore there should
+// only be an opener and name if the frameOrigin and popupOrigin are same-origin with this document.
 [
-[SAME_ORIGIN, SAME_ORIGIN, "same-origin", true, true],
-[SAME_SITE, SAME_ORIGIN, "same-origin", false, false],
-[CROSS_ORIGIN, SAME_ORIGIN, "same-origin", false, false],
-[SAME_ORIGIN, SAME_SITE, "same-origin", false, false],
-[SAME_SITE, SAME_SITE, "same-origin", false, false],
-[CROSS_ORIGIN, SAME_SITE, "same-origin", false, false],
-[SAME_ORIGIN, CROSS_ORIGIN, "same-origin", false, false],
-[SAME_SITE, CROSS_ORIGIN, "same-origin", false, false],
-[CROSS_ORIGIN, CROSS_ORIGIN, "same-origin", false, false],
-].forEach( value => {
-    run_coop_test_iframe("same-origin", value[0], value[1], value[2], value[3], value[4]);
+[SAME_ORIGIN, SAME_ORIGIN, true],
+[SAME_SITE, SAME_ORIGIN, false],
+[CROSS_ORIGIN, SAME_ORIGIN, false],
+[SAME_ORIGIN, SAME_SITE, false],
+[SAME_SITE, SAME_SITE, false],
+[CROSS_ORIGIN, SAME_SITE, false],
+[SAME_ORIGIN, CROSS_ORIGIN, false],
+[SAME_SITE, CROSS_ORIGIN, false],
+[CROSS_ORIGIN, CROSS_ORIGIN, false],
+].forEach(([frameOrigin, popupOrigin, popupHasOpenerAndName]) => {
+    const testTitleStart = "same-origin";
+    const popupCOOP = "same-origin";
+    run_coop_test_iframe(testTitleStart, frameOrigin, popupOrigin, popupCOOP, popupHasOpenerAndName, popupHasOpenerAndName);
 });
-
 </script>

--- a/html/cross-origin-opener-policy/iframe-popup-same-origin-to-unsafe-none.https.html
+++ b/html/cross-origin-opener-policy/iframe-popup-same-origin-to-unsafe-none.https.html
@@ -8,18 +8,22 @@
 
 <div id=log></div>
 <script>
+// This document has COOP "same-origin". The popup has no COOP. Therefore there should be no
+// opener or name.
 [
-[SAME_ORIGIN, SAME_ORIGIN, "", false, false],
-[SAME_SITE, SAME_ORIGIN, "", false, true],
-[CROSS_ORIGIN, SAME_ORIGIN, "", false, true],
-[SAME_ORIGIN, SAME_SITE, "", false, false],
-[SAME_SITE, SAME_SITE, "", false, true],
-[CROSS_ORIGIN, SAME_SITE, "", false, true],
-[SAME_ORIGIN, CROSS_ORIGIN, "", false, false],
-[SAME_SITE, CROSS_ORIGIN, "", false, true],
-[CROSS_ORIGIN, CROSS_ORIGIN, "", false, true],
-].forEach( value => {
-    run_coop_test_iframe("same-origin", value[0], value[1], value[2], value[3], value[4]);
+[SAME_ORIGIN, SAME_ORIGIN],
+[SAME_SITE, SAME_ORIGIN],
+[CROSS_ORIGIN, SAME_ORIGIN],
+[SAME_ORIGIN, SAME_SITE],
+[SAME_SITE, SAME_SITE],
+[CROSS_ORIGIN, SAME_SITE],
+[SAME_ORIGIN, CROSS_ORIGIN],
+[SAME_SITE, CROSS_ORIGIN],
+[CROSS_ORIGIN, CROSS_ORIGIN],
+].forEach(([frameOrigin, popupOrigin]) => {
+    const testTitleStart = "same-origin";
+    const popupCOOP = "";
+    const popupHasOpenerAndName = false;
+    run_coop_test_iframe(testTitleStart, frameOrigin, popupOrigin, popupCOOP, popupHasOpenerAndName, popupHasOpenerAndName);
 });
-
 </script>


### PR DESCRIPTION
The two tests had inconsistent expectations as discovered by Valentin. When COOP is involved and COOP causes noopener to be set, we should simultaneously not copy over any name.

Unfortunately this was not clearly reflected by the specification, but is the intended behavior as the fewer unintentended communication channels the better.