### PR TITLE
Improving hyphens-manual-[011-013] related files

### DIFF
--- a/css/css-text/hyphens/hyphens-manual-011.html
+++ b/css/css-text/hyphens/hyphens-manual-011.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-011-ref.html">
+  <link rel="match" href="reference/hyphens-manual-011M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-011H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual', then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 2 hyphenation opportunities, so it can be hyphenated. Since 9 characters can all fit inside the line box of the block box, then the word 'Deoxyribonucleic' is hyphenated only after the 2nd soft hyphen." name="assert">
@@ -17,26 +28,19 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
-      width: 10ch;
-    }
-
-  div#test
-    {
       hyphens: manual;
-    }
-
-  div#reference
-    {
-      hyphens: none;
+      width: 10ch;
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+  <div>Deoxy&shy;ribo&shy;nucleic acid</div>
 
-  <div id="test">Deoxy&shy;ribo&shy;nucleic acid</div>
-
-  <div id="reference">Deoxyribo-nucleic acid</div>
+  <!--
+        Expected result:
+        Deoxyribo-
+        nucleic
+        acid
+  -->
 
   <!--
 

--- a/css/css-text/hyphens/hyphens-manual-012.html
+++ b/css/css-text/hyphens/hyphens-manual-012.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-011-ref.html">
+  <link rel="match" href="reference/hyphens-manual-011M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-011H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual', then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 4 hyphenation opportunities. Since 9 characters can all fit inside the line box of the block box, then the word 'Deoxyribonucleic' is hyphenated only after the 3rd soft hyphen." name="assert">
@@ -17,26 +28,19 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
-      width: 10ch;
-    }
-
-  div#test
-    {
       hyphens: manual;
-    }
-
-  div#reference
-    {
-      hyphens: none;
+      width: 10ch;
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+  <div>Deo&shy;xy&shy;ribo&shy;nu&shy;cleic acid</div>
 
-  <div id="test">Deo&shy;xy&shy;ribo&shy;nu&shy;cleic acid</div>
-
-  <div id="reference">Deoxyribo-nucleic acid</div>
+  <!--
+        Expected result:
+        Deoxyribo-
+        nucleic
+        acid
+  -->
 
   <!--
 

--- a/css/css-text/hyphens/hyphens-manual-013.html
+++ b/css/css-text/hyphens/hyphens-manual-013.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-013-ref.html">
+  <link rel="match" href="reference/hyphens-manual-013M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-013H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual', then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 1 and only 1 hyphenation opportunity, so it can be hyphenated only at such point." name="assert">
@@ -17,26 +28,19 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
-      width: 10ch;
-    }
-
-  div#test
-    {
       hyphens: manual;
-    }
-
-  div#reference
-    {
-      hyphens: none;
+      width: 10ch;
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically. Only the "c" of "nucleic" should be outside of each black-bordered rectangles.
+  <div>Deoxy&shy;ribonucleic acid</div>
 
-  <div id="test">Deoxy&shy;ribonucleic acid</div>
-
-  <div id="reference">Deoxy-ribonucleic acid</div>
+  <!--
+        Expected result:
+        Deoxy-
+        ribonucleic
+        acid
+  -->
 
   <!--
 

--- a/css/css-text/hyphens/reference/hyphens-manual-011H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-011H-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 10ch;
+    }
+  </style>
+
+  <div>Deoxyribo&#x2010;<br>nucleic acid</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-011M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-011M-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
       width: 10ch;
     }
   </style>
 
-  <body>
+  <div>Deoxyribo&#x002D;<br>nucleic acid</div>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically. Only the "c" of "nucleic" should be outside of each black-bordered rectangles.
+<!--
 
-  <div>Deoxy-ribonucleic acid</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>Deoxy-ribonucleic acid</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-013H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-013H-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
       width: 10ch;
     }
   </style>
 
-  <body>
+  <div>Deoxy&#x2010;<br>ribonucleic acid</div>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+<!--
 
-  <div>Deoxyribo-nucleic acid</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>Deoxyribo-nucleic acid</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-013M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-013M-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 10ch;
+    }
+  </style>
+
+  <div>Deoxy&#x002D;<br>ribonucleic acid</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->


### PR DESCRIPTION
User agents may use U+2010 HYPHEN when the font has the glyph, or may use U+002D HYPHEN-MINUS otherwise. Some fonts will display slightly different glyphs for these code points. Therefore several hyphens tests needed to be redesigned to take under consideration this font reality and they needed 2 possible reference files.

**3 modified tests**
hyphens-manual-011.html
hyphens-manual-012.html
hyphens-manual-013.html

**4 new reference files**
reference/hyphens-manual-011M-ref.html
reference/hyphens-manual-011H-ref.html
reference/hyphens-manual-013M-ref.html
reference/hyphens-manual-013H-ref.html

**2 removed reference files**
reference/hyphens-manual-011-ref.html
reference/hyphens-manual-013-ref.html