### PR TITLE
Suppress hypothesis.HealtCheck.too_slow on Python 3

### DIFF
--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -1,5 +1,5 @@
 import os
-import platform
+import sys
 
 import mock
 
@@ -109,7 +109,7 @@ def manifest_tree(draw):
 
 @h.given(manifest_tree())
 # FIXME: Workaround for https://github.com/web-platform-tests/wpt/issues/22758
-@h.settings(suppress_health_check=(h.HealthCheck.too_slow,) if platform.system() != "Linux" else ())
+@h.settings(suppress_health_check=(h.HealthCheck.too_slow,) if sys.version_info.major == 3 else ())
 @h.example([SourceFileWithTest("a", "0"*40, item.ConformanceCheckerTest)])
 def test_manifest_to_json(s):
     m = manifest.Manifest()
@@ -126,7 +126,7 @@ def test_manifest_to_json(s):
 
 @h.given(manifest_tree())
 # FIXME: Workaround for https://github.com/web-platform-tests/wpt/issues/22758
-@h.settings(suppress_health_check=(h.HealthCheck.too_slow,) if platform.system() != "Linux" else ())
+@h.settings(suppress_health_check=(h.HealthCheck.too_slow,) if sys.version_info.major == 3 else ())
 @h.example([SourceFileWithTest("a", "0"*40, item.TestharnessTest)])
 @h.example([SourceFileWithTest("a", "0"*40, item.RefTest, references=[("/aa", "==")])])
 def test_manifest_idempotent(s):

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 import mock
 
@@ -105,7 +106,10 @@ def manifest_tree(draw):
 
     return output
 
+
 @h.given(manifest_tree())
+# FIXME: Workaround for https://github.com/web-platform-tests/wpt/issues/22758
+@h.settings(suppress_health_check=(h.HealthCheck.too_slow,) if platform.system() != "Linux" else ())
 @h.example([SourceFileWithTest("a", "0"*40, item.ConformanceCheckerTest)])
 def test_manifest_to_json(s):
     m = manifest.Manifest()
@@ -119,7 +123,10 @@ def test_manifest_to_json(s):
 
     assert loaded.to_json() == json_str
 
+
 @h.given(manifest_tree())
+# FIXME: Workaround for https://github.com/web-platform-tests/wpt/issues/22758
+@h.settings(suppress_health_check=(h.HealthCheck.too_slow,) if platform.system() != "Linux" else ())
 @h.example([SourceFileWithTest("a", "0"*40, item.TestharnessTest)])
 @h.example([SourceFileWithTest("a", "0"*40, item.RefTest, references=[("/aa", "==")])])
 def test_manifest_idempotent(s):


### PR DESCRIPTION
This is a workaround for #22758.

https://hypothesis.readthedocs.io/en/latest/healthchecks.html#hypothesis.HealthCheck