### PR TITLE
Improving hyphens-manual-inline-[011-012] related files

### DIFF
--- a/css/css-text/hyphens/hyphens-manual-inline-011.html
+++ b/css/css-text/hyphens/hyphens-manual-inline-011.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-inline-011-ref.html">
+  <link rel="match" href="reference/hyphens-manual-inline-011M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-inline-011H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual' and applied to an inline element, then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 2 hyphenation opportunities, so it can be hyphenated. Since 9 characters can all fit inside the line box of the block box, then the word 'Deoxyribonucleic' is hyphenated only after the 2nd soft hyphen." name="assert">
@@ -17,23 +28,21 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
       width: 10ch;
     }
 
-  span#test
+  span
     {
       hyphens: manual;
     }
-
-  div#reference
-    {
-      hyphens: none;
-    }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+  <div>DNA <span>means Deoxy&shy;ribo&shy;nucleic acid</span>.</div>
 
-  <div>DNA <span id="test">means Deoxy&shy;ribo&shy;nucleic acid</span>.</div>
-
-  <div id="reference">DNA means Deoxyribo-nucleic acid.</div>
+  <!--
+        Expected result:
+        DNA means
+        Deoxyribo-
+        nucleic
+        acid.
+  -->

--- a/css/css-text/hyphens/hyphens-manual-inline-012.html
+++ b/css/css-text/hyphens/hyphens-manual-inline-012.html
@@ -6,7 +6,18 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hyphenation">
-  <link rel="match" href="reference/hyphens-manual-inline-012-ref.html">
+  <link rel="match" href="reference/hyphens-manual-inline-012M-ref.html">
+  <link rel="match" href="reference/hyphens-manual-inline-012H-ref.html">
+
+  <!--
+  User agents may use U+2010 HYPHEN <https://codepoints.net/U+2010>
+  when the font has the glyph, or
+  may use U+002D HYPHEN-MINUS <https://codepoints.net/U+002d>
+  otherwise. Some fonts will display slightly different glyphs for
+  these code points. Therefore these 2 reference files.
+  The M-ref.html reference file means the hyphen-Minus character U+002D.
+  The H-ref.html reference file means the Hyphen character U+2010.
+  -->
 
   <meta content="" name="flags">
   <meta content="When 'hyphens' is set to 'manual' and applied to an inline element, then words can be hyphenated only if characters inside the words explicitly define hyphenation opportunities. In this test, the characters inside the word 'Deoxyribonucleic' explicitly define 4 hyphenation opportunities. Since 'Deoxy' has 5 characters and 'Deoxyribo' has 9 characters and since the content width of the block box can take 8 characters, then a soft hyphen will occur after 'Deoxy'. Since 'ribonu' has 6 characters and 'ribonucleic' has 11 characters and since the content width of the block box can take 8 characters, then a soft hyphen will occur after 'ribonu'." name="assert">
@@ -17,23 +28,23 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      margin-bottom: 0.25em;
       width: 8ch;
     }
 
-  span#test
+  span
     {
       hyphens: manual;
     }
-
-  div#reference
-    {
-      hyphens: none;
-    }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+  <div>DNA <span>means Deo&shy;xy&shy;ribo&shy;nu&shy;cleic acid</span>.</div>
 
-  <div>DNA <span id="test">means Deo&shy;xy&shy;ribo&shy;nu&shy;cleic acid</span>.</div>
-
-  <div id="reference">DNA means Deoxy-ribonu-cleic acid.</div>
+  <!--
+        Expected result:
+        DNA
+        means
+        Deoxy-
+        ribonu-
+        cleic
+        acid.
+  -->

--- a/css/css-text/hyphens/reference/hyphens-manual-inline-011H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-inline-011H-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
-      width: 8ch;
+      width: 10ch;
     }
   </style>
 
- <body lang="en">
+  <div>DNA means<br>Deoxyribo&#x2010;<br>nucleic<br>acid.</div>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+<!--
 
-  <div>DNA means Deoxy-ribonu-cleic acid.</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>DNA means Deoxy-ribonu-cleic acid.</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-inline-011M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-inline-011M-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 10ch;
+    }
+  </style>
+
+  <div>DNA means<br>Deoxyribo&#x002D;<br>nucleic<br>acid.</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-inline-012H-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-inline-012H-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      width: 8ch;
+    }
+  </style>
+
+  <div>DNA<br>means<br>Deoxy&#x2010;<br>ribonu&#x2010;<br>cleic<br>acid.</div>
+
+<!--
+
+  Hyphen-minus == &#x002D; == &#0045;
+
+  Hyphen == &#x2010; == &#8208;
+
+-->

--- a/css/css-text/hyphens/reference/hyphens-manual-inline-012M-ref.html
+++ b/css/css-text/hyphens/reference/hyphens-manual-inline-012M-ref.html
@@ -12,16 +12,16 @@
       border: black solid 2px;
       font-family: monospace;
       font-size: 32px;
-      hyphens: none;
-      margin-bottom: 0.25em;
-      width: 10ch;
+      width: 8ch;
     }
   </style>
 
-  <body>
+  <div>DNA<br>means<br>Deoxy&#x002D;<br>ribonu&#x002D;<br>cleic<br>acid.</div>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically.
+<!--
 
-  <div>DNA means Deoxyribo-nucleic acid.</div>
+  Hyphen-minus == &#x002D; == &#0045;
 
-  <div>DNA means Deoxyribo-nucleic acid.</div>
+  Hyphen == &#x2010; == &#8208;
+
+-->


### PR DESCRIPTION
User agents may use U+2010 HYPHEN when the font has the glyph, or may use U+002D HYPHEN-MINUS otherwise. Some fonts will display slightly different glyphs for these code points. Therefore several hyphens tests needed to be redesigned to take under consideration this font reality and they needed 2 possible reference files.

**2 modified tests**
hyphens-manual-inline-011.html
hyphens-manual-inline-012.html

**4 new reference files**
reference/hyphens-manual-inline-011M-ref.html
reference/hyphens-manual-inline-011H-ref.html
reference/hyphens-manual-inline-012M-ref.html
reference/hyphens-manual-inline-012H-ref.html

**2 removed reference files**
reference/hyphens-manual-inline-011-ref.html
reference/hyphens-manual-inline-012-ref.html