### PR TITLE
DOM: latest DocumentFragment adoption changes

### DIFF
--- a/custom-elements/adopted-callback.html
+++ b/custom-elements/adopted-callback.html
@@ -127,7 +127,7 @@ document_types().forEach(function (entry) {
 
             calls = [];
             doc.documentElement.appendChild(shadowRoot);
-            assert_array_equals(calls, ['disconnected', 'adopted', document, doc, 'connected']);
+            assert_array_equals(calls, ['adopted', document, doc, 'disconnected', 'connected']);
         });
     }, 'Moving the shadow host\'s shadow of a custom element from the owner document into ' + documentName + ' must enqueue and invoke adoptedCallback');
 

--- a/dom/nodes/adoption.window.js
+++ b/dom/nodes/adoption.window.js
@@ -29,24 +29,28 @@ test(() => {
     "name": "ShadowRoot",
     "creator": doc => doc.createElementNS("http://www.w3.org/1999/xhtml", "div").attachShadow({mode: "closed"})
   }
-].forEach(dfTest => {
+].forEach(({ name, creator }) => {
   test(() => {
     const doc = new Document();
-    const df = dfTest.creator(doc);
+    const df = creator(doc);
     const child = df.appendChild(new Text('hi'));
     assert_equals(df.ownerDocument, doc);
 
     document.body.appendChild(df);
     assert_equals(df.childNodes.length, 0);
     assert_equals(child.ownerDocument, document);
-    assert_equals(df.ownerDocument, doc);
-  }, `appendChild() and ${dfTest.name}`);
+    if (name === "ShadowRoot") {
+      assert_equals(df.ownerDocument, doc);
+    } else {
+      assert_equals(df.ownerDocument, document);
+    }
+  }, `appendChild() and ${name}`);
 
   test(() => {
     const doc = new Document();
-    const df = dfTest.creator(doc);
+    const df = creator(doc);
     const child = df.appendChild(new Text('hi'));
-    if (dfTest.name === "ShadowRoot") {
+    if (name === "ShadowRoot") {
       assert_throws_dom("HierarchyRequestError", () => document.adoptNode(df));
     } else {
       document.adoptNode(df);
@@ -54,5 +58,5 @@ test(() => {
       assert_equals(child.ownerDocument, document);
       assert_equals(df.ownerDocument, document);
     }
-  }, `adoptNode() and ${dfTest.name}`);
+  }, `adoptNode() and ${name}`);
 });

--- a/dom/nodes/adoption.window.js
+++ b/dom/nodes/adoption.window.js
@@ -1,10 +1,15 @@
 // Testing DocumentFragment with host separately as it has a different node document by design
-test(() => {
+function create(doc, localName = "div") {
+  return doc.createElementNS("http://www.w3.org/1999/xhtml", localName);
+}
+
+test(t => {
   const df = document.createElement("template").content;
   const child = df.appendChild(new Text('hi'));
   assert_not_equals(df.ownerDocument, document);
   const nodeDocument = df.ownerDocument;
   document.body.appendChild(df);
+  t.add_cleanup(() => child.remove());
   assert_equals(df.childNodes.length, 0);
   assert_equals(child.ownerDocument, document);
   assert_equals(df.ownerDocument, nodeDocument);
@@ -27,16 +32,16 @@ test(() => {
   },
   {
     "name": "ShadowRoot",
-    "creator": doc => doc.createElementNS("http://www.w3.org/1999/xhtml", "div").attachShadow({mode: "closed"})
+    "creator": doc => create(doc).attachShadow({mode: "closed"})
   }
 ].forEach(({ name, creator }) => {
-  test(() => {
+  test(t => {
     const doc = new Document();
     const df = creator(doc);
     const child = df.appendChild(new Text('hi'));
     assert_equals(df.ownerDocument, doc);
-
     document.body.appendChild(df);
+    t.add_cleanup(() => child.remove());
     assert_equals(df.childNodes.length, 0);
     assert_equals(child.ownerDocument, document);
     if (name === "ShadowRoot") {
@@ -60,3 +65,18 @@ test(() => {
     }
   }, `adoptNode() and ${name}`);
 });
+
+test(t => {
+  const doc = new Document();
+  const host = create(doc);
+  const shadow = host.attachShadow({mode: "closed"});
+  const childHost = shadow.appendChild(create(doc, "body"));
+  const childShadow = childHost.attachShadow({mode: "closed"});
+  const descendant = childShadow.appendChild(new Text("hi"));
+  document.body.appendChild(shadow);
+  t.add_cleanup(() => childHost.remove());
+  assert_equals(shadow.childNodes.length, 0);
+  assert_equals(childHost.ownerDocument, document);
+  assert_equals(childShadow.ownerDocument, document);
+  assert_equals(descendant.ownerDocument, document);
+}, "Nested ShadowRoots");


### PR DESCRIPTION
See https://github.com/whatwg/dom/pull/819.

Verified with https://github.com/jsdom/jsdom/pull/2925.

I should probably add other tests to dom/nodes/adoption.window.js though to cover a host whose DF contains another host and variants on that as no test in web-platform-tests caught my accidental logic bug.