### PR TITLE
Replace assert_precondition with assert_implements in vibration/

### DIFF
--- a/vibration/invalid-values.html
+++ b/vibration/invalid-values.html
@@ -8,7 +8,7 @@
 <div id='log'></div>
 <script>
   test(function() {
-    assert_precondition(navigator.vibrate, 'navigator.vibrate exists');
+    assert_implements(navigator.vibrate, 'navigator.vibrate exists');
     assert_throws_js(TypeError, function() {
       navigator.vibrate();
     }, 'Argument is required, so was expecting a TypeError.');


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).
Since navigator.vibrate is not an OPTIONAL part of the Vibration API
spec, this test should use assert_implements.