### PR TITLE
Make stability.py work with py3

### DIFF
--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -5,6 +5,7 @@ import io
 import os
 from collections import OrderedDict, defaultdict
 from datetime import datetime
+from six import iteritems
 
 from mozlog import reader
 from mozlog.formatters import JSONFormatter
@@ -140,10 +141,10 @@ def process_results(log, iterations):
     handler = LogHandler()
     reader.handle_log(reader.read(log), handler)
     results = handler.results
-    for test_name, test in results.iteritems():
+    for test_name, test in iteritems(results):
         if is_inconsistent(test["status"], iterations):
             inconsistent.append((test_name, None, test["status"], []))
-        for subtest_name, subtest in test["subtests"].iteritems():
+        for subtest_name, subtest in iteritems(test["subtests"]):
             if is_inconsistent(subtest["status"], iterations):
                 inconsistent.append((test_name, subtest_name, subtest["status"], subtest["messages"]))
 
@@ -208,7 +209,7 @@ def write_results(log, results, iterations, pr_number=None, use_details=False):
                                                   "tests" if len(results) > 1
                                                   else "test"))
 
-    for test_name, test in results.iteritems():
+    for test_name, test in iteritems(results):
         baseurl = "http://w3c-test.org/submissions"
         if "https" in os.path.splitext(test_name)[0].split(".")[1:]:
             baseurl = "https://w3c-test.org/submissions"
@@ -236,7 +237,7 @@ def write_results(log, results, iterations, pr_number=None, use_details=False):
 
 
 def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwargs):
-    import wptrunner
+    from . import wptrunner
     kwargs = copy.deepcopy(kwargs)
 
     if restart_after_iteration:
@@ -278,7 +279,7 @@ def get_steps(logger, repeat_loop, repeat_restart, kwargs_extras):
     for kwargs_extra in kwargs_extras:
         if kwargs_extra:
             flags_string = " with flags %s" % " ".join(
-                "%s=%s" % item for item in kwargs_extra.iteritems())
+                "%s=%s" % item for item in iteritems(kwargs_extra))
         else:
             flags_string = ""
 

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -339,7 +339,7 @@ def run_tests(config, test_paths, product, **kwargs):
 
 
 def check_stability(**kwargs):
-    import stability
+    from . import stability
     if kwargs["stability"]:
         logger.warning("--stability is deprecated; please use --verify instead!")
         kwargs['verify_max_time'] = None


### PR DESCRIPTION
Running `wpt run --verify` was failing in py3 for 2 reasons:
   * Importing modules from the same dir was not working
   * iteritems() is not defined for collections