### PR TITLE
Replace assert_precondition with assert_implements in credential-management/

### DIFF
--- a/credential-management/federatedcredential-framed-get.sub.https.html
+++ b/credential-management/federatedcredential-framed-get.sub.https.html
@@ -2,7 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-assert_precondition('FederatedCredential' in window, "`FederatedCredential` is supported.");
+assert_implements('FederatedCredential' in window, "`FederatedCredential` is supported.");
 
 // Ensure that the check is "same origin", not "same origin-domain".
 document.domain = window.location.hostname;

--- a/credential-management/passwordcredential-framed-get.sub.https.html
+++ b/credential-management/passwordcredential-framed-get.sub.https.html
@@ -2,7 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-assert_precondition('PasswordCredential' in window, "`PasswordCredential` is supported.");
+assert_implements('PasswordCredential' in window, "`PasswordCredential` is supported.");
 
 // Ensure that the check is "same origin", not "same origin-domain".
 document.domain = window.location.hostname;


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).
Since PasswordCredential is not an OPTIONAL part of the Credential
Management spec, these tests should use assert_implements.