### PR TITLE
fix specificity subtest in css/selectors/invalidation/is.html

### DIFF
--- a/css/selectors/invalidation/is.html
+++ b/css/selectors/invalidation/is.html
@@ -73,7 +73,7 @@
         </div>
       </div>
       <div class="h" id="h1">
-        Black
+        Blue
       </div>
     </div>
     <div class="c" id="c2">
@@ -132,7 +132,7 @@
       test(() => {
         a1.className = "a";
         assert_equals(getComputedStyle(b2).color, blue);
-        assert_equals(getComputedStyle(h1).color, black);
+        assert_equals(getComputedStyle(h1).color, blue);
       }, "Test specificity of :is().");
     </script>
   </body>


### PR DESCRIPTION
https://www.w3.org/TR/selectors-4/#specificity-rules

"The specificity of an :is(), :not(), or :has() pseudo-class is replaced by the specificity of the most specific complex selector in its selector list argument"

 The test has rule

```
.a :is(.e+.f, .g>.b, .h) {
    color: blue;
}
```
which has specificity of

(0, 1, 0) + (0, 2, 0) = (0, 3, 0)

This is higher than (0, 2, 0) of rule

```
.a .h {
    color: black;
}
```

so correct results is blue color being applied.