### PR TITLE
introduce loop over each mathml element

### DIFF
--- a/mathml/relations/html5-tree/tabindex-001.html
+++ b/mathml/relations/html5-tree/tabindex-001.html
@@ -6,36 +6,53 @@
 <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#css-styling">
 <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-top-level-math-element">
 <meta name="assert" content="Verify default values for the tabIndex attribute">
+
+<script src="/mathml/support/mathml-fragments.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
-  <div id="log"></div>
+  <div id="log"></div>a
   <math>
-    <mrow id="mrow" onfocus="alert('fail')"></mrow>
-    <mrow id="mrow-link" href="javascript:alert('fail')" onfocus="alert('fail')"></mrow>
   </math>
   <script>
+    const htmlLinkableElements = 
+      new Set([
+        'mi', 'mo', 'mn', 'ms', 'mtext', 'mrow'
+      ]);
+
+    Object.keys(MathMLFragments).forEach(elName => {
+        const mathEl = document.querySelector('math');
+
+        mathEl.innerHTML = `
+        <${elName} id="el" onfocus="alert('fail')"></${elName}>
+        <${elName} id="el-link" href="javascript:alert('fail')" onfocus="alert('fail')"></${elName}>
+        `;
+
+        const el = mathEl.querySelector('#el');
+        const elLink = mathEl.querySelector('#el-link');
+      
+        const expectedDefault = (htmlLinkableElements.has(elName)) ? 0 : -1;
+
         test(() => {
-            const mrow = document.getElementById('mrow');
-            assert_equals(mrow.tabIndex, 0, "no attribute");
-            mrow.setAttribute("tabindex", "invalid");
-            assert_equals(mrow.getAttribute("tabindex"), "invalid");
-            assert_equals(mrow.tabIndex, 0, "invalid");
-            mrow.setAttribute("tabindex", "9999999999");
-            assert_equals(mrow.getAttribute("tabindex"), "9999999999");
-            assert_equals(mrow.tabIndex, 0, "too large integer");
-        }, "default and invalid values on mrow");
+            assert_equals(el.tabIndex, expectedDefault, "no attribute");
+            el.setAttribute("tabindex", "invalid");
+            assert_equals(el.getAttribute("tabindex"), "invalid");
+            assert_equals(el.tabIndex, expectedDefault, "invalid");
+            el.setAttribute("tabindex", "9999999999");
+            assert_equals(el.getAttribute("tabindex"), "9999999999");
+            assert_equals(el.tabIndex, expectedDefault, "too large integer");
+        }, `default and invalid values for ${elName} without href`);
         test(() => {
-            const mrowLink = document.getElementById('mrow-link');
-            assert_equals(mrow.tabIndex, 0, "no attribute");
-            mrow.setAttribute("tabindex", "invalid");
-            assert_equals(mrow.getAttribute("tabindex"), "invalid");
-            assert_equals(mrow.tabIndex, 0, "invalid");
-            mrow.setAttribute("tabindex", "9999999999");
-            assert_equals(mrow.getAttribute("tabindex"), "9999999999");
-            assert_equals(mrow.tabIndex, 0, "too large integer");
-        }, "default and invalid values on MathML link");
+            assert_equals(elLink.tabIndex, expectedDefault, "no attribute");
+            elLink.setAttribute("tabindex", "invalid");
+            assert_equals(elLink.getAttribute("tabindex"), "invalid");
+            assert_equals(elLink.tabIndex, expectedDefault, "invalid");
+            elLink.setAttribute("tabindex", "9999999999");
+            assert_equals(elLink.getAttribute("tabindex"), "9999999999");
+            assert_equals(elLink.tabIndex, expectedDefault, "too large integer");
+        }, `default and invalid values for ${elName} with href`);
+    });
   </script>
 </body>
 </html>

--- a/mathml/relations/html5-tree/tabindex-001.html
+++ b/mathml/relations/html5-tree/tabindex-001.html
@@ -12,7 +12,6 @@
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
-  <div id="log"></div>a
   <math>
   </math>
   <script>

--- a/mathml/relations/html5-tree/tabindex-001.html
+++ b/mathml/relations/html5-tree/tabindex-001.html
@@ -12,10 +12,11 @@
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
+  <div id="log"></div>
   <math>
   </math>
   <script>
-    const htmlLinkableElements = 
+    const htmlLinkableElements =
       new Set([
         'mi', 'mo', 'mn', 'ms', 'mtext', 'mrow'
       ]);
@@ -30,7 +31,7 @@
 
         const el = mathEl.querySelector('#el');
         const elLink = mathEl.querySelector('#el-link');
-      
+
         const expectedDefault = (htmlLinkableElements.has(elName)) ? 0 : -1;
 
         test(() => {


### PR DESCRIPTION
Adds a loop over the MathML elements which checks the same stuff we were checking for mrow, but variable expectation based on whether it is a linkable element