### PR TITLE
flexbox-with-multi-column-property.html: set "font-kerning: none;"

### DIFF
--- a/css/css-flexbox/flexbox-with-multi-column-property.html
+++ b/css/css-flexbox/flexbox-with-multi-column-property.html
@@ -10,6 +10,7 @@
     column-count: 2;
     column-gap: 100px;
     width: 20em;
+    font-kerning: none;
 }
 </style>
 <div class="flexbox">


### PR DESCRIPTION
* The reference for this test uses `font-kerning: none;` but not the test itself, this causes small pixel differences on WebKit that trigger a failure on the test, when the test its really passing.

* Failures on WebKit:
   * Safari: https://wpt.fyi/analyzer?screenshot=sha1%3Aa4846453ae53d439a7b186fa8f1cadbc4b4a9351&screenshot=sha1%3Aa8354dfbd5b5a757e1e80f43ba69aecf74c33b77
   * WebKitGTK: https://wpt.fyi/analyzer?screenshot=sha1%3Aa67d107249a5aef92619ed5daa35c6240cdbd91e&screenshot=sha1%3A24848c9389ca4e5c7daf98931334da44e98b12a3

* Removing `font-kerning: none;` from [the reference](https://github.com/web-platform-tests/wpt/blob/master/css/css-flexbox/reference/flexbox-with-multi-column-property-ref.html) causes failures on Chrome, so let's add `font-kerning: none;` to the test itself. That allow both Chrome and WebKit to pass.