### PR TITLE
Revert "Unskip linting unit test by making it work with python3"

### DIFF
--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -633,6 +633,8 @@ def test_late_timeout():
             ]
 
 
+# Note: This test checks the print *statement* (which doesn't exist in python 3).
+#       The print *function* is checked in test_print_function below.
 @pytest.mark.skipif(six.PY3, reason="Cannot parse print statements from python 3")
 def test_print_statement():
     error_map = check_with_files(b"def foo():\n  print 'statement'\n  print\n")

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -633,8 +633,9 @@ def test_late_timeout():
             ]
 
 
+@pytest.mark.skipif(six.PY3, reason="Cannot parse print statements from python 3")
 def test_print_statement():
-    error_map = check_with_files(b"def foo():\n  print('statement')\n  print\n")
+    error_map = check_with_files(b"def foo():\n  print 'statement'\n  print\n")
 
     for (filename, (errors, kind)) in error_map.items():
         check_errors(errors)


### PR DESCRIPTION
Reverts web-platform-tests/wpt#21954

The `print` function is already tested in the `test_print_function` test below. As long as we support Python 2, we should also have the `test_print_statement` test for `print` *statements*.