### PR TITLE
New unit test for the screenshot formatter

### DIFF
--- a/tools/wptrunner/wptrunner/tests/test_formatters.py
+++ b/tools/wptrunner/wptrunner/tests/test_formatters.py
@@ -174,19 +174,19 @@ def test_wptscreenshot_test_end(capfd):
 
     # Empty
     data = {}
-    assert None == formatter.test_end(data)
+    assert formatter.test_end(data) is None
 
     # No items
-    data['extra'] = { "reftest_screenshots": [] }
-    assert None == formatter.test_end(data)
+    data['extra'] = {"reftest_screenshots": []}
+    assert formatter.test_end(data) is None
 
     # Invalid item
     data['extra']['reftest_screenshots'] = ["no dict item"]
-    assert None == formatter.test_end(data)
+    assert formatter.test_end(data) is None
 
     # Random hash
     data['extra']['reftest_screenshots'] = [{"hash": "HASH", "screenshot": "DATA"}]
     assert 'data:image/png;base64,DATA\n' == formatter.test_end(data)
 
     # Already cached hash
-    assert None == formatter.test_end(data)
+    assert formatter.test_end(data) is None

--- a/tools/wptrunner/wptrunner/tests/test_formatters.py
+++ b/tools/wptrunner/wptrunner/tests/test_formatters.py
@@ -7,6 +7,7 @@ import mock
 from mozlog import handlers, structuredlog
 
 from ..formatters import wptreport
+from ..formatters.wptscreenshot import WptscreenshotFormatter
 from ..formatters.wptreport import WptreportFormatter
 
 
@@ -166,3 +167,26 @@ def test_wptreport_known_intermittent(capfd):
     subtest = test["subtests"][0]
     assert subtest["expected"] == u"PASS"
     assert subtest["known_intermittent"] == [u'FAIL']
+
+
+def test_wptscreenshot_test_end(capfd):
+    formatter = WptscreenshotFormatter()
+
+    # Empty
+    data = {}
+    assert None == formatter.test_end(data)
+
+    # No items
+    data['extra'] = { "reftest_screenshots": [] }
+    assert None == formatter.test_end(data)
+
+    # Invalid item
+    data['extra']['reftest_screenshots'] = ["no dict item"]
+    assert None == formatter.test_end(data)
+
+    # Random hash
+    data['extra']['reftest_screenshots'] = [{"hash": "HASH", "screenshot": "DATA"}]
+    assert 'data:image/png;base64,DATA\n' == formatter.test_end(data)
+
+    # Already cached hash
+    assert None == formatter.test_end(data)


### PR DESCRIPTION
New unit test for the `test_end()` method. Increases `wptscreenshot.py` code coverage from 13% to 55%.