### PR TITLE
Replace assert_precondition with assert_implements in speech-api/

### DIFF
--- a/speech-api/historical.html
+++ b/speech-api/historical.html
@@ -18,7 +18,7 @@
 });
 
 test(() => {
-  assert_precondition('SpeechRecognition' in window, 'SpeechRecognition exposed');
+  assert_implements('SpeechRecognition' in window, 'SpeechRecognition exposed');
   assert_false("serviceURI" in SpeechRecognition.prototype);
 }, "SpeechRecognition's serviceURI attribute should not exist");
 
@@ -27,7 +27,7 @@ test(() => {
   "emma",
 ].forEach(name => {
   test(() => {
-    assert_precondition('SpeechRecognitionEvent' in window, 'SpeechRecognitionEvent exposed');
+    assert_implements('SpeechRecognitionEvent' in window, 'SpeechRecognitionEvent exposed');
     assert_false(name in SpeechRecognitionEvent.prototype);
   }, `SpeechRecognitionEvent's ${name} attribute should not exist`);
 });


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).
Since the interfaces tested here are not OPTIONAL parts of the Web
Speech spec, this test should use assert_implements.