### PR TITLE
Add a test for unexpected activation triggered during space keydown driven focus management

### DIFF
--- a/uievents/order-of-events/focus-events/focus-management-expectations.html
+++ b/uievents/order-of-events/focus-events/focus-management-expectations.html
@@ -16,22 +16,31 @@
 <body>
   <button type="button" id="fromEl">Focus management from button</button>
   <button type="button" id="toEl">To button</button>
+  <button type="button" id="EndTestEl">End test button</button>
 </body>
 
 <script>
   const from = document.getElementById("fromEl")
   const to = document.getElementById("toEl")
+  const endTest = document.getElementById("EndTestEl")
+
+  from.addEventListener("keydown", function (event) {
+    if (event.key === " ") to.focus()
+  })
 
   async_test(function (t) {
-    from.addEventListener("keydown", function (event) {
-      if (event.key === " ") to.focus()
-    })
-
     to.addEventListener("click", t.unreached_func("Button should not be clicked"))
+    endTest.addEventListener('click', () => t.done())
 
+    // execute test
     from.focus()
     new test_driver.Actions().keyDown("\ue00d").keyUp("\ue00d").send().then(() =>
-      t.done()
+      // end test
+      new test_driver.Actions()
+        .pointerMove(0, 0, { origin: endTest })
+        .pointerDown()
+        .pointerUp()
+        .send()
     )
   }, "Keydown to focus should not trigger activation")
 </script>

--- a/uievents/order-of-events/focus-events/focus-management-expectations.html
+++ b/uievents/order-of-events/focus-events/focus-management-expectations.html
@@ -29,8 +29,13 @@
   })
 
   async_test(function (t) {
+    let buttonFocused = false
     to.addEventListener("click", t.unreached_func("Button should not be clicked"))
-    endTest.addEventListener('click', () => t.done())
+    to.addEventListener("focus", () => buttonFocused = true)
+    endTest.addEventListener('click', () => {
+      assert_true(buttonFocused, "Button should be focused")
+      t.step_timeout(() => t.done(), 200)
+    })
 
     // execute test
     from.focus()

--- a/uievents/order-of-events/focus-events/focus-management-expectations.html
+++ b/uievents/order-of-events/focus-events/focus-management-expectations.html
@@ -35,12 +35,7 @@
     // execute test
     from.focus()
     new test_driver.Actions().keyDown("\ue00d").keyUp("\ue00d").send().then(() =>
-      // end test
-      new test_driver.Actions()
-        .pointerMove(0, 0, { origin: endTest })
-        .pointerDown()
-        .pointerUp()
-        .send()
+      new test_driver.click(endTest)
     )
   }, "Keydown to focus should not trigger activation")
 </script>

--- a/uievents/order-of-events/focus-events/focus-management-expectations.html
+++ b/uievents/order-of-events/focus-events/focus-management-expectations.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Focus management event expectations</title>
+  <link rel="author" title="Mu-An Chiou" href="https://muan.co">
+  <link rel="help" href="https://w3c.github.io/uievents/#event-flow-activation">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+</head>
+
+<body>
+  <button type="button" id="fromEl">Focus management from button</button>
+  <button type="button" id="toEl">To button</button>
+</body>
+
+<script>
+  const from = document.getElementById("fromEl")
+  const to = document.getElementById("toEl")
+
+  async_test(function (t) {
+    from.addEventListener("keydown", function (event) {
+      if (event.key === " ") to.focus()
+    })
+
+    to.addEventListener("click", t.unreached_func("Button should not be clicked"))
+
+    from.focus()
+    new test_driver.Actions().keyDown("\ue00d").keyUp("\ue00d").send().then(() =>
+      t.done()
+    )
+  }, "Keydown to focus should trigger activation")
+</script>
+
+</html>

--- a/uievents/order-of-events/focus-events/focus-management-expectations.html
+++ b/uievents/order-of-events/focus-events/focus-management-expectations.html
@@ -33,7 +33,7 @@
     new test_driver.Actions().keyDown("\ue00d").keyUp("\ue00d").send().then(() =>
       t.done()
     )
-  }, "Keydown to focus should trigger activation")
+  }, "Keydown to focus should not trigger activation")
 </script>
 
 </html>


### PR DESCRIPTION
Relevant spec: https://w3c.github.io/uievents/#event-flow-activation

This is targeting [a Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1220143) where when forwarding focus on space and enter keydown events, a unexpected click event is triggered on the forward target.

Here's a demo page for the buggy behavior: https://html-is.glitch.me/firefox-space-focus.html

Since this is my first WPT pull request, I want to keep it small– this test case only cover the Space key case where Firefox is the outlier. 

There might be a better place for this test file. I'd be happy to take any suggestions and make changes accordingly.

Many thanks to @hexcles & @jgraham for helping me in IRC.

---

Reference re `\ue00d`: https://bugzilla.mozilla.org/show_bug.cgi?id=1417955

