### PR TITLE
Replace assert_precondition with assert_implements in portals/

### DIFF
--- a/portals/about-blank-cannot-host.html
+++ b/portals/about-blank-cannot-host.html
@@ -4,7 +4,7 @@
 <script>
 
 promise_test(async (t) => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   let hostWindow = window.open();
   assert_equals(hostWindow.location.href, "about:blank");
 

--- a/portals/csp/frame-src.sub.html
+++ b/portals/csp/frame-src.sub.html
@@ -6,7 +6,7 @@
 </body>
 <script>
   async_test(function(t) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var w = window.open("resources/frame-src.sub.html?frame_src_policy=%27none%27");
     w.onload = function() {
       w.document.addEventListener("securitypolicyviolation",
@@ -21,7 +21,7 @@
   }, "Tests that a portal can't be loaded when it violates frame-src");
 
   async_test(function(t) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var w = window.open(`resources/frame-src.sub.html?frame_src_policy=http://{{hosts[][www]}}:{{ports[http][0]}}`);
     w.onload = function() {
       w.document.onsecuritypolicyviolation = t.unreached_func("Portal should load.");
@@ -32,7 +32,7 @@
     }
   }, "Tests that a portal can be loaded when the origin matches the frame-src CSP header.");
   async_test(function(t) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var w = window.open(`resources/frame-src.sub.html?frame_src_policy=http://{{hosts[][www]}}:{{ports[http][0]}}`);
     w.onload = function() {
       var portal = w.document.createElement("portal");

--- a/portals/history/history-manipulation-inside-portal.html
+++ b/portals/history/history-manipulation-inside-portal.html
@@ -16,42 +16,42 @@
   }
 
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     assertInitialHistoryState();
     await runTestInPortal(portalSrc, 'testHistoryPushStateInPortal');
     assertInitialHistoryState();
   }, 'history.pushState navigates independently with replacement in a portal');
 
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     assertInitialHistoryState();
     await runTestInPortal(portalSrc, 'testHistoryReplaceStateInPortal');
     assertInitialHistoryState();
   }, 'history.replaceState navigates independently in a portal');
 
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     assertInitialHistoryState();
     await runTestInPortal(portalSrc, 'testLocationAssignInPortal');
     assertInitialHistoryState();
   }, 'location.assign navigates independently with replacement in a portal');
 
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     assertInitialHistoryState();
     await runTestInPortal(portalSrc, 'testLocationReplaceInPortal');
     assertInitialHistoryState();
   }, 'location.replace navigates independently in a portal');
 
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     assertInitialHistoryState();
     await runTestInPortal(portalSrc, 'testSetLocationHrefInPortal');
     assertInitialHistoryState();
   }, 'Setting location.href navigates independently with replacement in a portal');
 
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     assertInitialHistoryState();
     await runTestInPortal(portalSrc, 'testSyntheticAnchorClickInPortal');
     assertInitialHistoryState();

--- a/portals/htmlportalelement-event-handler-content-attributes.html
+++ b/portals/htmlportalelement-event-handler-content-attributes.html
@@ -7,7 +7,7 @@
 let eventNames = ["load", "message", "messageerror"];
 test(() => {
   try {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     let portal = document.createElement("portal");
     for (let eventName of eventNames) {
       window.testValue = "not fired";

--- a/portals/portal-activate-data.html
+++ b/portals/portal-activate-data.html
@@ -13,7 +13,7 @@ function nextMessage(target) {
 }
 
 async function openPortalAndActivate(logic, activateOptions, testWindow) {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   const w = testWindow || await openBlankPortalHost();
   try {
     const portal = w.document.createElement('portal');

--- a/portals/portal-activate-event.html
+++ b/portals/portal-activate-event.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
   async_test(function(t) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     let test = "eventlistener";
     var bc = new BroadcastChannel(`test-${test}`);
     bc.onmessage = t.step_func_done(function(e) {
@@ -16,7 +16,7 @@
   }, "Tests that the PortalActivateEvent is dispatched when a portal is activated.");
 
   async_test(function(t) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     let test = "eventhandler";
     var bc = new BroadcastChannel(`test-${test}`);
     bc.onmessage = t.step_func_done(function(e) {
@@ -28,7 +28,7 @@
   }, "Tests that the portalactivate event handler is dispatched when a portal is activated.");
 
   async_test(function(t) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     let test = "bodyeventhandler";
     var bc = new BroadcastChannel(`test-${test}`);
     bc.onmessage = t.step_func_done(function(e) {

--- a/portals/portal-non-http-navigation.html
+++ b/portals/portal-non-http-navigation.html
@@ -5,7 +5,7 @@
 <body>
 <script>
 async_test(t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   var portal = document.createElement("portal");
   portal.src = "data:text/html,empty portal";
   portal.onload = t.unreached_func("Portal loaded data URL.");
@@ -14,7 +14,7 @@ async_test(t => {
 }, "Tests that a portal can't navigate to a data URL.");
 
 async_test(t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   var portal = document.createElement("portal");
   portal.src = "about:blank";
   portal.onload = t.unreached_func("Portal loaded about:blank.");
@@ -23,7 +23,7 @@ async_test(t => {
 }, "Tests that a portal can't navigate to about:blank.");
 
 async_test(t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   var portal = document.createElement("portal");
   portal.src = "resources/simple-portal.html";
   portal.onload = t.step_func(() => {

--- a/portals/portal-onload-event.html
+++ b/portals/portal-onload-event.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
   async_test(function(t) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var w = window.open("resources/simple-portal.html");
     w.onload = function() {
       var portal = w.document.createElement("portal");

--- a/portals/portals-activate-empty-browsing-context.html
+++ b/portals/portals-activate-empty-browsing-context.html
@@ -4,7 +4,7 @@
 <body>
 <script>
 promise_test(async t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   let portal = document.createElement('portal');
   document.body.appendChild(portal);
   t.add_cleanup(() => { document.body.removeChild(portal); });
@@ -13,7 +13,7 @@ promise_test(async t => {
 }, "A portal that has never been navigated cannot be activated");
 
 promise_test(async t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   let portal = document.createElement('portal');
   document.body.appendChild(portal);
   t.add_cleanup(() => { document.body.removeChild(portal); });

--- a/portals/portals-activate-inside-iframe.html
+++ b/portals/portals-activate-inside-iframe.html
@@ -4,7 +4,7 @@
 <body>
   <script>
     promise_test(async t => {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       var iframe = document.createElement("iframe");
       iframe.src = "resources/portal-inside-iframe.html"
       var waitForLoad = new Promise((resolve, reject) => {

--- a/portals/portals-activate-inside-portal.html
+++ b/portals/portals-activate-inside-portal.html
@@ -4,7 +4,7 @@
 <body>
   <script>
     promise_test(async () => {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       var portal = document.createElement("portal");
       portal.src = "resources/portal-activate-inside-portal.html";
       let waitForMessage = new Promise((resolve, reject) => {

--- a/portals/portals-activate-network-error.html
+++ b/portals/portals-activate-network-error.html
@@ -4,7 +4,7 @@
 <body>
 <script>
 async_test(t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   let portal = document.createElement('portal');
   portal.src = "resources/invalid.asis";
   document.body.appendChild(portal);

--- a/portals/portals-activate-no-browsing-context.html
+++ b/portals/portals-activate-no-browsing-context.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 promise_test(async t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   let activatePromise = document.createElement('portal').activate();
   await promise_rejects_dom(t, 'InvalidStateError', activatePromise);
 }, "A portal with nothing in it cannot be activated");

--- a/portals/portals-activate-resolution.html
+++ b/portals/portals-activate-resolution.html
@@ -4,7 +4,7 @@
 <script src="resources/open-blank-host.js"></script>
 <script>
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var win = await openBlankPortalHost();
     var portal = win.document.createElement("portal");
     portal.src = new URL("resources/simple-portal.html", location.href)

--- a/portals/portals-activate-twice.html
+++ b/portals/portals-activate-twice.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 promise_test(async t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   let waitForMessage = new Promise((resolve, reject) => {
     window.onmessage = e => resolve(e.data);
   });
@@ -13,7 +13,7 @@ promise_test(async t => {
 }, "Calling activate when a portal is already activating should fail");
 
 promise_test(async t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   let waitForMessage = new Promise((resolve, reject) => {
     window.onmessage = e => resolve(e.data);
   });

--- a/portals/portals-adopt-predecessor.html
+++ b/portals/portals-adopt-predecessor.html
@@ -13,7 +13,7 @@
   }
 
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var test = "adopt-once";
     window.open(`resources/portals-adopt-predecessor.html?test=${test}`);
     var message = await waitForCompletion(test);
@@ -21,7 +21,7 @@
   }, "Tests that a portal can adopt its predecessor.");
 
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var test = "adopt-twice";
     window.open(`resources/portals-adopt-predecessor.html?test=${test}`);
     var message = await waitForCompletion(test);
@@ -29,7 +29,7 @@
   }, "Tests that trying to adopt the predecessor twice will throw an exception.");
 
   async_test(function(t) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var test = "adopt-after-event";
     var bc = new BroadcastChannel(`test-${test}`);
     bc.onmessage = t.step_func_done(function(e) {
@@ -40,7 +40,7 @@
   }, "Tests that trying to adopt the predecessor after the PortalActivateEvent will throw an exception.");
 
   promise_test(async t => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var test = "adopt-and-activate";
     window.open(`resources/portals-adopt-predecessor.html?test=${test}`);
     var message = await waitForCompletion(test);
@@ -48,7 +48,7 @@
   }, "Tests that activating an adopted predecessor without inserting it works");
 
   async_test(t => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var test = "adopt-attach-remove";
     var bc = new BroadcastChannel(`test-${test}`);
     bc.onmessage = t.step_func_done(function(e) {
@@ -59,7 +59,7 @@
   }, "Tests that an adopting, inserting and then removing a predecessor works correctly");
 
   async_test(t => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var test = "adopt-and-discard";
     var bc = new BroadcastChannel(`test-${test}`);
     bc.onmessage = t.step_func_done(function(e) {
@@ -70,7 +70,7 @@
   }, "Tests that the adopted predecessor is destroyed if it isn't inserted");
 
   async_test(t => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var test = "adopt-to-disconnected-node";
     var bc = new BroadcastChannel(`test-${test}`);
     bc.onmessage = t.step_func_done(function(e) {

--- a/portals/portals-cross-origin-load.sub.html
+++ b/portals/portals-cross-origin-load.sub.html
@@ -4,7 +4,7 @@
 <body>
 <script>
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     var portal = document.createElement("portal");
     portal.src = "http://{{hosts[alt][www]}}:{{ports[http][0]}}/portals/resources/simple-portal.html";
     return new Promise((resolve, reject) => {

--- a/portals/portals-focus.sub.html
+++ b/portals/portals-focus.sub.html
@@ -8,7 +8,7 @@
 <body>
 <script>
   async function createPortal(doc, url) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     let portal = doc.createElement("portal");
     portal.src = url;
     doc.body.appendChild(portal);

--- a/portals/portals-host-exposure.sub.html
+++ b/portals/portals-host-exposure.sub.html
@@ -4,7 +4,7 @@
 <body>
 <script>
   function openPortalAndReceiveMessage(portalSrc) {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     let portal = document.createElement('portal');
     portal.src = portalSrc;
     let received = new Promise((resolve, reject) => {

--- a/portals/portals-host-hidden-after-activation.html
+++ b/portals/portals-host-hidden-after-activation.html
@@ -19,7 +19,7 @@
   }
 
   promise_test(async () => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     const portalUrl = encodeURIComponent("portal-host-hidden-after-activation-portal.html");
     window.open(`resources/portal-embed-and-activate.html?url=${portalUrl}`);
     var results = await waitForMessages();

--- a/portals/portals-host-post-message.sub.html
+++ b/portals/portals-host-post-message.sub.html
@@ -17,7 +17,7 @@
     }
 
     async function createPortalAndLoopMessage(portalSrc, params) {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       var portal = await createPortal(portalSrc);
       var waitForResponse = new Promise((resolve, reject) => {
         portal.addEventListener("message", e => { resolve(e); });
@@ -73,7 +73,7 @@
     }, "postMessage with object message");
 
     promise_test(async () => {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       function checkPort(port) {
         return new Promise((resolve, reject) => {
           var channel = new MessageChannel();
@@ -138,7 +138,7 @@
     }, "postMessage with invalid transferable should throw error");
 
     promise_test(async () => {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
        var receiveMessage = new Promise((resolve, reject) => {
          var bc = new BroadcastChannel("portal-host-post-message-after-activate");
          bc.onmessage = e => { resolve(e); };
@@ -151,7 +151,7 @@
     }, "Calling postMessage after receiving onactivate event should fail");
 
     promise_test(() => {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       var portal = document.createElement("portal");
       portal.src = "resources/portal-host-post-message-navigate-1.html";
       var count = 0;

--- a/portals/portals-navigate-after-adoption.html
+++ b/portals/portals-navigate-after-adoption.html
@@ -27,7 +27,7 @@ async function openPortalAndActivate(logic) {
 }
 
 promise_test(async () => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   let messageFromNewSrc = await openPortalAndActivate(
       'let predecessor = event.adoptPredecessor();' +
       'let readyPromise = new Promise((resolve, reject) => {' +

--- a/portals/portals-nested.html
+++ b/portals/portals-nested.html
@@ -4,7 +4,7 @@
 <body>
   <script>
     promise_test(() => {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       var portal = document.createElement("portal");
       portal.src = "resources/portals-nested-portal.html";
       document.body.appendChild(portal);

--- a/portals/portals-post-message.sub.html
+++ b/portals/portals-post-message.sub.html
@@ -12,7 +12,7 @@
     const crossOriginUrl = "http://{{hosts[alt][www]}}:{{ports[http][0]}}/portals/resources/portal-post-message-portal.html"
 
     async function createAndInsertPortal(portalSrc) {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       var portal = document.createElement("portal");
       portal.src = portalSrc;
       document.body.append(portal);
@@ -185,7 +185,7 @@
     }
 
     promise_test(async t => {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       window.open("resources/portal-post-message-before-activate-window.html");
       let {postMessageTS, activateTS} = await waitForMessage(
           "portals-post-message-before-activate");
@@ -193,14 +193,14 @@
     }, "postMessage before activate should work and preserve order");
 
     promise_test(async t => {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       window.open("resources/portal-post-message-during-activate-window.html");
       let error = await waitForMessage("portals-post-message-during-activate");
       assert_equals(error, "InvalidStateError");
     }, "postMessage during activate throws error");
 
     promise_test(async t => {
-      assert_precondition("HTMLPortalElement" in self);
+      assert_implements("HTMLPortalElement" in self);
       window.open("resources/portal-post-message-after-activate-window.html");
       let error = await waitForMessage("portals-post-message-after-activate");
       assert_equals(error, "InvalidStateError");

--- a/portals/portals-referrer-inherit-header.html
+++ b/portals/portals-referrer-inherit-header.html
@@ -4,7 +4,7 @@
 <body>
 <script>
 promise_test(async () => {
-  assert_precondition('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
+  assert_implements('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
   let portal = document.createElement('portal');
   let referrerPromise = new Promise((resolve, reject) => {
     portal.addEventListener('message', e => resolve(e.data), {once: true});

--- a/portals/portals-referrer-inherit-meta.html
+++ b/portals/portals-referrer-inherit-meta.html
@@ -5,7 +5,7 @@
 <body>
 <script>
 promise_test(async () => {
-  assert_precondition('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
+  assert_implements('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
   let portal = document.createElement('portal');
   let referrerPromise = new Promise((resolve, reject) => {
     portal.addEventListener('message', e => resolve(e.data), {once: true});

--- a/portals/portals-referrer.html
+++ b/portals/portals-referrer.html
@@ -4,7 +4,7 @@
 <body>
 <script>
 promise_test(async () => {
-  assert_precondition('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
+  assert_implements('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
   let portal = document.createElement('portal');
   let referrerPromise = new Promise((resolve, reject) => {
     portal.addEventListener('message', e => resolve(e.data), {once: true});
@@ -21,7 +21,7 @@ promise_test(async () => {
 }, "portal contents should be loaded with referrer");
 
 promise_test(async () => {
-  assert_precondition('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
+  assert_implements('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
   let portal = document.createElement('portal');
   portal.referrerPolicy = 'no-referrer';
   let referrerPromise = new Promise((resolve, reject) => {
@@ -39,7 +39,7 @@ promise_test(async () => {
 }, "portal contents should be loaded with no referrer if referrerpolicy=no-referrer");
 
 promise_test(async () => {
-  assert_precondition('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
+  assert_implements('HTMLPortalElement' in self, 'HTMLPortalElement is required for this test');
   let portal = document.createElement('portal');
   portal.referrerPolicy = 'origin';
   let referrerPromise = new Promise((resolve, reject) => {

--- a/portals/portals-repeated-activate.html
+++ b/portals/portals-repeated-activate.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
   async_test(t => {
-    assert_precondition("HTMLPortalElement" in self);
+    assert_implements("HTMLPortalElement" in self);
     let win = window.open("resources/portal-repeated-activate-window.html");
     win.onload = () => win.activate();
     window.onmessage = t.step_func_done(() => {});

--- a/portals/portals-set-src-after-activate.html
+++ b/portals/portals-set-src-after-activate.html
@@ -10,7 +10,7 @@ function nextMessage(target) {
 }
 
 promise_test(async () => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   const w = await openBlankPortalHost();
   try {
     const portal = w.document.createElement('portal');

--- a/portals/predecessor-fires-unload.html
+++ b/portals/predecessor-fires-unload.html
@@ -12,7 +12,7 @@ function timePasses(delay) {
 }
 
 promise_test(async () => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   const w = await openBlankPortalHost();
   try {
     const portal = w.document.createElement('portal');
@@ -30,7 +30,7 @@ promise_test(async () => {
 }, "pagehide and unload should fire if the predecessor is not adopted");
 
 promise_test(async () => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   localStorage.setItem('predecessor-fires-unload-events', '');
   window.open('resources/predecessor-fires-unload-watch-unload.html', '_blank', 'noopener');
   while (localStorage.getItem('predecessor-fires-unload-events') != 'pagehide unload') {

--- a/portals/xfo/portals-xfo-deny.sub.html
+++ b/portals/xfo/portals-xfo-deny.sub.html
@@ -8,7 +8,7 @@
 // completion event.
 
 async_test(t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   var portal = document.createElement('portal');
   portal.src = "/portals/xfo/resources/xfo-deny.asis";
   portal.onmessage = t.unreached_func("should not have received a message");
@@ -18,7 +18,7 @@ async_test(t => {
 }, "`XFO: DENY` blocks same-origin portals.");
 
 async_test(t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   var portal = document.createElement('portal');
   portal.src = "http://{{domains[www]}}:{{ports[http][0]}}/portals/xfo/resources/xfo-deny.asis";
   portal.onmessage = t.unreached_func("should not have received a message");
@@ -28,7 +28,7 @@ async_test(t => {
 }, "`XFO: DENY` blocks cross-origin portals.");
 
 async_test(t => {
-  assert_precondition("HTMLPortalElement" in self);
+  assert_implements("HTMLPortalElement" in self);
   var portal = document.createElement('portal');
   portal.src = "/portals/xfo/resources/xfo-deny.asis";
   portal.onmessage = t.unreached_func("should not have received a message");


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).
Since HTMLPortalElement is not an OPTIONAL part of the Portals spec,
these tests should use assert_implements.