### PR TITLE
Extend webxr idlharness tests

### DIFF
--- a/webxr/ar-module/idlharness.https.window.js
+++ b/webxr/ar-module/idlharness.https.window.js
@@ -10,7 +10,8 @@ idl_test(
   ['webxr', 'dom'],
   async idl_array => {
     idl_array.add_objects({
-      // TODO: XRSession
+      XRSession: ['xrSession'],
     });
+    self.xrSession = await navigator.xr.requestSession('inline');
   }
 );

--- a/webxr/idlharness.https.window.js
+++ b/webxr/idlharness.https.window.js
@@ -1,5 +1,6 @@
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
+// META: timeout=long
 
 'use strict';
 
@@ -7,11 +8,48 @@
 
 idl_test(
   ['webxr'],
-  ['permissions', 'webgl1', 'html', 'dom'],
+  ['permissions', 'webgl1', 'geometry', 'html', 'dom'],
   async idl_array => {
     idl_array.add_objects({
       Navigator: ['navigator'],
       XR: ['navigator.xr'],
+      // TODO: XRSystem
+      XRSession: ['xrSession'],
+      XRRenderState: ['xrRenderState'],
+      // TODO: XRFrame
+      // TODO: XRSpace
+      XRReferenceSpace: ['xrReferenceSpace'],
+      // TODO: XRBoundedReferenceSpace
+      // TODO: XRView
+      // TODO: XRViewport
+      XRRigidTransform: ['new XRRigidTransform()'],
+      // TODO: XRPose
+      // TODO: XRViewerPose
+      // TODO: XRInputSource
+      XRInputSourceArray: ['xrInputSourceArray'],
+      XRWebGLLayer: ['xrWebGLLayer'],
+      WebGLRenderingContextBase: ['webGLRenderingContextBase'],
+      XRSessionEvent: ['xrSessionEvent'],
+      // TODO: XRInputSourceEvent
+      XRInputSourcesChangeEvent: ['xrInputSourcesChangeEvent'],
+      // TODO: XRReferenceSpaceEvent
+      // TODO: XRPermissionStatus
     });
+
+    self.xrSession = await navigator.xr.requestSession('inline');
+    self.xrRenderState = self.xrSession.renderState;
+    self.xrReferenceSpace = await self.xrSession.requestReferenceSpace('viewer');
+    self.xrInputSourceArray = self.xrSession.inputSources;
+    self.xrSessionEvent = new XRSessionEvent('end', {session: self.xrSession});
+    self.xrInputSourcesChangeEvent = new XRInputSourcesChangeEvent('inputsourceschange', {
+      session: self.xrSession,
+      added: [],
+      removed: [],
+    });
+
+    // XRWebGLRenderingContext is a typedef to either WebGLRenderingContext or WebGL2RenderingContext.
+    const canvas = document.createElement('canvas');
+    self.webGLRenderingContextBase = canvas.getContext('webgl');
+    self.xrWebGLLayer = new XRWebGLLayer(self.xrSession, self.webGLRenderingContextBase);
   }
 );


### PR DESCRIPTION
This change adds roughly half of the interfaces in webxr to
webxr/idlharness.https.window.js. It is still unclear how to get an
XFrame using upstream WPT, so that and any interface which relies on it
were excluded for now.