### PR TITLE
Add interfaces/hit-test.idl and test

### DIFF
--- a/hit-test/idlharness.https.html
+++ b/hit-test/idlharness.https.html
@@ -11,7 +11,7 @@
 
   idl_test(
     ['hit-test'],
-    ['webxr', 'dom'],
+    ['webxr', 'geometry', 'dom'],
     async idl_array => {
       idl_array.add_objects({
         // TODO: XRHitTestSource
@@ -20,7 +20,7 @@
         // TODO: XRTransientInputHitTestResult
         XRSession: ['xrSession'],
         // TODO: XRFrame
-        // TODO: XRRay
+        XRRay: ['new XRRay()'],
       });
 
       self.xrSession = await navigator.xr.requestSession("inline");

--- a/hit-test/idlharness.https.html
+++ b/hit-test/idlharness.https.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<title>WebXR hit-test IDL tests</title>
+<link rel="help" href="https://immersive-web.github.io/hit-test/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+
+<script>
+  'use strict';
+
+  idl_test(
+    ['hit-test'],
+    ['webxr', 'dom'],
+    async idl_array => {
+      idl_array.add_objects({
+        // TODO: XRHitTestSource
+        // TODO: XRTransientInputHitTestSource
+        // TODO: XRHitTestResult
+        // TODO: XRTransientInputHitTestResult
+        XRSession: ['xrSession'],
+        // TODO: XRFrame
+        // TODO: XRRay
+      });
+
+      self.xrSession = await navigator.xr.requestSession("inline");
+    }
+  );
+</script>

--- a/interfaces/hit-test.idl
+++ b/interfaces/hit-test.idl
@@ -1,0 +1,62 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content was automatically extracted by Reffy into reffy-reports
+// (https://github.com/tidoust/reffy-reports)
+// Source: WebXR Hit Test Module (https://immersive-web.github.io/hit-test/)
+
+enum XRHitTestTrackableType {
+  "point",
+  "plane",
+  "mesh"
+};
+
+dictionary XRHitTestOptionsInit {
+  required XRSpace space;
+  FrozenArray<XRHitTestTrackableType> entityTypes;
+  XRRay offsetRay;
+};
+
+dictionary XRTransientInputHitTestOptionsInit {
+  required DOMString profile;
+  FrozenArray<XRHitTestTrackableType> entityTypes;
+  XRRay offsetRay;
+};
+
+[SecureContext, Exposed=Window]
+interface XRHitTestSource {
+  void cancel();
+};
+
+[SecureContext, Exposed=Window]
+interface XRTransientInputHitTestSource {
+  void cancel();
+};
+
+[SecureContext, Exposed=Window]
+interface XRHitTestResult {
+  XRPose? getPose(XRSpace baseSpace);
+};
+
+[SecureContext, Exposed=Window]
+interface XRTransientInputHitTestResult {
+  [SameObject] readonly attribute XRInputSource inputSource;
+  readonly attribute FrozenArray<XRHitTestResult> results;
+};
+
+partial interface XRSession {
+  Promise<XRHitTestSource> requestHitTestSource(XRHitTestOptionsInit options);
+  Promise<XRTransientInputHitTestSource> requestHitTestSourceForTransientInput(XRTransientInputHitTestOptionsInit options);
+};
+
+partial interface XRFrame {
+  FrozenArray<XRHitTestResult> getHitTestResults(XRHitTestSource hitTestSource);
+  FrozenArray<XRTransientInputHitTestResult> getHitTestResultsForTransientInput(XRTransientInputHitTestSource hitTestSource);
+};
+
+[SecureContext, Exposed=Window,
+ Constructor(optional DOMPointInit origin, optional DOMPointInit direction),
+ Constructor(XRRigidTransform transform)]
+interface XRRay {
+  [SameObject] readonly attribute DOMPointReadOnly origin;
+  [SameObject] readonly attribute DOMPointReadOnly direction;
+  [SameObject] readonly attribute Float32Array matrix;
+};


### PR DESCRIPTION
Due to the difficulty in testing webxr until test-only APIs are
supported in WPT (see
https://github.com/web-platform-tests/wpt/issues/16455#issuecomment-532040838),
the added test only tests the XRSession interface additions for now.

Closes https://github.com/web-platform-tests/wpt/pull/22155