### PR TITLE
css-grid: Use documents.font.ready() for tests with Ahem font.

### DIFF
--- a/css/css-grid/abspos/absolute-positioning-definite-sizes-001.html
+++ b/css/css-grid/abspos/absolute-positioning-definite-sizes-001.html
@@ -35,8 +35,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/abspos/absolute-positioning-grid-container-containing-block-001.html
+++ b/css/css-grid/abspos/absolute-positioning-grid-container-containing-block-001.html
@@ -114,7 +114,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.html
+++ b/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.html
@@ -36,7 +36,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.container')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.container'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/abspos/grid-positioned-items-implicit-grid-001.html
+++ b/css/css-grid/abspos/grid-positioned-items-implicit-grid-001.html
@@ -32,8 +32,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/abspos/grid-positioned-items-implicit-grid-line-001.html
+++ b/css/css-grid/abspos/grid-positioned-items-implicit-grid-line-001.html
@@ -53,8 +53,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/abspos/grid-positioned-items-unknown-named-grid-line-001.html
+++ b/css/css-grid/abspos/grid-positioned-items-unknown-named-grid-line-001.html
@@ -46,8 +46,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/abspos/grid-sizing-positioned-items-001.html
+++ b/css/css-grid/abspos/grid-sizing-positioned-items-001.html
@@ -57,8 +57,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/abspos/positioned-grid-items-should-not-create-implicit-tracks-001.html
+++ b/css/css-grid/abspos/positioned-grid-items-should-not-create-implicit-tracks-001.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/abspos/positioned-grid-items-should-not-take-up-space-001.html
+++ b/css/css-grid/abspos/positioned-grid-items-should-not-take-up-space-001.html
@@ -35,8 +35,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/alignment/grid-align-content-distribution-vertical-lr.html
+++ b/css/css-grid/alignment/grid-align-content-distribution-vertical-lr.html
@@ -44,8 +44,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that the align-content property is applied correctly when using content-distribution values in vertical-lr writing mode.</p>
 

--- a/css/css-grid/alignment/grid-align-content-distribution-vertical-rl.html
+++ b/css/css-grid/alignment/grid-align-content-distribution-vertical-rl.html
@@ -44,8 +44,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that the align-content property is applied correctly when using content-distribution values for vertical-rl mode.</p>
 

--- a/css/css-grid/alignment/grid-align-content-distribution.html
+++ b/css/css-grid/alignment/grid-align-content-distribution.html
@@ -39,8 +39,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that the align-content property is applied correctly when using content-distribution values.</p>
 

--- a/css/css-grid/alignment/grid-align-content-vertical-lr.html
+++ b/css/css-grid/alignment/grid-align-content-vertical-lr.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div style="position: relative">
     <p>direction: LTR | align-content: 'center'</p>

--- a/css/css-grid/alignment/grid-align-content-vertical-rl.html
+++ b/css/css-grid/alignment/grid-align-content-vertical-rl.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div style="position: relative">
     <p>direction: LTR | align-content: 'center'</p>

--- a/css/css-grid/alignment/grid-align-content.html
+++ b/css/css-grid/alignment/grid-align-content.html
@@ -36,8 +36,11 @@ body {
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div style="position: relative">
     <p>direction: LTR | align-content: 'center'</p>

--- a/css/css-grid/alignment/grid-align-justify-margin-border-padding-vertical-lr.html
+++ b/css/css-grid/alignment/grid-align-justify-margin-border-padding-vertical-lr.html
@@ -33,8 +33,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that the 'margin', 'border' and 'padding' properties are applied together correctly for 'align' and 'justify' properties on vertical-LR grids.</p>
 

--- a/css/css-grid/alignment/grid-align-justify-margin-border-padding-vertical-rl.html
+++ b/css/css-grid/alignment/grid-align-justify-margin-border-padding-vertical-rl.html
@@ -33,8 +33,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that the 'margin', 'border' and 'padding' properties are applied together correctly for 'align' and 'justify' properties on vertical-RL grids.</p>
 

--- a/css/css-grid/alignment/grid-align-justify-margin-border-padding.html
+++ b/css/css-grid/alignment/grid-align-justify-margin-border-padding.html
@@ -32,8 +32,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that the 'margin', 'border' and 'padding' properties are applied together correctly for 'align' and 'justify' properties.</p>
 

--- a/css/css-grid/alignment/grid-align-justify-overflow.html
+++ b/css/css-grid/alignment/grid-align-justify-overflow.html
@@ -34,8 +34,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that the 'overflow' keyword is applied correctly for 'align' and 'justify' properties.</p>
 

--- a/css/css-grid/alignment/grid-align-justify-stretch-with-orthogonal-flows.html
+++ b/css/css-grid/alignment/grid-align-justify-stretch-with-orthogonal-flows.html
@@ -41,8 +41,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that stretching alignment works as expected with orthogonal flows.</p>
 

--- a/css/css-grid/alignment/grid-align-justify-stretch.html
+++ b/css/css-grid/alignment/grid-align-justify-stretch.html
@@ -39,8 +39,11 @@ body {
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div style="position: relative">
     <div class="grid fit-content" data-expected-width="200" data-expected-height="400">

--- a/css/css-grid/alignment/grid-align-stretching-replaced-items.html
+++ b/css/css-grid/alignment/grid-align-stretching-replaced-items.html
@@ -29,8 +29,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
     <p>This test checks that the alignment properties align-self and justify-self apply the 'stretch' value correctly on replaced elements.</p>
 

--- a/css/css-grid/alignment/grid-align.html
+++ b/css/css-grid/alignment/grid-align.html
@@ -35,8 +35,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div style="position: relative">
     <div class="grid fit-content" data-expected-width="200" data-expected-height="400">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-001.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-001.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-002.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-002.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-003.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-003.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-004.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-004.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-005.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-005.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-006.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-006.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-007.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-007.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-008.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-008.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 80);
   grid.style.alignItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-009.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-009.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-010.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-010.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 80);
   grid.style.alignItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-width="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-011.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-011.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-width="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-012.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-012.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-width="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-013.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-013.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-width="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-014.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-014.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-width="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-015.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-015.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-width="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-016.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-016.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-width="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-017.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-017.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-width="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-018.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-018.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 80);
   grid.style.alignItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-width="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-019.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-019.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-020.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-020.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 120);
   grid.style.justifyItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-021.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-021.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.alignItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-022.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-022.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-023.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-023.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 120);
   grid.style.justifyItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-024.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-024.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XX X<br>X XXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-025.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-025.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 120);
   grid.style.justifyItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XXXXXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-026.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-026.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 80);
   grid.style.justifyItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XXXXXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-027.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-027.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 120);
   grid.style.justifyItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XXXXXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-028.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-028.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 80);
   grid.style.justifyItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <div data-expected-height="100" id="item">XXXXXX<br>X<br>XX XXX</div>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-029.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-029.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-height="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-030.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-030.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-height="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-031.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-031.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-height="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-032.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-032.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-width="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-033.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-033.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "normal";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-height="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-034.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-034.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-height="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-035.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-035.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "stretch";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-height="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-036.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-036.html
@@ -29,6 +29,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 80);
   grid.style.justifyItems = "start";
@@ -36,7 +37,7 @@ function runTest() {
   done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
 <div class="grid" id="grid">
   <img data-expected-height="100" id="item" src="support/100x100-green.png"></img>
 </div>

--- a/css/css-grid/alignment/grid-alignment-style-changes-005.html
+++ b/css/css-grid/alignment/grid-alignment-style-changes-005.html
@@ -36,6 +36,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
     let before = {
         item1: {"data-offset-y": 16 },
@@ -55,7 +56,7 @@ function runTest() {
     done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
     <div id="container">
         <div id="item1" data-expected-width="50" data-expected-height="20" data-offset-x="0">É</div>
         <div id="item2" data-expected-width="50" data-expected-height="40" data-offset-x="50">É</div>

--- a/css/css-grid/alignment/grid-alignment-style-changes-006.html
+++ b/css/css-grid/alignment/grid-alignment-style-changes-006.html
@@ -37,6 +37,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
     let before = {
         item1: {"data-offset-y": 8  },
@@ -56,7 +57,7 @@ function runTest() {
     done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
     <div id="container">
         <div id="item1" data-expected-width="50" data-expected-height="20" data-offset-x="0">É</div>
         <div id="item2" data-expected-width="50" data-expected-height="40" data-offset-x="50">É</div>

--- a/css/css-grid/alignment/grid-alignment-style-changes-007.html
+++ b/css/css-grid/alignment/grid-alignment-style-changes-007.html
@@ -38,6 +38,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
     let before = {
         item1: {"data-offset-x": 4 },
@@ -57,7 +58,7 @@ function runTest() {
     done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
     <div id="container">
         <div id="item1" data-expected-width="20" data-expected-height="50" data-offset-y="0">É</div>
         <div id="item2" data-expected-width="40" data-expected-height="50" data-offset-y="50">É</div>

--- a/css/css-grid/alignment/grid-alignment-style-changes-008.html
+++ b/css/css-grid/alignment/grid-alignment-style-changes-008.html
@@ -39,6 +39,7 @@
 <script src="/resources/check-layout-th.js"></script>
 <script src="support/style-change.js"></script>
 <script>
+setup({ explicit_done: true });
 function runTest() {
     let before = {
         item1: {"data-offset-x": 2  },
@@ -58,7 +59,7 @@ function runTest() {
     done();
 }
 </script>
-<body onload="runTest()">
+<body onload="document.fonts.ready.then(() => { runTest(); })">
     <div id="container">
         <div id="item1" data-expected-width="20" data-expected-height="50" data-offset-y="0">É</div>
         <div id="item2" data-expected-width="40" data-expected-height="50" data-offset-y="50">É</div>

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-001.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-001.html
@@ -35,6 +35,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-y", "75");
     item2.setAttribute("data-offset-y", "300");

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-002.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-002.html
@@ -35,6 +35,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-y", "75");
     item2.setAttribute("data-offset-y", "300");

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-003.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-003.html
@@ -36,6 +36,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-y", "75");
     item2.setAttribute("data-offset-y", "300");

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-004.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-004.html
@@ -36,6 +36,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-y", "75");
     item2.setAttribute("data-offset-y", "300");

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-005.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-005.html
@@ -34,6 +34,7 @@
     <div id="item2">XXXXX</div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-y", "90");
     item2.setAttribute("data-offset-y", "345");

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-006.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-006.html
@@ -34,6 +34,7 @@
     <div id="item2">XXXXX</div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-y", "95");
     item2.setAttribute("data-offset-y", "345");

--- a/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-007.html
+++ b/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-007.html
@@ -35,6 +35,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-y", "75");
     item2.setAttribute("data-offset-y", "300");

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-001.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-001.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-002.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-002.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="140" data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="120" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-003.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-003.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-004.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-004.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-005.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-005.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="70"  data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="60"  data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-006.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-006.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-007.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-007.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="140" data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="120" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-008.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-008.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-009.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-009.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="140" data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="120" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-010.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-010.html
@@ -54,7 +54,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="RTL firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="RTL firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-011.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-011.html
@@ -54,7 +54,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="140" data-expected-width="60" data-expected-height="10" class="RTL firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="120" data-expected-width="70" data-expected-height="30" class="RTL firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-012.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-012.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="100" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-013.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-013.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="0"   data-offset-y="90"  data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="220" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-014.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-014.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="0"   data-offset-y="45"  data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="160" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-015.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-015.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="RTL firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="100" data-expected-width="70" data-expected-height="30" class="RTL firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-016.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-016.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="0"   data-offset-y="90"  data-expected-width="60" data-expected-height="10" class="RTL firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="220" data-expected-width="70" data-expected-height="30" class="RTL firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-017.html
+++ b/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-017.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-column-axis-self-baseline-synthesized-001.html
+++ b/css/css-grid/alignment/grid-column-axis-self-baseline-synthesized-001.html
@@ -31,7 +31,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <pre>Horizontal grid and verticalRL item</pre>
 

--- a/css/css-grid/alignment/grid-column-axis-self-baseline-synthesized-002.html
+++ b/css/css-grid/alignment/grid-column-axis-self-baseline-synthesized-002.html
@@ -34,7 +34,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <pre>Horizontal grid and item with fixed height</pre>
 

--- a/css/css-grid/alignment/grid-column-axis-self-baseline-synthesized-003.html
+++ b/css/css-grid/alignment/grid-column-axis-self-baseline-synthesized-003.html
@@ -36,7 +36,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <pre>Horizontal grid and item with relative height</pre>
 

--- a/css/css-grid/alignment/grid-column-axis-self-baseline-synthesized-004.html
+++ b/css/css-grid/alignment/grid-column-axis-self-baseline-synthesized-004.html
@@ -34,7 +34,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <pre>Horizontal grid and item with fixed height</pre>
 

--- a/css/css-grid/alignment/grid-content-alignment-second-pass-001.html
+++ b/css/css-grid/alignment/grid-content-alignment-second-pass-001.html
@@ -23,8 +23,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onLoad="checkLayout('.grid');">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/alignment/grid-content-alignment-second-pass-002.html
+++ b/css/css-grid/alignment/grid-content-alignment-second-pass-002.html
@@ -23,8 +23,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onLoad="checkLayout('.grid');">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/alignment/grid-fit-content-tracks-dont-stretch-001.html
+++ b/css/css-grid/alignment/grid-fit-content-tracks-dont-stretch-001.html
@@ -39,8 +39,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onLoad="checkLayout('.grid');">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/alignment/grid-gutters-and-alignment.html
+++ b/css/css-grid/alignment/grid-gutters-and-alignment.html
@@ -87,8 +87,11 @@ div.gridWithPaddingBorder > div.cell {
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <!-- Check that gutters do not interfere with self alignment computation. -->
 <div class="container">

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-001.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-001.html
@@ -35,6 +35,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-x", "75");
     item2.setAttribute("data-offset-x", "300");

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-002.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-002.html
@@ -35,6 +35,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-x", "75");
     item2.setAttribute("data-offset-x", "300");

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-003.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-003.html
@@ -36,6 +36,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-x", "75");
     item2.setAttribute("data-offset-x", "300");

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-004.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-004.html
@@ -36,6 +36,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-x", "75");
     item2.setAttribute("data-offset-x", "300");

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-005.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-005.html
@@ -36,6 +36,7 @@
     <div id="item2">XXXXX</div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-x", "50");
     item2.setAttribute("data-offset-x", "325");

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-006.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-006.html
@@ -35,6 +35,7 @@
     <div id="item2">XX</div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-x", "80");
     item2.setAttribute("data-offset-x", "340");

--- a/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-007.html
+++ b/css/css-grid/alignment/grid-inline-axis-alignment-auto-margins-007.html
@@ -35,6 +35,7 @@
     <div id="item2"></div>
 </div>
 <script>
+setup({ explicit_done: true });
 document.fonts.ready.then(() => {
     item1.setAttribute("data-offset-x", "75");
     item2.setAttribute("data-offset-x", "300");

--- a/css/css-grid/alignment/grid-item-alignment-with-orthogonal-flows-vertical-lr.html
+++ b/css/css-grid/alignment/grid-item-alignment-with-orthogonal-flows-vertical-lr.html
@@ -29,8 +29,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that grid items alignment works as expected with VERTICAL-LR vs HORIZONTAL-TB orthogonal flows.</p>
 

--- a/css/css-grid/alignment/grid-item-alignment-with-orthogonal-flows-vertical-rl.html
+++ b/css/css-grid/alignment/grid-item-alignment-with-orthogonal-flows-vertical-rl.html
@@ -29,8 +29,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that grid items alignment works as expected with VERTICAL-RL vs HORIZONTAL-TB orthogonal flows.</p>
 

--- a/css/css-grid/alignment/grid-item-alignment-with-orthogonal-flows.html
+++ b/css/css-grid/alignment/grid-item-alignment-with-orthogonal-flows.html
@@ -29,8 +29,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that grid items alignment works as expected with HORIZONTAL-TB vs VERTICAL-RL orthogonal flows.</p>
 

--- a/css/css-grid/alignment/grid-item-auto-margins-alignment-vertical-lr.html
+++ b/css/css-grid/alignment/grid-item-auto-margins-alignment-vertical-lr.html
@@ -33,8 +33,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that align-self and justify-self properties are not applied when there is auto-margin in the corresponding axis. Instead, auto-margin alignment should be applied.</p>
 

--- a/css/css-grid/alignment/grid-item-auto-margins-alignment-vertical-rl.html
+++ b/css/css-grid/alignment/grid-item-auto-margins-alignment-vertical-rl.html
@@ -33,8 +33,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that align-self and justify-self properties are not applied when there is auto-margin in the corresponding axis. Instead, auto-margin alignment should be applied.</p>
 

--- a/css/css-grid/alignment/grid-item-auto-margins-alignment.html
+++ b/css/css-grid/alignment/grid-item-auto-margins-alignment.html
@@ -33,8 +33,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <p>This test checks that align-self and justify-self properties are not applied when there is auto-margin in the corresponding axis. Instead, auto-margin alignment should be applied.</p>
 

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-001.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-001.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-002.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-002.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="40"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="180" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-003.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-003.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-004.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-004.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="40"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="180" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-005.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-005.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="20"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="140" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-006.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-006.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-007.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-007.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="40"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="180" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-008.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-008.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-009.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-009.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="40"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="180" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-010.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-010.html
@@ -54,7 +54,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="40"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="RTL firstRowFirstColumn">X XX X</div>
   <div data-offset-x="180" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="RTL firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-011.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-011.html
@@ -54,7 +54,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="RTL firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="RTL firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-012.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-012.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="200" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-013.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-013.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="40"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="380" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-014.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-014.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="20"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="290" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-015.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-015.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="40"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="RTL firstRowFirstColumn">X XX X</div>
   <div data-offset-x="380" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="RTL firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-016.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-016.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="RTL firstRowFirstColumn">X XX X</div>
   <div data-offset-x="200" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="RTL firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-017.html
+++ b/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-017.html
@@ -53,7 +53,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-001.html
+++ b/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-001.html
@@ -32,7 +32,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <pre>Horizontal grid and verticalRL item</pre>
 

--- a/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-002.html
+++ b/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-002.html
@@ -35,7 +35,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <pre>Horizontal grid and verticalLR item with fixed width</pre>
 

--- a/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-003.html
+++ b/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-003.html
@@ -35,7 +35,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <pre>Horizontal grid and verticalLR item with relative width</pre>
 

--- a/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-004.html
+++ b/css/css-grid/alignment/grid-row-axis-self-baseline-synthesized-004.html
@@ -35,7 +35,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.inline-grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.inline-grid'); })">
 
 <pre>Horizontal grid and verticalLR item with relative width</pre>
 

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-001.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-001.html
@@ -60,7 +60,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="5"   data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="170" data-offset-y="120" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-002.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-002.html
@@ -62,7 +62,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="25"  data-offset-y="5"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="160" data-offset-y="105" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-003.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-003.html
@@ -66,7 +66,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="5"   data-offset-y="0"   data-expected-width="90"  data-expected-height="30" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="140" data-offset-y="100" data-expected-width="100" data-expected-height="50" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-004.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-004.html
@@ -62,7 +62,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="5"   data-offset-y="0"   data-expected-width="90"  data-expected-height="30" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="140" data-offset-y="100" data-expected-width="100" data-expected-height="50" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-005.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-005.html
@@ -68,7 +68,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="13"  data-offset-y="2"   data-expected-width="76" data-expected-height="20" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="150" data-offset-y="104" data-expected-width="86" data-expected-height="40" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-006.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-006.html
@@ -76,7 +76,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="16"  data-offset-y="3"   data-expected-width="76" data-expected-height="20" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="153" data-offset-y="105" data-expected-width="86" data-expected-height="40" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-007.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-007.html
@@ -61,7 +61,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="5"   data-offset-y="0"   data-expected-width="10" data-expected-height="60" class="firstRowFirstColumn verticalLR">X XX X</div>
   <div data-offset-x="210" data-offset-y="80"  data-expected-width="30" data-expected-height="70" class="firstRowSecondColumn verticalRL">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-008.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-008.html
@@ -63,7 +63,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="25"  data-offset-y="5"   data-expected-width="10" data-expected-height="60" class="firstRowFirstColumn verticalLR">X XX X</div>
   <div data-offset-x="210" data-offset-y="65"  data-expected-width="30" data-expected-height="70" class="firstRowSecondColumn verticalRL">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-009.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-009.html
@@ -67,7 +67,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <!-- The test cases with vertical-rl wirting-mode will fail becauuse of bug 779105 -->
 <div class="grid">
   <div data-offset-x="5"   data-offset-y="0"   data-expected-width="40" data-expected-height="80" class="firstRowFirstColumn verticalLR">X XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-010.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-010.html
@@ -63,7 +63,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <!-- The test cases with vertical-rl wirting-mode will fail becauuse of bug 779105 -->
 <div class="grid">
   <div data-offset-x="5"   data-offset-y="0"   data-expected-width="40" data-expected-height="80" class="firstRowFirstColumn verticalLR">X XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-011.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-011.html
@@ -69,7 +69,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <!-- The test cases with vertical-rl wirting-mode will fail becauuse of bug 779105 -->
 <div class="grid">
   <div data-offset-x="13"  data-offset-y="2"   data-expected-width="26" data-expected-height="70" class="firstRowFirstColumn verticalLR">X XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-012.html
+++ b/css/css-grid/alignment/grid-self-alignment-non-static-positioned-items-012.html
@@ -73,7 +73,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <!-- The test cases with vertical-rl wirting-mode will fail becauuse of bug 779105 -->
 <div class="grid">
   <div data-offset-x="70"  data-offset-y="2"   data-expected-width="26" data-expected-height="70" class="firstRowFirstColumn verticalLR">X XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-001.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-001.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="30"  data-offset-y="5"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="145" data-offset-y="105" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-002.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-002.html
@@ -61,7 +61,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="10"  data-offset-y="0"   data-expected-width="90"  data-expected-height="30" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="125" data-offset-y="100" data-expected-width="100" data-expected-height="50" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-003.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-003.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="10"  data-offset-y="0"   data-expected-width="90"  data-expected-height="30" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="125" data-offset-y="100" data-expected-width="100" data-expected-height="50" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-004.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-004.html
@@ -63,7 +63,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="20"  data-offset-y="2"   data-expected-width="76" data-expected-height="20" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="134" data-offset-y="104" data-expected-width="86" data-expected-height="40" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-005.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-005.html
@@ -71,7 +71,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="23"  data-offset-y="3"   data-expected-width="76" data-expected-height="20" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="137" data-offset-y="105" data-expected-width="86" data-expected-height="40" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-006.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-006.html
@@ -59,7 +59,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="80"  data-offset-y="5"   data-expected-width="10" data-expected-height="60" class="firstRowFirstColumn verticalLR">X XX X</div>
   <div data-offset-x="165" data-offset-y="65"  data-expected-width="30" data-expected-height="70" class="firstRowSecondColumn verticalRL">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-007.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-007.html
@@ -63,7 +63,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="60"  data-offset-y="0"   data-expected-width="40" data-expected-height="80" class="firstRowFirstColumn verticalLR">X XX X</div>
   <div data-offset-x="145" data-offset-y="60"  data-expected-width="60" data-expected-height="90" class="firstRowSecondColumn verticalRL">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-008.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-008.html
@@ -59,7 +59,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="60"  data-offset-y="0"   data-expected-width="40" data-expected-height="80" class="firstRowFirstColumn verticalLR">X XX X</div>
   <div data-offset-x="145" data-offset-y="60"  data-expected-width="60" data-expected-height="90" class="firstRowSecondColumn verticalRL">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-009.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-009.html
@@ -65,7 +65,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="70"  data-offset-y="2"   data-expected-width="26" data-expected-height="70" class="firstRowFirstColumn verticalLR">X XX X</div>
   <div data-offset-x="154" data-offset-y="64"  data-expected-width="46" data-expected-height="80" class="firstRowSecondColumn verticalRL">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-010.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-010.html
@@ -73,7 +73,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="73"  data-offset-y="3"   data-expected-width="26" data-expected-height="70" class="firstRowFirstColumn verticalLR">X XX X</div>
   <div data-offset-x="157" data-offset-y="65"  data-expected-width="46" data-expected-height="80" class="firstRowSecondColumn verticalRL">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-011.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-011.html
@@ -60,7 +60,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="40"  data-offset-y="0"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="290" data-offset-y="120" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-012.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-012.html
@@ -62,7 +62,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="30"  data-offset-y="5"   data-expected-width="60" data-expected-height="10" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="295" data-offset-y="105" data-expected-width="70" data-expected-height="30" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-013.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-013.html
@@ -66,7 +66,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="10"  data-offset-y="0"   data-expected-width="90"  data-expected-height="30" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="275" data-offset-y="100" data-expected-width="100" data-expected-height="50" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-014.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-014.html
@@ -62,7 +62,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="10"  data-offset-y="0"   data-expected-width="90"  data-expected-height="30" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="275" data-offset-y="100" data-expected-width="100" data-expected-height="50" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-015.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-015.html
@@ -68,7 +68,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="20"  data-offset-y="2"   data-expected-width="76" data-expected-height="20" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="284" data-offset-y="104" data-expected-width="86" data-expected-height="40" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-016.html
+++ b/css/css-grid/alignment/grid-self-alignment-positioned-items-with-margin-border-padding-016.html
@@ -76,7 +76,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid LTR">
   <div data-offset-x="23"  data-offset-y="3"   data-expected-width="76" data-expected-height="20" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="289" data-offset-y="105" data-expected-width="86" data-expected-height="40" class="firstRowSecondColumn">XX X<br>X XXX X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-001.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-001.html
@@ -50,7 +50,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="100" data-expected-height="10"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="60"  data-expected-height="150" class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-002.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-002.html
@@ -54,7 +54,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="90"  data-expected-height="10"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="60"  data-expected-height="130" class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-003.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-003.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="100" data-expected-height="10"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="60"  data-expected-height="150" class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-004.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-004.html
@@ -54,7 +54,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="100" data-expected-height="10"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="60"  data-expected-height="150" class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-005.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-005.html
@@ -51,7 +51,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="100" data-expected-height="60"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="40"  data-expected-height="150" class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-006.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-006.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="90"  data-expected-height="60"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="40"  data-expected-height="130" class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-007.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-007.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="100" data-expected-height="60"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="40"  data-expected-height="150" class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-008.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-008.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="100" data-expected-height="60"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="0"   data-expected-width="40"  data-expected-height="150" class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-009.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-009.html
@@ -50,7 +50,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="125" data-expected-height="20"  class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="125" data-offset-y="0"   data-expected-width="80"  data-expected-height="125" class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-010.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-010.html
@@ -54,7 +54,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="110" data-expected-height="20"  class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="0"   data-expected-width="80"  data-expected-height="110" class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-011.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-011.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="120" data-expected-height="20"  class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="0"   data-expected-width="80"  data-expected-height="130" class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-012.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-012.html
@@ -54,7 +54,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="120" data-expected-height="20"  class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="0"   data-expected-width="80"  data-expected-height="130" class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-013.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-013.html
@@ -51,7 +51,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="125" data-expected-height="80"  class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="125" data-offset-y="0"   data-expected-width="20"  data-expected-height="125" class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-014.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-014.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="110" data-expected-height="80"  class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="0"   data-expected-width="20"  data-expected-height="110" class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-015.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-015.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="120" data-expected-height="80"  class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="0"   data-expected-width="20"  data-expected-height="130" class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-016.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-016.html
@@ -54,7 +54,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="120" data-expected-height="80"  class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="0"   data-expected-width="20"  data-expected-height="130" class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-001.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-001.html
@@ -51,7 +51,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="10"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="0"   data-offset-y="100" data-expected-width="150" data-expected-height="60"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-002.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-002.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="10"  data-expected-height="90"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="0"   data-offset-y="100" data-expected-width="130" data-expected-height="60"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-003.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-003.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="10"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="0"   data-offset-y="100" data-expected-width="150" data-expected-height="60"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-004.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-004.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="10"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="0"   data-offset-y="100" data-expected-width="150" data-expected-height="60"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-005.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-005.html
@@ -52,7 +52,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="0"   data-offset-y="100" data-expected-width="150" data-expected-height="40"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-006.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-006.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60"  data-expected-height="90"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="0"   data-offset-y="100" data-expected-width="130" data-expected-height="40"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-007.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-007.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="0"   data-offset-y="100" data-expected-width="150" data-expected-height="40"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-008.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-008.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="60"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="0"   data-offset-y="100" data-expected-width="150" data-expected-height="40"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-009.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-009.html
@@ -51,7 +51,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="20"  data-expected-height="125" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="0"   data-offset-y="125" data-expected-width="125" data-expected-height="80"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-010.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-010.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="20"  data-expected-height="110" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="0"   data-offset-y="120" data-expected-width="110" data-expected-height="80"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-011.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-011.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="20"  data-expected-height="120" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="0"   data-offset-y="120" data-expected-width="130" data-expected-height="80"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-012.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-012.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="20"  data-expected-height="120" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="0"   data-offset-y="120" data-expected-width="130" data-expected-height="80"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-013.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-013.html
@@ -52,7 +52,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="80"  data-expected-height="125" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="0"   data-offset-y="125" data-expected-width="125" data-expected-height="20"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-014.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-014.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="80"  data-expected-height="110" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="0"   data-offset-y="120" data-expected-width="110" data-expected-height="20"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-015.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-015.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="80"  data-expected-height="120" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="0"   data-offset-y="120" data-expected-width="130" data-expected-height="20"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-016.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-lr-016.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="0"   data-offset-y="0"   data-expected-width="80"  data-expected-height="120" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="0"   data-offset-y="120" data-expected-width="130" data-expected-height="20"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-001.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-001.html
@@ -51,7 +51,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="240" data-offset-y="0"   data-expected-width="10"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="100" data-expected-width="150" data-expected-height="60"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-002.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-002.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="240" data-offset-y="0"   data-expected-width="10"  data-expected-height="90"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="120" data-offset-y="100" data-expected-width="130" data-expected-height="60"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-003.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-003.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="240" data-offset-y="0"   data-expected-width="10"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="100" data-expected-width="150" data-expected-height="60"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-004.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-004.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="240" data-offset-y="0"   data-expected-width="10"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="100" data-expected-width="150" data-expected-height="60"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-005.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-005.html
@@ -52,7 +52,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="190" data-offset-y="0"   data-expected-width="60"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="100" data-expected-width="150" data-expected-height="40"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-006.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-006.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="190" data-offset-y="0"   data-expected-width="60"  data-expected-height="90"  class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="100" data-expected-width="130" data-expected-height="40"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-007.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-007.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="190" data-offset-y="0"   data-expected-width="60"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="100" data-expected-width="150" data-expected-height="40"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-008.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-008.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="190" data-offset-y="0"   data-expected-width="60"  data-expected-height="100" class="firstRowFirstColumn">X XX X</div>
   <div data-offset-x="100" data-offset-y="100" data-expected-width="150" data-expected-height="40"  class="firstRowSecondColumn">XX X<br>X XXX<br>X<br>XX XXX</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-009.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-009.html
@@ -51,7 +51,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="230" data-offset-y="0"   data-expected-width="20"  data-expected-height="125" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="125" data-offset-y="125" data-expected-width="125" data-expected-height="80"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-010.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-010.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="230" data-offset-y="0"   data-expected-width="20"  data-expected-height="110" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="140" data-offset-y="120" data-expected-width="110" data-expected-height="80"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-011.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-011.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="230" data-offset-y="0"   data-expected-width="20"  data-expected-height="120" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="120" data-expected-width="130" data-expected-height="80"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-012.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-012.html
@@ -55,7 +55,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="230" data-offset-y="0"   data-expected-width="20"  data-expected-height="120" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="120" data-expected-width="130" data-expected-height="80"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-013.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-013.html
@@ -52,7 +52,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="170" data-offset-y="0"   data-expected-width="80"  data-expected-height="125" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="125" data-offset-y="125" data-expected-width="125" data-expected-height="20"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-014.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-014.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="170" data-offset-y="0"   data-expected-width="80"  data-expected-height="110" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="120" data-expected-width="110" data-expected-height="20"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-015.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-015.html
@@ -57,7 +57,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="170" data-offset-y="0"   data-expected-width="80"  data-expected-height="120" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="120" data-expected-width="130" data-expected-height="20"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-016.html
+++ b/css/css-grid/alignment/grid-self-alignment-stretch-vertical-rl-016.html
@@ -56,7 +56,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 <div class="grid">
   <div data-offset-x="170" data-offset-y="0"   data-expected-width="80"  data-expected-height="120" class="firstRowFirstColumn">XX X</div>
   <div data-offset-x="120" data-offset-y="120" data-expected-width="130" data-expected-height="20"  class="firstRowSecondColumn">XX X</div>

--- a/css/css-grid/alignment/grid-self-baseline-not-applied-if-sizing-cyclic-dependency-001.html
+++ b/css/css-grid/alignment/grid-self-baseline-not-applied-if-sizing-cyclic-dependency-001.html
@@ -49,7 +49,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.inline-grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.inline-grid'); })">
 
 <div style="height: 125px">
     <pre>auto-sized rows - items with relative height</pre>

--- a/css/css-grid/alignment/grid-self-baseline-not-applied-if-sizing-cyclic-dependency-002.html
+++ b/css/css-grid/alignment/grid-self-baseline-not-applied-if-sizing-cyclic-dependency-002.html
@@ -51,7 +51,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.inline-grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.inline-grid'); })">
 
 <pre>auto-sized rows - horizonal grid and verticalLR item - column-axis baseline</pre>
 <div class="inline-grid alignItemsBaseline columns height200">

--- a/css/css-grid/alignment/grid-self-baseline-not-applied-if-sizing-cyclic-dependency-003.html
+++ b/css/css-grid/alignment/grid-self-baseline-not-applied-if-sizing-cyclic-dependency-003.html
@@ -43,7 +43,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <pre>flex rows - column-axis baseline - the blue orthogonal item didn't participate in the first iteration</pre>
 <div class="grid row alignItemsBaseline">

--- a/css/css-grid/grid-definition/grid-change-fit-content-argument-001.html
+++ b/css/css-grid/grid-definition/grid-change-fit-content-argument-001.html
@@ -25,6 +25,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
 <script>
+setup({ explicit_done: true });
 function setGridTemplate(id, gridTemplateRows, gridTemplateColumns)
 {
   var gridElement = document.getElementById(id);
@@ -60,10 +61,9 @@ function testChangingGridDefinitions()
 
   done();
 }
-
-window.addEventListener("load", testChangingGridDefinitions, false);
 </script>
 
+<body onload="document.fonts.ready.then(() => { testChangingGridDefinitions(); })">
 <div id="grid1" class="grid">
   <div id="item1" class="autoRowAutoColumn">XXXX XXX XX X X</div>
 </div>
@@ -71,3 +71,4 @@ window.addEventListener("load", testChangingGridDefinitions, false);
 <div id="grid2" class="grid">
   <div id="item2" class="autoRowAutoColumn verticalLR">XXXX XXX XX X X</div>
 </div>
+</body>

--- a/css/css-grid/grid-definition/grid-percentage-rows-indefinite-height-001.html
+++ b/css/css-grid/grid-definition/grid-percentage-rows-indefinite-height-001.html
@@ -26,7 +26,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid');">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-definition/grid-percentage-rows-indefinite-height-002.html
+++ b/css/css-grid/grid-definition/grid-percentage-rows-indefinite-height-002.html
@@ -19,7 +19,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid');">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-definition/grid-support-repeat-002.html
+++ b/css/css-grid/grid-definition/grid-support-repeat-002.html
@@ -25,6 +25,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({explicit_done: true});
 var {style} = document.getElementById("grid");
 
 function testGridTemplateColumnsRows(assignedValue, expectedValue = assignedValue) {
@@ -36,31 +37,34 @@ function testGridTemplateColumnsRows(assignedValue, expectedValue = assignedValu
   }, `grid-template-columns: ${assignedValue}; and grid-template-rows: ${assignedValue};`);
 }
 
-// Valid values.
-testGridTemplateColumnsRows("repeat(1, auto)");
-testGridTemplateColumnsRows("repeat(2, auto)");
-testGridTemplateColumnsRows("repeat(2, minmax(50px, calc(50% + 50px)))");
-testGridTemplateColumnsRows("repeat(5, 10%)");
-testGridTemplateColumnsRows("max-content repeat(2, 25%) 1fr");
-testGridTemplateColumnsRows("repeat(2, min-content 50px)");
-testGridTemplateColumnsRows("repeat(2, [a] minmax(50px, 100px) [b] 25em [c])");
-testGridTemplateColumnsRows("[a] repeat(2, auto [b] 100px) [c]");
-testGridTemplateColumnsRows("[a] auto repeat(2, [b] 100px) [c]");
-testGridTemplateColumnsRows("[a] repeat(2, auto [b]) 100px [c]");
-testGridTemplateColumnsRows("[a] repeat(2, [b] 100px)");
-testGridTemplateColumnsRows("[a] repeat(2, [b] auto [c]) [d]");
-testGridTemplateColumnsRows("[a] min-content repeat(2, [b] 1fr [c] calc(10% + 20px)) [d] minmax(30em, 50em) [e]");
+document.fonts.ready.then(() => {
+  // Valid values.
+  testGridTemplateColumnsRows("repeat(1, auto)");
+  testGridTemplateColumnsRows("repeat(2, auto)");
+  testGridTemplateColumnsRows("repeat(2, minmax(50px, calc(50% + 50px)))");
+  testGridTemplateColumnsRows("repeat(5, 10%)");
+  testGridTemplateColumnsRows("max-content repeat(2, 25%) 1fr");
+  testGridTemplateColumnsRows("repeat(2, min-content 50px)");
+  testGridTemplateColumnsRows("repeat(2, [a] minmax(50px, 100px) [b] 25em [c])");
+  testGridTemplateColumnsRows("[a] repeat(2, auto [b] 100px) [c]");
+  testGridTemplateColumnsRows("[a] auto repeat(2, [b] 100px) [c]");
+  testGridTemplateColumnsRows("[a] repeat(2, auto [b]) 100px [c]");
+  testGridTemplateColumnsRows("[a] repeat(2, [b] 100px)");
+  testGridTemplateColumnsRows("[a] repeat(2, [b] auto [c]) [d]");
+  testGridTemplateColumnsRows("[a] min-content repeat(2, [b] 1fr [c] calc(10% + 20px)) [d] minmax(30em, 50em) [e]");
 
-// Reset values.
-style.gridTemplateColumns = "";
-style.gridTemplateRows = "";
+  // Reset values.
+  style.gridTemplateColumns = "";
+  style.gridTemplateRows = "";
 
-// Wrong values.
-testGridTemplateColumnsRows("repeat(-1, auto)", "");
-testGridTemplateColumnsRows("repeat(auto, 2)", "");
-testGridTemplateColumnsRows("repeat 2, auto", "");
-testGridTemplateColumnsRows("repeat(2 auto)", "");
-testGridTemplateColumnsRows("100px (repeat 2, auto)", "");
-testGridTemplateColumnsRows("repeat(2, 50px repeat(2, 100px))", "");
-testGridTemplateColumnsRows("100px repeat(2, [a])", "");
+  // Wrong values.
+  testGridTemplateColumnsRows("repeat(-1, auto)", "");
+  testGridTemplateColumnsRows("repeat(auto, 2)", "");
+  testGridTemplateColumnsRows("repeat 2, auto", "");
+  testGridTemplateColumnsRows("repeat(2 auto)", "");
+  testGridTemplateColumnsRows("100px (repeat 2, auto)", "");
+  testGridTemplateColumnsRows("repeat(2, 50px repeat(2, 100px))", "");
+  testGridTemplateColumnsRows("100px repeat(2, [a])", "");
+  done();
+});
 </script>

--- a/css/css-grid/grid-items/grid-items-percentage-margins-001.html
+++ b/css/css-grid/grid-items/grid-items-percentage-margins-001.html
@@ -30,8 +30,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-margins-002.html
+++ b/css/css-grid/grid-items/grid-items-percentage-margins-002.html
@@ -30,8 +30,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-margins-vertical-lr-001.html
+++ b/css/css-grid/grid-items/grid-items-percentage-margins-vertical-lr-001.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-margins-vertical-lr-002.html
+++ b/css/css-grid/grid-items/grid-items-percentage-margins-vertical-lr-002.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-margins-vertical-rl-001.html
+++ b/css/css-grid/grid-items/grid-items-percentage-margins-vertical-rl-001.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-margins-vertical-rl-002.html
+++ b/css/css-grid/grid-items/grid-items-percentage-margins-vertical-rl-002.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-paddings-001.html
+++ b/css/css-grid/grid-items/grid-items-percentage-paddings-001.html
@@ -30,8 +30,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-paddings-002.html
+++ b/css/css-grid/grid-items/grid-items-percentage-paddings-002.html
@@ -30,8 +30,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-paddings-vertical-lr-001.html
+++ b/css/css-grid/grid-items/grid-items-percentage-paddings-vertical-lr-001.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-paddings-vertical-lr-002.html
+++ b/css/css-grid/grid-items/grid-items-percentage-paddings-vertical-lr-002.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-paddings-vertical-rl-001.html
+++ b/css/css-grid/grid-items/grid-items-percentage-paddings-vertical-rl-001.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-items-percentage-paddings-vertical-rl-002.html
+++ b/css/css-grid/grid-items/grid-items-percentage-paddings-vertical-rl-002.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-minimum-size-grid-items-021.html
+++ b/css/css-grid/grid-items/grid-minimum-size-grid-items-021.html
@@ -70,7 +70,6 @@
   }
 
   setup({ explicit_done: true });
-  window.addEventListener("load", runTests);
 
   function runTests() {
     checkGridSizeTracksAndImageSize("grid-1", "img-1", "200px", "200px", "200px", "200px", "200px", "200px");
@@ -102,6 +101,7 @@
   }
 </script>
 
+<body onload="document.fonts.ready.then(() => { runTests(); })">
 <div id=log></div>
 
 <!-- Grids with only a 50x50 image as grid item. -->
@@ -219,3 +219,4 @@
   <img id="img-24" class="width100percent" src="support/500x500-green.png">
   <div>ITEM</div>
 </div>
+</body>

--- a/css/css-grid/grid-items/grid-minimum-size-grid-items-022.html
+++ b/css/css-grid/grid-items/grid-minimum-size-grid-items-022.html
@@ -27,8 +27,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-minimum-size-grid-items-023.html
+++ b/css/css-grid/grid-items/grid-minimum-size-grid-items-023.html
@@ -28,8 +28,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-minimum-size-grid-items-024.html
+++ b/css/css-grid/grid-items/grid-minimum-size-grid-items-024.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/grid-items/grid-minimum-size-grid-items-025.html
+++ b/css/css-grid/grid-items/grid-minimum-size-grid-items-025.html
@@ -32,8 +32,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-001.html
+++ b/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-001.html
@@ -26,8 +26,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
     <div class="grid justifyContentSpaceBetween" data-expected-width="200" data-expected-height="40">
         <div class="item" data-expected-width="200" data-expected-height="40">XXX XX X XX X XXX</div>
     </div>

--- a/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-002.html
+++ b/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-002.html
@@ -27,11 +27,14 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
 <!-- Heuristic for estimating row-size for orthogonal items should
 also consider Content Alignment, so that grid container width is 40px.
 https://github.com/w3c/csswg-drafts/issues/2697 -->
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
     <div class="grid justifyContentStart alignContentSpaceBetween" data-expected-width="80" data-expected-height="200">
         <div class="item" data-expected-width="40" data-expected-height="200">XXX XX X XX X XXX</div>
     </div>

--- a/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-003.html
+++ b/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-003.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
     <div class="grid justifyContentSpaceAround" data-expected-width="200" data-expected-height="60">
         <div class="item1" data-expected-width="100" data-expected-height="40">XXXX XXX</div>
         <div class="item2" data-expected-width="100" data-expected-height="20">XXX</div>

--- a/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-004.html
+++ b/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-004.html
@@ -31,8 +31,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
 
-<body onload="checkLayout('.grid')">
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
     <div class="grid justifyContentSpaceBetween" data-expected-width="220" data-expected-height="40">
         <div class="item1" data-expected-width="110" data-expected-height="40">XXXX XXX</div>
         <div class="item2" data-expected-width="60" data-expected-height="40">XXX</div>

--- a/css/css-grid/layout-algorithm/grid-find-fr-size-gutters-001.html
+++ b/css/css-grid/layout-algorithm/grid-find-fr-size-gutters-001.html
@@ -33,7 +33,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/layout-algorithm/grid-find-fr-size-gutters-002.html
+++ b/css/css-grid/layout-algorithm/grid-find-fr-size-gutters-002.html
@@ -20,7 +20,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <div id="log"></div>
 

--- a/css/css-grid/layout-algorithm/grid-intrinsic-size-with-orthogonal-items.html
+++ b/css/css-grid/layout-algorithm/grid-intrinsic-size-with-orthogonal-items.html
@@ -26,7 +26,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<body onload="checkLayout('.grid')">
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
 
 <pre>rows: auto</pre>
 


### PR DESCRIPTION
On WebKit based browsers, web-fonts may not be ready when the document.onload signal is triggered, so to avoid flakiness or unexpected failures on the css-grid tests that use the Ahem font this patch changes those tests to start with document.font.ready().

Most of the changes were done in a batch with sed, but there were also some manual edits on the tests below:

```
css/css-grid/grid-definition/grid-change-fit-content-argument-001.html
css/css-grid/grid-definition/grid-inline-support-grid-template-areas-001.html
css/css-grid/grid-definition/grid-support-grid-template-areas-001.html
css/css-grid/grid-definition/grid-support-repeat-002.html
css/css-grid/grid-items/grid-minimum-size-grid-items-021.html
```