### PR TITLE
Test if CORS-enable module workers can be instantiated

### DIFF
--- a/workers/modules/resources/import-test-cases.js
+++ b/workers/modules/resources/import-test-cases.js
@@ -45,5 +45,10 @@ const testCases = [
         scriptURL: '/workers/modules/resources/eval-dynamic-import-worker.js',
         expectation: ['export-on-load-script.js'],
         description: 'eval(import()).'
+    },
+    {
+        scriptURL: `http://www1.${location.host}/workers/modules/resources/post-message-on-load-cors-worker.js`,
+        expectation: ['LOADED'],
+        description: 'Cross-origin.'
     }
 ];

--- a/workers/modules/resources/post-message-on-load-cors-worker.headers
+++ b/workers/modules/resources/post-message-on-load-cors-worker.headers
@@ -1,0 +1,1 @@
+Access-Control-Allow-Origin: *

--- a/workers/modules/resources/post-message-on-load-cors-worker.js
+++ b/workers/modules/resources/post-message-on-load-cors-worker.js
@@ -1,0 +1,10 @@
+if ('DedicatedWorkerGlobalScope' in self &&
+    self instanceof DedicatedWorkerGlobalScope) {
+  postMessage(['LOADED']);
+} else if (
+    'SharedWorkerGlobalScope' in self &&
+    self instanceof SharedWorkerGlobalScope) {
+  self.onconnect = e => {
+    e.ports[0].postMessage(['LOADED']);
+  };
+}


### PR DESCRIPTION
The [spec] reads:

> Note that such module-based workers follow different restrictions regarding cross-origin content, compared to classic workers. Unlike classic workers, module workers can be instantiated using a cross-origin script, as long as that script is exposed using the CORS protocol. Additionally, the importScripts() method will automatically fail inside module workers; the JavaScript import statement is generally a better choice.

AFAICT, there was no test for this and Chrome is currently _not_ spec compliant in that it throws when you try to instantiate a module Worker with a cross-origin script. (Bug to be filed.)

[spec]: https://html.spec.whatwg.org/multipage/workers.html#module-worker-example

(cc @jakearchibald @developit)