### PR TITLE
Allow wpt.py to be called from outside the WPT directory

### DIFF
--- a/wpt.py
+++ b/wpt.py
@@ -1,3 +1,7 @@
 # This file exists to allow `python wpt <command>` to work on Windows:
-# https://github.com/web-platform-tests/wpt/pull/6907
+# https://github.com/web-platform-tests/wpt/pull/6907 and
+# https://github.com/web-platform-tests/wpt/issues/23095
+import os
+abspath = os.path.abspath(__file__)
+os.chdir(os.path.dirname(abspath))
 exec(compile(open("wpt", "r").read(), "wpt", 'exec'))


### PR DESCRIPTION
Note that this is about wpt.py, which is a file specifically used for
Windows, and not 'wpt' which is the main entry-point file.

Previously wpt.py would just try to exec 'wpt' in the current working
directory, which may not be the directory that contains 'wpt.py' (and
thus, no 'wpt'!). To fix that, we os.chdir into the same directory as
the `__file__`.

Fixes https://github.com/web-platform-tests/wpt/issues/23095