### PR TITLE
[css-cascade] Test "all" shorthand with "color" property

### DIFF
--- a/css/css-cascade/all-prop-inherit-color.html
+++ b/css/css-cascade/all-prop-inherit-color.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Cascade: "color" property preceded by "all: initial"</title>
+  <link rel="help" href="https://www.w3.org/TR/css-cascade-4/#all-shorthand">
+  <link rel="match" href="reference/ref-green-text.html">
+  <meta name="flags" content="">
+  <meta name="assert" content="Own 'color', preceded by 'all: inherit', overrides inherited 'color'.">
+  <style>
+    .outer {
+      color: red;
+    }
+
+    .inner {
+      all: inherit;
+      color: green;
+    }
+  </style>
+</head>
+<body>
+  <p class="outer"><span class="inner">Test passes if this text is green.</span></p>
+</body>
+</html>

--- a/css/css-cascade/all-prop-initial-color.html
+++ b/css/css-cascade/all-prop-initial-color.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Cascade: "color" property preceded by "all: initial"</title>
+  <link rel="help" href="https://www.w3.org/TR/css-cascade-4/#all-shorthand">
+  <link rel="match" href="reference/ref-green-text.html">
+  <meta name="flags" content="">
+  <meta name="assert" content="Own 'color', preceded by 'all: initial', overrides inherited 'color'.">
+  <style>
+    .outer {
+      color: red;
+    }
+
+    .inner {
+      all: initial;
+      color: green;
+    }
+  </style>
+</head>
+<body>
+  <p class="outer"><span class="inner">Test passes if this text is green.</span></p>
+</body>
+</html>

--- a/css/css-cascade/all-prop-revert-color.html
+++ b/css/css-cascade/all-prop-revert-color.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Cascade: "color" property preceded by "all: revert"</title>
+  <link rel="help" href="https://www.w3.org/TR/css-cascade-4/#all-shorthand">
+  <link rel="match" href="reference/ref-green-text.html">
+  <meta name="flags" content="">
+  <meta name="assert" content="Own 'color', preceded by 'all: revert', overrides inherited 'color'.">
+  <style>
+    .outer {
+      color: red;
+    }
+
+    .inner {
+      all: revert;
+      color: green;
+    }
+  </style>
+</head>
+<body>
+  <p class="outer"><span class="inner">Test passes if this text is green.</span></p>
+</body>
+</html>

--- a/css/css-cascade/all-prop-unset-color.html
+++ b/css/css-cascade/all-prop-unset-color.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Cascade: "color" property preceded by "all: unset"</title>
+  <link rel="help" href="https://www.w3.org/TR/css-cascade-4/#all-shorthand">
+  <link rel="match" href="reference/ref-green-text.html">
+  <meta name="flags" content="">
+  <meta name="assert" content="Own 'color', preceded by 'all: unset', overrides inherited 'color'.">
+  <style>
+    .outer {
+      color: red;
+    }
+
+    .inner {
+      all: unset;
+      color: green;
+    }
+  </style>
+</head>
+<body>
+  <p class="outer"><span class="inner">Test passes if this text is green.</span></p>
+</body>
+</html>

--- a/css/css-cascade/reference/ref-green-text.html
+++ b/css/css-cascade/reference/ref-green-text.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Green text reference</title>
+<style>
+  .test { color: green; }
+</style>
+<body>
+  <p class="test">Test passes if this text is green.</p>
+</body>


### PR DESCRIPTION
Spec: [CSS Cascading and Inheritance Level 4](https://www.w3.org/TR/css-cascade-4/#all-shorthand).

Blink bug: [The CSS `color` property doesn't work when used with `all:unset` or `all:inherit`](https://bugs.chromium.org/p/chromium/issues/detail?id=420781).
WebKit bug: [`all: unset` prevents `color` from being set](https://bugs.webkit.org/show_bug.cgi?id=158782).