### PR TITLE
dom/events/Event-dispatch-redispatch.html emits exact text metrics

### DIFF
--- a/dom/events/Event-dispatch-redispatch.html
+++ b/dom/events/Event-dispatch-redispatch.html
@@ -104,7 +104,7 @@ async function testMouseUpAndClickEvent() {
 
   await waitForLoad;
   let bounds = buttonElement.getBoundingClientRect();
-  test(() => { assert_true(true); }, `Synthesizing click on button... (button width / height: ${bounds.width} / ${bounds.height})`);
+  test(() => { assert_true(true); }, `Synthesizing click on button...`);
   new test_driver.Actions()
       .pointerMove(Math.floor(bounds.width / 5),
                    Math.floor(bounds.height / 2),


### PR DESCRIPTION
It doesn't make sense to emit exact pixel sizes for text runs.
These pixel sizes will change from OS to OS, thereby causing
false failures when comparing textual output from tests.