### PR TITLE
Add interfaces/page-lifecycle.idl and test

### DIFF
--- a/interfaces/page-lifecycle.idl
+++ b/interfaces/page-lifecycle.idl
@@ -1,0 +1,19 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content was automatically extracted by Reffy into reffy-reports
+// (https://github.com/tidoust/reffy-reports)
+// Source: Page Lifecycle (https://wicg.github.io/page-lifecycle/)
+
+partial interface Document {
+    attribute EventHandler onfreeze;
+    attribute EventHandler onresume;
+    readonly attribute boolean wasDiscarded;
+};
+
+partial interface Client {
+    readonly attribute ClientLifecycleState lifecycleState;
+};
+
+enum ClientLifecycleState {
+    "active",
+    "frozen"
+};

--- a/page-lifecycle/idlharness.html
+++ b/page-lifecycle/idlharness.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>Page Lifecycle IDL tests</title>
+<link rel="help" href="https://wicg.github.io/page-lifecycle/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+
+<script>
+  'use strict';
+
+  idl_test(
+    ['page-lifecycle'],
+    ['service-workers', 'html', 'dom'],
+    idl_array => {
+      idl_array.add_objects({
+        Document: ['document'],
+        // TODO: Test instance of Client object.
+      });
+
+      assert_true(false, 'Test bug: does not test Client object');
+    }
+  );
+</script>

--- a/page-lifecycle/idlharness.html
+++ b/page-lifecycle/idlharness.html
@@ -15,10 +15,8 @@
     idl_array => {
       idl_array.add_objects({
         Document: ['document'],
-        // TODO: Test instance of Client object.
+        // TODO: Client.
       });
-
-      assert_true(false, 'Test bug: does not test Client object');
     }
   );
 </script>


### PR DESCRIPTION
A test for Client is not added as even
service-workers/service-worker/resources/interfaces-worker.sub.js does
not test this interface yet.

Closes https://github.com/web-platform-tests/wpt/pull/21313