### PR TITLE
service worker: Fix fetch-event-handled-worker.js

### DIFF
--- a/service-workers/service-worker/fetch-event-handled.https.html
+++ b/service-workers/service-worker/fetch-event-handled.https.html
@@ -30,14 +30,21 @@ promise_test(async (t) => {
       await service_worker_unregister_and_register(t, script, scope);
   worker = registration.installing;
   await wait_for_state(t, worker, 'activated');
-  frame = await with_iframe(scope);
 }, 'global setup');
+
+promise_test(async (t) => {
+  frame = await with_iframe(scope);
+  const message = await wait_for_message_from_worker();
+  assert_equals(message, 'RESOLVED');
+}, 'FetchEvent.handled should resolve when respondWith() is not called for a' +
+    ' navigation request');
 
 promise_test(async (t) => {
   frame.contentWindow.fetch('dummy.txt?respondWith-not-called');
   const message = await wait_for_message_from_worker();
   assert_equals(message, 'RESOLVED');
-}, 'FetchEvent.handled should resolve when respondWith() is not called');
+}, 'FetchEvent.handled should resolve when respondWith() is not called for a' +
+    ' sub-resource request');
 
 promise_test(async (t) => {
   frame.contentWindow.fetch(

--- a/service-workers/service-worker/resources/fetch-event-handled-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-handled-worker.js
@@ -9,7 +9,9 @@ function send_message_to_client(message, clientId) {
 }
 
 self.addEventListener('fetch', function(event) {
-  const clientId = event.clientId;
+  const clientId = (event.request.mode === 'navigate') ?
+      event.resultingClientId : event.clientId;
+
   try {
     event.handled.then(() => {
       send_message_to_client('RESOLVED', clientId);


### PR DESCRIPTION
In the fetch event handler, the client of the fetch event for
simple.html is undefined as this request is made by
fetch-event-handled.https.html which is not controlled.

This change makes sure messages are only sent to valid clients.