### PR TITLE
Re-orient script block pattern

### DIFF
--- a/mathml/relations/html5-tree/tabindex-001.html
+++ b/mathml/relations/html5-tree/tabindex-001.html
@@ -8,30 +8,6 @@
 <meta name="assert" content="Verify default values for the tabIndex attribute">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
-  window.addEventListener("load", function() {
-      test(() => {
-          const mrow = document.getElementById('mrow');
-          assert_equals(mrow.tabIndex, 0, "no attribute");
-          mrow.setAttribute("tabindex", "invalid");
-          assert_equals(mrow.getAttribute("tabindex"), "invalid");
-          assert_equals(mrow.tabIndex, 0, "invalid");
-          mrow.setAttribute("tabindex", "9999999999");
-          assert_equals(mrow.getAttribute("tabindex"), "9999999999");
-          assert_equals(mrow.tabIndex, 0, "too large integer");
-      }, "default and invalid values on mrow");
-      test(() => {
-          const mrowLink = document.getElementById('mrow-link');
-          assert_equals(mrow.tabIndex, 0, "no attribute");
-          mrow.setAttribute("tabindex", "invalid");
-          assert_equals(mrow.getAttribute("tabindex"), "invalid");
-          assert_equals(mrow.tabIndex, 0, "invalid");
-          mrow.setAttribute("tabindex", "9999999999");
-          assert_equals(mrow.getAttribute("tabindex"), "9999999999");
-          assert_equals(mrow.tabIndex, 0, "too large integer");
-      }, "default and invalid values on MathML link");
-  });
-</script>
 </head>
 <body>
   <div id="log"></div>
@@ -39,5 +15,27 @@
     <mrow id="mrow" onfocus="alert('fail')"></mrow>
     <mrow id="mrow-link" href="javascript:alert('fail')" onfocus="alert('fail')"></mrow>
   </math>
+  <script>
+        test(() => {
+            const mrow = document.getElementById('mrow');
+            assert_equals(mrow.tabIndex, 0, "no attribute");
+            mrow.setAttribute("tabindex", "invalid");
+            assert_equals(mrow.getAttribute("tabindex"), "invalid");
+            assert_equals(mrow.tabIndex, 0, "invalid");
+            mrow.setAttribute("tabindex", "9999999999");
+            assert_equals(mrow.getAttribute("tabindex"), "9999999999");
+            assert_equals(mrow.tabIndex, 0, "too large integer");
+        }, "default and invalid values on mrow");
+        test(() => {
+            const mrowLink = document.getElementById('mrow-link');
+            assert_equals(mrow.tabIndex, 0, "no attribute");
+            mrow.setAttribute("tabindex", "invalid");
+            assert_equals(mrow.getAttribute("tabindex"), "invalid");
+            assert_equals(mrow.tabIndex, 0, "invalid");
+            mrow.setAttribute("tabindex", "9999999999");
+            assert_equals(mrow.getAttribute("tabindex"), "9999999999");
+            assert_equals(mrow.tabIndex, 0, "too large integer");
+        }, "default and invalid values on MathML link");
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Re-orient the script to the end of the page.  This is common practice, even most of the tests I see use this pattern to avoid complexities of async.  It seems you can wind up with racey false positives the other way that don't actually complete too... I want to shift this next to generate tests for the elements and I can't have it be racing too or it gets quite complex, it seems.