### PR TITLE
MathML fonts: Use explicit copyright for mathfont.create

### DIFF
--- a/mathml/tools/axisheight.py
+++ b/mathml/tools/axisheight.py
@@ -6,7 +6,8 @@ import fontforge
 verticalArrowCodePoint = 0x21A8
 v1 = 5 * mathfont.em
 v2 = 14 * mathfont.em
-f = mathfont.create("axisheight%d-verticalarrow%d" % (v1, v2))
+f = mathfont.create("axisheight%d-verticalarrow%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v1
 f.math.MinConnectorOverlap = 0
 mathfont.createSquareGlyph(f, verticalArrowCodePoint)

--- a/mathml/tools/fractions.py
+++ b/mathml/tools/fractions.py
@@ -5,7 +5,8 @@ import fontforge
 
 v1 = 7 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("fraction-axisheight%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("fraction-axisheight%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v1
 f.math.FractionDenominatorDisplayStyleGapMin = 0
 f.math.FractionDenominatorDisplayStyleShiftDown = 0
@@ -20,7 +21,8 @@ mathfont.save(f)
 
 v1 = 5 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("fraction-denominatordisplaystylegapmin%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("fraction-denominatordisplaystylegapmin%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = 0
 f.math.FractionDenominatorDisplayStyleGapMin = v1
 f.math.FractionDenominatorDisplayStyleShiftDown = 0
@@ -35,7 +37,8 @@ mathfont.save(f)
 
 v1 = 6 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("fraction-denominatordisplaystyleshiftdown%d-axisheight%d-rulethickness%d" % (v1, v2, v2))
+f = mathfont.create("fraction-denominatordisplaystyleshiftdown%d-axisheight%d-rulethickness%d" % (v1, v2, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v2
 f.math.FractionDenominatorDisplayStyleGapMin = 0
 f.math.FractionDenominatorDisplayStyleShiftDown = v1
@@ -50,7 +53,8 @@ mathfont.save(f)
 
 v1 = 4 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("fraction-denominatorgapmin%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("fraction-denominatorgapmin%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = 0
 f.math.FractionDenominatorDisplayStyleGapMin = 0
 f.math.FractionDenominatorDisplayStyleShiftDown = 0
@@ -65,7 +69,8 @@ mathfont.save(f)
 
 v1 = 3 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("fraction-denominatorshiftdown%d-axisheight%d-rulethickness%d" % (v1, v2, v2))
+f = mathfont.create("fraction-denominatorshiftdown%d-axisheight%d-rulethickness%d" % (v1, v2, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v2
 f.math.FractionDenominatorDisplayStyleGapMin = 0
 f.math.FractionDenominatorDisplayStyleShiftDown = 0
@@ -80,7 +85,8 @@ mathfont.save(f)
 
 v1 = 8 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("fraction-numeratordisplaystylegapmin%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("fraction-numeratordisplaystylegapmin%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = 0
 f.math.FractionDenominatorDisplayStyleGapMin = 0
 f.math.FractionDenominatorDisplayStyleShiftDown = 0
@@ -95,7 +101,8 @@ mathfont.save(f)
 
 v1 = 2 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("fraction-numeratordisplaystyleshiftup%d-axisheight%d-rulethickness%d" % (v1, v2, v2))
+f = mathfont.create("fraction-numeratordisplaystyleshiftup%d-axisheight%d-rulethickness%d" % (v1, v2, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v2
 f.math.FractionDenominatorDisplayStyleGapMin = 0
 f.math.FractionDenominatorDisplayStyleShiftDown = 0
@@ -110,7 +117,8 @@ mathfont.save(f)
 
 v1 = 9 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("fraction-numeratorgapmin%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("fraction-numeratorgapmin%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = 0
 f.math.FractionDenominatorDisplayStyleGapMin = 0
 f.math.FractionDenominatorDisplayStyleShiftDown = 0
@@ -125,7 +133,8 @@ mathfont.save(f)
 
 v1 = 11 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("fraction-numeratorshiftup%d-axisheight%d-rulethickness%d" % (v1, v2, v2))
+f = mathfont.create("fraction-numeratorshiftup%d-axisheight%d-rulethickness%d" % (v1, v2, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v2
 f.math.FractionDenominatorDisplayStyleGapMin = 0
 f.math.FractionDenominatorDisplayStyleShiftDown = 0
@@ -139,7 +148,8 @@ f.math.FractionRuleThickness = v2
 mathfont.save(f)
 
 v1 = 10 * mathfont.em
-f = mathfont.create("fraction-rulethickness%d" % v1)
+f = mathfont.create("fraction-rulethickness%d" % v1,
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = 0
 f.math.FractionDenominatorDisplayStyleGapMin = 0
 f.math.FractionDenominatorDisplayStyleShiftDown = 0

--- a/mathml/tools/largeop.py
+++ b/mathml/tools/largeop.py
@@ -5,7 +5,8 @@ import fontforge
 
 nAryWhiteVerticalBarCodePoint = 0x2AFF
 v1 = 5 * mathfont.em
-f = mathfont.create("largeop-displayoperatorminheight%d" % v1)
+f = mathfont.create("largeop-displayoperatorminheight%d" % v1,
+                    "Copyright (c) 2016 MathML Association")
 f.math.DisplayOperatorMinHeight = v1
 mathfont.createSquareGlyph(f, nAryWhiteVerticalBarCodePoint)
 g = f.createChar(-1, "uni2AFF.display")
@@ -15,8 +16,8 @@ mathfont.save(f)
 
 v1 = 2 * mathfont.em
 v2 = 3 * mathfont.em
-f = mathfont.create("largeop-displayoperatorminheight%d-2AFF-italiccorrection%d" % (v1, v2))
-f.copyright = "Copyright (c) 2018 Igalia S.L."
+f = mathfont.create("largeop-displayoperatorminheight%d-2AFF-italiccorrection%d" % (v1, v2),
+                    "Copyright (c) 2018 Igalia S.L.")
 f.math.DisplayOperatorMinHeight = v1
 mathfont.createSquareGlyph(f, nAryWhiteVerticalBarCodePoint)
 g = f.createChar(-1, "uni2AFF.display")
@@ -33,8 +34,8 @@ mathfont.save(f)
 
 v1 = 7 * mathfont.em
 v2 = 5 * mathfont.em
-f = mathfont.create("largeop-displayoperatorminheight%d-2AFF-italiccorrection%d" % (v1, v2))
-f.copyright = "Copyright (c) 2020 Igalia S.L."
+f = mathfont.create("largeop-displayoperatorminheight%d-2AFF-italiccorrection%d" % (v1, v2),
+                    "Copyright (c) 2020 Igalia S.L.")
 f.math.DisplayOperatorMinHeight = v1
 f.math.MinConnectorOverlap = 0
 mathfont.createSquareGlyph(f, nAryWhiteVerticalBarCodePoint)

--- a/mathml/tools/limits.py
+++ b/mathml/tools/limits.py
@@ -6,7 +6,8 @@ import fontforge
 nArySumCodePoint = 0x2211 # largeop operator
 
 v = 3 * mathfont.em
-f = mathfont.create("limits-lowerlimitbaselinedropmin%d" % v)
+f = mathfont.create("limits-lowerlimitbaselinedropmin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, nArySumCodePoint)
 f.math.LowerLimitBaselineDropMin = v
 f.math.LowerLimitGapMin = 0
@@ -23,7 +24,8 @@ f.math.UpperLimitGapMin = 0
 mathfont.save(f)
 
 v = 11 * mathfont.em
-f = mathfont.create("limits-lowerlimitgapmin%d" % v)
+f = mathfont.create("limits-lowerlimitgapmin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, nArySumCodePoint)
 f.math.LowerLimitBaselineDropMin = 0
 f.math.LowerLimitGapMin = v
@@ -40,7 +42,8 @@ f.math.UpperLimitGapMin = 0
 mathfont.save(f)
 
 v = 5 * mathfont.em
-f = mathfont.create("limits-upperlimitbaselinerisemin%d" % v)
+f = mathfont.create("limits-upperlimitbaselinerisemin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, nArySumCodePoint)
 f.math.LowerLimitBaselineDropMin = 0
 f.math.LowerLimitGapMin = 0
@@ -57,7 +60,8 @@ f.math.UpperLimitGapMin = 0
 mathfont.save(f)
 
 v = 7 * mathfont.em
-f = mathfont.create("limits-upperlimitgapmin%d" % v)
+f = mathfont.create("limits-upperlimitgapmin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, nArySumCodePoint)
 f.math.LowerLimitBaselineDropMin = 0
 f.math.LowerLimitGapMin = 0

--- a/mathml/tools/mathvariant-transforms.py
+++ b/mathml/tools/mathvariant-transforms.py
@@ -64,7 +64,7 @@ mathvariantTransforms["auto"] = mathvariantTransforms["italic"]
 for mathvariant in mathvariantTransforms:
     if mathvariant == "auto":
         continue
-    font = mathfont.create("mathvariant-%s" % mathvariant)
+    font = mathfont.create("mathvariant-%s" % mathvariant, "Copyright (c) 2016 MathML Association")
     for baseChar in mathvariantTransforms[mathvariant]:
         if baseChar not in font:
             mathfont.createGlyphFromValue(font, baseChar)

--- a/mathml/tools/operator-dictionary.py
+++ b/mathml/tools/operator-dictionary.py
@@ -96,7 +96,7 @@ for form in ["infix", "prefix", "suffix"]:
     operatorDictionary[key] = value
 
 # Create a WOFF font with glyphs for all the operator strings.
-font = mathfont.create("operators")
+font = mathfont.create("operators", "Copyright (c) 2019 Igalia S.L.")
 
 # Set parameters for largeop and stretchy tests.
 font.math.DisplayOperatorMinHeight = 2 * mathfont.em

--- a/mathml/tools/percentscaledown.py
+++ b/mathml/tools/percentscaledown.py
@@ -5,17 +5,20 @@ import fontforge
 
 v1 = 80
 v2 = 40
-f = mathfont.create("scriptpercentscaledown%d-scriptscriptpercentscaledown%d" % (v1, v2))
+f = mathfont.create("scriptpercentscaledown%d-scriptscriptpercentscaledown%d" % (v1, v2),
+                    "Copyright (c) 2019 Igalia S.L.")
 f.math.ScriptPercentScaleDown = v1
 f.math.ScriptScriptPercentScaleDown = v2
 mathfont.save(f)
 
-f = mathfont.create("scriptpercentscaledown0-scriptscriptpercentscaledown%d" % v2)
+f = mathfont.create("scriptpercentscaledown0-scriptscriptpercentscaledown%d" % v2,
+                    "Copyright (c) 2019 Igalia S.L.")
 f.math.ScriptPercentScaleDown = 0
 f.math.ScriptScriptPercentScaleDown = v2
 mathfont.save(f)
 
-f = mathfont.create("scriptpercentscaledown%d-scriptscriptpercentscaledown0" % v1)
+f = mathfont.create("scriptpercentscaledown%d-scriptscriptpercentscaledown0" % v1,
+                    "Copyright (c) 2019 Igalia S.L.")
 f.math.ScriptPercentScaleDown = v1
 f.math.ScriptScriptPercentScaleDown = 0
 mathfont.save(f)

--- a/mathml/tools/radicals.py
+++ b/mathml/tools/radicals.py
@@ -20,7 +20,8 @@ def createStretchyRadical(aFont):
 
 v1 = 25
 v2 = 1 * mathfont.em
-f = mathfont.create("radical-degreebottomraisepercent%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("radical-degreebottomraisepercent%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 createStretchyRadical(f)
 f.math.RadicalDegreeBottomRaisePercent = v1
 f.math.RadicalDisplayStyleVerticalGap = 0
@@ -33,7 +34,8 @@ mathfont.save(f)
 
 v1 = 7 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("radical-displaystyleverticalgap%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("radical-displaystyleverticalgap%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 createStretchyRadical(f)
 f.math.RadicalDegreeBottomRaisePercent = 0
 f.math.RadicalDisplayStyleVerticalGap = v1
@@ -46,7 +48,8 @@ mathfont.save(f)
 
 v1 = 3 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("radical-extraascender%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("radical-extraascender%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 createStretchyRadical(f)
 f.math.RadicalDegreeBottomRaisePercent = 0
 f.math.RadicalDisplayStyleVerticalGap = 0
@@ -59,7 +62,8 @@ mathfont.save(f)
 
 v1 = 5 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("radical-kernafterdegreeminus%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("radical-kernafterdegreeminus%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 createStretchyRadical(f)
 f.math.RadicalDegreeBottomRaisePercent = 0
 f.math.RadicalDisplayStyleVerticalGap = 0
@@ -72,7 +76,8 @@ mathfont.save(f)
 
 v1 = 4 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("radical-kernbeforedegree%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("radical-kernbeforedegree%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 createStretchyRadical(f)
 f.math.RadicalDegreeBottomRaisePercent = 0
 f.math.RadicalDisplayStyleVerticalGap = 0
@@ -84,7 +89,8 @@ f.math.RadicalVerticalGap = 0
 mathfont.save(f)
 
 v = 8 * mathfont.em
-f = mathfont.create("radical-rulethickness%d" % v)
+f = mathfont.create("radical-rulethickness%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 createStretchyRadical(f)
 f.math.RadicalDegreeBottomRaisePercent = 0
 f.math.RadicalDisplayStyleVerticalGap = 0
@@ -97,7 +103,8 @@ mathfont.save(f)
 
 v1 = 6 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("radical-verticalgap%d-rulethickness%d" % (v1, v2))
+f = mathfont.create("radical-verticalgap%d-rulethickness%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 createStretchyRadical(f)
 f.math.RadicalDegreeBottomRaisePercent = 0
 f.math.RadicalDisplayStyleVerticalGap = 0

--- a/mathml/tools/scripts.py
+++ b/mathml/tools/scripts.py
@@ -4,7 +4,8 @@ from utils import mathfont
 import fontforge
 
 v = 3 * mathfont.em
-f = mathfont.create("scripts-spaceafterscript%d" % v)
+f = mathfont.create("scripts-spaceafterscript%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = v
 f.math.SubSuperscriptGapMin = 0
 f.math.SubscriptBaselineDropMin = 0
@@ -18,7 +19,8 @@ f.math.SuperscriptShiftUpCramped = 0
 mathfont.save(f)
 
 v = 7 * mathfont.em
-f = mathfont.create("scripts-superscriptshiftup%d" % v)
+f = mathfont.create("scripts-superscriptshiftup%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = 0
 f.math.SubSuperscriptGapMin = 0
 f.math.SubscriptBaselineDropMin = 0
@@ -32,7 +34,8 @@ f.math.SuperscriptShiftUpCramped = 0
 mathfont.save(f)
 
 v = 5 * mathfont.em
-f = mathfont.create("scripts-superscriptshiftupcramped%d" % v)
+f = mathfont.create("scripts-superscriptshiftupcramped%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = 0
 f.math.SubSuperscriptGapMin = 0
 f.math.SubscriptBaselineDropMin = 0
@@ -46,7 +49,8 @@ f.math.SuperscriptShiftUpCramped = v
 mathfont.save(f)
 
 v = 6 * mathfont.em
-f = mathfont.create("scripts-subscriptshiftdown%d" % v)
+f = mathfont.create("scripts-subscriptshiftdown%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = 0
 f.math.SubSuperscriptGapMin = 0
 f.math.SubscriptBaselineDropMin = 0
@@ -60,7 +64,8 @@ f.math.SuperscriptShiftUpCramped = 0
 mathfont.save(f)
 
 v = 11 * mathfont.em
-f = mathfont.create("scripts-subsuperscriptgapmin%d" % v)
+f = mathfont.create("scripts-subsuperscriptgapmin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = 0
 f.math.SubSuperscriptGapMin = v
 f.math.SubscriptBaselineDropMin = 0
@@ -75,7 +80,8 @@ mathfont.save(f)
 
 v1 = 11 * mathfont.em
 v2 = 3 * mathfont.em
-f = mathfont.create("scripts-subsuperscriptgapmin%d-superscriptbottommaxwithsubscript%d" % (v1, v2))
+f = mathfont.create("scripts-subsuperscriptgapmin%d-superscriptbottommaxwithsubscript%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = 0
 f.math.SubSuperscriptGapMin = v1
 f.math.SubscriptBaselineDropMin = 0
@@ -89,7 +95,8 @@ f.math.SuperscriptShiftUpCramped = 0
 mathfont.save(f)
 
 v = 4 * mathfont.em
-f = mathfont.create("scripts-subscripttopmax%d" % v)
+f = mathfont.create("scripts-subscripttopmax%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = 0
 f.math.SubSuperscriptGapMin = 0
 f.math.SubscriptBaselineDropMin = 0
@@ -103,7 +110,8 @@ f.math.SuperscriptShiftUpCramped = 0
 mathfont.save(f)
 
 v = 8 * mathfont.em
-f = mathfont.create("scripts-superscriptbottommin%d" % v)
+f = mathfont.create("scripts-superscriptbottommin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = 0
 f.math.SubSuperscriptGapMin = 0
 f.math.SubscriptBaselineDropMin = 0
@@ -117,7 +125,8 @@ f.math.SuperscriptShiftUpCramped = 0
 mathfont.save(f)
 
 v = 9 * mathfont.em
-f = mathfont.create("scripts-subscriptbaselinedropmin%d" % v)
+f = mathfont.create("scripts-subscriptbaselinedropmin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = 0
 f.math.SubSuperscriptGapMin = 0
 f.math.SubscriptBaselineDropMin = v
@@ -131,7 +140,8 @@ f.math.SuperscriptShiftUpCramped = 0
 mathfont.save(f)
 
 v = 10 * mathfont.em
-f = mathfont.create("scripts-superscriptbaselinedropmax%d" % v)
+f = mathfont.create("scripts-superscriptbaselinedropmax%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.SpaceAfterScript = 0
 f.math.SubSuperscriptGapMin = 0
 f.math.SubscriptBaselineDropMin = 0

--- a/mathml/tools/stacks.py
+++ b/mathml/tools/stacks.py
@@ -5,7 +5,8 @@ import fontforge
 
 v1 = 5 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("stack-bottomdisplaystyleshiftdown%d-axisheight%d" % (v1, v2))
+f = mathfont.create("stack-bottomdisplaystyleshiftdown%d-axisheight%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v2
 f.math.StackBottomDisplayStyleShiftDown = v1
 f.math.StackBottomShiftDown = 0
@@ -17,7 +18,8 @@ mathfont.save(f)
 
 v1 = 6 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("stack-bottomshiftdown%d-axisheight%d" % (v1, v2))
+f = mathfont.create("stack-bottomshiftdown%d-axisheight%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v2
 f.math.StackBottomDisplayStyleShiftDown = 0
 f.math.StackBottomShiftDown = v1
@@ -28,7 +30,8 @@ f.math.StackTopShiftUp = 0
 mathfont.save(f)
 
 v = 4 * mathfont.em
-f = mathfont.create("stack-displaystylegapmin%d" % v)
+f = mathfont.create("stack-displaystylegapmin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = 0
 f.math.StackBottomDisplayStyleShiftDown = 0
 f.math.StackBottomShiftDown = 0
@@ -39,7 +42,8 @@ f.math.StackTopShiftUp = 0
 mathfont.save(f)
 
 v = 8 * mathfont.em
-f = mathfont.create("stack-gapmin%d" % v)
+f = mathfont.create("stack-gapmin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = 0
 f.math.StackBottomDisplayStyleShiftDown = 0
 f.math.StackBottomShiftDown = 0
@@ -51,7 +55,8 @@ mathfont.save(f)
 
 v1 = 3 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("stack-topdisplaystyleshiftup%d-axisheight%d" % (v1, v2))
+f = mathfont.create("stack-topdisplaystyleshiftup%d-axisheight%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v2
 f.math.StackBottomDisplayStyleShiftDown = 0
 f.math.StackBottomShiftDown = 0
@@ -63,7 +68,8 @@ mathfont.save(f)
 
 v1 = 9 * mathfont.em
 v2 = 1 * mathfont.em
-f = mathfont.create("stack-topshiftup%d-axisheight%d" % (v1, v2))
+f = mathfont.create("stack-topshiftup%d-axisheight%d" % (v1, v2),
+                    "Copyright (c) 2016 MathML Association")
 f.math.AxisHeight = v2
 f.math.StackBottomDisplayStyleShiftDown = 0
 f.math.StackBottomShiftDown = 0

--- a/mathml/tools/stretchstacks.py
+++ b/mathml/tools/stretchstacks.py
@@ -6,7 +6,8 @@ import fontforge
 arrowCodePoint = 0x2192 # horizontal stretch operator
 
 v = 3 * mathfont.em
-f = mathfont.create("stretchstack-bottomshiftdown%d" % v)
+f = mathfont.create("stretchstack-bottomshiftdown%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, arrowCodePoint)
 f.math.LowerLimitBaselineDropMin = 0
 f.math.LowerLimitGapMin = 0
@@ -23,7 +24,8 @@ f.math.UpperLimitGapMin = 0
 mathfont.save(f)
 
 v = 11 * mathfont.em
-f = mathfont.create("stretchstack-gapbelowmin%d" % v)
+f = mathfont.create("stretchstack-gapbelowmin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, arrowCodePoint)
 f.math.LowerLimitBaselineDropMin = 0
 f.math.LowerLimitGapMin = 0
@@ -40,7 +42,8 @@ f.math.UpperLimitGapMin = 0
 mathfont.save(f)
 
 v = 5 * mathfont.em
-f = mathfont.create("stretchstack-topshiftup%d" % v)
+f = mathfont.create("stretchstack-topshiftup%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, arrowCodePoint)
 f.math.LowerLimitBaselineDropMin = 0
 f.math.LowerLimitGapMin = 0
@@ -57,7 +60,8 @@ f.math.UpperLimitGapMin = 0
 mathfont.save(f)
 
 v = 7 * mathfont.em
-f = mathfont.create("stretchstack-gapabovemin%d" % v)
+f = mathfont.create("stretchstack-gapabovemin%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, arrowCodePoint)
 f.math.LowerLimitBaselineDropMin = 0
 f.math.LowerLimitGapMin = 0

--- a/mathml/tools/underover.py
+++ b/mathml/tools/underover.py
@@ -8,7 +8,8 @@ degreeCodePoint = 0xB0 # nonaccent operator
 accentBaseHeight = 4 * mathfont.em
 
 v = 3 * mathfont.em
-f = mathfont.create("underover-accentbaseheight%d-overbarextraascender%d" % (accentBaseHeight, v))
+f = mathfont.create("underover-accentbaseheight%d-overbarextraascender%d" % (accentBaseHeight, v),
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, breveCodePoint)
 mathfont.createSquareGlyph(f, degreeCodePoint)
 f.math.AccentBaseHeight = accentBaseHeight
@@ -27,7 +28,8 @@ f.math.UpperLimitGapMin = 0
 mathfont.save(f)
 
 v = 11 * mathfont.em
-f = mathfont.create("underover-accentbaseheight%d-overbarverticalgap%d" % (accentBaseHeight, v))
+f = mathfont.create("underover-accentbaseheight%d-overbarverticalgap%d" % (accentBaseHeight, v),
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, breveCodePoint)
 mathfont.createSquareGlyph(f, degreeCodePoint)
 f.math.AccentBaseHeight = accentBaseHeight
@@ -46,7 +48,8 @@ f.math.UpperLimitGapMin = 0
 mathfont.save(f)
 
 v = 5 * mathfont.em
-f = mathfont.create("underover-accentbaseheight%d-underbarextradescender%d" % (accentBaseHeight, v))
+f = mathfont.create("underover-accentbaseheight%d-underbarextradescender%d" % (accentBaseHeight, v),
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, breveCodePoint)
 mathfont.createSquareGlyph(f, degreeCodePoint)
 f.math.AccentBaseHeight = accentBaseHeight
@@ -65,7 +68,8 @@ f.math.UpperLimitGapMin = 0
 mathfont.save(f)
 
 v = 7 * mathfont.em
-f = mathfont.create("underover-accentbaseheight%d-underbarverticalgap%d" % (accentBaseHeight, v))
+f = mathfont.create("underover-accentbaseheight%d-underbarverticalgap%d" % (accentBaseHeight, v),
+                    "Copyright (c) 2016 MathML Association")
 mathfont.createSquareGlyph(f, breveCodePoint)
 mathfont.createSquareGlyph(f, degreeCodePoint)
 f.math.AccentBaseHeight = accentBaseHeight

--- a/mathml/tools/use-typo-lineheight.py
+++ b/mathml/tools/use-typo-lineheight.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 from __future__ import print_function
-from utils.misc import MathMLAssociationCopyright
 import fontforge
 
 font = fontforge.font()
@@ -12,7 +11,7 @@ name = "font-lineheight%d-typolineheight%d" % (winHeight, typoLineHeight)
 font.fontname = name
 font.familyname = name
 font.fullname = name
-font.copyright = MathMLAssociationCopyright
+font.copyright = "Copyright (c) 2016 MathML Association"
 
 glyph = font.createChar(ord(" "), "space")
 glyph.width = 1000

--- a/mathml/tools/utils/mathfont.py
+++ b/mathml/tools/utils/mathfont.py
@@ -1,16 +1,15 @@
 from __future__ import print_function
 import fontforge
-from misc import MathMLAssociationCopyright
 
 em = 1000
 
-def create(aName):
+def create(aName, aCopyRight):
     print("Generating %s.woff..." % aName, end="")
     mathFont = fontforge.font()
     mathFont.fontname = aName
     mathFont.familyname = aName
     mathFont.fullname = aName
-    mathFont.copyright = MathMLAssociationCopyright
+    mathFont.copyright = aCopyRight
     mathFont.encoding = "UnicodeFull"
 
     # Create a space character. Also force the creation of some MATH subtables

--- a/mathml/tools/utils/misc.py
+++ b/mathml/tools/utils/misc.py
@@ -8,7 +8,6 @@ except ImportError:
 
 UnicodeXMLURL = "https://mathml-refresh.github.io/xml-entities/unicode.xml"
 InlineAxisOperatorsURL = "https://mathml-refresh.github.io/mathml-core/tables/inline-axis-operators.txt"
-MathMLAssociationCopyright = "Copyright (c) 2016 MathML Association"
 
 def downloadWithProgressBar(url, outputDirectory="./", forceDownload=False):
 

--- a/mathml/tools/xHeight.py
+++ b/mathml/tools/xHeight.py
@@ -4,7 +4,8 @@ from utils import mathfont
 import fontforge
 
 v = mathfont.em / 2
-f = mathfont.create("xheight%d" % v)
+f = mathfont.create("xheight%d" % v,
+                    "Copyright (c) 2016 MathML Association")
 g = f.createChar(ord('x'))
 mathfont.drawRectangleGlyph(g, mathfont.em, v, 0)
 assert f.xHeight == v, "Bad x-height value!"


### PR DESCRIPTION
Currently a default 2016 copyright is used, which is confusing.
This commit adds a mandatory argument to mathfont.create to
ensure proper copyright is specified by the caller.