### PR TITLE
Add note to crashtest.md about testharness.js

### DIFF
--- a/docs/writing-tests/crashtest.md
+++ b/docs/writing-tests/crashtest.md
@@ -19,3 +19,7 @@ root. At the time when the test would otherwise have ended a `TestRendered`
 event is emitted; test authors can use this event to perform modifications that
 are guaranteed not to be batched with the initial paint. This matches the
 behaviour of [reftests](reftests).
+
+Note that crash tests **do not** need to include `testharness.js` or use any of
+the [testharness API](testharness-api.md) (e.g. they do not need to declare a
+`test(..)`).


### PR DESCRIPTION
Authors often assume that they need to include testharness.js or use the
standard 'test(..)' methods they are familiar with when writing crash
tests, which is not the case.