### PR TITLE
Remove a non-ASCII character from #22927

### DIFF
--- a/webdriver/tests/support/__init__.py
+++ b/webdriver/tests/support/__init__.py
@@ -3,7 +3,7 @@ import sys
 from .merge_dictionaries import merge_dictionaries
 
 platform_name = {
-    # From Python version 3.3: On Linux, sys.platform doesn’t contain the major version anymore.
+    # From Python version 3.3: On Linux, sys.platform doesn't contain the major version anymore.
     # It is always 'linux'. See
     # https://docs.python.org/3/library/sys.html#sys.platform
     "linux": "linux",


### PR DESCRIPTION
Python 2 does not like them without declaring file encoding.