### PR TITLE
Remove obsolete kExprEnd from Wasm function body

### DIFF
--- a/wasm/jsapi/table/grow-reftypes.tentative.any.js
+++ b/wasm/jsapi/table/grow-reftypes.tentative.any.js
@@ -16,7 +16,7 @@ test(() => {
   const builder = new WasmModuleBuilder();
   builder
     .addFunction("fn", kSig_v_v)
-    .addBody([kExprEnd])
+    .addBody([])
     .exportFunc();
   const bin = builder.toBuffer()
   const argument = { "element": "anyfunc", "initial": 1 };


### PR DESCRIPTION
kExprEnd will automatically be added by the addBody method of the WasmModuleBuilder and therefore will produce superfluous instructions after function end otherwise.

See https://github.com/web-platform-tests/wpt/blob/1bb27f712b066bbb5751c0d3037b28d282bcfcfa/wasm/jsapi/wasm-module-builder.js#L617 for reference.