### PR TITLE
Correctly test document.all quirks

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2746,10 +2746,19 @@ IdlInterface.prototype.test_object = function(desc)
         exception = e;
     }
 
-    var expected_typeof =
-        this.members.some(function(member) { return member.legacycaller; })
-        ? "function"
-        : "object";
+    var expected_typeof;
+    if (this.name == "HTMLAllCollection")
+    {
+        // Willful violation of JS.  :(
+        expected_typeof = "undefined";
+    } else if (this.members.some(function(member) { return member.legacycaller; }))
+    {
+        expected_typeof = "function";
+    }
+    else
+    {
+        expected_typeof = "object";
+    }
 
     this.test_primary_interface_of(desc, obj, exception, expected_typeof);
 
@@ -2911,7 +2920,15 @@ IdlInterface.prototype.test_interface_of = function(desc, obj, exception, expect
                         }
                         if (!thrown)
                         {
-                            this.array.assert_type_is(property, member.idlType);
+                            if (this.name == "Document" && member.name == "all")
+                            {
+                                // Willful violation of JS :(
+                                assert_equals(typeof property, "undefined");
+                            }
+                            else
+                            {
+                                this.array.assert_type_is(property, member.idlType);
+                            }
                         }
                     }
                     if (member.type == "operation")

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1483,7 +1483,9 @@ policies and contribution forms [3].
     function _assert_inherits(name) {
         return function (object, property_name, description)
         {
-            assert(typeof object === "object" || typeof object === "function",
+            assert(typeof object === "object" || typeof object === "function" ||
+                   // Willful violation of JS.  :(
+                   String(object) === "[object HTMLAllCollection]",
                    name, description,
                    "provided value is not an object");
 


### PR DESCRIPTION
For legacy compatibility, this property is specified with some willful
violations of JS: <https://html.spec.whatwg.org/#dom-document-all>.
Prior to this commit, idlharness wasn't accounting for these, so
html/dom/interfaces.html was wrong for document.all/HTMLAllCollection
tests.

It's a bit ugly to include this directly in idlharness.js and
testharness.js, but it's the cleanest solution I can think of.

Fixes #4207.