### PR TITLE
The WebKit EWS (early warning system) bots sometimes print a harness …

### DIFF
--- a/web-animations/timing-model/animations/finishing-an-animation.html
+++ b/web-animations/timing-model/animations/finishing-an-animation.html
@@ -304,7 +304,7 @@ promise_test(async t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
   await animation.ready;
 
-  const originalFinishPromise = animation.finished;
+  const originalFinishPromise = animation.finished.catch(() => {});
 
   animation.cancel();
   assert_equals(animation.startTime, null);


### PR DESCRIPTION
…error message when running this test due to an unhandled rejected promise, even though all the assertions pass. In order to have cleaner test output, we set a no-op rejection handler for the animation.ready promise before calling animation.cancel().