### PR TITLE
Fix ci_resources_unittest

### DIFF
--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -414,7 +414,7 @@
     {
       "status_string": "FAIL",
       "name": "Test throw DOM exception expected to fail",
-      "message": "assert_throws_dom: function \"function () {a.appendChild(b)}\" threw object \"HierarchyRequestError: Node cannot be inserted at the specified point in the hierarchy\" that is not a DOMException NOT_FOUND_ERR: property \"code\" is equal to 3, expected 8",
+      "message": "assert_throws_dom: function \"function () {a.appendChild(b)}\" threw object \"HierarchyRequestError: Node.appendChild: Cannot add children to a Text\" that is not a DOMException NOT_FOUND_ERR: property \"code\" is equal to 3, expected 8",
       "properties": {}
     },
     {


### PR DESCRIPTION
Firefox has changed an error message recently, and the test is so
verbose that any change in output will cause failures.

This is blocking anything that touches `resources` from merging.