### PR TITLE
Update MathML cramped tests to match the updated specification

### DIFF
--- a/mathml/presentation-markup/scripts/cramped-001.html
+++ b/mathml/presentation-markup/scripts/cramped-001.html
@@ -129,6 +129,15 @@
           assert_cramped("munderover-006", false, "overscript");
       }, "accent child of munderover (accent overscript)");
 
+      test(function() {
+          assert_true(MathMLFeatureDetection.has_mspace());
+          assert_cramped("mmultiscripts-001", false, "base");
+          assert_cramped("mmultiscripts-002", true, "post-subscript");
+          assert_cramped("mmultiscripts-003", false, "post-superscript");
+          assert_cramped("mmultiscripts-004", true, "pre-subscript");
+          assert_cramped("mmultiscripts-005", false, "post-superscript");
+      }, "mmultiscripts");
+
       done();
   }
 </script>
@@ -462,6 +471,121 @@
           <mspace height="1em" width="1em"/>
         </msup>
       </munderover>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mmultiscripts id="mmultiscripts-001">
+        <msup class="testedElement">
+          <mspace height="2em" width="2em"/>
+          <mspace height="1em" width="1em"/>
+        </msup>
+        <mn>1</mn>
+        <mn>2</mn>
+        <mn>3</mn>
+        <mn>4</mn>
+        <mn>5</mn>
+        <mn>6</mn>
+        <mprescripts/>
+        <mn>7</mn>
+        <mn>8</mn>
+        <mn>9</mn>
+        <mn>10</mn>
+        <mn>11</mn>
+        <mn>12</mn>
+      </mmultiscripts>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mmultiscripts id="mmultiscripts-002">
+        <mn>0</mn>
+        <mn>1</mn>
+        <mn>2</mn>
+        <msup class="testedElement">
+          <mspace height="2em" width="2em"/>
+          <mspace height="1em" width="1em"/>
+        </msup>
+        <mn>4</mn>
+        <mn>5</mn>
+        <mn>6</mn>
+        <mprescripts/>
+        <mn>7</mn>
+        <mn>8</mn>
+        <mn>9</mn>
+        <mn>10</mn>
+        <mn>11</mn>
+        <mn>12</mn>
+      </mmultiscripts>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mmultiscripts id="mmultiscripts-003">
+        <mn>0</mn>
+        <mn>1</mn>
+        <mn>2</mn>
+        <mn>3</mn>
+        <msup class="testedElement">
+          <mspace height="2em" width="2em"/>
+          <mspace height="1em" width="1em"/>
+        </msup>
+        <mn>5</mn>
+        <mn>6</mn>
+        <mprescripts/>
+        <mn>7</mn>
+        <mn>8</mn>
+        <mn>9</mn>
+        <mn>10</mn>
+        <mn>11</mn>
+        <mn>12</mn>
+      </mmultiscripts>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mmultiscripts id="mmultiscripts-004">
+        <mn>0</mn>
+        <mn>1</mn>
+        <mn>2</mn>
+        <mn>3</mn>
+        <mn>4</mn>
+        <mn>5</mn>
+        <mn>6</mn>
+        <mprescripts/>
+        <mn>7</mn>
+        <mn>8</mn>
+        <msup class="testedElement">
+          <mspace height="2em" width="2em"/>
+          <mspace height="1em" width="1em"/>
+        </msup>
+        <mn>10</mn>
+        <mn>11</mn>
+        <mn>12</mn>
+      </mmultiscripts>
+    </math>
+  </p>
+  <p>
+    <math>
+      <mmultiscripts id="mmultiscripts-005">
+        <mn>0</mn>
+        <mn>1</mn>
+        <mn>2</mn>
+        <mn>3</mn>
+        <mn>4</mn>
+        <mn>5</mn>
+        <mn>6</mn>
+        <mprescripts/>
+        <mn>7</mn>
+        <mn>8</mn>
+        <mn>9</mn>
+        <msup class="testedElement">
+          <mspace height="2em" width="2em"/>
+          <mspace height="1em" width="1em"/>
+        </msup>
+        <mn>11</mn>
+        <mn>12</mn>
+      </mmultiscripts>
     </math>
   </p>
 </body>

--- a/mathml/presentation-markup/scripts/cramped-001.html
+++ b/mathml/presentation-markup/scripts/cramped-001.html
@@ -70,7 +70,7 @@
       test(function() {
           assert_true(MathMLFeatureDetection.has_mspace());
           assert_cramped("mroot-001", true);
-      }, "child of parent");
+      }, "child of mroot");
 
       test(function() {
           assert_true(MathMLFeatureDetection.has_mspace());
@@ -100,33 +100,34 @@
       test(function() {
           assert_true(MathMLFeatureDetection.has_mspace());
           assert_cramped("munder-001", false, "base");
-          assert_cramped("munder-002", true, "underscript");
+          assert_cramped("munder-002", false, "underscript");
       }, "child of munder");
 
       test(function() {
           assert_true(MathMLFeatureDetection.has_mspace());
           assert_cramped("mover-001", false, "base");
-          assert_cramped("mover-002", false, "non-accent overscript");
-      }, "child of mover");
+          assert_cramped("mover-002", false, "overscript");
+      }, "child of mover (non-accent overscript)");
 
       test(function() {
           assert_true(MathMLFeatureDetection.has_mspace());
           assert_cramped("munderover-001", false, "base");
-          assert_cramped("munderover-002", true, "underscript");
-          assert_cramped("munderover-003", false, "non-accent overscript");
-      }, "child of munderover");
+          assert_cramped("munderover-002", false, "underscript");
+          assert_cramped("munderover-003", false, "overscript");
+      }, "child of munderover (non-accent overscript)");
 
       test(function() {
           assert_true(MathMLFeatureDetection.has_mspace());
-          assert_cramped("mover-003", false, "accent overscript");
-          assert_cramped("mover-004", false, "accent superscript");
-      }, "accent child of mover");
+          assert_cramped("mover-003", true, "base");
+          assert_cramped("mover-004", false, "overscript");
+      }, "accent child of mover (accent overscript)");
 
       test(function() {
           assert_true(MathMLFeatureDetection.has_mspace());
-          assert_cramped("munderover-004", false, "accent overscript");
-          assert_cramped("munderover-005", false, "accent superscript");
-      }, "accent child of munderover");
+          assert_cramped("munderover-004", true, "base");
+          assert_cramped("munderover-005", false, "underscript");
+          assert_cramped("munderover-006", false, "overscript");
+      }, "accent child of munderover (accent overscript)");
 
       done();
   }
@@ -372,18 +373,18 @@
   <p>
     <math>
       <mover accent="true" id="mover-003">
-        <mn>0</mn>
         <msup class="testedElement">
           <mspace height="2em" width="2em"/>
           <mspace height="1em" width="1em"/>
         </msup>
+        <mn>1</mn>
       </mover>
     </math>
   </p>
   <p>
     <math>
       <mover accent="true" id="mover-004">
-        <mo movablelimits="true">0</mo>
+        <mn>0</mn>
         <msup class="testedElement">
           <mspace height="2em" width="2em"/>
           <mspace height="1em" width="1em"/>
@@ -430,19 +431,31 @@
   <p>
     <math>
       <munderover accent="true" id="munderover-004">
-        <mn>0</mn>
-        <mn>1</mn>
         <msup class="testedElement">
           <mspace height="2em" width="2em"/>
           <mspace height="1em" width="1em"/>
         </msup>
+        <mn>1</mn>
+        <mn>2</mn>
       </munderover>
     </math>
   </p>
   <p>
     <math>
       <munderover accent="true" id="munderover-005">
-        <mo movablelimits="true">0</mo>
+        <mn>0</mn>
+        <msup class="testedElement">
+          <mspace height="2em" width="2em"/>
+          <mspace height="1em" width="1em"/>
+        </msup>
+        <mn>2</mn>
+      </munderover>
+    </math>
+  </p>
+  <p>
+    <math>
+      <munderover accent="true" id="munderover-006">
+        <mn>0</mn>
         <mn>1</mn>
         <msup class="testedElement">
           <mspace height="2em" width="2em"/>


### PR DESCRIPTION
The new effect on scripts is described by https://mathml-refresh.github.io/mathml-core/#displaystyle-and-scriptlevel-in-scripts
