### PR TITLE
remove superfluous style in bottom-offset-001-ref

### DIFF
--- a/css/CSS2/positioning/bottom-offset-001-ref.xht
+++ b/css/CSS2/positioning/bottom-offset-001-ref.xht
@@ -9,8 +9,6 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
 
   <style type="text/css"><![CDATA[
-  div#inline-block {display: inline-block;}
-
   img {vertical-align: top;}
   ]]></style>
 
@@ -20,7 +18,7 @@
 
   <p>Test passes if there is a blue square with its bottom-left corner missing.</p>
 
-  <div id="inline-block">
+  <div>
   		<div><img src="support/blue15x15.png" width="48" height="48" alt="Image download support must be enabled" /><img src="support/blue15x15.png" width="48" height="48" alt="Image download support must be enabled" /></div>
   		<div><img src="support/1x1-white.png" width="48" height="48" alt="Image download support must be enabled" /><img src="support/blue15x15.png" width="48" height="48" alt="Image download support must be enabled" /></div>
   </div>


### PR DESCRIPTION
The "display:inline-block" was superfluous

Note: this is in the reference, not the test.

(Keeping the references minimal helps while building a new layout engine.)