### PR TITLE
Added 6 break-spaces and new line tests

### DIFF
--- a/css/css-text/white-space/break-spaces-newline-011.html
+++ b/css/css-text/white-space/break-spaces-newline-011.html
@@ -2,7 +2,7 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Text: 'white-space: break-spaces' with a sequence of white spaces and 1 line feed</title>
+  <title>CSS Text: 'white-space: break-spaces' with 4 white spaces and 4 line feeda</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
@@ -41,9 +41,9 @@
 
   <div id="overlapped-red-reference"></div>
 
-  <div id="overlapping-green-test">             &NewLine;</div>
-  <!--                             ^           ^
-      13 consecutive white spaces: 1234567890123
+  <div id="overlapping-green-test">&NewLine;&NewLine;    &NewLine;&NewLine;</div>
+  <!--                                               ^  ^
+                         4 consecutive white spaces: 1234
   -->
 
 <!--

--- a/css/css-text/white-space/break-spaces-newline-011.html
+++ b/css/css-text/white-space/break-spaces-newline-011.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text: 'white-space: break-spaces' with a sequence of white spaces and 1 line feed</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
+  <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that when 'white-space' is set to 'break-spaces', then line feeds (&amp;NewLine; in the code) are preserved, just like with 'white-space: pre' or with 'white-space: pre-wrap'.">
+
+  <style>
+  div
+    {
+      font-family: Ahem;
+      font-size: 25px;
+      line-height: 1;
+      width: 4em;
+    }
+
+  div#overlapped-red-reference
+    {
+      background-color: red;
+      height: 4em;
+    }
+
+  div#overlapping-green-test
+    {
+      background-color: green;
+      bottom: 4em;
+      color: red;
+      position: relative;
+      white-space: break-spaces;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <div id="overlapped-red-reference"></div>
+
+  <div id="overlapping-green-test">             &NewLine;</div>
+  <!--                             ^           ^
+      13 consecutive white spaces: 1234567890123
+  -->
+
+<!--
+
+  &NewLine; == Line feed == &#x000A; == &#0010;
+
+-->

--- a/css/css-text/white-space/break-spaces-newline-012.html
+++ b/css/css-text/white-space/break-spaces-newline-012.html
@@ -2,7 +2,7 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Text: 'white-space: break-spaces', 10 white spaces and 2 line feeds</title>
+  <title>CSS Text: 'white-space: break-spaces', 10 white spaces and 1 line feed</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
@@ -41,7 +41,7 @@
 
   <div id="overlapped-red-reference"></div>
 
-  <div id="overlapping-green-test"> &NewLine;         &NewLine;</div>
+  <div id="overlapping-green-test"> &NewLine;         </div>
   <!--                             ^         ^       ^
                   10 white spaces: 1         234567890
   -->

--- a/css/css-text/white-space/break-spaces-newline-012.html
+++ b/css/css-text/white-space/break-spaces-newline-012.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text: 'white-space: break-spaces', 10 white spaces and 2 line feeds</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
+  <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that when 'white-space' is set to 'break-spaces', then line feeds (&amp;NewLine; in the code) are preserved, just like with 'white-space: pre' or with 'white-space: pre-wrap'.">
+
+  <style>
+  div
+    {
+      font-family: Ahem;
+      font-size: 25px;
+      line-height: 1;
+      width: 4em;
+    }
+
+  div#overlapped-red-reference
+    {
+      background-color: red;
+      height: 4em;
+    }
+
+  div#overlapping-green-test
+    {
+      background-color: green;
+      bottom: 4em;
+      color: red;
+      position: relative;
+      white-space: break-spaces;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <div id="overlapped-red-reference"></div>
+
+  <div id="overlapping-green-test"> &NewLine;         &NewLine;</div>
+  <!--                             ^         ^       ^
+                  10 white spaces: 1         234567890
+  -->
+
+<!--
+
+  &NewLine; == Line feed == &#x000A; == &#0010;
+
+-->

--- a/css/css-text/white-space/break-spaces-newline-013.html
+++ b/css/css-text/white-space/break-spaces-newline-013.html
@@ -2,7 +2,7 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Text: 'white-space: break-spaces', 7 white spaces and 3 line feeds</title>
+  <title>CSS Text: 'white-space: break-spaces', 7 white spaces and 2 line feeds</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
@@ -41,7 +41,7 @@
 
   <div id="overlapped-red-reference"></div>
 
-  <div id="overlapping-green-test"> &NewLine; &NewLine;     &NewLine;</div>
+  <div id="overlapping-green-test"> &NewLine; &NewLine;     </div>
   <!--                             ^         ^         ^   ^
                    7 white spaces: 1         2         34567
   -->

--- a/css/css-text/white-space/break-spaces-newline-013.html
+++ b/css/css-text/white-space/break-spaces-newline-013.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text: 'white-space: break-spaces', 7 white spaces and 3 line feeds</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
+  <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that when 'white-space' is set to 'break-spaces', then line feeds (&amp;NewLine; in the code) are preserved, just like with 'white-space: pre' or with 'white-space: pre-wrap'.">
+
+  <style>
+  div
+    {
+      font-family: Ahem;
+      font-size: 25px;
+      line-height: 1;
+      width: 4em;
+    }
+
+  div#overlapped-red-reference
+    {
+      background-color: red;
+      height: 4em;
+    }
+
+  div#overlapping-green-test
+    {
+      background-color: green;
+      bottom: 4em;
+      color: red;
+      position: relative;
+      white-space: break-spaces;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <div id="overlapped-red-reference"></div>
+
+  <div id="overlapping-green-test"> &NewLine; &NewLine;     &NewLine;</div>
+  <!--                             ^         ^         ^   ^
+                   7 white spaces: 1         2         34567
+  -->
+
+<!--
+
+  &NewLine; == Line feed == &#x000A; == &#0010;
+
+-->

--- a/css/css-text/white-space/break-spaces-newline-014.html
+++ b/css/css-text/white-space/break-spaces-newline-014.html
@@ -2,7 +2,7 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Text: 'white-space: break-spaces', 4 white spaces and 4 line feeds</title>
+  <title>CSS Text: 'white-space: break-spaces', 4 white spaces and 3 line feeds</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
@@ -41,7 +41,7 @@
 
   <div id="overlapped-red-reference"></div>
 
-  <div id="overlapping-green-test"> &NewLine; &NewLine; &NewLine; &NewLine;</div>
+  <div id="overlapping-green-test"> &NewLine; &NewLine; &NewLine; </div>
   <!--                             ^         ^         ^         ^
                    4 white spaces: 1         2         3         4
   -->

--- a/css/css-text/white-space/break-spaces-newline-014.html
+++ b/css/css-text/white-space/break-spaces-newline-014.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text: 'white-space: break-spaces', 4 white spaces and 4 line feeds</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
+  <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that when 'white-space' is set to 'break-spaces', then line feeds (&amp;NewLine; in the code) are preserved, just like with 'white-space: pre' or with 'white-space: pre-wrap'.">
+
+  <style>
+  div
+    {
+      font-family: Ahem;
+      font-size: 25px;
+      line-height: 1;
+      width: 4em;
+    }
+
+  div#overlapped-red-reference
+    {
+      background-color: red;
+      height: 4em;
+    }
+
+  div#overlapping-green-test
+    {
+      background-color: green;
+      bottom: 4em;
+      color: red;
+      position: relative;
+      white-space: break-spaces;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <div id="overlapped-red-reference"></div>
+
+  <div id="overlapping-green-test"> &NewLine; &NewLine; &NewLine; &NewLine;</div>
+  <!--                             ^         ^         ^         ^
+                   4 white spaces: 1         2         3         4
+  -->
+
+<!--
+
+  &NewLine; == Line feed == &#x000A; == &#0010;
+
+-->

--- a/css/css-text/white-space/break-spaces-newline-015.html
+++ b/css/css-text/white-space/break-spaces-newline-015.html
@@ -2,7 +2,7 @@
 
   <meta charset="UTF-8">
 
-  <title>CSS Text: 'white-space: break-spaces', 3 white spaces and 4 line feeds</title>
+  <title>CSS Text: 'white-space: break-spaces', 3 white spaces and 3 line feeds</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
@@ -41,7 +41,7 @@
 
   <div id="overlapped-red-reference"></div>
 
-  <div id="overlapping-green-test">&NewLine; &NewLine; &NewLine; &NewLine;</div>
+  <div id="overlapping-green-test">&NewLine; &NewLine; &NewLine; </div>
   <!--                                      ^         ^         ^
                             3 white spaces: 1         2         3
   -->

--- a/css/css-text/white-space/break-spaces-newline-015.html
+++ b/css/css-text/white-space/break-spaces-newline-015.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text: 'white-space: break-spaces', 3 white spaces and 4 line feeds</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
+  <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that when 'white-space' is set to 'break-spaces', then line feeds (&amp;NewLine; in the code) are preserved, just like with 'white-space: pre' or with 'white-space: pre-wrap'.">
+
+  <style>
+  div
+    {
+      font-family: Ahem;
+      font-size: 25px;
+      line-height: 1;
+      width: 4em;
+    }
+
+  div#overlapped-red-reference
+    {
+      background-color: red;
+      height: 4em;
+    }
+
+  div#overlapping-green-test
+    {
+      background-color: green;
+      bottom: 4em;
+      color: red;
+      position: relative;
+      white-space: break-spaces;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <div id="overlapped-red-reference"></div>
+
+  <div id="overlapping-green-test">&NewLine; &NewLine; &NewLine; &NewLine;</div>
+  <!--                                      ^         ^         ^
+                            3 white spaces: 1         2         3
+  -->
+
+<!--
+
+  &NewLine; == Line feed == &#x000A; == &#0010;
+
+-->

--- a/css/css-text/white-space/break-spaces-newline-016.html
+++ b/css/css-text/white-space/break-spaces-newline-016.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text: 'white-space: break-spaces' and 4 consecutive line feeds</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-property">
+  <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that when 'white-space' is set to 'break-spaces', then line feeds (&amp;NewLine; in the code) are preserved, just like with 'white-space: pre' or with 'white-space: pre-wrap'.">
+
+  <style>
+  div
+    {
+      font-family: Ahem;
+      font-size: 25px;
+      line-height: 1;
+      width: 4em;
+    }
+
+  div#overlapped-red-reference
+    {
+      background-color: red;
+      height: 4em;
+    }
+
+  div#overlapping-green-test
+    {
+      background-color: green;
+      bottom: 4em;
+      color: red;
+      position: relative;
+      white-space: break-spaces;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.
+
+  <div id="overlapped-red-reference"></div>
+
+  <div id="overlapping-green-test">&NewLine;&NewLine;&NewLine;&NewLine;</div>
+
+<!--
+
+  &NewLine; == Line feed == &#x000A; == &#0010;
+
+-->


### PR DESCRIPTION
break-spaces-newline-011.html
break-spaces-newline-012.html
break-spaces-newline-013.html
break-spaces-newline-014.html
break-spaces-newline-015.html
break-spaces-newline-016.html

These 6 tests are trying to test that 
When 'white-space' is set to 'break-spaces', then line feeds are preserved and they are not collapsed, just like when 'white-space' is set to 'pre' or set to 'pre-wrap'