### PR TITLE
A test for CanvasRenderingContext2D.drawImage() with image-orientatio…

### DIFF
--- a/css/css-images/image-orientation/image-orientation-none-canvas-drawImage.html
+++ b/css/css-images/image-orientation/image-orientation-none-canvas-drawImage.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Images Module Level 3: image-orientation: none in canvas</title>
+<link rel="author" title="Said Abou-Hallawa" href="mailto:sabouhallawa@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
+<link rel="match" href="reference/image-orientation-none-canvas-drawImage-ref.html">
+<meta name=fuzzy content="10;100">
+<style>
+    body {
+        overflow: hidden;
+        image-orientation: none;
+    }
+    div {
+        display: inline-block;
+        width: 100px;
+        vertical-align: top;
+    }
+    img {
+        image-orientation: none;
+        display: none;
+    }
+</style>
+<script>
+    function runTest() {
+        let images = document.querySelectorAll("img");
+        let canvases = document.querySelectorAll("canvas");
+        for (let i = 0; i < images.length; i++) {
+            let image = images[i];
+            let canvas = canvases[i];
+            canvas.width = image.width;
+            canvas.height = image.height;
+            let context = canvas.getContext("2d");
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        }
+    }
+</script>
+</head>
+<body onload="runTest()">
+    <p>CanvasRenderingContext2D.drawImage should not rotate images respecting
+       their EXIF orientation because image-orientation: none is specified.</p>
+    <div><img src="support/exif-orientation-1-ul.jpg"/><canvas></canvas></div>
+    <div><img src="support/exif-orientation-2-ur.jpg"/><canvas></canvas></div>
+    <div><img src="support/exif-orientation-3-lr.jpg"/><canvas></canvas></div>
+    <div><img src="support/exif-orientation-4-lol.jpg"/><canvas></canvas></div>
+    <div><img src="support/exif-orientation-5-lu.jpg"/><canvas></canvas></div>
+    <div><img src="support/exif-orientation-6-ru.jpg"/><canvas></canvas></div>
+    <div><img src="support/exif-orientation-7-rl.jpg"/><canvas></canvas></div>
+    <div><img src="support/exif-orientation-8-llo.jpg"/><canvas></canvas></div>
+    <div><img src="support/exif-orientation-9-u.jpg"/><canvas></canvas></div>
+</body>
+</html>

--- a/css/css-images/image-orientation/reference/image-orientation-none-canvas-drawImage-ref.html
+++ b/css/css-images/image-orientation/reference/image-orientation-none-canvas-drawImage-ref.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Images Module Level 3: image-orientation: none in canvas</title>
+<link rel="author" title="Said Abou-Hallawa" href="mailto:sabouhallawa@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
+<style>
+    body {
+        overflow: hidden;
+    }
+    div {
+        display: inline-block;
+        width: 100px;
+        vertical-align: top;
+    }
+    img {
+        display: none;
+    }
+</style>
+<script>
+    function runTest() {
+        let image = document.querySelector("img");
+        let canvases = document.querySelectorAll("canvas");
+        for (let i = 0; i < canvases.length; i++) {
+            let canvas = canvases[i];
+            canvas.width = image.width;
+            canvas.height = image.height;
+            let context = canvas.getContext("2d");
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        }
+    }
+</script>
+</head>
+<body onload="runTest()">
+    <p>CanvasRenderingContext2D.drawImage should not rotate images respecting
+       their EXIF orientation because image-orientation: none is specified.</p>
+    <div><img src="../support/exif-orientation-1-ul.jpg"/><canvas></canvas></div>
+    <div><canvas></canvas></div>
+    <div><canvas></canvas></div>
+    <div><canvas></canvas></div>
+    <div><canvas></canvas></div>
+    <div><canvas></canvas></div>
+    <div><canvas></canvas></div>
+    <div><canvas></canvas></div>
+    <div><canvas></canvas></div>
+</body>
+</html>


### PR DESCRIPTION
When image-orientation: none is specified, CanvasRenderingContext2D.drawImage should not rotate images respecting their EXIF orientation.