### PR TITLE
allowing the body to shrink when necessary on mobile

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -1,0 +1,7 @@
+div.body {
+  min-width: auto;
+}
+
+#video-introduction-transcript iframe {
+  max-width: 100%;
+}


### PR DESCRIPTION
don't allow the video to exceed 100% width

fixes #20014 

I went through a random selection of other documentation pages and none that I looked at had horizontal scrolling either, so for the moment this appears to do it.