### PR TITLE
Python 3: Fix xrange import in tests using six library

### DIFF
--- a/fetch/api/resources/bad-chunk-encoding.py
+++ b/fetch/api/resources/bad-chunk-encoding.py
@@ -1,5 +1,7 @@
 import time
 
+from six.moves import xrange
+
 def main(request, response):
     delay = float(request.GET.first("ms", 1000)) / 1E3
     count = int(request.GET.first("count", 50))

--- a/service-workers/service-worker/resources/trickle.py
+++ b/service-workers/service-worker/resources/trickle.py
@@ -1,5 +1,7 @@
 import time
 
+from six.moves import xrange
+
 def main(request, response):
     delay = float(request.GET.first("ms", 500)) / 1E3
     count = int(request.GET.first("count", 50))

--- a/xhr/resources/trickle.py
+++ b/xhr/resources/trickle.py
@@ -1,5 +1,7 @@
 import time
 
+from six.moves import xrange
+
 def main(request, response):
     chunk = "TEST_TRICKLE\n"
     delay = float(request.GET.first("ms", 500)) / 1E3


### PR DESCRIPTION
In python 2.x, xrange is used to return a generator. In python 3.x,
xrange has been removed and range returns a generator just like xrange
in python 2.x.

six.moves.xrange corresponds xrange in python 2.x and range in python 3.x