### PR TITLE
test for dynamic shipping options

### DIFF
--- a/payment-request/dynamically-change-shipping-options-manual.https.html
+++ b/payment-request/dynamically-change-shipping-options-manual.https.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<!-- Copyright © 2017 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
+<meta charset="utf-8">
+<title>Test for PaymentRequest shippingOption dynamic updating</title>
+<link rel="help" href="https://w3c.github.io/payment-request/#shippingoption-attribute">
+<link rel="help" href="https://w3c.github.io/payment-request/#onshippingoptionchange-attribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({ explicit_done: true, explicit_timeout: true });
+const validMethod = Object.freeze({ supportedMethods: "basic-card" });
+const applePayMethod = {
+  supportedMethods: "https://apple.com/apple-pay",
+  data: {
+    version: 3,
+    merchantIdentifier: "merchant.com.example",
+    countryCode: "US",
+    merchantCapabilities: ["supports3DS"],
+    supportedNetworks: ["visa"],
+  },
+};
+const validMethods = Object.freeze([validMethod, applePayMethod]);
+const validAmount = Object.freeze({ currency: "USD", value: "5.00" });
+const validTotal = Object.freeze({
+  label: "label",
+  amount: validAmount,
+});
+const validDetails = Object.freeze({ total: validTotal });
+
+const validShippingOption1 = Object.freeze({
+  id: "default-method",
+  label: "Default shipping method",
+  amount: validAmount,
+  selected: true,
+});
+
+const validDynamicShippingOption = Object.freeze({
+  id: "dynamically-added-id",
+  label: "Dynamically added shipping option",
+  amount: validAmount,
+  selected: false,
+});
+
+const requestShipping = Object.freeze({
+  requestShipping: true,
+});
+
+function testShippingOptionChanged() {
+  promise_test(async t => {
+    const detailsWithShippingOptions = Object.assign({}, validDetails, {
+      shippingOptions: [validShippingOption1],
+    });
+    const request = new PaymentRequest(
+      validMethods,
+      detailsWithShippingOptions,
+      requestShipping
+    );
+    const shippingAddressChangeListener = new Promise(resolve => {
+      request.addEventListener("shippingaddresschange", (ev) => {
+        // resolve(request.shippingOption);
+        ev.updateWith(Object.assign({}, {
+          shippingOptions: [validShippingOption1, validDynamicShippingOption]
+        }))
+        resolve()
+      }, {once:true});
+    });
+    const handlerPromise = new Promise(resolve => {
+      request.onshippingoptionchange = () => {
+        resolve(request.shippingOption);
+      };
+    });
+    request.show().catch(err => err);
+
+    const results = await Promise.all([shippingAddressChangeListener, handlerPromise]);
+    assert_true(
+      results[1] === "dynamically-added-id",
+      "Expected dynamically-added-id as the shippingOption"
+    );
+    await request.abort();
+  });
+  done();
+}
+</script>
+
+<h2>PaymentRequest shippingOption attribute</h2>
+<p>
+  Click on each button in sequence from top to bottom without refreshing the page.
+  Each button will bring up the Payment Request UI window.
+</p>
+  <ol>
+    <li>
+      When the payment sheet is presented, view options for Shipping Method. There should only be one: "Default shipping method"
+    </li>
+    <li>
+      Change your Shipping Address - either update your existing one by changing something (name, address, etc), or select a different Shipping Address, or add a new Shipping Address and select it.
+    </li>
+    <li>
+      Go back to Shipping Method, and there is now an option called "Dynamically added shipping option". Select it
+    </li>
+  </ol>
+<ul>
+  <li>
+    <button onclick="testShippingOptionChanged()">
+      When the address is changed, shipping methods can be updated
+    </button>
+  </li>
+</ul>
+<small>
+  If you find a buggy test, please <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a>
+  and tag one of the <a href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml">suggested reviewers</a>.
+</small>

--- a/payment-request/dynamically-change-shipping-options-manual.https.html
+++ b/payment-request/dynamically-change-shipping-options-manual.https.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!-- Copyright © 2017 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <meta charset="utf-8">
 <title>Test for PaymentRequest shippingOption dynamic updating</title>
 <link rel="help" href="https://w3c.github.io/payment-request/#shippingoption-attribute">
@@ -27,7 +26,7 @@ const validTotal = Object.freeze({
 });
 const validDetails = Object.freeze({ total: validTotal });
 
-const validShippingOption1 = Object.freeze({
+const initialValidShippingOption = Object.freeze({
   id: "default-method",
   label: "Default shipping method",
   amount: validAmount,
@@ -47,9 +46,9 @@ const requestShipping = Object.freeze({
 
 function testShippingOptionChanged() {
   promise_test(async t => {
-    const detailsWithShippingOptions = Object.assign({}, validDetails, {
-      shippingOptions: [validShippingOption1],
-    });
+    const detailsWithShippingOptions = {...validDetails,
+      shippingOptions: [initialValidShippingOption],
+    };
     const request = new PaymentRequest(
       validMethods,
       detailsWithShippingOptions,
@@ -58,9 +57,9 @@ function testShippingOptionChanged() {
     const shippingAddressChangeListener = new Promise(resolve => {
       request.addEventListener("shippingaddresschange", (ev) => {
         // resolve(request.shippingOption);
-        ev.updateWith(Object.assign({}, {
-          shippingOptions: [validShippingOption1, validDynamicShippingOption]
-        }))
+        ev.updateWith({
+          shippingOptions: [initialValidShippingOption, validDynamicShippingOption]
+        })
         resolve()
       }, {once:true});
     });
@@ -78,14 +77,13 @@ function testShippingOptionChanged() {
     );
     await request.abort();
   });
-  done();
 }
 </script>
 
 <h2>PaymentRequest shippingOption attribute</h2>
 <p>
   Click on each button in sequence from top to bottom without refreshing the page.
-  Each button will bring up the Payment Request UI window.
+  Each button (except the 'Done' button) will bring up the Payment Request UI window.
 </p>
   <ol>
     <li>
@@ -97,12 +95,18 @@ function testShippingOptionChanged() {
     <li>
       Go back to Shipping Method, and there is now an option called "Dynamically added shipping option". Select it
     </li>
+    <li>
+      Click on the 'Done' button
+    </li>
   </ol>
 <ul>
   <li>
     <button onclick="testShippingOptionChanged()">
       When the address is changed, shipping methods can be updated
     </button>
+  </li>
+  <li>
+    <button onclick="done()">Done</button>
   </li>
 </ul>
 <small>

--- a/payment-request/dynamically-change-shipping-options-manual.https.html
+++ b/payment-request/dynamically-change-shipping-options-manual.https.html
@@ -1,104 +1,126 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>Test for PaymentRequest shippingOption dynamic updating</title>
-<link rel="help" href="https://w3c.github.io/payment-request/#shippingoption-attribute">
-<link rel="help" href="https://w3c.github.io/payment-request/#onshippingoptionchange-attribute">
+<link
+  rel="help"
+  href="https://w3c.github.io/payment-request/#shippingoption-attribute"
+/>
+<link
+  rel="help"
+  href="https://w3c.github.io/payment-request/#onshippingoptionchange-attribute"
+/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-setup({ explicit_done: true, explicit_timeout: true });
-const validMethod = Object.freeze({ supportedMethods: "basic-card" });
-const applePayMethod = {
-  supportedMethods: "https://apple.com/apple-pay",
-  data: {
-    version: 3,
-    merchantIdentifier: "merchant.com.example",
-    countryCode: "US",
-    merchantCapabilities: ["supports3DS"],
-    supportedNetworks: ["visa"],
-  },
-};
-const validMethods = Object.freeze([validMethod, applePayMethod]);
-const validAmount = Object.freeze({ currency: "USD", value: "5.00" });
-const validTotal = Object.freeze({
-  label: "label",
-  amount: validAmount,
-});
-const validDetails = Object.freeze({ total: validTotal });
-
-const initialValidShippingOption = Object.freeze({
-  id: "default-method",
-  label: "Default shipping method",
-  amount: validAmount,
-  selected: true,
-});
-
-const validDynamicShippingOption = Object.freeze({
-  id: "dynamically-added-id",
-  label: "Dynamically added shipping option",
-  amount: validAmount,
-  selected: false,
-});
-
-const requestShipping = Object.freeze({
-  requestShipping: true,
-});
-
-function testShippingOptionChanged() {
-  promise_test(async t => {
-    const detailsWithShippingOptions = {...validDetails,
-      shippingOptions: [initialValidShippingOption],
-    };
-    const request = new PaymentRequest(
-      validMethods,
-      detailsWithShippingOptions,
-      requestShipping
-    );
-    const shippingAddressChangeListener = new Promise(resolve => {
-      request.addEventListener("shippingaddresschange", (ev) => {
-        // resolve(request.shippingOption);
-        ev.updateWith({
-          shippingOptions: [initialValidShippingOption, validDynamicShippingOption]
-        })
-        resolve()
-      }, {once:true});
-    });
-    const handlerPromise = new Promise(resolve => {
-      request.onshippingoptionchange = () => {
-        resolve(request.shippingOption);
-      };
-    });
-    request.show().catch(err => err);
-
-    const results = await Promise.all([shippingAddressChangeListener, handlerPromise]);
-    assert_true(
-      results[1] === "dynamically-added-id",
-      "Expected dynamically-added-id as the shippingOption"
-    );
-    await request.abort();
+  setup({ explicit_done: true, explicit_timeout: true });
+  const validMethod = Object.freeze({ supportedMethods: "basic-card" });
+  const applePayMethod = {
+    supportedMethods: "https://apple.com/apple-pay",
+    data: {
+      version: 3,
+      merchantIdentifier: "merchant.com.example",
+      countryCode: "US",
+      merchantCapabilities: ["supports3DS"],
+      supportedNetworks: ["visa"],
+    },
+  };
+  const validMethods = Object.freeze([validMethod, applePayMethod]);
+  const validAmount = Object.freeze({ currency: "USD", value: "5.00" });
+  const validTotal = Object.freeze({
+    label: "label",
+    amount: validAmount,
   });
-}
+  const validDetails = Object.freeze({ total: validTotal });
+
+  const initialValidShippingOption = Object.freeze({
+    id: "default-method",
+    label: "Default shipping method",
+    amount: validAmount,
+    selected: true,
+  });
+
+  const validDynamicShippingOption = Object.freeze({
+    id: "dynamically-added-id",
+    label: "Dynamically added shipping option",
+    amount: validAmount,
+    selected: false,
+  });
+
+  const requestShipping = Object.freeze({
+    requestShipping: true,
+  });
+
+  function testShippingOptionChanged() {
+    promise_test(async (t) => {
+      const detailsWithShippingOptions = {
+        ...validDetails,
+        shippingOptions: [initialValidShippingOption],
+      };
+      const request = new PaymentRequest(
+        validMethods,
+        detailsWithShippingOptions,
+        requestShipping
+      );
+      const shippingAddressChangeListener = new Promise((resolve) => {
+        request.addEventListener(
+          "shippingaddresschange",
+          (ev) => {
+            // resolve(request.shippingOption);
+            ev.updateWith({
+              shippingOptions: [
+                initialValidShippingOption,
+                validDynamicShippingOption,
+              ],
+            });
+            resolve();
+          },
+          { once: true }
+        );
+      });
+      const handlerPromise = new Promise((resolve) => {
+        request.onshippingoptionchange = () => {
+          resolve(request.shippingOption);
+        };
+      });
+      request.show().catch((err) => err);
+
+      const results = await Promise.all([
+        shippingAddressChangeListener,
+        handlerPromise,
+      ]);
+      assert_true(
+        results[1] === "dynamically-added-id",
+        "Expected dynamically-added-id as the shippingOption"
+      );
+      await request.abort();
+    });
+  }
 </script>
 
 <h2>PaymentRequest shippingOption attribute</h2>
 <p>
-  Click on each button in sequence from top to bottom without refreshing the page.
-  Each button (except the 'Done' button) will bring up the Payment Request UI window.
+  Click on each button in sequence from top to bottom without refreshing the
+  page. Each button (except the 'Done' button) will bring up the Payment Request
+  UI window.
 </p>
-  <ol>
-    <li>
-      When the payment sheet is presented, view options for Shipping Method. There should only be one: "Default shipping method"
-    </li>
-    <li>
-      Change your Shipping Address - either update your existing one by changing something (name, address, etc), or select a different Shipping Address, or add a new Shipping Address and select it.
-    </li>
-    <li>
-      Go back to Shipping Method, and there is now an option called "Dynamically added shipping option". Select it
-    </li>
-    <li>
-      Click on the 'Done' button
-    </li>
-  </ol>
+<ol>
+  <li>
+    When the payment sheet is presented, view options for Shipping Method. There
+    should only be one: "Default shipping method"
+  </li>
+  <li>
+    Change your Shipping Address - either update your existing one by changing
+    something (name, address, etc), or select a different Shipping Address, or
+    add a new Shipping Address and select it.
+  </li>
+  <li>
+    Go back to Shipping Method, and there is now an option called "Dynamically
+    added shipping option". Select it
+  </li>
+  <li>
+    Click on the 'Done' button
+  </li>
+</ol>
 <ul>
   <li>
     <button onclick="testShippingOptionChanged()">
@@ -110,6 +132,11 @@ function testShippingOptionChanged() {
   </li>
 </ul>
 <small>
-  If you find a buggy test, please <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a>
-  and tag one of the <a href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml">suggested reviewers</a>.
+  If you find a buggy test, please
+  <a href="https://github.com/web-platform-tests/wpt/issues">file a bug</a> and
+  tag one of the
+  <a
+    href="https://github.com/web-platform-tests/wpt/blob/master/payment-request/META.yml"
+    >suggested reviewers</a
+  >.
 </small>


### PR DESCRIPTION
adding a manual test to ensure that shipping methods can be changed when the address is changed.

Fixes #14883

Notes:
* This is my first PR. Feel free to correct any mistakes I may have made
* The [notes](https://github.com/web-platform-tests/wpt/issues/14883#issuecomment-456232525) in #14883 mention adding a listener for `shippingoptionchange` and then updating shipping options in that handler. However, in reading the [original reason](https://github.com/w3c/payment-request/issues/791) that issue was created, it seems that what was wanted was to verify that Shipping Options could change when Shipping Addresses were changed. Let me know if I misunderstood that though.
* Note that #14883 was claimed by someone else; however, that was over a year ago. If this is duplicate work, though, feel free to close it anyway. 

Thank you!