### PR TITLE
Update interfaces/{screen-}wake-lock.idl and test

### DIFF
--- a/interfaces/wake-lock.idl
+++ b/interfaces/wake-lock.idl
@@ -1,7 +1,7 @@
 // GENERATED CONTENT - DO NOT EDIT
 // Content was automatically extracted by Reffy into reffy-reports
 // (https://github.com/tidoust/reffy-reports)
-// Source: Screen Wake Lock API (https://w3c.github.io/wake-lock/)
+// Source: Screen Wake Lock API (https://w3c.github.io/screen-wake-lock/)
 
 [SecureContext]
 partial interface Navigator {

--- a/interfaces/wake-lock.idl
+++ b/interfaces/wake-lock.idl
@@ -1,7 +1,7 @@
 // GENERATED CONTENT - DO NOT EDIT
 // Content was automatically extracted by Reffy into reffy-reports
 // (https://github.com/tidoust/reffy-reports)
-// Source: Screen Wake Lock API (https://w3c.github.io/screen-wake-lock/)
+// Source: Screen Wake Lock API (https://w3c.github.io/wake-lock/)
 
 [SecureContext]
 partial interface Navigator {

--- a/screen-wake-lock/idlharness.https.window.js
+++ b/screen-wake-lock/idlharness.https.window.js
@@ -8,7 +8,7 @@
 'use strict';
 
 idl_test(
-  ['screen-wake-lock'],
+  ['wake-lock'],
   ['dom', 'html'],
   async idl_array => {
     idl_array.add_objects({ Navigator: ['navigator'] });


### PR DESCRIPTION
In 229773d606f8b9603046580b32935968a4326004, the interface file was moved
manually from `interfaces/wake-lock.idl` to `interfaces/screen-wake-lock.idl` because
the spec had been renamed. However as a TR for it has not yet been published,
[reffy](https://github.com/tidoust/reffy) still views this as being called `wake-lock.idl`
(albeit with the correct https://w3c.github.io/screen-wake-lock/ spec link in it), and
will keep trying to change the file back.

For now, move back to `interfaces/wake-lock.idl` to stop fighting the automated bot.
Once a TR for this is published, reffy will automatically rename the file and we can
update the idlharness.html test alongside it, and life will be good 🌻 

Closes https://github.com/web-platform-tests/wpt/pull/23106
Closes https://github.com/web-platform-tests/wpt/pull/23107