### PR TITLE
Restore invalid code test.

### DIFF
--- a/wasm/webapi/invalid-code.any.js
+++ b/wasm/webapi/invalid-code.any.js
@@ -8,8 +8,14 @@ setup(() => {
 
 for (const method of ["compileStreaming", "instantiateStreaming"]) {
   promise_test(t => {
+    const buffer = new Uint8Array(Array.from(emptyModuleBinary).concat([0, 0]));
+    const response = new Response(buffer, { headers: { "Content-Type": "application/wasm" } });
+    return promise_rejects_js(t, WebAssembly.CompileError, WebAssembly[method](response));
+  }, `Invalid code (0x0000): ${method}`);
+
+  promise_test(t => {
     const buffer = new Uint8Array(Array.from(emptyModuleBinary).concat([0xCA, 0xFE]));
     const response = new Response(buffer, { headers: { "Content-Type": "application/wasm" } });
     return promise_rejects_js(t, WebAssembly.CompileError, WebAssembly[method](response));
-  }, `Invalid code: ${method}`);
+  }, `Invalid code (0xCAFE): ${method}`);
 }


### PR DESCRIPTION
The test, while correct, was removed in #21931 because V8 failed it.