### PR TITLE
Collect code coverage for code in tools/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .virtualenv/
 _venv*/
 _virtualenv/
+html-*-cov/
 
 # Node
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 .virtualenv/
 _venv*/
 _virtualenv/
-html-*-cov/
 
 # Node
 node_modules/

--- a/tools/.coveragerc
+++ b/tools/.coveragerc
@@ -10,6 +10,9 @@ omit =
   webdriver/*
   */site-packages/*
   */lib_pypy/*
+  wpt/*
+  wptrunner/*
+  */tests/*
 
 [paths]
 html5lib =

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,{py27,py35,py36,py37,py38}-flake8,{py35,py36,py37,py38}-mypy,{py27,py35,py36,py37,py38}-cov
+envlist = py27,py35,py36,py37,py38,{py27,py35,py36,py37,py38}-flake8,{py35,py36,py37,py38}-mypy
 skipsdist=True
 skip_missing_interpreters = False
 
 [testenv]
 deps =
   pytest
-  {py27,py35,py36,py37,py38}-cov: pytest-cov
+  pytest-cov
   mock
   hypothesis
   requests
@@ -15,7 +15,7 @@ deps =
   json-e
   jsonschema
 
-commands = pytest {posargs}
+commands = pytest --cov=tools --cov-report=term {posargs}
 
 passenv =
   HYPOTHESIS_PROFILE
@@ -65,21 +65,3 @@ deps = -rrequirements_mypy.txt
 changedir = {toxinidir}/..
 commands =
   mypy --config-file={toxinidir}/mypy.ini --no-incremental --py2 -p tools.manifest -p tools.lint -p tools.gitignore
-
-[testenv:py27-cov]
-commands =
-  coverage erase
-  pytest --cov=tools --cov-report=html:html-{envname} --cov-config=.coveragerc {posargs}
-  coverage html
-
-[testenv:py35-cov]
-commands = {[testenv:py27-cov]commands}
-
-[testenv:py36-cov]
-commands = {[testenv:py27-cov]commands}
-
-[testenv:py37-cov]
-commands = {[testenv:py27-cov]commands}
-
-[testenv:py38-cov]
-commands = {[testenv:py27-cov]commands}

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,{py27,py35,py36,py37,py38}-flake8,{py35,py36,py37,py38}-mypy
+envlist = py27,py35,py36,py37,py38,{py27,py35,py36,py37,py38}-flake8,{py35,py36,py37,py38}-mypy,{py27,py35,py36,py37,py38}-cov
 skipsdist=True
 skip_missing_interpreters = False
 
 [testenv]
 deps =
   pytest
-  pytest-cov
+  {py27,py35,py36,py37,py38}-cov: pytest-cov
   mock
   hypothesis
   requests
@@ -65,3 +65,21 @@ deps = -rrequirements_mypy.txt
 changedir = {toxinidir}/..
 commands =
   mypy --config-file={toxinidir}/mypy.ini --no-incremental --py2 -p tools.manifest -p tools.lint -p tools.gitignore
+
+[testenv:py27-cov]
+commands =
+  coverage erase
+  pytest --cov=tools --cov-report=html:html-{envname} --cov-config=.coveragerc {posargs}
+  coverage html
+
+[testenv:py35-cov]
+commands = {[testenv:py27-cov]commands}
+
+[testenv:py36-cov]
+commands = {[testenv:py27-cov]commands}
+
+[testenv:py37-cov]
+commands = {[testenv:py27-cov]commands}
+
+[testenv:py38-cov]
+commands = {[testenv:py27-cov]commands}


### PR DESCRIPTION
Added separate targets for each python environment. In addition, we're removing data from wpt/, wpttestrunner/ as they have separate tox.ini files.

Test code is also not included in the coverage reports.