### PR TITLE
Fix deprecation warnings for collections.abc

### DIFF
--- a/tools/manifest/typedata.py
+++ b/tools/manifest/typedata.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from six.moves.collections_abc import MutableMapping
 
 from six import itervalues, iteritems
 

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -3,7 +3,7 @@ import json
 import os
 import stat
 from collections import deque
-from collections import MutableMapping
+from six.moves.collections_abc import MutableMapping
 
 from six import with_metaclass, PY2
 

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -2,7 +2,9 @@ import copy
 import logging
 import os
 
-from collections import defaultdict, Mapping
+
+from collections import defaultdict
+from six.moves.collections_abc import Mapping
 from six import integer_types, iteritems, itervalues, string_types
 
 from . import sslutils


### PR DESCRIPTION
Fixes this: `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working`