### PR TITLE
HTML: use Wasm to get a SharedArrayBuffer instance

### DIFF
--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.js
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.js
@@ -1,18 +1,29 @@
+// META: global=window,worker
+
 test(() => {
-  const sab = new SharedArrayBuffer();
+  // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+  assert_equals(globalThis.SharedArrayBuffer, undefined);
+  assert_false("SharedArrayBuffer" in globalThis);
+}, "SharedArrayBuffer constructor does not exist without COOP+COEP");
+
+test(() => {
+  // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+  const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
   const channel = new MessageChannel();
   assert_throws_dom("DataCloneError", () => channel.port1.postMessage(sab));
 }, "SharedArrayBuffer over MessageChannel without COOP+COEP");
 
 test(() => {
-  const sab = new SharedArrayBuffer();
+  // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+  const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
   const channel = new BroadcastChannel("Is mir egal");
   assert_throws_dom("DataCloneError", () => channel.postMessage(sab));
 }, "SharedArrayBuffer over BroadcastChannel without COOP+COEP");
 
 if (self.GLOBAL.isWindow()) {
   test(() => {
-    const sab = new SharedArrayBuffer();
+    // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+    const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
     assert_throws_dom("DataCloneError", () => self.postMessage(sab));
   }, "SharedArrayBuffer over postMessage() without COOP+COEP");
 }

--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-idb.any.js
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-idb.any.js
@@ -7,9 +7,11 @@ async_test(t => {
   openReq.onupgradeneeded = e => {
     const db = e.target.result;
     const store = db.createObjectStore("store", { keyPath: "key" });
+    // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+    const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
 
     assert_throws_dom("DataCloneError", () => {
-      store.put({ key: 1, property: new SharedArrayBuffer() });
+      store.put({ key: 1, property: sab });
     });
     t.done();
   };
@@ -21,6 +23,8 @@ async_test(t => {
   openReq.onupgradeneeded = e => {
     const db = e.target.result;
     const store = db.createObjectStore("store", { keyPath: "key" });
+    // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+    const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
 
     let getter1Called = false;
     let getter2Called = false;
@@ -28,7 +32,7 @@ async_test(t => {
     assert_throws_dom("DataCloneError", () => {
       store.put({ key: 1, property: [
         { get x() { getter1Called = true; return 5; } },
-        new SharedArrayBuffer(),
+        sab,
         { get x() { getter2Called = true; return 5; } }
       ]});
     });

--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-notifications-api.any.js
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-notifications-api.any.js
@@ -2,18 +2,23 @@
 
 test(() => {
   assert_throws_dom("DataCloneError", () => {
-    new Notification("Bob: Hi", { data: new SharedArrayBuffer() });
+    // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+    const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
+    new Notification("Bob: Hi", { data: sab });
   })
 }, "SharedArrayBuffer cloning via the Notifications API's data member: basic case");
 
 test(() => {
+  // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+  const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
+
   let getter1Called = false;
   let getter2Called = false;
 
   assert_throws_dom("DataCloneError", () => {
     new Notification("Bob: Hi", { data: [
       { get x() { getter1Called = true; return 5; } },
-      new SharedArrayBuffer(),
+      sab,
       { get x() { getter2Called = true; return 5; } }
     ]});
   });

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-failure.https.any.js
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-failure.https.any.js
@@ -1,7 +1,8 @@
 // META: global=!default,window,serviceworker
 
 test(() => {
-  const sab = new SharedArrayBuffer(16);
+  // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+  const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
   const ta = new Int32Array(sab);
 
   assert_throws_js(TypeError, () => {

--- a/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-success.any.js
+++ b/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-success.any.js
@@ -1,7 +1,8 @@
 // META: global=!default,dedicatedworker,sharedworker
 
 test(() => {
-  const sab = new SharedArrayBuffer(16);
+  // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
+  const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
   const ta = new Int32Array(sab);
 
   assert_equals(Atomics.wait(ta, 0, 0, 10), "timed-out");


### PR DESCRIPTION
And verify that the SharedArrayBuffer constructor isn't exposed without COOP+COEP.

For https://github.com/web-platform-tests/wpt/issues/22358.