### PR TITLE
Python 3: Add key "Content-Type" check for python 3 in webdriver test

### DIFF
--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -2,6 +2,8 @@ import base64
 import imghdr
 import struct
 
+from six import PY3
+
 from webdriver import Element, NoSuchAlertException, WebDriverException
 
 
@@ -81,8 +83,15 @@ def assert_response_headers(headers):
     """
     assert 'cache-control' in headers
     assert 'no-cache' == headers['cache-control']
-    assert 'content-type' in headers
-    assert 'application/json; charset=utf-8' == headers['content-type']
+    # In Python 2, HTTPResponse normalizes header keys to lowercase, whereas
+    # Python 3 preserves the case. See
+    # https://github.com/web-platform-tests/wpt/pull/22858#issuecomment-612656097
+    if PY3:
+        assert 'Content-Type' in headers
+        assert 'application/json; charset=utf-8' == headers['Content-Type']
+    else:
+        assert 'content-type' in headers
+        assert 'application/json; charset=utf-8' == headers['content-type']
 
 
 def assert_dialog_handled(session, expected_text, expected_retval):


### PR DESCRIPTION
In webdriver getheaders() API of http response returns lowercase key
"content-type" in python 2 and capitalized key "Content-Type" in python 3.
This probably is caused by different http libraries used. Python 2 uses
httplib and python 3 uses http.client for http connection.