### PR TITLE
Replace assert_precondition with assert_implements in layout-instability/

### DIFF
--- a/layout-instability/buffer-layout-shift.html
+++ b/layout-instability/buffer-layout-shift.html
@@ -11,7 +11,7 @@
 <script src="resources/util.js"></script>
 <script>
 promise_test(async t => {
-  assert_precondition(window.LayoutShift, 'Layout Instability is not supported.');
+  assert_implements(window.LayoutShift, 'Layout Instability is not supported.');
   // Wait for the initial render to complete.
   await waitForAnimationFrames(2);
 

--- a/layout-instability/buffered-flag.html
+++ b/layout-instability/buffered-flag.html
@@ -11,7 +11,7 @@
 <script src="resources/util.js"></script>
 <script>
 promise_test(async t => {
-  assert_precondition(window.LayoutShift, 'Layout Instability is not supported.');
+  assert_implements(window.LayoutShift, 'Layout Instability is not supported.');
   // Wait for the initial render to complete.
   await waitForAnimationFrames(2);
 

--- a/layout-instability/recent-input.html
+++ b/layout-instability/recent-input.html
@@ -22,7 +22,7 @@
 let timeAfterClick;
 
 promise_test(async t => {
-  assert_precondition(window.LayoutShift, 'Layout Instability is not supported.');
+  assert_implements(window.LayoutShift, 'Layout Instability is not supported.');
   // Wait for the initial render to complete.
   await waitForAnimationFrames(2);
 

--- a/layout-instability/supported-layout-type.html
+++ b/layout-instability/supported-layout-type.html
@@ -7,8 +7,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 test(() => {
-  assert_precondition(window.LayoutShift, 'Layout Instability is not supported.');
-  assert_precondition(typeof PerformanceObserver.supportedEntryTypes !== "undefined",
+  assert_implements(window.LayoutShift, 'Layout Instability is not supported.');
+  assert_implements(typeof PerformanceObserver.supportedEntryTypes !== "undefined",
       'supportedEntryTypes is not supported.');
   assert_greater_than(PerformanceObserver.supportedEntryTypes.indexOf("layout-shift"), -1,
     "There should be an entry 'layout-shift' in PerformanceObserver.supportedEntryTypes");

--- a/layout-instability/toJSON.html
+++ b/layout-instability/toJSON.html
@@ -11,7 +11,7 @@
 <script src="resources/util.js"></script>
 <script>
 promise_test(async t => {
-  assert_precondition(window.LayoutShift, 'Layout Instability is not supported.');
+  assert_implements(window.LayoutShift, 'Layout Instability is not supported.');
   // Wait for the initial render to complete.
   await waitForAnimationFrames(2);
 


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).
Since LayoutShift is not an OPTIONAL part of the Layout Instability
spec, these tests should use assert_implements.