### PR TITLE
Fix Windows hosts setup command

### DIFF
--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -76,8 +76,8 @@ On Linux, macOS or other UNIX-like system:
 
 And on Windows (this must be run in a PowerShell session with Administrator privileges):
 
-```bash
-python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -Encoding ascii -Append
+```pwsh
+python wpt make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
 ```
 
 If you are behind a proxy, you also need to make sure the domains above are

--- a/docs/running-tests/from-local-system.md
+++ b/docs/running-tests/from-local-system.md
@@ -76,7 +76,7 @@ On Linux, macOS or other UNIX-like system:
 
 And on Windows (this must be run in a PowerShell session with Administrator privileges):
 
-```pwsh
+```
 python wpt make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
 ```
 


### PR DESCRIPTION
`%SystemRoot%` is a `cmd` way to get an environment variable, and its `pwsh` counterpart is `$env:SystemRoot`.