### PR TITLE
Replace assert_precondition with assert_equals in domparsing/

### DIFF
--- a/domparsing/DOMParser-parseFromString-encoding.html
+++ b/domparsing/DOMParser-parseFromString-encoding.html
@@ -14,7 +14,7 @@ function assertEncoding(doc) {
 }
 
 setup(() => {
-  assert_precondition(document.characterSet === "windows-1252", "the meta charset must be in effect, making the main document windows-1252");
+  assert_equals(document.characterSet, "windows-1252", "the meta charset must be in effect, making the main document windows-1252");
 });
 
 test(() => {


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).
In this particular case, the assertion is actually checking for an
equality rather than an 'implements' phrase, so switch to assert_equals.