### PR TITLE
Add retry logic for downloading Chrome in TaskCluster

### DIFF
--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -150,9 +150,9 @@ def install_chrome(channel):
         raise ValueError("Unrecognized release channel: %s" % channel)
 
     dest = os.path.join("/tmp", deb_archive)
-    resp = urlopen("https://dl.google.com/linux/direct/%s" % deb_archive)
+    deb_url = "https://dl.google.com/linux/direct/%s" % deb_archive
     with open(dest, "w") as f:
-        f.write(resp.read())
+        download_url_to_descriptor(f, deb_url)
 
     run(["sudo", "apt-get", "-qqy", "update"])
     run(["sudo", "gdebi", "-qn", "/tmp/%s" % deb_archive])

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -152,7 +152,9 @@ def install_chrome(channel):
     dest = os.path.join("/tmp", deb_archive)
     deb_url = "https://dl.google.com/linux/direct/%s" % deb_archive
     with open(dest, "w") as f:
-        download_url_to_descriptor(f, deb_url)
+        if not download_url_to_descriptor(f, deb_url):
+            raise RuntimeError("Can't download %s. Aborting" % deb_url)
+
 
     run(["sudo", "apt-get", "-qqy", "update"])
     run(["sudo", "gdebi", "-qn", "/tmp/%s" % deb_archive])


### PR DESCRIPTION
In `run_tc.py`, we install Chrome by downloading a deb package from
https://dl.google.com/linux/direct/{package_name}. This download has been
flaking heavily lately, so this PR changes that code to use `download_url_to_descriptor`
which retries (by default) 3 times before giving up on the download. This works
around underlying network flake but doesn't actually fix anything.

See https://github.com/web-platform-tests/wpt/issues/21529