### PR TITLE
css-flexbox/auto-margins-001.html: Use Ahem font for alignment tests.

### DIFF
--- a/css/css-flexbox/auto-margins-001-ref.html
+++ b/css/css-flexbox/auto-margins-001-ref.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <link rel="author" title="Google Inc." href="http://www.google.com/">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 
 #circles, #circles div {
@@ -17,13 +18,13 @@
 <body>
 <p>These tests are from the spec: <a href="http://dev.w3.org/csswg/css3-flexbox/#auto-margins">http://dev.w3.org/csswg/css3-flexbox/#auto-margins</a>.</p>
 
-<p>The word OK should be centered vertically and horizontally.</p>
+<p>The black rectangle should be centered vertically and horizontally.</p>
 <div style="width: 4em; height: 4em; background: silver">
-  <table style="width: 100%; height: 100%;"><tr><td style="text-align: center">OK</td></tr></table>
+  <table style="width: 100%; height: 100%;"><tr><td style="text-align: center; font-family: Ahem;">OK</td></tr></table>
 </div>
 
 <div style="width: 4em; height: 4em; margin-top: 10px; background: silver; writing-mode: vertical-rl">
-  <table style="width: 100%; height: 100%;"><tr><td style="text-align: center">OK</td></tr></table>
+  <table style="width: 100%; height: 100%;"><tr><td style="text-align: center; font-family: Ahem;">OK</td></tr></table>
 </div>
 
 <p>You should see 3 blue concentric circles.</p>

--- a/css/css-flexbox/auto-margins-001.html
+++ b/css/css-flexbox/auto-margins-001.html
@@ -3,6 +3,7 @@
 <head>
 <title>CSS Test: Aligning with auto margins</title>
 <link href="support/flexbox.css" rel="stylesheet">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <link rel="author" title="Google Inc." href="http://www.google.com/">
 <link rel="help" href="https://drafts.csswg.org/css-flexbox/#auto-margins">
 <link rel="match" href="auto-margins-001-ref.html">
@@ -27,13 +28,13 @@
 <body>
 <p>These tests are from the spec: <a href="http://dev.w3.org/csswg/css3-flexbox/#auto-margins">http://dev.w3.org/csswg/css3-flexbox/#auto-margins</a>.</p>
 
-<p>The word OK should be centered vertically and horizontally.</p>
+<p>The black rectangle should be centered vertically and horizontally.</p>
 <div class="flexbox" style="width: 4em; height: 4em; background: silver">
-  <p id="ok" style="margin: auto;">OK</p>
+  <p id="ok" style="margin: auto; font-family: Ahem;">OK</p>
 </div>
 
 <div class="flexbox" style="width: 4em; height: 4em; margin-top: 10px; background: silver; writing-mode: vertical-rl">
-  <p id="okVertical" style="margin: auto;">OK</p>
+  <p id="okVertical" style="margin: auto; font-family: Ahem;">OK</p>
 </div>
 
 <p>You should see 3 blue concentric circles.</p>


### PR DESCRIPTION
On WebKit this test fails because of very few pixel differences on the word `OK`. This its perhaps caused by antialiasing differences applied to the font in each case.

See: 
* [Safari image diff](https://wpt.fyi/analyzer?screenshot=sha1%3Af27bbea88d18e5fd05a246ed2ec6f7aa0bc55080&screenshot=sha1%3Ac30240d1a3daaefd15f4b86d27f59a313731f24d)
* [WebKitGTK diff](https://wpt.fyi/analyzer?screenshot=sha1%3Af2bb378c74272a6d55a1acf92bf738065d0249f3&screenshot=sha1%3A6f55e22eea4919817c199204338b6fbc53bf1c98)

To avoid this problem we use Ahem font to render the word `OK`, that way we drawn a rectangle where antialising doesn't have any effect. This is because WebKit disables antialising for this test font.