### PR TITLE
Adjust assert in css-text tests to be more specific

### DIFF
--- a/css/css-text/line-breaking/line-breaking-009.html
+++ b/css/css-text/line-breaking/line-breaking-009.html
@@ -2,7 +2,7 @@
 <html>
 <meta charset="utf-8">
 <title>CSS Text — line breaking at element boundary</title>
-<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the properties on nearest common ancestor of the two characters controls breaking.">
+<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the white-space property on nearest common ancestor of the two characters controls breaking.">
 <link rel=help href="https://www.w3.org/TR/css-text-3/#line-break-details">
 <link rel=match href="reference/line-breaking-001-ref.html">
 <link rel=author title="Florian Rivoal" href="http://florian.rivoal.net">

--- a/css/css-text/line-breaking/line-breaking-010.html
+++ b/css/css-text/line-breaking/line-breaking-010.html
@@ -2,7 +2,7 @@
 <html>
 <meta charset="utf-8">
 <title>CSS Text — line breaking at element boundary 2</title>
-<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the properties on nearest common ancestor of the two characters controls breaking.">
+<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the white-space property on nearest common ancestor of the two characters controls breaking.">
 <link rel=help href="https://www.w3.org/TR/css-text-3/#line-break-details">
 <link rel=match href="reference/line-breaking-001-ref.html">
 <link rel=author title="Florian Rivoal" href="http://florian.rivoal.net">

--- a/css/css-text/line-breaking/line-breaking-011.html
+++ b/css/css-text/line-breaking/line-breaking-011.html
@@ -2,7 +2,7 @@
 <html>
 <meta charset="utf-8">
 <title>CSS Text — line breaking at element boundary 3</title>
-<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the properties on nearest common ancestor of the two characters controls breaking.">
+<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the white-space property on nearest common ancestor of the two characters controls breaking.">
 <link rel=help href="https://www.w3.org/TR/css-text-3/#line-break-details">
 <link rel=match href="reference/line-breaking-001-ref.html">
 <link rel=author title="Florian Rivoal" href="http://florian.rivoal.net">

--- a/css/css-text/line-breaking/line-breaking-ic-001.html
+++ b/css/css-text/line-breaking/line-breaking-ic-001.html
@@ -2,7 +2,7 @@
 <html>
 <meta charset="utf-8">
 <title>CSS Text — line breaking at element boundary with ideographic caracters 1</title>
-<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the properties on nearest common ancestor of the two characters controls breaking.">
+<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the white-space property on nearest common ancestor of the two characters controls breaking.">
 <link rel=help href="https://www.w3.org/TR/css-text-3/#line-break-details">
 <link rel=match href="reference/line-breaking-ic-001-ref.html">
 <link rel=author title="Florian Rivoal" href="http://florian.rivoal.net">

--- a/css/css-text/line-breaking/line-breaking-ic-002.html
+++ b/css/css-text/line-breaking/line-breaking-ic-002.html
@@ -2,7 +2,7 @@
 <html>
 <meta charset="utf-8">
 <title>CSS Text — line breaking at element boundary with ideographic caracters 2</title>
-<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the properties on nearest common ancestor of the two characters controls breaking.">
+<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the white-space property on nearest common ancestor of the two characters controls breaking.">
 <link rel=help href="https://www.w3.org/TR/css-text-3/#line-break-details">
 <link rel=match href="reference/line-breaking-ic-001-ref.html">
 <link rel=author title="Florian Rivoal" href="http://florian.rivoal.net">

--- a/css/css-text/line-breaking/line-breaking-ic-003.html
+++ b/css/css-text/line-breaking/line-breaking-ic-003.html
@@ -2,7 +2,7 @@
 <html>
 <meta charset="utf-8">
 <title>CSS Text — line breaking at element boundary with ideographic caracters 1</title>
-<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the properties on nearest common ancestor of the two characters controls breaking.">
+<meta name=assert content="For soft wrap opportunities defined by the boundary between two characters, the white-space property on nearest common ancestor of the two characters controls breaking.">
 <link rel=help href="https://www.w3.org/TR/css-text-3/#line-break-details">
 <link rel=match href="reference/line-breaking-ic-001-ref.html">
 <link rel=author title="Florian Rivoal" href="http://florian.rivoal.net">


### PR DESCRIPTION
The spec used to be broader, but has narrowed down the case where this
logic is applicable. The tests are still valid but the claim made by the
assert was now too broad.