### PR TITLE
Remove assert_precondition usages in *-timing/

### DIFF
--- a/element-timing/background-image-data-uri.html
+++ b/element-timing/background-image-data-uri.html
@@ -18,7 +18,7 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/background-image-multiple-elements.html
+++ b/element-timing/background-image-multiple-elements.html
@@ -23,7 +23,7 @@ body {
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     let beforeRender = performance.now();
     let numObservedElements = 0;
     let observedDiv1 = false;

--- a/element-timing/background-image-stretched.html
+++ b/element-timing/background-image-stretched.html
@@ -18,7 +18,7 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/buffer-before-onload.html
+++ b/element-timing/buffer-before-onload.html
@@ -13,7 +13,7 @@
   is available from the observer with the buffered flag set to true.
   */
   async_test(function(t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     beforeRender = performance.now();
     const img = document.createElement('img');
     img.src = 'resources/square20.jpg';

--- a/element-timing/buffered-flag.html
+++ b/element-timing/buffered-flag.html
@@ -12,7 +12,7 @@ body {
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test(t => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const beforeRender = performance.now();
     const img = document.createElement('img');
     // Initial observer used to know when entry has been dispatched

--- a/element-timing/cross-origin-element.sub.html
+++ b/element-timing/cross-origin-element.sub.html
@@ -12,7 +12,7 @@ body {
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test((t) => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     let img;
     const pathname = 'http://{{domains[www]}}:{{ports[http][1]}}'
           + '/element-timing/resources/square100.png';

--- a/element-timing/cross-origin-iframe-element.sub.html
+++ b/element-timing/cross-origin-iframe-element.sub.html
@@ -7,7 +7,7 @@
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test((t) => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done((entryList) => {
         assert_unreached("We should not observe a cross origin element.");

--- a/element-timing/css-generated-text.html
+++ b/element-timing/css-generated-text.html
@@ -17,7 +17,7 @@ body {
 <script>
   async_test(function (t) {
     const beforeRender = performance.now();
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/disconnect-image.html
+++ b/element-timing/disconnect-image.html
@@ -9,7 +9,7 @@
   let beforeRender;
   let img;
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/element-only-when-fully-active.html
+++ b/element-timing/element-only-when-fully-active.html
@@ -8,7 +8,7 @@
 <script>
   let t = async_test('Only expose element attribute for fully active documents');
   t.step(() => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
   });
   window.triggerTest = t.step_func_done(elementEntry => {
     assert_not_equals(elementEntry.element, null);

--- a/element-timing/first-letter-background.html
+++ b/element-timing/first-letter-background.html
@@ -16,7 +16,7 @@
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const div = document.getElementById('target');
     let textObserved = false;
     let imageObserved = false;

--- a/element-timing/fixed-id-identifier.html
+++ b/element-timing/fixed-id-identifier.html
@@ -8,7 +8,7 @@
 <p elementtiming='my_identifier' id='my_id'>Text</p>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-TAO.sub.html
+++ b/element-timing/image-TAO.sub.html
@@ -7,7 +7,7 @@
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test(t => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const beforeRender = performance.now();
     const remote_img = 'http://{{domains[www]}}:{{ports[http][1]}}/element-timing/resources/TAOImage.py?'
         + 'origin=' + window.location.origin +'&tao=';

--- a/element-timing/image-carousel.html
+++ b/element-timing/image-carousel.html
@@ -26,7 +26,7 @@ body {
 
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const beforeRenderTimes = [];
     let entry_count = 0;
     const entry_count_per_element = [0, 0];

--- a/element-timing/image-clipped-svg.html
+++ b/element-timing/image-clipped-svg.html
@@ -7,7 +7,7 @@
 <script>
 let beforeRender;
 async_test(function (t) {
-  assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+  assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
   const observer = new PerformanceObserver(
     t.step_func_done(function(entryList) {
       assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-data-uri.html
+++ b/element-timing/image-data-uri.html
@@ -16,7 +16,7 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-not-added.html
+++ b/element-timing/image-not-added.html
@@ -5,7 +5,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(() => {
         // The image should not have caused an entry, so fail test.

--- a/element-timing/image-not-fully-visible.html
+++ b/element-timing/image-not-fully-visible.html
@@ -14,7 +14,7 @@ body {
   let beforeRender;
   let img;
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-rect-iframe.html
+++ b/element-timing/image-rect-iframe.html
@@ -11,7 +11,7 @@ body {
 <script src="/resources/testharnessreport.js"></script>
 <script>
   async_test((t) => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     on_event(window, 'message', e => {
       assert_equals(e.data.length, 1);
       assert_equals(e.data.entryType, 'element');

--- a/element-timing/image-src-change.html
+++ b/element-timing/image-src-change.html
@@ -13,7 +13,7 @@ body {
 <img src='resources/square100.png' elementtiming='my_image' id='my_id'/>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     let beforeRender = performance.now();
     const img = document.getElementById('my_id');
     let firstCallback = true;

--- a/element-timing/image-with-css-scale.html
+++ b/element-timing/image-with-css-scale.html
@@ -21,7 +21,7 @@ body {
 <script>
   const beforeRender = performance.now();
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/image-with-rotation.html
+++ b/element-timing/image-with-rotation.html
@@ -21,7 +21,7 @@ body {
 <script>
   const beforeRender = performance.now();
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/images-repeated-resource.html
+++ b/element-timing/images-repeated-resource.html
@@ -20,7 +20,7 @@ body {
   let img;
   let img2;
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/invisible-images.html
+++ b/element-timing/invisible-images.html
@@ -16,7 +16,7 @@
 </style>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done((entries) => {
         // The image should not have caused an entry, so fail test.

--- a/element-timing/multiple-background-images.html
+++ b/element-timing/multiple-background-images.html
@@ -18,7 +18,7 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     let numObservedElements = 0;
     let observedCircle = false;
     let observedSquare = false;

--- a/element-timing/multiple-redirects-TAO.html
+++ b/element-timing/multiple-redirects-TAO.html
@@ -11,7 +11,7 @@
 <body>
 <script>
 async_test(t => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     let destUrl = get_host_info().HTTP_REMOTE_ORIGIN
         + '/element-timing/resources/multiple-redirects.py?';
     destUrl += 'redirect_count=2';

--- a/element-timing/observe-background-image.html
+++ b/element-timing/observe-background-image.html
@@ -18,7 +18,7 @@ body {
 <script>
   let beforeRender = performance.now();
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/observe-child-element.html
+++ b/element-timing/observe-child-element.html
@@ -12,7 +12,7 @@ body {
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test((t) => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done((entryList) => {
         assert_unreached("Should not have received an entry!");

--- a/element-timing/observe-elementtiming.html
+++ b/element-timing/observe-elementtiming.html
@@ -14,7 +14,7 @@ body {
   let beforeRender;
   let img;
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/observe-empty-attribute.html
+++ b/element-timing/observe-empty-attribute.html
@@ -7,7 +7,7 @@
 <script>
 let beforeRender;
 async_test(function (t) {
-  assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+  assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
   let observedImage = false;
   let observedText = false;
   const observer = new PerformanceObserver(

--- a/element-timing/observe-multiple-images.html
+++ b/element-timing/observe-multiple-images.html
@@ -22,7 +22,7 @@ body {
 <script>
   let beforeRender, image1Observed=0, image2Observed=0, image3Observed=0;
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func(function(entryList) {
         entryList.getEntries().forEach( entry => {

--- a/element-timing/observe-shadow-image.html
+++ b/element-timing/observe-shadow-image.html
@@ -12,7 +12,7 @@ body {
 <div id='target'></div>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_unreached('Should not observe elements in shadow trees!');

--- a/element-timing/observe-shadow-text.html
+++ b/element-timing/observe-shadow-text.html
@@ -12,7 +12,7 @@ body {
 <div id='target'></div>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_unreached('Should not observe text elements in shadow trees!');

--- a/element-timing/observe-svg-image.html
+++ b/element-timing/observe-svg-image.html
@@ -7,7 +7,7 @@
 <script>
 let beforeRender;
 async_test(function (t) {
-  assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+  assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
   const observer = new PerformanceObserver(
     t.step_func_done(function(entryList) {
       assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/observe-text.html
+++ b/element-timing/observe-text.html
@@ -15,7 +15,7 @@ p {
 <script src="resources/element-timing-helpers.js"></script>
 <script>
   async_test((t) => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     let paragraph;
     let beforeRender;
     const observer = new PerformanceObserver(

--- a/element-timing/observe-video-poster.html
+++ b/element-timing/observe-video-poster.html
@@ -7,7 +7,7 @@
 <script>
 let beforeRender;
 async_test(function (t) {
-  assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+  assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
   const observer = new PerformanceObserver(
     t.step_func_done(function(entryList) {
       assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/progressively-loaded-image.html
+++ b/element-timing/progressively-loaded-image.html
@@ -14,7 +14,7 @@
   let numInitial = 75;
   let sleep = 500;
   async_test(function(t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const img_src = 'resources/progressive-image.py?name=square20.jpg&numInitial='
       + numInitial + '&sleep=' + sleep;
     const observer = new PerformanceObserver(

--- a/element-timing/rectangular-image.html
+++ b/element-timing/rectangular-image.html
@@ -14,7 +14,7 @@ body {
   let beforeRender;
   let img;
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/element-timing/redirects-tao-star.html
+++ b/element-timing/redirects-tao-star.html
@@ -11,7 +11,7 @@
 <body>
 <script>
 async_test(t => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     let destUrl = get_host_info().HTTP_REMOTE_ORIGIN
             + '/resource-timing/resources/multi_redirect.py?';
     destUrl += 'page_origin=' +  get_host_info().HTTP_ORIGIN;

--- a/element-timing/retrievability.html
+++ b/element-timing/retrievability.html
@@ -7,7 +7,7 @@
 <script>
   let img;
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const beforeRender = performance.now();
     new PerformanceObserver(
       t.step_func_done(function(entryList) {

--- a/element-timing/same-origin-redirects.html
+++ b/element-timing/same-origin-redirects.html
@@ -10,7 +10,7 @@
 <body>
 <script>
 async_test(t => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     // First redirect
     let destUrl = '/common/redirect.py?location='
     // Second redirect

--- a/element-timing/scroll-to-text.html
+++ b/element-timing/scroll-to-text.html
@@ -15,7 +15,7 @@
 <p elementtiming='observeMe'>Test text</p>
 <script>
   async_test((t) => {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(t.step_func_done(() => {}));
     observer.observe({type: 'element', buffered: true});
     window.onload = () => {

--- a/element-timing/text-with-display-style.html
+++ b/element-timing/text-with-display-style.html
@@ -21,7 +21,7 @@ h3 {
 <h3 id='title3' elementtiming='h3'>I am h3</h3>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const beforeRender = performance.now();
     let observedFlex = false;
     let observedGrid = false;

--- a/element-timing/toJSON.html
+++ b/element-timing/toJSON.html
@@ -8,7 +8,7 @@
 <img elementtiming='img' src="resources/square100.png"/>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
+    assert_implements(window.PerformanceElementTiming, "PerformanceElementTiming is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         assert_equals(entryList.getEntries().length, 1);

--- a/event-timing/buffered-flag.html
+++ b/event-timing/buffered-flag.html
@@ -12,7 +12,7 @@
   let firstInputSeen = false;
   let eventSeen = false;
   async_test(t => {
-    assert_precondition(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     const validateEntry = t.step_func(entry => {
       if (entry.entryType === 'first-input')
         firstInputSeen = true;

--- a/event-timing/click-timing.html
+++ b/event-timing/click-timing.html
@@ -21,7 +21,7 @@
   let timeAfterSecondClick;
   let observedEntries = [];
   async_test(function(t) {
-    assert_precondition(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     new PerformanceObserver(t.step_func(entryList => {
       observedEntries = observedEntries.concat(entryList.getEntries().filter(
         entry => entry.name === 'mousedown'));

--- a/event-timing/crossiframe.html
+++ b/event-timing/crossiframe.html
@@ -48,7 +48,7 @@
   }
 
   promise_test(async t => {
-    assert_precondition(window.PerformanceEventTiming, "Event Timing is not supported");
+    assert_implements(window.PerformanceEventTiming, "Event Timing is not supported");
     clickTimeMin = performance.now();
     let observedEntries = false;
     const observerPromise = new Promise(resolve => {

--- a/event-timing/event-click-counts.html
+++ b/event-timing/event-click-counts.html
@@ -10,7 +10,7 @@
 <button id='button'>Click me</button>
 <script>
   promise_test( t => {
-    assert_precondition(window.EventCounts, "Event Counts isn't supported");
+    assert_implements(window.EventCounts, "Event Counts isn't supported");
     function testClicks(expectedCount, resolve) {
       const clickCount = performance.eventCounts.get('click');
       if (clickCount < expectedCount) {

--- a/event-timing/event-counts-zero.html
+++ b/event-timing/event-counts-zero.html
@@ -8,7 +8,7 @@
 <script src=/resources/testdriver-vendor.js></script>
 <script>
   test(() => {
-    assert_precondition(window.EventCounts, "Event Counts isn't supported");
+    assert_implements(window.EventCounts, "Event Counts isn't supported");
     const eventTypes = [
         'auxclick',
         'click',

--- a/event-timing/only-observe-firstInput.html
+++ b/event-timing/only-observe-firstInput.html
@@ -20,7 +20,7 @@
      PerformanceObserver should observe one and only one entry.
   */
   async_test(function(t) {
-    assert_precondition(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     let hasObservedFirstInput = false;
     new PerformanceObserver(t.step_func((entryList) => {
         assert_false(hasObservedFirstInput);

--- a/event-timing/programmatic-click-not-observed.html
+++ b/event-timing/programmatic-click-not-observed.html
@@ -18,7 +18,7 @@
     delayCalled = true;
   }
   async_test(function(t) {
-    assert_precondition(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     const observer = new PerformanceObserver(t.step_func_done((entryList) => {
       const entries = entryList.getEntries().filter(e => e.name === 'mousedown');
       // There must only be one click entry: from the clickAndBlockMain() call.

--- a/event-timing/retrievability.html
+++ b/event-timing/retrievability.html
@@ -30,7 +30,7 @@
      Validate entries
   */
   async_test(function(t) {
-    assert_precondition(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     new PerformanceObserver(t.step_func_done(() => {
       validateEntries();
       t.done();

--- a/event-timing/retrieve-firstInput.html
+++ b/event-timing/retrieve-firstInput.html
@@ -12,7 +12,7 @@
 
 <script>
   async_test(function(t) {
-    assert_precondition(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     function testEntries() {
       // First callback is not ensured to have the entry.
       if (performance.getEntriesByType('first-input').length === 0) {

--- a/event-timing/timingconditions.html
+++ b/event-timing/timingconditions.html
@@ -35,7 +35,7 @@
   }
 
   async_test(function(t) {
-    assert_precondition(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     new PerformanceObserver(t.step_func_done(entryList => {
       const observerCallbackTime = performance.now();
       const entries = entryList.getEntries().filter(

--- a/event-timing/toJSON.html
+++ b/event-timing/toJSON.html
@@ -10,7 +10,7 @@
 <button id='button'>Generate a 'click' event</button>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceEventTiming, 'Event Timing is not supported.');
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         const entry = entryList.getEntries()[0];

--- a/longtask-timing/buffered-flag.window.js
+++ b/longtask-timing/buffered-flag.window.js
@@ -1,5 +1,5 @@
 async_test(t => {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     new PerformanceObserver(t.step_func((entryList, obs) => {
         const observer = new PerformanceObserver(t.step_func_done(list => {
             let longtaskObserved = false;

--- a/longtask-timing/containerTypes.html
+++ b/longtask-timing/containerTypes.html
@@ -19,7 +19,7 @@ const Containers = [
 ];
 Containers.forEach(container => {
   promise_test(async t => {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     const initialTime = performance.now();
     return new Promise(resolve => {
       const observer = new PerformanceObserver(t.step_func(entryList => {

--- a/longtask-timing/long-microtask.window.js
+++ b/longtask-timing/long-microtask.window.js
@@ -1,5 +1,5 @@
 async_test(function (t) {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     new PerformanceObserver(
         t.step_func_done(entryList => {
             const entries = entryList.getEntries();

--- a/longtask-timing/longtask-attributes.html
+++ b/longtask-timing/longtask-attributes.html
@@ -10,7 +10,7 @@
 <div id="log"></div>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     const observer = new PerformanceObserver(
         t.step_func(function (entryList) {
             const entries = entryList.getEntries();

--- a/longtask-timing/longtask-in-childiframe-crossorigin.html
+++ b/longtask-timing/longtask-in-childiframe-crossorigin.html
@@ -10,7 +10,7 @@
 <div id="log"></div>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     const observer = new PerformanceObserver(
         t.step_func(function (entryList) {
             const entries = entryList.getEntries();

--- a/longtask-timing/longtask-in-childiframe.html
+++ b/longtask-timing/longtask-in-childiframe.html
@@ -11,7 +11,7 @@
 <script>
   const initialTime = performance.now();
   async_test(function (t) {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     const observer = new PerformanceObserver(
         t.step_func(function (entryList) {
             const entries = entryList.getEntries();

--- a/longtask-timing/longtask-in-externalscript.html
+++ b/longtask-timing/longtask-in-externalscript.html
@@ -10,7 +10,7 @@
 <div id="log"></div>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     const observer = new PerformanceObserver(
         t.step_func(function (entryList) {
             const entries = entryList.getEntries();

--- a/longtask-timing/longtask-in-parentiframe.html
+++ b/longtask-timing/longtask-in-parentiframe.html
@@ -8,7 +8,7 @@
 
 <script>
   const t = async_test(t => {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     window.addEventListener('message', t.step_func(e => {
       assert_equals(e.data['entryType'], 'longtask');
       assert_equals(e.data['frame-attribution'], 'same-origin-ancestor');

--- a/longtask-timing/longtask-in-raf.html
+++ b/longtask-timing/longtask-in-raf.html
@@ -10,7 +10,7 @@
 <div id="log"></div>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     const observer = new PerformanceObserver(
         t.step_func(function (entryList) {
             const entries = entryList.getEntries();

--- a/longtask-timing/longtask-in-sibling-iframe-crossorigin.html
+++ b/longtask-timing/longtask-in-sibling-iframe-crossorigin.html
@@ -8,7 +8,7 @@
 
 <script>
   async_test(t => {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     window.addEventListener('message', t.step_func(e => {
       assert_equals(e.data['entryType'], 'longtask');
       assert_equals(e.data['frame-attribution'], 'cross-origin-unreachable');

--- a/longtask-timing/longtask-in-sibling-iframe.html
+++ b/longtask-timing/longtask-in-sibling-iframe.html
@@ -8,7 +8,7 @@
 
 <script>
   async_test(t => {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     window.addEventListener('message', t.step_func(e => {
       assert_equals(e.data['entryType'], 'longtask');
       // Ignore any long task that may be produced by the top-level frame.

--- a/longtask-timing/longtask-tojson.html
+++ b/longtask-timing/longtask-tojson.html
@@ -7,7 +7,7 @@
 <body>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+    assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
     const observer = new PerformanceObserver(
       t.step_func(function (entryList) {
         const entries = entryList.getEntries();

--- a/longtask-timing/shared-renderer/longtask-in-new-window.html
+++ b/longtask-timing/shared-renderer/longtask-in-new-window.html
@@ -11,7 +11,7 @@
   This window opens a new window which contains a longtask. We test that the
   longtask from the new window is not observed by the observer of this window. */
 async_test(t => {
-  assert_precondition(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
+  assert_implements(window.PerformanceLongTaskTiming, 'Longtasks are not supported.');
   const observer = new PerformanceObserver(
       t.step_func(function (entryList) {
           const entries = entryList.getEntries();

--- a/longtask-timing/supported-longtask-types.window.js
+++ b/longtask-timing/supported-longtask-types.window.js
@@ -1,5 +1,5 @@
 test(() => {
-  assert_precondition(typeof PerformanceObserver.supportedEntryTypes !== "undefined", 'supportedEntryTypes is not supported');
+  assert_implements(typeof PerformanceObserver.supportedEntryTypes !== "undefined", 'supportedEntryTypes is not supported');
   const types = PerformanceObserver.supportedEntryTypes;
   assert_true(types.includes("longtask"),
     "There should be 'longtask' in PerformanceObserver.supportedEntryTypes");
@@ -21,8 +21,8 @@ function syncWait(waitDuration) {
 
 const entryType = "longtask";
 promise_test(async () => {
-  assert_precondition(typeof PerformanceObserver.supportedEntryTypes !== "undefined", 'supportedEntryTypes is not supported');
-  assert_precondition(typeof PerformanceObserver.supportedEntryTypes.includes(entryType), `supportedEntryTypes does not include '${entryType}'`);
+  assert_implements(typeof PerformanceObserver.supportedEntryTypes !== "undefined", 'supportedEntryTypes is not supported');
+  assert_implements(typeof PerformanceObserver.supportedEntryTypes.includes(entryType), `supportedEntryTypes does not include '${entryType}'`);
   await new Promise((resolve) => {
     new PerformanceObserver(function (list, observer) {
       observer.disconnect();

--- a/paint-timing/basetest.html
+++ b/paint-timing/basetest.html
@@ -9,7 +9,7 @@
 
 <script>
 async_test(function(t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     t.step(function() {
         const bufferedEntries = performance.getEntriesByType('paint');
         assert_equals(bufferedEntries.length, 0, "No paint entries yet");

--- a/paint-timing/buffered-flag.window.js
+++ b/paint-timing/buffered-flag.window.js
@@ -1,5 +1,5 @@
 async_test(t => {
-  assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+  assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
   // First observer creates second in callback to ensure the entry has been dispatched by the time
   // the second observer begins observing.
   let entries_seen = 0;

--- a/paint-timing/child-painting-first-image.html
+++ b/paint-timing/child-painting-first-image.html
@@ -5,7 +5,7 @@
 
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     window.addEventListener('message', t.step_func(e => {
         assert_equals(e.data, '2 paint first-paint paint first-contentful-paint');
         // When only child frame paints, expect only first-paint.

--- a/paint-timing/fcp-only/fcp-canvas-context.html
+++ b/paint-timing/fcp-only/fcp-canvas-context.html
@@ -9,7 +9,7 @@
 <canvas id="canvas" width="50" height="50"></canvas>
 <script>
   promise_test(async t => {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     await new Promise(r => window.addEventListener('load', r));
     await assertNoFirstContentfulPaint(t);
     const canvas = document.getElementById('canvas');

--- a/paint-timing/fcp-only/fcp-gradient.html
+++ b/paint-timing/fcp-only/fcp-gradient.html
@@ -16,7 +16,7 @@
 <div id="main"></div>
 <script>
   promise_test(async t => {
-      assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+      assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
       await new Promise(r => window.addEventListener('load', r));
       await assertNoFirstContentfulPaint(t);
   },  'Gradients should not count as contentful');

--- a/paint-timing/fcp-only/fcp-text-input.html
+++ b/paint-timing/fcp-only/fcp-text-input.html
@@ -9,7 +9,7 @@
 <input id="input" type="text" />
 <script>
   promise_test(async t => {
-      assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+      assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
       await new Promise(r => window.addEventListener('load', r));
       await assertNoFirstContentfulPaint(t);
       const input = document.getElementById('input');

--- a/paint-timing/fcp-only/fcp-video-frame.html
+++ b/paint-timing/fcp-only/fcp-video-frame.html
@@ -9,7 +9,7 @@
 <video id="video" autoplay></video>
 <script>
   promise_test(async t => {
-      assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+      assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
       await new Promise(r => window.addEventListener('load', r));
       await assertNoFirstContentfulPaint(t);
       // Set actual video content to trigger FCP.

--- a/paint-timing/fcp-only/fcp-video-poster.html
+++ b/paint-timing/fcp-only/fcp-video-poster.html
@@ -9,7 +9,7 @@
 <video id="video" width="50" height="50"></video>
 <script>
   promise_test(async t => {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     await new Promise(r => window.addEventListener('load', r));
     await assertNoFirstContentfulPaint(t);
     const video = document.getElementById('video');

--- a/paint-timing/fcp-only/fcp-with-rtl.html
+++ b/paint-timing/fcp-only/fcp-with-rtl.html
@@ -19,7 +19,7 @@
 <div id="text">TEXT</div>
 <script>
   promise_test(async t => {
-      assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+      assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
       await new Promise(r => window.addEventListener('load', r));
       await assertNoFirstContentfulPaint(t);
       document.body.style.direction = 'ltr'

--- a/paint-timing/first-contentful-bg-image.html
+++ b/paint-timing/first-contentful-bg-image.html
@@ -11,7 +11,7 @@
 <footer>
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const body = document.getElementsByTagName('body')[0];
     body.style.backgroundImage = 'url(resources/circles.png)';
     window.onload = function() {

--- a/paint-timing/first-contentful-canvas.html
+++ b/paint-timing/first-contentful-canvas.html
@@ -9,7 +9,7 @@
 
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const canvas = document.getElementById("canvas");
     const context = canvas.getContext("2d");
     context.beginPath();

--- a/paint-timing/first-contentful-image.html
+++ b/paint-timing/first-contentful-image.html
@@ -9,7 +9,7 @@
 
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const img = document.createElement("IMG");
     img.src = "resources/circles.png";
     img.onload = function() {

--- a/paint-timing/first-contentful-paint.html
+++ b/paint-timing/first-contentful-paint.html
@@ -10,7 +10,7 @@
 
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const bufferedEntries = performance.getEntriesByType('paint');
     assert_equals(bufferedEntries.length, 0, "No paint entries yet");
     const div = document.createElement("div");

--- a/paint-timing/first-contentful-svg.html
+++ b/paint-timing/first-contentful-svg.html
@@ -9,7 +9,7 @@
 
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const img = document.createElement("IMG");
     img.src = "resources/circle.svg";
     img.onload = function() {

--- a/paint-timing/first-image-child.html
+++ b/paint-timing/first-image-child.html
@@ -10,7 +10,7 @@
 <img src='resources/circles.png'/>
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
 
     window.addEventListener('message', t.step_func(e => {
         // Child iframe should not have any paint-timing entries.

--- a/paint-timing/first-paint-bg-color.html
+++ b/paint-timing/first-paint-bg-color.html
@@ -11,7 +11,7 @@
 <footer>
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     document.body.style.backgroundColor = "#AA0000";
 
     function testPaintEntries() {

--- a/paint-timing/first-paint-only.html
+++ b/paint-timing/first-paint-only.html
@@ -9,7 +9,7 @@
 
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const div = document.createElement("div");
     div.style.width = "100px";
     div.style.height = "100px";

--- a/paint-timing/paint-visited.html
+++ b/paint-timing/paint-visited.html
@@ -21,7 +21,7 @@ window.onload = function() {
   history.replaceState({}, "", current_url);
 }
 async_test(function(t) {
-  assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+  assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
   function testPaintEntries() {
       const bufferedEntries = performance.getEntriesByType('paint');
       if (bufferedEntries.length < 2) {

--- a/paint-timing/resources/utils.js
+++ b/paint-timing/resources/utils.js
@@ -36,7 +36,7 @@ async function test_fcp(label) {
   const style = document.createElement('style');
   document.head.appendChild(style);
   await promise_test(async t => {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const main = document.getElementById('main');
     await new Promise(r => window.addEventListener('load', r));
     await assertNoFirstContentfulPaint(t);

--- a/paint-timing/sibling-painting-first-image.html
+++ b/paint-timing/sibling-painting-first-image.html
@@ -6,7 +6,7 @@
 <iframe id="listening-iframe" src="resources/subframe-sending-paint.html"></iframe>
 <script>
 async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     let paintingIframeHasDispatchedEntries = false;
     window.addEventListener('message', t.step_func(e => {
         if (!paintingIframeHasDispatchedEntries) {

--- a/paint-timing/supported-paint-type.window.js
+++ b/paint-timing/supported-paint-type.window.js
@@ -1,13 +1,13 @@
 test(() => {
-  assert_precondition(typeof PerformanceObserver.supportedEntryTypes !== "undefined", 'supportedEntryTypes is not supported');
+  assert_implements(typeof PerformanceObserver.supportedEntryTypes !== "undefined", 'supportedEntryTypes is not supported');
   assert_true(PerformanceObserver.supportedEntryTypes.includes("paint"),
     "There should be an entry 'paint' in PerformanceObserver.supportedEntryTypes");
 }, "supportedEntryTypes contains 'paint'.");
 
 const entryType = 'paint';
 promise_test(async() => {
-  assert_precondition(typeof PerformanceObserver.supportedEntryTypes !== "undefined", 'supportedEntryTypes is not supported');
-  assert_precondition(typeof PerformanceObserver.supportedEntryTypes.includes(entryType), `supportedEntryTypes does not include '${entryType}'`);
+  assert_implements(typeof PerformanceObserver.supportedEntryTypes !== "undefined", 'supportedEntryTypes is not supported');
+  assert_implements(typeof PerformanceObserver.supportedEntryTypes.includes(entryType), `supportedEntryTypes does not include '${entryType}'`);
   await new Promise((resolve) => {
     new PerformanceObserver(function (list, observer) {
       observer.disconnect();


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).

As the usages in these directories were for non-OPTIONAL parts of specs, replace with
assert_implements.