### PR TITLE
Python 3: Improve webdriver tests compatibility with Python 3

### DIFF
--- a/webdriver/tests/add_cookie/add.py
+++ b/webdriver/tests/add_cookie/add.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from six import text_type
 
 from webdriver.transport import Response
 
@@ -59,11 +60,11 @@ def test_add_domain_cookie(session, url, server_config):
 
     cookie = session.cookies("hello")
     assert "domain" in cookie
-    assert isinstance(cookie["domain"], basestring)
+    assert isinstance(cookie["domain"], text_type)
     assert "name" in cookie
-    assert isinstance(cookie["name"], basestring)
+    assert isinstance(cookie["name"], text_type)
     assert "value" in cookie
-    assert isinstance(cookie["value"], basestring)
+    assert isinstance(cookie["value"], text_type)
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"
@@ -89,11 +90,11 @@ def test_add_cookie_for_ip(session, url, server_config, configuration):
 
     cookie = session.cookies("hello")
     assert "name" in cookie
-    assert isinstance(cookie["name"], basestring)
+    assert isinstance(cookie["name"], text_type)
     assert "value" in cookie
-    assert isinstance(cookie["value"], basestring)
+    assert isinstance(cookie["value"], text_type)
     assert "domain" in cookie
-    assert isinstance(cookie["domain"], basestring)
+    assert isinstance(cookie["domain"], text_type)
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"
@@ -118,9 +119,9 @@ def test_add_non_session_cookie(session, url):
 
     cookie = session.cookies("hello")
     assert "name" in cookie
-    assert isinstance(cookie["name"], basestring)
+    assert isinstance(cookie["name"], text_type)
     assert "value" in cookie
-    assert isinstance(cookie["value"], basestring)
+    assert isinstance(cookie["value"], text_type)
     assert "expiry" in cookie
     assert isinstance(cookie["expiry"], int)
 
@@ -143,9 +144,9 @@ def test_add_session_cookie(session, url):
 
     cookie = session.cookies("hello")
     assert "name" in cookie
-    assert isinstance(cookie["name"], basestring)
+    assert isinstance(cookie["name"], text_type)
     assert "value" in cookie
-    assert isinstance(cookie["value"], basestring)
+    assert isinstance(cookie["value"], text_type)
     if "expiry" in cookie:
         assert cookie.get("expiry") is None
 
@@ -168,11 +169,11 @@ def test_add_session_cookie_with_leading_dot_character_in_domain(session, url, s
 
     cookie = session.cookies("hello")
     assert "name" in cookie
-    assert isinstance(cookie["name"], basestring)
+    assert isinstance(cookie["name"], text_type)
     assert "value" in cookie
-    assert isinstance(cookie["value"], basestring)
+    assert isinstance(cookie["value"], text_type)
     assert "domain" in cookie
-    assert isinstance(cookie["domain"], basestring)
+    assert isinstance(cookie["domain"], text_type)
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"

--- a/webdriver/tests/execute_async_script/collections.py
+++ b/webdriver/tests/execute_async_script/collections.py
@@ -1,5 +1,7 @@
 import os
 
+from six import text_type
+
 from tests.support.asserts import assert_same_element, assert_success
 from tests.support.inline import inline
 
@@ -52,7 +54,7 @@ def test_file_list(session, tmpdir):
     for expected, actual in zip(files, value):
         assert isinstance(actual, dict)
         assert "name" in actual
-        assert isinstance(actual["name"], basestring)
+        assert isinstance(actual["name"], text_type)
         assert os.path.basename(str(expected)) == actual["name"]
 
 

--- a/webdriver/tests/execute_script/collections.py
+++ b/webdriver/tests/execute_script/collections.py
@@ -1,5 +1,7 @@
 import os
 
+from six import text_type
+
 from tests.support.asserts import assert_same_element, assert_success
 from tests.support.inline import inline
 
@@ -45,7 +47,7 @@ def test_file_list(session, tmpdir):
     for expected, actual in zip(files, value):
         assert isinstance(actual, dict)
         assert "name" in actual
-        assert isinstance(actual["name"], basestring)
+        assert isinstance(actual["name"], text_type)
         assert os.path.basename(str(expected)) == actual["name"]
 
 

--- a/webdriver/tests/get_alert_text/get.py
+++ b/webdriver/tests/get_alert_text/get.py
@@ -1,3 +1,5 @@
+from six import text_type
+
 from webdriver.error import NoSuchAlertException
 
 from tests.support.asserts import assert_error, assert_success
@@ -27,7 +29,7 @@ def test_get_alert_text(session):
     assert isinstance(response.body, dict)
     assert "value" in response.body
     alert_text = response.body["value"]
-    assert isinstance(alert_text, basestring)
+    assert isinstance(alert_text, text_type)
     assert alert_text == "Hello"
 
 
@@ -38,7 +40,7 @@ def test_get_confirm_text(session):
     assert isinstance(response.body, dict)
     assert "value" in response.body
     confirm_text = response.body["value"]
-    assert isinstance(confirm_text, basestring)
+    assert isinstance(confirm_text, text_type)
     assert confirm_text == "Hello"
 
 
@@ -49,7 +51,7 @@ def test_get_prompt_text(session):
     assert isinstance(response.body, dict)
     assert "value" in response.body
     prompt_text = response.body["value"]
-    assert isinstance(prompt_text, basestring)
+    assert isinstance(prompt_text, text_type)
     assert prompt_text == "Enter Your Name: "
 
 

--- a/webdriver/tests/get_current_url/get.py
+++ b/webdriver/tests/get_current_url/get.py
@@ -1,3 +1,5 @@
+from six import text_type
+
 from tests.support import platform_name
 from tests.support.inline import inline
 from tests.support.asserts import assert_error, assert_success
@@ -31,7 +33,7 @@ def test_get_current_url_payload(session):
 
     response = get_current_url(session)
     assert response.status == 200
-    assert isinstance(response.body["value"], basestring)
+    assert isinstance(response.body["value"], text_type)
 
 
 def test_get_current_url_special_pages(session):

--- a/webdriver/tests/get_named_cookie/get.py
+++ b/webdriver/tests/get_named_cookie/get.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta
+from six import integer_types, text_type
+
 
 from tests.support.asserts import assert_error, assert_success
 from tests.support.helpers import clear_all_cookies
@@ -28,13 +30,13 @@ def test_get_named_session_cookie(session, url):
     # table for cookie conversion
     # https://w3c.github.io/webdriver/webdriver-spec.html#dfn-table-for-cookie-conversion
     assert "name" in cookie
-    assert isinstance(cookie["name"], basestring)
+    assert isinstance(cookie["name"], text_type)
     assert "value" in cookie
-    assert isinstance(cookie["value"], basestring)
+    assert isinstance(cookie["value"], text_type)
     assert "path" in cookie
-    assert isinstance(cookie["path"], basestring)
+    assert isinstance(cookie["path"], text_type)
     assert "domain" in cookie
-    assert isinstance(cookie["domain"], basestring)
+    assert isinstance(cookie["domain"], text_type)
     assert "secure" in cookie
     assert isinstance(cookie["secure"], bool)
     assert "httpOnly" in cookie
@@ -60,11 +62,11 @@ def test_get_named_cookie(session, url):
     assert isinstance(cookie, dict)
 
     assert "name" in cookie
-    assert isinstance(cookie["name"], basestring)
+    assert isinstance(cookie["name"], text_type)
     assert "value" in cookie
-    assert isinstance(cookie["value"], basestring)
+    assert isinstance(cookie["value"], text_type)
     assert "expiry" in cookie
-    assert isinstance(cookie["expiry"], (int, long))
+    assert isinstance(cookie["expiry"], integer_types)
 
     assert cookie["name"] == "foo"
     assert cookie["value"] == "bar"
@@ -99,9 +101,9 @@ def test_duplicated_cookie(session, url, server_config):
     assert isinstance(cookie, dict)
 
     assert "name" in cookie
-    assert isinstance(cookie["name"], basestring)
+    assert isinstance(cookie["name"], text_type)
     assert "value" in cookie
-    assert isinstance(cookie["value"], basestring)
+    assert isinstance(cookie["value"], text_type)
 
     assert cookie["name"] == new_cookie["name"]
     assert cookie["value"] == "newworld"

--- a/webdriver/tests/new_session/create_alwaysMatch.py
+++ b/webdriver/tests/new_session/create_alwaysMatch.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from conftest import product, flatten
+from .conftest import product, flatten
 
 from tests.support.asserts import assert_success
 from tests.new_session.support.create import valid_data

--- a/webdriver/tests/new_session/create_firstMatch.py
+++ b/webdriver/tests/new_session/create_firstMatch.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from conftest import product, flatten
+from .conftest import product, flatten
 
 
 from tests.support.asserts import assert_success

--- a/webdriver/tests/new_session/invalid_capabilities.py
+++ b/webdriver/tests/new_session/invalid_capabilities.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import product, flatten
+from .conftest import product, flatten
 
 from tests.new_session.support.create import invalid_data, invalid_extensions
 from tests.support.asserts import assert_error

--- a/webdriver/tests/new_session/response.py
+++ b/webdriver/tests/new_session/response.py
@@ -1,6 +1,7 @@
 import uuid
-
 import pytest
+
+from six import text_type
 
 from tests.support.asserts import assert_success
 
@@ -8,21 +9,21 @@ from tests.support.asserts import assert_success
 def test_sessionid(new_session, add_browser_capabilities):
     response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({})}})
     value = assert_success(response)
-    assert isinstance(value["sessionId"], basestring)
+    assert isinstance(value["sessionId"], text_type)
     uuid.UUID(hex=value["sessionId"])
 
 
 @pytest.mark.parametrize("capability, type", [
-    ("browserName", basestring),
-    ("browserVersion", basestring),
-    ("platformName", basestring),
+    ("browserName", text_type),
+    ("browserVersion", text_type),
+    ("platformName", text_type),
     ("acceptInsecureCerts", bool),
-    ("pageLoadStrategy", basestring),
+    ("pageLoadStrategy", text_type),
     ("proxy", dict),
     ("setWindowRect", bool),
     ("timeouts", dict),
     ("strictFileInteractability", bool),
-    ("unhandledPromptBehavior", basestring),
+    ("unhandledPromptBehavior", text_type),
 ])
 def test_capability_type(session, capability, type):
     assert isinstance(session.capabilities, dict)

--- a/webdriver/tests/perform_actions/support/keys.py
+++ b/webdriver/tests/perform_actions/support/keys.py
@@ -17,9 +17,10 @@
 
 """The Keys implementation."""
 
-from inspect import getmembers
 import sys
 
+from inspect import getmembers
+from six import text_type
 
 class Keys(object):
     """
@@ -105,7 +106,7 @@ class Keys(object):
     R_DELETE = u"\uE05D"
 
 
-ALL_KEYS = getmembers(Keys, lambda x: type(x) == unicode)
+ALL_KEYS = getmembers(Keys, lambda x: type(x) == text_type)
 
 ALL_EVENTS = {
     "ADD": {

--- a/webdriver/tests/status/status.py
+++ b/webdriver/tests/status/status.py
@@ -1,5 +1,7 @@
 import json
 
+from six import text_type
+
 from tests.support.asserts import assert_success
 
 
@@ -16,7 +18,7 @@ def test_get_status_no_session(http):
         value = parsed_obj["value"]
 
         assert value["ready"] in [True, False]
-        assert isinstance(value["message"], basestring)
+        assert isinstance(value["message"], text_type)
 
 
 def test_status_with_session_running_on_endpoint_node(session):

--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -2,7 +2,7 @@ import base64
 import imghdr
 import struct
 
-from six import PY3
+from six import ensure_binary, text_type, PY3
 
 from webdriver import Element, NoSuchAlertException, WebDriverException
 
@@ -52,8 +52,8 @@ def assert_error(response, error_code):
     assert response.status == errors[error_code]
     assert "value" in response.body
     assert response.body["value"]["error"] == error_code
-    assert isinstance(response.body["value"]["message"], basestring)
-    assert isinstance(response.body["value"]["stacktrace"], basestring)
+    assert isinstance(response.body["value"]["message"], text_type)
+    assert isinstance(response.body["value"]["stacktrace"], text_type)
     assert_response_headers(response.headers)
 
 
@@ -221,6 +221,6 @@ def assert_move_to_coordinates(point, target, events):
 
 def assert_png(screenshot):
     """Test that screenshot is a Base64 encoded PNG file."""
-    image = base64.decodestring(screenshot)
+    image = base64.decodestring(ensure_binary(screenshot))
     mime_type = imghdr.what("", image)
     assert mime_type == "png", "Expected image to be PNG, but it was {}".format(mime_type)

--- a/webdriver/tests/support/authentication.py
+++ b/webdriver/tests/support/authentication.py
@@ -1,4 +1,4 @@
-import urllib
+from six.moves.urllib.parse import urlencode
 
 
 def basic_authentication(username=None, password=None, protocol="http"):
@@ -8,7 +8,7 @@ def basic_authentication(username=None, password=None, protocol="http"):
     query = {}
 
     return build_url("/webdriver/tests/support/authentication.py",
-                     query=urllib.urlencode(query),
+                     query=urlencode(query),
                      protocol=protocol)
 
 

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -1,10 +1,13 @@
 import copy
 import json
 import os
-import urlparse
 
 import pytest
 import webdriver
+
+from six import string_types
+
+from six.moves.urllib.parse import urlunsplit
 
 from tests.support import defaults
 from tests.support.helpers import cleanup_session
@@ -172,7 +175,7 @@ def url(server_config):
         domain = server_config["domains"][domain][subdomain]
         port = server_config["ports"][protocol][0]
         host = "{0}:{1}".format(domain, port)
-        return urlparse.urlunsplit((protocol, host, path, query, fragment))
+        return urlunsplit((protocol, host, path, query, fragment))
 
     inner.__name__ = "url"
     return inner
@@ -191,7 +194,7 @@ def create_dialog(session):
         if text is None:
             text = ""
 
-        assert isinstance(text, basestring), "`text` parameter must be a string"
+        assert isinstance(text, string_types), "`text` parameter must be a string"
 
         # Script completes itself when the user prompt has been opened.
         # For prompt() dialogs, add a value for the 'default' argument,

--- a/webdriver/tests/support/http_request.py
+++ b/webdriver/tests/support/http_request.py
@@ -1,8 +1,9 @@
 import contextlib
-import httplib
 import json
 
 from six import text_type
+
+from six.moves.http_client import HTTPConnection
 
 
 class HTTPRequest(object):
@@ -33,7 +34,7 @@ class HTTPRequest(object):
             if isinstance(payload, text_type):
                 payload = body.encode("utf-8")
 
-        conn = httplib.HTTPConnection(self.host, self.port)
+        conn = HTTPConnection(self.host, self.port)
         try:
             conn.request(method, path, payload)
             yield conn.getresponse()

--- a/webdriver/tests/support/image.py
+++ b/webdriver/tests/support/image.py
@@ -2,11 +2,13 @@ import base64
 import math
 import struct
 
+from six import ensure_binary
+
 from tests.support.asserts import assert_png
 
 
 def png_dimensions(screenshot):
     assert_png(screenshot)
-    image = base64.decodestring(screenshot)
+    image = base64.decodestring(ensure_binary(screenshot))
     width, height = struct.unpack(">LL", image[16:24])
     return int(width), int(height)

--- a/webdriver/tests/support/inline.py
+++ b/webdriver/tests/support/inline.py
@@ -1,6 +1,6 @@
 """Helpers for inlining extracts of documents in tests."""
 
-import urllib
+from six.moves.urllib.parse import urlencode
 
 
 BOILERPLATES = {
@@ -58,7 +58,7 @@ def inline(src, doctype="html", mime=None, charset=None, **kwargs):
     query = {"doc": doc, "mime": mime, "charset": charset}
     return build_url(
         "/webdriver/tests/support/inline.py",
-        query=urllib.urlencode(query),
+        query=urlencode(query),
         **kwargs)
 
 

--- a/webdriver/tests/switch_to_frame/cross_origin.py
+++ b/webdriver/tests/switch_to_frame/cross_origin.py
@@ -1,4 +1,4 @@
-from urlparse import urlparse
+from six.moves.urllib.parse import urlparse
 
 import webdriver.protocol as protocol
 

--- a/webdriver/tests/switch_to_frame/switch.py
+++ b/webdriver/tests/switch_to_frame/switch.py
@@ -18,7 +18,7 @@ def switch_to_frame(session, frame):
 
 
 def frameset(*docs):
-    frames = map(lambda doc: "<frame src='{}'></frame>".format(inline(doc)), docs)
+    frames = list(map(lambda doc: "<frame src='{}'></frame>".format(inline(doc)), docs))
     return "<frameset rows='{}'>\n{}</frameset>".format(len(frames) * "*,", "\n".join(frames))
 
 


### PR DESCRIPTION
[1] Change urlparse, httplib imports to work with both 2.x and 3.x
[2] Replace basestring with six.string_types. basestring in
Python 2.x has been replaced with "str" in Python 3.x.
six.string_types is basestring() in Python 2 and str in Python 3