### PR TITLE
Modified several hyphens tests

### DIFF
--- a/css/css-text/hyphens/hyphens-auto-010.html
+++ b/css/css-text/hyphens/hyphens-auto-010.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-auto-010-ref.html">
+  <link rel="match" href="reference/hyphens-auto-010M-ref.html">
+  <link rel="match" href="reference/hyphens-auto-010H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'auto' and when 'lang' attribute is also set to a valid value, then words may be broken at hyphenation opportunities determined automatically by an hyphenation resource appropriate to the language of the text involved.">
@@ -17,25 +28,20 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
-      width: 6ch;
-    }
-
-  div#test
-    {
       hyphens: auto;
-    }
-
-  div#reference
-    {
-      hyphens: none;
+      width: 6ch;
     }
   </style>
 
  <body lang="en">
 
-  <p>Test passes if each black-bordered rectangles have identical inside content.
+  <div>regulation implementation</div>
 
-  <div id="test">regulation implementation</div>
-
-  <div id="reference">regu-lation imple-menta-tion</div>
+  <!--
+        Expected result:
+        regu-
+        lation
+        imple-
+        menta-
+        tion
+  -->

--- a/css/css-text/hyphens/hyphens-auto-inline-010.html
+++ b/css/css-text/hyphens/hyphens-auto-inline-010.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-auto-inline-010-ref.html">
+  <link rel="match" href="reference/hyphens-auto-inline-010M-ref.html">
+  <link rel="match" href="reference/hyphens-auto-inline-010H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'auto' and applied to an inline element and when 'lang' attribute is also set to a valid value, then words may be broken at hyphenation opportunities determined automatically by an hyphenation resource appropriate to the language of the text involved.">
@@ -17,25 +28,25 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
       width: 6ch;
     }
 
-  span#test
+  span
     {
       hyphens: auto;
-    }
-
-  div#reference
-    {
-      hyphens: none;
     }
   </style>
 
  <body lang="en">
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+  <div>There are <span>new guidelines now</span>.</div>
 
-  <div>There are <span id="test">new guidelines now</span>.</div>
-
-  <div id="reference">There are new guide-lines now.</div>
+  <!--
+        Expected result:
+        There
+        are
+        new
+        guide-
+        lines
+        now.
+  -->

--- a/css/css-text/hyphens/hyphens-manual-011.html
+++ b/css/css-text/hyphens/hyphens-manual-011.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-011-ref.html">
+  <link rel="match" href="reference/hyphens-manual-011M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-011H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual', then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 2 hyphenation opportunities, so it can be hyphenated. Since 9 characters can all fit inside the line box of the block box, then the word 'Deoxyribonucleic' is hyphenated only after the 2nd soft hyphen." name="assert">
@@ -17,26 +28,19 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
-      width: 10ch;
-    }
-
-  div#test
-    {
       hyphens: manual;
-    }
-
-  div#reference
-    {
-      hyphens: none;
+      width: 10ch;
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+  <div>Deoxy&shy;ribo&shy;nucleic acid</div>
 
-  <div id="test">Deoxy&shy;ribo&shy;nucleic acid</div>
-
-  <div id="reference">Deoxyribo-nucleic acid</div>
+  <!--
+        Expected result:
+        Deoxyribo-
+        nucleic
+        acid
+  -->
 
   <!--
 

--- a/css/css-text/hyphens/hyphens-manual-012.html
+++ b/css/css-text/hyphens/hyphens-manual-012.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-011-ref.html">
+  <link rel="match" href="reference/hyphens-manual-011M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-011H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual', then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 4 hyphenation opportunities. Since 9 characters can all fit inside the line box of the block box, then the word 'Deoxyribonucleic' is hyphenated only after the 3rd soft hyphen." name="assert">
@@ -17,26 +28,19 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
-      width: 10ch;
-    }
-
-  div#test
-    {
       hyphens: manual;
-    }
-
-  div#reference
-    {
-      hyphens: none;
+      width: 10ch;
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+  <div>Deo&shy;xy&shy;ribo&shy;nu&shy;cleic acid</div>
 
-  <div id="test">Deo&shy;xy&shy;ribo&shy;nu&shy;cleic acid</div>
-
-  <div id="reference">Deoxyribo-nucleic acid</div>
+  <!--
+        Expected result:
+        Deoxyribo-
+        nucleic
+        acid
+  -->
 
   <!--
 

--- a/css/css-text/hyphens/hyphens-manual-013.html
+++ b/css/css-text/hyphens/hyphens-manual-013.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-013-ref.html">
+  <link rel="match" href="reference/hyphens-manual-013M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-013H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual', then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 1 and only 1 hyphenation opportunity, so it can be hyphenated only at such point." name="assert">
@@ -17,26 +28,19 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
-      width: 10ch;
-    }
-
-  div#test
-    {
       hyphens: manual;
-    }
-
-  div#reference
-    {
-      hyphens: none;
+      width: 10ch;
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically. Only the "c" of "nucleic" should be outside of each black-bordered rectangles.
+  <div>Deoxy&shy;ribonucleic acid</div>
 
-  <div id="test">Deoxy&shy;ribonucleic acid</div>
-
-  <div id="reference">Deoxy-ribonucleic acid</div>
+  <!--
+        Expected result:
+        Deoxy-
+        ribonucleic
+        acid
+  -->
 
   <!--
 

--- a/css/css-text/hyphens/hyphens-manual-inline-011.html
+++ b/css/css-text/hyphens/hyphens-manual-inline-011.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-inline-011-ref.html">
+  <link rel="match" href="reference/hyphens-manual-inline-011M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-inline-011H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual' and applied to an inline element, then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 2 hyphenation opportunities, so it can be hyphenated. Since 9 characters can all fit inside the line box of the block box, then the word 'Deoxyribonucleic' is hyphenated only after the 2nd soft hyphen." name="assert">
@@ -17,23 +28,21 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
       width: 10ch;
     }
 
-  span#test
+  span
     {
       hyphens: manual;
     }
-
-  div#reference
-    {
-      hyphens: none;
-    }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+  <div>DNA <span>means Deoxy&shy;ribo&shy;nucleic acid</span>.</div>
 
-  <div>DNA <span id="test">means Deoxy&shy;ribo&shy;nucleic acid</span>.</div>
-
-  <div id="reference">DNA means Deoxyribo-nucleic acid.</div>
+  <!--
+        Expected result:
+        DNA means
+        Deoxyribo-
+        nucleic
+        acid.
+  -->

--- a/css/css-text/hyphens/hyphens-manual-inline-012.html
+++ b/css/css-text/hyphens/hyphens-manual-inline-012.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-inline-012-ref.html">
+  <link rel="match" href="reference/hyphens-manual-inline-012M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-inline-012H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual' and applied to an inline element, then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 4 hyphenation opportunities. Since 'Deoxy' has 5 characters and 'Deoxyribo' has 9 characters and since the content width of the block box can take 8 characters, then a soft hyphen will occur after 'Deoxy'. Since 'ribonu' has 6 characters and 'ribonucleic' has 11 characters and since the content width of the block box can take 8 characters, then a soft hyphen will occur after 'ribonu'." name="assert">
@@ -17,23 +28,23 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
       width: 8ch;
     }
 
-  span#test
+  span
     {
       hyphens: manual;
     }
-
-  div#reference
-    {
-      hyphens: none;
-    }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+  <div>DNA <span>means Deo&shy;xy&shy;ribo&shy;nu&shy;cleic acid</span>.</div>
 
-  <div>DNA <span id="test">means Deo&shy;xy&shy;ribo&shy;nu&shy;cleic acid</span>.</div>
-
-  <div id="reference">DNA means Deoxy-ribonu-cleic acid.</div>
+  <!--
+        Expected result:
+        DNA
+        means
+        Deoxy-
+        ribonu-
+        cleic
+        acid.
+  -->

--- a/css/css-text/hyphens/hyphens-none-012.html
+++ b/css/css-text/hyphens/hyphens-none-012.html
@@ -6,7 +6,7 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-auto-010-ref.html">
+  <link rel="match" href="reference/hyphens-auto-010M-ref.html">
 
   <meta content="" name="flags">
   <meta content="This test checks that 'hyphens: none' does not suppress line wrapping after encountering an actual hyphen-minus character (U+002D).">
@@ -17,23 +17,21 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
-      width: 6ch;
-    }
-
-  div#test
-    {
       hyphens: none;
+      width: 6ch;
     }
   </style>
 
- <body>
+  <div>regu&#x002D;lation imple&#x002D;menta&#x002D;tion</div>
 
-  <p>Test passes if each black-bordered rectangles have identical inside content.
-
-  <div id="test">regu-lation imple-menta-tion</div>
-
-  <div id="reference">regu&#x002D;<br>lation<br>imple&#x002D;<br>menta&#x002D;<br>tion</div>
+  <!--
+        Expected result:
+        regu-
+        lation
+        imple-
+        menta-
+        tion
+  -->
 
 <!--
 

--- a/css/css-text/hyphens/hyphens-none-013.html
+++ b/css/css-text/hyphens/hyphens-none-013.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-auto-010-ref.html">
+  <link rel="match" href="reference/hyphens-auto-010M-ref.html">
+  <link rel="match" href="reference/hyphens-auto-010H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="This test checks that 'hyphens: none' does not suppress line wrapping after encountering an actual hyphen character (U+2010).">
@@ -17,23 +28,21 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
-      width: 6ch;
-    }
-
-  div#test
-    {
       hyphens: none;
+      width: 6ch;
     }
   </style>
 
- <body>
+  <div>regu&#x2010;lation imple&#x2010;menta&#x2010;tion</div>
 
-  <p>Test passes if each black-bordered rectangles have identical inside content.
-
-  <div id="test">regu-lation imple-menta-tion</div>
-
-  <div id="reference">regu&#x2010;<br>lation<br>imple&#x2010;<br>menta&#x2010;<br>tion</div>
+  <!--
+        Expected result:
+        regu-
+        lation
+        imple-
+        menta-
+        tion
+  -->
 
 <!--
 

--- a/css/css-text/hyphens/reference/hyphens-auto-010H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-auto-010H-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 6ch;
+    }
+  </style>
+
+ <body lang="en">
+
+  <div>regu&#x2010;<br>lation<br>imple&#x2010;<br>menta&#x2010;<br>tion</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-auto-010M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-auto-010M-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 6ch;
+    }
+  </style>
+
+ <body lang="en">
+
+  <div>regu&#x002D;<br>lation<br>imple&#x002D;<br>menta&#x002D;<br>tion</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-auto-inline-010H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-auto-inline-010H-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 6ch;
+    }
+  </style>
+
+ <body lang="en">
+
+  <div>There<br>are<br>new<br>guide&#x2010;<br>lines<br>now.</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-auto-inline-010M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-auto-inline-010M-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 6ch;
+    }
+  </style>
+
+ <body lang="en">
+
+  <div>There<br>are<br>new<br>guide&#x002D;<br>lines<br>now.</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-011H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-011H-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 10ch;
+    }
+  </style>
+
+  <div>Deoxyribo&#x2010;<br>nucleic acid</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-011M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-011M-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
       width: 10ch;
     }
   </style>
 
-  <body>
+  <div>Deoxyribo&#x002D;<br>nucleic acid</div>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+<!--
 
-  <div>Deoxyribo-nucleic acid</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>Deoxyribo-nucleic acid</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-013H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-013H-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
-      width: 8ch;
+      width: 10ch;
     }
   </style>
 
- <body lang="en">
+  <div>Deoxy&#x2010;<br>ribonucleic acid</div>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+<!--
 
-  <div>DNA means Deoxy-ribonu-cleic acid.</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>DNA means Deoxy-ribonu-cleic acid.</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-013M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-013M-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
       width: 10ch;
     }
   </style>
 
-  <body>
+  <div>Deoxy&#x002D;<br>ribonucleic acid</div>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically. Only the "c" of "nucleic" should be outside of each black-bordered rectangles.
+<!--
 
-  <div>Deoxy-ribonucleic acid</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>Deoxy-ribonucleic acid</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-inline-011H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-inline-011H-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
       width: 10ch;
     }
   </style>
 
-  <body>
+  <div>DNA means<br>Deoxyribo&#x2010;<br>nucleic<br>acid.</div>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+<!--
 
-  <div>DNA means Deoxyribo-nucleic acid.</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>DNA means Deoxyribo-nucleic acid.</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-inline-011M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-inline-011M-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
-      width: 6ch;
+      width: 10ch;
     }
   </style>
 
- <body lang="en">
+  <div>DNA means<br>Deoxyribo&#x002D;<br>nucleic<br>acid.</div>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+<!--
 
-  <div>There are new guide-lines now.</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>There are new guide-lines now.</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-inline-012H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-inline-012H-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 8ch;
+    }
+  </style>
+
+  <div>DNA<br>means<br>Deoxy&#x2010;<br>ribonu&#x2010;<br>cleic<br>acid.</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-inline-012M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-inline-012M-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
-      width: 6ch;
+      width: 8ch;
     }
   </style>
 
- <body lang="en">
+  <div>DNA<br>means<br>Deoxy&#x002D;<br>ribonu&#x002D;<br>cleic<br>acid.</div>
 
-  <p>Test passes if each black-bordered rectangles have identical inside content.
+<!--
 
-  <div>regu-lation imple-menta-tion</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>regu-lation imple-menta-tion</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->


### PR DESCRIPTION
User agents may use [U+2010 HYPHEN](https://codepoints.net/U+2010)  when the font has the glyph, or may use [U+002D HYPHEN-MINUS](https://codepoints.net/U+002d) otherwise. Some fonts will display slightly different glyphs for these code points. Therefore several hyphens tests needed to be redesigned to take under consideration this font reality and they needed 2 possible reference files.

**9 modified tests**
hyphens-auto-010.html 
hyphens-auto-inline-010.html 
hyphens-manual-011.html 
hyphens-manual-012.html 
hyphens-manual-013.html 
hyphens-manual-inline-011.html 
hyphens-manual-inline-012.html 
hyphens-none-012.html 
hyphens-none-013.html

**12 new reference files**
reference/hyphens-auto-010M-ref.html 
reference/hyphens-auto-010H-ref.html 
reference/hyphens-auto-inline-010M-ref.html reference/hyphens-auto-inline-010H-ref.html reference/hyphens-manual-011M-ref.html
reference/hyphens-manual-011H-ref.html
reference/hyphens-manual-013M-ref.html
reference/hyphens-manual-013H-ref.html
reference/hyphens-manual-inline-011M-ref.html
reference/hyphens-manual-inline-011H-ref.html
reference/hyphens-manual-inline-012M-ref.html
reference/hyphens-manual-inline-012H-ref.html

**6 removed reference files**
reference/hyphens-auto-010-ref.html 
reference/hyphens-auto-inline-010-ref.html
reference/hyphens-manual-011-ref.html 
reference/hyphens-manual-013-ref.html 
reference/hyphens-manual-inline-011-ref.html
reference/hyphens-manual-inline-012-ref.html

@kojiishi , @frivoal 