### PR TITLE
Add WebKit support for WebXR tests

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -684,6 +684,7 @@ LAYOUTTESTS APIS: resources/chromium/webxr-test.js
 LAYOUTTESTS APIS: web-nfc/NDEFReader-document-hidden-manual.https.html
 LAYOUTTESTS APIS: web-nfc/NDEFReader_scan.https.html
 LAYOUTTESTS APIS: web-nfc/NDEFWriter_write.https.html
+LAYOUTTESTS APIS: webxr/resources/webxr_util.js
 
 # Signed Exchange files have hard-coded URLs in the certUrl field
 WEB-PLATFORM.TEST:signed-exchange/resources/*.sxg

--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -22,6 +22,13 @@ function xr_promise_test(name, func, properties) {
       xr_debug = navigator.xr.test.Debug;
     }
 
+    if (self.internals && internals.xrTest && navigator.xr) {
+      // WebKit setup. The internals object is used by the WebKit test runner
+      // to provide JS access to internal APIs. In this case it's used to
+      // ensure that XRTest is only exposed to wpt tests.
+      navigator.xr.test = internals.xrTest;
+    }
+
     // Ensure that any devices are disconnected when done. If this were done in
     // a .then() for the success case, a test that expected failure would
     // already be marked done at the time that runs and the shutdown would

--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -23,10 +23,8 @@ function xr_promise_test(name, func, properties) {
     }
 
     if (self.internals && internals.xrTest && navigator.xr) {
-      // WebKit setup. The internals object is used by the WebKit test runner
-      // to provide JS access to internal APIs. In this case it's used to
-      // ensure that XRTest is only exposed to wpt tests.
-      navigator.xr.test = internals.xrTest;
+      // WebKit setup
+      await setupWebKitWebXRTestAPI;
     }
 
     // Ensure that any devices are disconnected when done. If this were done in
@@ -205,4 +203,12 @@ let loadChromiumResources = Promise.resolve().then(() => {
   });
 
   return chain;
+});
+
+let setupWebKitWebXRTestAPI = Promise.resolve().then(() => {
+  // WebKit setup. The internals object is used by the WebKit test runner
+  // to provide JS access to internal APIs. In this case it's used to
+  // ensure that XRTest is only exposed to wpt tests.
+  navigator.xr.test = internals.xrTest;
+  return Promise.resolve();
 });

--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -206,6 +206,11 @@ let loadChromiumResources = Promise.resolve().then(() => {
 });
 
 let setupWebKitWebXRTestAPI = Promise.resolve().then(() => {
+  if (!self.internals) {
+    // Do nothing on non-WebKit-based browsers.
+    return;
+  }
+
   // WebKit setup. The internals object is used by the WebKit test runner
   // to provide JS access to internal APIs. In this case it's used to
   // ensure that XRTest is only exposed to wpt tests.


### PR DESCRIPTION
WebXR and the WebXR testing API is in the process of being implemented. The way we designed the integration of the test API with the rest of the engine is by adding `WebXRTest` to an object called _Internals_ which is injected in JSC and that provides JS access to WebKit's internal APIs. That _Internals_ object is only available for testing so we can ensure that `WebXRTest` is never exposed to the Web.