### PR TITLE
Update interfaces/pointerevents.idl and test

### DIFF
--- a/interfaces/pointerevents.idl
+++ b/interfaces/pointerevents.idl
@@ -31,7 +31,7 @@ interface PointerEvent : MouseEvent {
     readonly        attribute long        twist;
     readonly        attribute DOMString   pointerType;
     readonly        attribute boolean     isPrimary;
-    sequence<PointerEvent> getCoalescedEvents();
+    [SecureContext] sequence<PointerEvent> getCoalescedEvents();
     sequence<PointerEvent> getPredictedEvents();
 };
 
@@ -46,6 +46,7 @@ partial interface mixin GlobalEventHandlers {
     attribute EventHandler onlostpointercapture;
     attribute EventHandler onpointerdown;
     attribute EventHandler onpointermove;
+    [SecureContext] attribute EventHandler onpointerrawupdate;
     attribute EventHandler onpointerup;
     attribute EventHandler onpointercancel;
     attribute EventHandler onpointerover;

--- a/pointerevents/idlharness.window.js
+++ b/pointerevents/idlharness.window.js
@@ -7,9 +7,10 @@
 
 idl_test(
   ['pointerevents'],
-  ['uievents', 'dom', 'html'],
+  ['uievents', 'html', 'dom'],
   idl_array => {
     idl_array.add_objects({
+      Document: ['document'],
       Element: ['document'],
       Window: ['window'],
       Navigator: ['navigator'],


### PR DESCRIPTION
The test had an incorrect import order, which was causing an error
during the IDL setup.

Closes https://github.com/web-platform-tests/wpt/pull/23086