### PR TITLE
[performance-timeline] simplify idlharness.js test signficantly

### DIFF
--- a/performance-timeline/idlharness.any.js
+++ b/performance-timeline/idlharness.any.js
@@ -6,46 +6,20 @@
 
 'use strict';
 
-promise_test(async t => {
-  const observe = new Promise((resolve, reject) => {
-    try {
-      self.observer = new PerformanceObserver((entries, observer) => {
-        self.entryList = entries;
-        self.mark = entries.getEntries()[0];
-        resolve();
-      });
+idl_test(
+  ['performance-timeline'],
+  ['hr-time', 'dom'],
+  async idl_array => {
+    idl_array.add_objects({
+      Performance: ['performance'],
+      PerformanceObserver: ['observer'],
+      PerformanceObserverEntryList: ['entryList'],
+    });
+
+    self.entryList = await new Promise((resolve, reject) => {
+      self.observer = new PerformanceObserver(resolve);
       observer.observe({ entryTypes: ['mark'] });
       performance.mark('test');
-    } catch (e) {
-      reject(e);
-    }
-  });
-  const timeout = new Promise((_, reject) => {
-    t.step_timeout(() => reject('Timed out waiting for observation'), 3000);
-  });
-  const user = await fetch('/interfaces/user-timing.idl').then(r => r.text());
-  const execute_test = () => {
-    idl_test(
-      ['performance-timeline'],
-      ['hr-time', 'dom'],
-      idl_array => {
-        idl_array.add_idls(user, {only: ['PerformanceMark']});
-        idl_array.add_objects({
-          Performance: ['performance'],
-          // NOTE: PerformanceMark cascadingly tests PerformanceEntry
-          PerformanceMark: ['mark'],
-          PerformanceObserver: ['observer'],
-          PerformanceObserverEntryList: ['entryList'],
-        });
-      }
-    );
-  };
-
-  return Promise.race([observe, timeout]).then(
-    execute_test,
-    reason => {
-      execute_test();
-      return Promise.reject(reason);
-    }
-  );
-})
+    });
+  }
+);


### PR DESCRIPTION
All of the complexity here was due to using a PerformanceMark to test
some of the aspects of PerformanceEntry which can only be tested with an
instance, and PerformanceEntry is an abstract interface with no
instances.

However, the downside is that this ends up testing more than should be
tested for Performance Timeline. This is not a good tradeoff.