### PR TITLE
Improve the logging when a server fails to start.

### DIFF
--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -64,12 +64,6 @@ handler returns, or for directly writing to the output stream.
 """
 
 
-EDIT_HOSTS_HELP = ("Please ensure all the necessary WPT subdomains "
-                   "are mapped to a loopback device in /etc/hosts. "
-                   "See https://web-platform-tests.org/running-tests/from-local-system.html#system-setup "
-                   "for instructions.")
-
-
 class RequestRewriter(object):
     def __init__(self, rules):
         """Object for rewriting the request path.
@@ -676,7 +670,8 @@ class WebTestHttpd(object):
 
             _host, self.port = self.httpd.socket.getsockname()
         except Exception:
-            self.logger.critical("Failed to start HTTP server. {}".format(EDIT_HOSTS_HELP))
+            self.logger.critical("Failed to start HTTP server on port %s; "
+                                 "is something already using that port?" % port)
             raise
 
     def start(self, block=False):


### PR DESCRIPTION
Make sure we have a useful error message when the servers don't start,
and also update wptrunner to fail early in the case that the process
has exited rather than trying to reconnect to a server that isn't running
until we reach the timeout.

The patch contains a little blemish in that we always print to stderr from
the Websockets processes; the logger isn't correctly configured there and
fixing it is outside the scope of this patch (we've had regressions in
the past from that code, so I want to keep the scope as small as possible.