### PR TITLE
Replace assert_precondition with assert_implements in largest-contentful-paint/

### DIFF
--- a/largest-contentful-paint/contracted-image.html
+++ b/largest-contentful-paint/contracted-image.html
@@ -13,7 +13,7 @@
 <script src="resources/largest-contentful-paint-helpers.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     const beforeLoad = performance.now();
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {

--- a/largest-contentful-paint/cross-origin-image.sub.html
+++ b/largest-contentful-paint/cross-origin-image.sub.html
@@ -7,7 +7,7 @@
 <script src="resources/largest-contentful-paint-helpers.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     const beforeLoad = performance.now();
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {

--- a/largest-contentful-paint/expanded-image.html
+++ b/largest-contentful-paint/expanded-image.html
@@ -13,7 +13,7 @@
 <script src="resources/largest-contentful-paint-helpers.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     const beforeLoad = performance.now();
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {

--- a/largest-contentful-paint/first-letter-background.html
+++ b/largest-contentful-paint/first-letter-background.html
@@ -15,7 +15,7 @@ div {
 <script src="resources/largest-contentful-paint-helpers.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let beforeLoad = performance.now();
     let observedFirstLetter = false;
     const observer = new PerformanceObserver(

--- a/largest-contentful-paint/first-paint-equals-lcp-text.html
+++ b/largest-contentful-paint/first-paint-equals-lcp-text.html
@@ -6,8 +6,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.PerformancePaintTiming, "PerformancePaintTiming is not implemented");
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.PerformancePaintTiming, "PerformancePaintTiming is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let firstPaintTime = 0;
     let firstContentfulPaintTime = 0;
     let largestContentfulPaintTime = 0;

--- a/largest-contentful-paint/iframe-content-not-observed.html
+++ b/largest-contentful-paint/iframe-content-not-observed.html
@@ -8,7 +8,7 @@
 <body>
 <script>
   async_test((t) => {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(entryList => {
         assert_unreached("Should not have received an entry!");

--- a/largest-contentful-paint/image-src-change.html
+++ b/largest-contentful-paint/image-src-change.html
@@ -8,7 +8,7 @@
 <img src='/images/blue.png' id='image_id'/>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let beforeLoad = performance.now();
     let firstCallback = true;
     const observer = new PerformanceObserver(

--- a/largest-contentful-paint/larger-image.html
+++ b/largest-contentful-paint/larger-image.html
@@ -13,7 +13,7 @@
 <p>More text!</p>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     const beforeLoad = performance.now();
     const observer = new PerformanceObserver(
       t.step_func(entryList => {

--- a/largest-contentful-paint/larger-text.html
+++ b/largest-contentful-paint/larger-text.html
@@ -18,7 +18,7 @@
 <img src='/images/green-2x2.png'/>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let beforeRender;
     const observer = new PerformanceObserver(
       t.step_func(entryList => {

--- a/largest-contentful-paint/loadTime-after-appendChild.html
+++ b/largest-contentful-paint/loadTime-after-appendChild.html
@@ -7,7 +7,7 @@
 <script src="resources/largest-contentful-paint-helpers.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let beforeLoad;
     const observer = new PerformanceObserver(
       t.step_func_done(entryList => {

--- a/largest-contentful-paint/multiple-redirects-TAO.html
+++ b/largest-contentful-paint/multiple-redirects-TAO.html
@@ -12,7 +12,7 @@
 <body>
 <script>
 async_test(t => {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let destUrl = get_host_info().HTTP_REMOTE_ORIGIN
         + '/element-timing/resources/multiple-redirects.py?';
     destUrl += 'redirect_count=2';

--- a/largest-contentful-paint/observe-after-untrusted-scroll.html
+++ b/largest-contentful-paint/observe-after-untrusted-scroll.html
@@ -7,7 +7,7 @@
 <script src="resources/largest-contentful-paint-helpers.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     const beforeLoad = performance.now();
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {

--- a/largest-contentful-paint/observe-image.html
+++ b/largest-contentful-paint/observe-image.html
@@ -7,7 +7,7 @@
 <script src="resources/largest-contentful-paint-helpers.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     const beforeLoad = performance.now();
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {

--- a/largest-contentful-paint/observe-text.html
+++ b/largest-contentful-paint/observe-text.html
@@ -11,7 +11,7 @@ p {
 </style>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let beforeRender;
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {

--- a/largest-contentful-paint/redirects-tao-star.html
+++ b/largest-contentful-paint/redirects-tao-star.html
@@ -11,7 +11,7 @@
 <body>
 <script>
 async_test(t => {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let destUrl = get_host_info().HTTP_REMOTE_ORIGIN
             + '/resource-timing/resources/multi_redirect.py?';
     destUrl += 'page_origin=' +  get_host_info().HTTP_ORIGIN;

--- a/largest-contentful-paint/repeated-image.html
+++ b/largest-contentful-paint/repeated-image.html
@@ -13,7 +13,7 @@
 <script src="resources/largest-contentful-paint-helpers.js"></script>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let beforeLoad = performance.now();
     let firstCallback = true;
     const url = window.location.origin + '/images/black-rectangle.png';

--- a/largest-contentful-paint/resources/invisible-images.js
+++ b/largest-contentful-paint/resources/invisible-images.js
@@ -1,5 +1,5 @@
 async_test(t => {
-  assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+  assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
   const observer = new PerformanceObserver(
     t.step_func(entryList => {
        entryList.getEntries().forEach(entry => {

--- a/largest-contentful-paint/same-origin-redirects.html
+++ b/largest-contentful-paint/same-origin-redirects.html
@@ -10,7 +10,7 @@
 <body>
 <script>
 async_test(t => {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     // First redirect
     let destUrl = '/common/redirect.py?location='
     // Second redirect

--- a/largest-contentful-paint/text-with-display-style.html
+++ b/largest-contentful-paint/text-with-display-style.html
@@ -12,7 +12,7 @@
 <h1 id='title'>I am a title!</h1>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     let beforeRender;
     /* In this test, we first observe a header with style 'display: flex'.
      * Once observed, we remove it and add a header with style 'display: grid'.

--- a/largest-contentful-paint/toJSON.html
+++ b/largest-contentful-paint/toJSON.html
@@ -7,7 +7,7 @@
 <p>Text!</p>
 <script>
   async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
     const observer = new PerformanceObserver(
       t.step_func_done(function(entryList) {
         const entry = entryList.getEntries()[0];

--- a/largest-contentful-paint/video-poster.html
+++ b/largest-contentful-paint/video-poster.html
@@ -6,7 +6,7 @@
 <script src="resources/largest-contentful-paint-helpers.js"></script>
 <script>
 async_test(function (t) {
-    assert_precondition(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+    assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
   const beforeLoad = performance.now();
   const observer = new PerformanceObserver(
     t.step_func_done(function(entryList) {


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).
Since LargestContentfulPaint is not an OPTIONAL part of the Largest
Contentful Paint spec, these tests should use assert_implements.