### PR TITLE
Wasm: test SharedArrayBuffer-ness in another way

### DIFF
--- a/wasm/jsapi/memory/grow.any.js
+++ b/wasm/jsapi/memory/grow.any.js
@@ -1,9 +1,13 @@
-// META: global=default,jsshell
+// META: global=jsshell
 
 function assert_ArrayBuffer(actual, expected, message) {
   // https://github.com/WebAssembly/spec/issues/840
+  // See https://github.com/whatwg/html/issues/5380 for why not `self.SharedArrayBuffer`
   const isShared = !("isView" in actual.constructor);
   assert_equals(isShared, expected.shared, `${message}: constructor`);
+  const sharedString = expected.shared ? "Shared" : "";
+  assert_equals(actual.toString(), `[object ${sharedString}ArrayBuffer]`, `${message}: toString()`);
+  assert_equals(Object.getPrototypeOf(actual).toString(), `[object ${sharedString}ArrayBuffer]`, `${message}: prototype toString()`);
   if (expected.detached) {
     // https://github.com/tc39/ecma262/issues/678
     let byteLength;

--- a/wasm/jsapi/memory/grow.any.js
+++ b/wasm/jsapi/memory/grow.any.js
@@ -1,10 +1,9 @@
-// META: global=jsshell
+// META: global=default,jsshell
 
 function assert_ArrayBuffer(actual, expected, message) {
   // https://github.com/WebAssembly/spec/issues/840
-  const bufferType = expected.shared ? self.SharedArrayBuffer : ArrayBuffer;
-  assert_equals(Object.getPrototypeOf(actual), bufferType.prototype,
-                `${message}: prototype`);
+  const isShared = !("isView" in actual.constructor);
+  assert_equals(isShared, expected.shared, `${message}: constructor`);
   if (expected.detached) {
     // https://github.com/tc39/ecma262/issues/678
     let byteLength;


### PR DESCRIPTION
If this is not acceptable we need to rewrite this to use COOP and COEP headers. However, that would not work for jsshell. And only running this in jsshell would lose coverage for user agents that do not run tests there.