### PR TITLE
Firefox and Safari print a harness error message when running this te…

### DIFF
--- a/web-animations/timing-model/animations/pausing-an-animation.html
+++ b/web-animations/timing-model/animations/pausing-an-animation.html
@@ -94,7 +94,7 @@ promise_test(async t => {
 
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
 
-  const originalReadyPromise = animation.ready;
+  const originalReadyPromise = animation.ready.catch(() => {});
   animation.cancel();
   assert_equals(animation.startTime, null);
   assert_equals(animation.currentTime, null);


### PR DESCRIPTION
…st due to an unhandled rejected promise, even though both browsers pass all the assertions. In order to have cleaner test output, we set a no-op rejection handler for the `animation.ready` promise before calling calling `animation.cancel()`.