### PR TITLE
Test getOwnPropertyDescriptor() with host objects as [[ProxyTarget]]

### DIFF
--- a/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
+++ b/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
@@ -13,9 +13,9 @@
 'use strict';
 
 test(() => {
-  let windowProxy = new Proxy(window, {});
+  const windowProxy = new Proxy(window, {});
   name = 'old_name';
-  let descriptor = Object.getOwnPropertyDescriptor(windowProxy, 'name');
+  const descriptor = Object.getOwnPropertyDescriptor(windowProxy, 'name');
 
   assert_equals(descriptor.get.call(window), 'old_name');
   descriptor.set.call(window, 'new_name');
@@ -25,7 +25,7 @@ test(() => {
 }, 'Window target, no trap, "name" attribute');
 
 test(() => {
-  let windowProxy = new Proxy(window, {});
+  const windowProxy = new Proxy(window, {});
 
   assert_object_equals(
     Object.getOwnPropertyDescriptor(windowProxy, 'document'),
@@ -34,8 +34,8 @@ test(() => {
 }, 'Window target, forwarding trap, [Unforgeable] "document" attribute');
 
 test(() => {
-  let trapResult = {get() {}, set(_val) {}, enumerable: false, configurable: true};
-  let windowProxy = new Proxy(new Proxy(window, {}), {
+  const trapResult = {get() {}, set(_val) {}, enumerable: false, configurable: true};
+  const windowProxy = new Proxy(new Proxy(window, {}), {
     getOwnPropertyDescriptor: () => trapResult,
   });
 
@@ -46,7 +46,7 @@ test(() => {
 }, 'Window proxy target, custom trap, "onclick" event handler attribute');
 
 test(() => {
-  let documentProxy = new Proxy(document, {
+  const documentProxy = new Proxy(document, {
     getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
   });
 
@@ -57,8 +57,8 @@ test(() => {
 }, 'Document target, forwarding trap, [Unforgeable] "location" attribute');
 
 test(() => {
-  let trapResult = {value: 4, writable: false, enumerable: true, configurable: true};
-  let documentProxy = new Proxy(new Proxy(document, {}), {
+  const trapResult = {value: 4, writable: false, enumerable: true, configurable: true};
+  const documentProxy = new Proxy(new Proxy(document, {}), {
     getOwnPropertyDescriptor: () => trapResult,
   });
 
@@ -69,9 +69,9 @@ test(() => {
 }, 'Document proxy target, custom trap, non-existent value attribute');
 
 test(() => {
-  let locationProxy = new Proxy(location, {});
+  const locationProxy = new Proxy(location, {});
   location.hash = '#old';
-  let descriptor = Object.getOwnPropertyDescriptor(locationProxy, 'hash');
+  const descriptor = Object.getOwnPropertyDescriptor(locationProxy, 'hash');
 
   assert_equals(descriptor.get.call(location), '#old');
   descriptor.set.call(location, '#new');
@@ -81,7 +81,7 @@ test(() => {
 }, 'Location target, no trap, [Unforgeable] "hash" attribute');
 
 test(() => {
-  let locationProxy = new Proxy(new Proxy(location, {}), {
+  const locationProxy = new Proxy(new Proxy(location, {}), {
     getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
   });
 

--- a/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
+++ b/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
@@ -39,12 +39,19 @@ test(() => {
 }, 'Window target, no trap, "name" attribute');
 
 test(() => {
-  const windowProxy = new Proxy(window, {});
+  let trapCalls = 0;
+  const windowProxy = new Proxy(window, {
+    getOwnPropertyDescriptor(...args) {
+      trapCalls++;
+      return Reflect.getOwnPropertyDescriptor(...args);
+    },
+  });
 
   assert_accessor_descriptor_equals(
     Object.getOwnPropertyDescriptor(windowProxy, 'document'),
     Object.getOwnPropertyDescriptor(window, 'document')
   );
+  assert_equals(trapCalls, 1);
 }, 'Window target, forwarding trap, [Unforgeable] "document" attribute');
 
 test(() => {
@@ -60,14 +67,19 @@ test(() => {
 }, 'Window proxy target, custom trap, "onclick" event handler attribute');
 
 test(() => {
+  let trapCalls = 0;
   const documentProxy = new Proxy(document, {
-    getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
+    getOwnPropertyDescriptor(...args) {
+      trapCalls++;
+      return Reflect.getOwnPropertyDescriptor(...args);
+    },
   });
 
   assert_accessor_descriptor_equals(
     Object.getOwnPropertyDescriptor(documentProxy, 'location'),
     Object.getOwnPropertyDescriptor(document, 'location')
   );
+  assert_equals(trapCalls, 1);
 }, 'Document target, forwarding trap, [Unforgeable] "location" attribute');
 
 test(() => {
@@ -95,14 +107,19 @@ test(() => {
 }, 'Location target, no trap, [Unforgeable] "hash" attribute');
 
 test(() => {
+  let trapCalls = 0;
   const locationProxy = new Proxy(new Proxy(location, {}), {
-    getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
+    getOwnPropertyDescriptor(...args) {
+      trapCalls++;
+      return Reflect.getOwnPropertyDescriptor(...args);
+    },
   });
 
   assert_data_descriptor_equals(
     Object.getOwnPropertyDescriptor(locationProxy, 'reload'),
     Object.getOwnPropertyDescriptor(location, 'reload')
   );
+  assert_equals(trapCalls, 1);
 }, 'Location proxy target, forwarding trap, [Unforgeable] "reload" method');
 </script>
 </body>

--- a/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
+++ b/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
@@ -12,6 +12,13 @@
 <script>
 'use strict';
 
+const assert_accessor_descriptor_equals = (actual, expected) => {
+  assert_equals(actual.get, expected.get, 'get');
+  assert_equals(actual.set, expected.set, 'set');
+  assert_equals(actual.enumerable, expected.enumerable, 'enumerable');
+  assert_equals(actual.configurable, expected.configurable, 'configurable');
+};
+
 test(() => {
   const windowProxy = new Proxy(window, {});
   name = 'old_name';
@@ -27,7 +34,7 @@ test(() => {
 test(() => {
   const windowProxy = new Proxy(window, {});
 
-  assert_object_equals(
+  assert_accessor_descriptor_equals(
     Object.getOwnPropertyDescriptor(windowProxy, 'document'),
     Object.getOwnPropertyDescriptor(window, 'document')
   );
@@ -39,7 +46,7 @@ test(() => {
     getOwnPropertyDescriptor: () => trapResult,
   });
 
-  assert_object_equals(
+  assert_accessor_descriptor_equals(
     Object.getOwnPropertyDescriptor(windowProxy, 'onclick'),
     trapResult
   );
@@ -50,7 +57,7 @@ test(() => {
     getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
   });
 
-  assert_object_equals(
+  assert_accessor_descriptor_equals(
     Object.getOwnPropertyDescriptor(documentProxy, 'location'),
     Object.getOwnPropertyDescriptor(document, 'location')
   );

--- a/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
+++ b/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
@@ -19,6 +19,13 @@ const assert_accessor_descriptor_equals = (actual, expected) => {
   assert_equals(actual.configurable, expected.configurable, 'configurable');
 };
 
+const assert_data_descriptor_equals = (actual, expected) => {
+  assert_equals(actual.value, expected.value, 'value');
+  assert_equals(actual.writable, expected.writable, 'writable');
+  assert_equals(actual.enumerable, expected.enumerable, 'enumerable');
+  assert_equals(actual.configurable, expected.configurable, 'configurable');
+};
+
 test(() => {
   const windowProxy = new Proxy(window, {});
   name = 'old_name';
@@ -69,7 +76,7 @@ test(() => {
     getOwnPropertyDescriptor: () => trapResult,
   });
 
-  assert_object_equals(
+  assert_data_descriptor_equals(
     Object.getOwnPropertyDescriptor(documentProxy, 'foo'),
     trapResult
   );
@@ -92,7 +99,7 @@ test(() => {
     getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
   });
 
-  assert_object_equals(
+  assert_data_descriptor_equals(
     Object.getOwnPropertyDescriptor(locationProxy, 'reload'),
     Object.getOwnPropertyDescriptor(location, 'reload')
   );

--- a/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
+++ b/html/browsers/the-window-object/proxy-getOwnPropertyDescriptor.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>getOwnPropertyDescriptor() is correct for Proxy with host object target</title>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/#window">
+  <link rel="help" href="https://heycam.github.io/webidl/#Unforgeable">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+'use strict';
+
+test(() => {
+  let windowProxy = new Proxy(window, {});
+  name = 'old_name';
+  let descriptor = Object.getOwnPropertyDescriptor(windowProxy, 'name');
+
+  assert_equals(descriptor.get.call(window), 'old_name');
+  descriptor.set.call(window, 'new_name');
+  assert_equals(name, 'new_name');
+  assert_true(descriptor.enumerable);
+  assert_true(descriptor.configurable);
+}, 'Window target, no trap, "name" attribute');
+
+test(() => {
+  let windowProxy = new Proxy(window, {});
+
+  assert_object_equals(
+    Object.getOwnPropertyDescriptor(windowProxy, 'document'),
+    Object.getOwnPropertyDescriptor(window, 'document')
+  );
+}, 'Window target, forwarding trap, [Unforgeable] "document" attribute');
+
+test(() => {
+  let trapResult = {get() {}, set(_val) {}, enumerable: false, configurable: true};
+  let windowProxy = new Proxy(new Proxy(window, {}), {
+    getOwnPropertyDescriptor: () => trapResult,
+  });
+
+  assert_object_equals(
+    Object.getOwnPropertyDescriptor(windowProxy, 'onclick'),
+    trapResult
+  );
+}, 'Window proxy target, custom trap, "onclick" event handler attribute');
+
+test(() => {
+  let documentProxy = new Proxy(document, {
+    getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
+  });
+
+  assert_object_equals(
+    Object.getOwnPropertyDescriptor(documentProxy, 'location'),
+    Object.getOwnPropertyDescriptor(document, 'location')
+  );
+}, 'Document target, forwarding trap, [Unforgeable] "location" attribute');
+
+test(() => {
+  let trapResult = {value: 4, writable: false, enumerable: true, configurable: true};
+  let documentProxy = new Proxy(new Proxy(document, {}), {
+    getOwnPropertyDescriptor: () => trapResult,
+  });
+
+  assert_object_equals(
+    Object.getOwnPropertyDescriptor(documentProxy, 'foo'),
+    trapResult
+  );
+}, 'Document proxy target, custom trap, non-existent value attribute');
+
+test(() => {
+  let locationProxy = new Proxy(location, {});
+  location.hash = '#old';
+  let descriptor = Object.getOwnPropertyDescriptor(locationProxy, 'hash');
+
+  assert_equals(descriptor.get.call(location), '#old');
+  descriptor.set.call(location, '#new');
+  assert_equals(location.hash, '#new');
+  assert_true(descriptor.enumerable);
+  assert_false(descriptor.configurable);
+}, 'Location target, no trap, [Unforgeable] "hash" attribute');
+
+test(() => {
+  let locationProxy = new Proxy(new Proxy(location, {}), {
+    getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
+  });
+
+  assert_object_equals(
+    Object.getOwnPropertyDescriptor(locationProxy, 'reload'),
+    Object.getOwnPropertyDescriptor(location, 'reload')
+  );
+}, 'Location proxy target, forwarding trap, [Unforgeable] "reload" method');
+</script>
+</body>
+</html>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1190,6 +1190,8 @@ policies and contribution forms [3].
     }
     expose(assert_in_array, "assert_in_array");
 
+    // This function was deprecated in July of 2015.
+    // See https://github.com/web-platform-tests/wpt/issues/2033
     function assert_object_equals(actual, expected, description)
     {
          assert(typeof actual === "object" && actual !== null, "assert_object_equals", description,


### PR DESCRIPTION
WebKit bug: [getOwnPropertyDescriptor() is incorrect with Proxy of exotic object](https://bugs.webkit.org/show_bug.cgi?id=200560).