### PR TITLE
Replace assert_precondition with assert_implements in workers/

### DIFF
--- a/workers/modules/shared-worker-parse-error-failure.html
+++ b/workers/modules/shared-worker-parse-error-failure.html
@@ -22,7 +22,7 @@ promise_setup(async () => {
     };
     worker.onerror = () => resolve(false);
   });
-  assert_precondition(
+  assert_implements(
     supportsModuleWorkers,
     "Static import must be supported on module shared worker to run this test."
   );


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).
Since SharedWorker is not an OPTIONAL part of the HTML spec, these tests
should use assert_implements.