### PR TITLE
[css-text] Update line-break-{normal,strict}-015.xht for ICU 66 line breaking rules

### DIFF
--- a/css/css-text/line-break/line-break-normal-015.xht
+++ b/css/css-text/line-break/line-break-normal-015.xht
@@ -50,7 +50,7 @@
 				<span>サンプルサンプル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -59,7 +59,7 @@
 				<span>サンプルサンプル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/line-break-strict-015.xht
+++ b/css/css-text/line-break/line-break-strict-015.xht
@@ -50,7 +50,7 @@
 				<span>サンプルサンプル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
@@ -59,7 +59,7 @@
 				<span>サンプルサンプル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-normal-015-ref.xht
+++ b/css/css-text/line-break/reference/line-break-normal-015-ref.xht
@@ -41,19 +41,19 @@
 		<div class="wrapper">
 			<!-- inseparable characters TWO DOT LEADER -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>

--- a/css/css-text/line-break/reference/line-break-strict-015-ref.xht
+++ b/css/css-text/line-break/reference/line-break-strict-015-ref.xht
@@ -41,19 +41,19 @@
 		<div class="wrapper">
 			<!-- inseparable characters TWO DOT LEADER -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2025;&#x2025;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2025;&#x2025;</span>サンプル文</span>
 			</p>
 		</div>
 		<div class="wrapper">
 			<!-- inseparable characters HORIZONTAL ELLIPSIS -->
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 			<p class="control" lang="ja">
-				<span>サンプルサンプル。<br /><span class="target">&#x2026;&#x2026;</span>サンプル文</span>
+				<span>サンプルサンプ<br />ル。<span class="target">&#x2026;&#x2026;</span>サンプル文</span>
 			</p>
 		</div>
 	</body>


### PR DESCRIPTION
ICU 66 says that, in `ja@lb=normal` and `ja@lb=strict` mode, there are no line break opportunities between the following code points:

- U+30EB and U+3002
- U+3002 and U+2025
- U+2025 and U+2025