### PR TITLE
Fix css/css-flexbox/reference/flexitem-stretch-range-ref.html

### DIFF
--- a/css/css-flexbox/reference/flexitem-stretch-range-ref.html
+++ b/css/css-flexbox/reference/flexitem-stretch-range-ref.html
@@ -3,7 +3,7 @@
 <body>
 <p>When stretching a range input, the thumb should be centered vertically.</p>
 <div style="height: 200px;">
-    <input type="range" style="width: 100%; height: 100%; margin: 0;">
+    <input type="range" style="width: 100%; height: 100%; margin: 0; box-sizing: border-box;">
 </div>
 </body>
 </html>


### PR DESCRIPTION
After latest syncing up of WPT repository into Mozilla, 
css/css-flexbox/reference/flexitem-stretch-range.html started failing on
Windows with a one-off pixel difference.

As per dholbert's insight in [1], this patch adds "box-sizing: border-box"
to css/css-flexbox/reference/flexitem-stretch-range-ref.html,
so that the reference case behaves similarly to the test case
in all platforms.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1626240#c5