### PR TITLE
Assert Symbol.toStringTag value in `assert_class_string`

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1651,10 +1651,7 @@ IdlInterface.prototype.test_self = function()
         //    section 19.2.3.8, unless otherwise specified."
         // TODO
 
-        // ES6 (rev 30) 19.1.3.6:
-        // "Else, if O has a [[Call]] internal method, then let builtinTag be
-        // "Function"."
-        assert_class_string(this.get_interface_object(), "Function", "class string of " + this.name);
+        assert_equals(typeof this.get_interface_object(), "function", this.name + " is callable");
 
         // "The [[Prototype]] internal property of an interface object for a
         // non-callback interface is determined as follows:"

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1462,6 +1462,11 @@ policies and contribution forms [3].
         assert(same_value(actual, expected), "assert_class_string", description,
                                              "expected ${expected} but got ${actual}",
                                              {expected:expected, actual:actual});
+
+        var tag = object[Symbol.toStringTag];
+        assert(same_value(tag, class_string), "assert_class_string", description,
+                                              "expected ${expected} but got ${actual}",
+                                              {expected:class_string, actual:tag});
     }
     expose(assert_class_string, "assert_class_string");
 


### PR DESCRIPTION
Superseded by #23140.