### PR TITLE
Add tests for font-family: <generic-family>;

### DIFF
--- a/css/css-fonts/generic-family-keywords-001.html
+++ b/css/css-fonts/generic-family-keywords-001.html
@@ -1,36 +1,56 @@
 <!DOCTYPE html>
-<title>CSS Test: Test generic family keywords do not match @font-face</title>
+<title>CSS Test: Test generic family keywords matching for @font-face</title>
 <link rel="help" href="https://drafts.csswg.org/css-fonts-4/#family-name-syntax">
 <link rel="author" title="Koji Ishii" href="mailto:kojii@chromium.com">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/css/css-fonts/support/font-family-keywords.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
 <style>
 div {
   font-size: 10px;
 }
+#ahem {
+  font-family: Ahem;
+}
 </style>
-<template id="fonts">
+<body>
+  <div><span id="ahem">00000</span></div>
+  <div><span id="test">00000</span></div>
+<script>
+  setup({ explicit_done: true });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  function runTests() {
+    let ahem = document.getElementById('ahem');
+    let ahem_expected_width = ahem.offsetWidth;
+    kGenericFontFamilyKeywords.forEach(keyword => {
+      test(() => {
+        let element = document.getElementById('test');
+        element.setAttribute("style", `font-family: ${keyword};`);
+        let expected_width = element.offsetWidth;
+
+        // Insert the @font-face rules for quoted and unquoted keywords.
+        document.documentElement.insertAdjacentHTML('beforeend', `
 <style>
 @font-face {
-  font-family: system-ui;
+  font-family: ${keyword};
   src: local(Ahem), url('/fonts/Ahem.ttf');
 }
 </style>
-</template>
-<body onload="onLoad()">
-  <div><span id="system-ui" style="font-family: system-ui">00000</span></div>
-<script>
-function onLoad() {
-  test(() => {
-    let element = document.getElementById('system-ui');
-    let expected_width = element.offsetWidth;
+<style>
+@font-face {
+  font-family: "${keyword}";
+  src: local(Ahem), url('/fonts/Ahem.ttf');
+}
+</style>`);
 
-    // Insert the @font-face rule.
-    let template = document.getElementById('fonts');
-    document.documentElement.appendChild(template.content.cloneNode(true));
+        assert_equals(element.offsetWidth, expected_width, `unquoted ${keyword} does not match @font-face rule`);
 
-    assert_equals(element.offsetWidth, expected_width);
-  });
-};
+        element.setAttribute("style", `font-family: "${keyword}";`);
+        assert_equals(element.offsetWidth, ahem_expected_width, `quoted ${keyword} matches  @font-face rule`);
+      }, `@font-face matching for quoted and unquoted ${keyword}`);
+    });
+    done();
+  }
 </script>
 </body>

--- a/css/css-fonts/generic-family-keywords-002.html
+++ b/css/css-fonts/generic-family-keywords-002.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Generic font family: -webkit-* treated as &lt;font-family&gt;</title>
+    <link rel="help" href="https://drafts.csswg.org/css-fonts-4/#generic-font-families">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/css/css-fonts/support/font-family-keywords.js"></script>
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+    <style>
+      div {
+        font-size: 10px;
+      }
+      #ahem {
+        font-family: Ahem;
+      }
+    </style>
+  </head>
+  <body>
+    <div><span id="ahem">00000</span></div>
+    <div><span id="test">00000</span></div>
+  </body>
+<script>
+  setup({ explicit_done: true });
+  window.addEventListener("load", () => { document.fonts.ready.then(runTests); });
+  function SetFontFamilyAndMeasure(fontFamilyValue) {
+    var element = document.getElementById('test');
+    element.setAttribute("style", `font-family: ${fontFamilyValue}, Ahem;`);
+    return element.offsetWidth;
+  }
+  function runTests() {
+    let ahem = document.getElementById('ahem');
+    let ahem_expected_width = ahem.offsetWidth;
+    let families = kGenericFontFamilyKeywords.map(keyword => `-webkit-${keyword}`).concat(kWebKitPrefixKeywords);
+    families.forEach(name => {
+      test(function() {
+      assert_equals(SetFontFamilyAndMeasure(name), ahem_expected_width);
+      }, `font-family: ${name} treated as <font-family>, not <generic-name>`);
+    });
+    done();
+  }
+</script>
+</html>

--- a/css/css-fonts/support/font-family-keywords.js
+++ b/css/css-fonts/support/font-family-keywords.js
@@ -1,0 +1,17 @@
+var kGenericFontFamilyKeywords = ["serif",
+                                  "sans-serif",
+                                  "cursive",
+                                  "fantasy",
+                                  "monospace",
+                                  "system",
+                                  "emoji",
+                                  "math",
+                                  "fangsong",
+                                  "ui-serif",
+                                  "ui-sans-serif",
+                                  "ui-monospace",
+                                  "ui-rounded"];
+
+var kWebKitPrefixKeywords = ["-webkit-body",
+                             "-webkit-standard",
+                             "-webkit-pictograph"];

--- a/css/cssom/font-family-serialization-001.html
+++ b/css/cssom/font-family-serialization-001.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+<meta charset="utf-8">
+<title>Serialization of font-family</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#serialize-a-css-declaration-block">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-family-prop">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/css-fonts/support/font-family-keywords.js"></script>
+<div id="target"></div>
+<script>
+  function SetFontFamilyAndSerialize(fontFamilyValue) {
+    var target = document.getElementById('target');
+    target.setAttribute("style", `font-family: ${fontFamilyValue}`);
+    return window.getComputedStyle(target).getPropertyValue('font-family');
+  }
+  test(function() {
+    kGenericFontFamilyKeywords.forEach(keyword => {
+      assert_equals(SetFontFamilyAndSerialize(keyword), keyword);
+    });
+  }, "Serialization of <generic-family>");
+
+  test(function() {
+    kGenericFontFamilyKeywords.forEach(keyword => {
+      var quoted_keyword = `"${keyword}"`;
+      assert_equals(SetFontFamilyAndSerialize(quoted_keyword), quoted_keyword);
+    });
+  }, "Serialization of quoted \"<generic-family>\"");
+
+  test(function() {
+    kGenericFontFamilyKeywords.forEach(keyword => {
+      var prefixed_keyword = `-webkit-${keyword}`;
+      assert_equals(SetFontFamilyAndSerialize(prefixed_keyword), prefixed_keyword);
+    });
+  }, "Serialization of prefixed -webkit-<generic-family>");
+
+  test(function() {
+    kWebKitPrefixKeywords.forEach(keyword => {
+      assert_equals(SetFontFamilyAndSerialize(keyword), keyword);
+    });
+  }, `Serialization of ${kWebKitPrefixKeywords}`);
+
+</script>
+</html>


### PR DESCRIPTION
    This adds tests to check rendering and serialization of the font-family
    property with the <generic-family> names [1]. It also checks that
    nonstandard -webkit-* values are treated as <family-name>. Because of
    the way font-family is implemented in WebKit and Chromium,
    such -webkit-* values are exposed and are even causing bugs in the
    implementation of standard generic font family names.
    
    [1] https://drafts.csswg.org/css-fonts-4/#generic-font-families
