### PR TITLE
Replace assert_precondition with assert_equals in native-io/

### DIFF
--- a/native-io/close_async.tentative.https.any.js
+++ b/native-io/close_async.tentative.https.any.js
@@ -17,7 +17,7 @@ async function createFile(testCase, fileName) {
   const writtenBytes = new Uint8Array(writeSharedArrayBuffer);
   writtenBytes.set([64, 65, 66, 67]);
   const writeCount = await file.write(writtenBytes, 0);
-  assert_precondition(writeCount == 4);
+  assert_equals(writeCount, 4);
 
   return file;
 }

--- a/native-io/close_sync.tentative.https.any.js
+++ b/native-io/close_sync.tentative.https.any.js
@@ -15,7 +15,7 @@ function createFileSync(testCase, fileName) {
 
   const writtenBytes = Uint8Array.from([64, 65, 66, 67]);
   const writeCount = file.write(writtenBytes, 0);
-  assert_precondition(writeCount == 4);
+  assert_equals(writeCount, 4);
 
   return file;
 }

--- a/native-io/concurrent_io_async.tentative.https.any.js
+++ b/native-io/concurrent_io_async.tentative.https.any.js
@@ -17,7 +17,7 @@ async function createFile(testCase, fileName) {
   const writtenBytes = new Uint8Array(writeSharedArrayBuffer);
   writtenBytes.set([64, 65, 66, 67]);
   const writeCount = await file.write(writtenBytes, 0);
-  assert_precondition(writeCount == 4);
+  assert_equals(writeCount, 4);
 
   return file;
 }


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).
The usage in these tests was to check equality rather than whether a
feature was supported, so replace with assert_equals.