### PR TITLE
Multipronged improvements for network issues on Taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -56,7 +56,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: harjgam/web-platform-tests:0.33
+            image: hexcles/web-platform-tests:0.35
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -43,6 +43,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import zipfile
 from socket import error as SocketError  # NOQA: N812
 import errno
@@ -152,12 +153,11 @@ def install_chrome(channel):
     dest = os.path.join("/tmp", deb_archive)
     deb_url = "https://dl.google.com/linux/direct/%s" % deb_archive
     with open(dest, "w") as f:
-        if not download_url_to_descriptor(f, deb_url):
-            raise RuntimeError("Can't download %s. Aborting" % deb_url)
-
+        download_url_to_descriptor(f, deb_url)
 
     run(["sudo", "apt-get", "-qqy", "update"])
     run(["sudo", "gdebi", "-qn", "/tmp/%s" % deb_archive])
+
 
 def install_webkitgtk_from_apt_repository(channel):
     # Configure webkitgtk.org/debian repository for $channel and pin it with maximum priority
@@ -178,12 +178,12 @@ def download_url_to_descriptor(fd, url, max_retries=3):
     """Download an URL in chunks and saves it to a file descriptor (truncating it)
     It doesn't close the descriptor, but flushes it on success.
     It retries the download in case of ECONNRESET up to max_retries."""
-    download_succeed = False
-    if max_retries < 0:
-        max_retries = 0
-    for current_retry in range(max_retries+1):
+    if max_retries < 1:
+        max_retries = 1
+    wait = 1
+    for current_retry in range(1, max_retries+1):
         try:
-            print("INFO: Downloading %s Try %d/%d" % (url, current_retry + 1, max_retries))
+            print("INFO: Downloading %s Try %d/%d" % (url, current_retry, max_retries))
             resp = urlopen(url)
             # We may come here in a retry, ensure to truncate fd before start writing.
             fd.seek(0)
@@ -194,22 +194,23 @@ def download_url_to_descriptor(fd, url, max_retries=3):
                     break  # Download finished
                 fd.write(chunk)
             fd.flush()
-            download_succeed = True
-            break  # Sucess
+            # Success
+            return
         except SocketError as e:
-            if e.errno != errno.ECONNRESET:
-                raise  # Unknown error
-            if current_retry < max_retries:
-                print("ERROR: Connection reset by peer. Retrying ...")
-                continue  # Retry
-    return download_succeed
+            if current_retry < max_retries and e.errno == errno.ECONNRESET:
+                # Retry
+                print("ERROR: Connection reset by peer. Retrying after %ds..." % wait)
+                time.sleep(wait)
+                wait *= 2
+            else:
+                # Maximum retries or unknown error
+                raise
 
 
 def install_webkitgtk_from_tarball_bundle(channel):
     with tempfile.NamedTemporaryFile(suffix=".tar.xz") as temp_tarball:
         download_url = "https://webkitgtk.org/built-products/nightly/webkitgtk-nightly-build-last.tar.xz"
-        if not download_url_to_descriptor(temp_tarball, download_url):
-            raise RuntimeError("Can't download %s. Aborting" % download_url)
+        download_url_to_descriptor(temp_tarball, download_url)
         run(["sudo", "tar", "xfa", temp_tarball.name, "-C", "/"])
     # Install dependencies
     run(["sudo", "apt-get", "-qqy", "update"])
@@ -223,6 +224,7 @@ def install_webkitgtk(channel):
         install_webkitgtk_from_apt_repository(channel)
     else:
         raise ValueError("Unrecognized release channel: %s" % channel)
+
 
 def start_xvfb():
     start(["sudo", "Xvfb", os.environ["DISPLAY"], "-screen", "0",

--- a/tools/ci/run_tc.py
+++ b/tools/ci/run_tc.py
@@ -269,8 +269,10 @@ def download_artifacts(artifacts):
     for artifact in artifacts:
         base_url = task_url(artifact["task"])
         if artifact["task"] not in artifact_list_by_task:
-            resp = urlopen(base_url + "/artifacts")
-            artifacts_data = json.load(resp)
+            with tempfile.TemporaryFile() as f:
+                download_url_to_descriptor(f, base_url + "/artifacts")
+                f.seek(0)
+                artifacts_data = json.load(f)
             artifact_list_by_task[artifact["task"]] = artifacts_data
 
         artifacts_data = artifact_list_by_task[artifact["task"]]
@@ -430,9 +432,10 @@ def fetch_event_data():
         # For example under local testing
         return None
 
-    url = task_url(task_id)
-    resp = urlopen(url)
-    task_data = json.load(resp)
+    with tempfile.TemporaryFile() as f:
+        download_url_to_descriptor(f, task_url(task_id))
+        f.seek(0)
+        task_data = json.load(f)
     event_data = task_data.get("extra", {}).get("github_event")
     if event_data is not None:
         return json.loads(event_data)

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -4,7 +4,8 @@ images must be updated as well. To do this, assuming you have docker installed:
 
 In this directory, run
 ```sh
-docker build -t <tag> .
+# --pull forces Docker to get the newest base image.
+docker build --pull -t <tag> .
 docker push <tag>
 ```
 

--- a/tools/docker/frontend.py
+++ b/tools/docker/frontend.py
@@ -8,6 +8,7 @@ wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
 def build(*args, **kwargs):
     subprocess.check_call(["docker",
                            "build",
+                           "--pull",
                            "--tag", "wpt:local",
                            here])
 


### PR DESCRIPTION
Apparently we are still seeing failures with the retry mechanism introduced in #22911 ([example](https://community-tc.services.mozilla.com/tasks/ft2jPkzhSGWgEUoa76j2pQ/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2Fft2jPkzhSGWgEUoa76j2pQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L82)), so here is a more aggressive approach to both improve the retry mechanism (using exponential backoff) and fix a potential concern of an out-of-date cert db in Docker (by updating the Docker image).