### PR TITLE
Wait for resource to be fetched completely

### DIFF
--- a/fetch/stale-while-revalidate/fetch.html
+++ b/fetch/stale-while-revalidate/fetch.html
@@ -17,9 +17,13 @@ promise_test(async (test) => {
   var request_token = token();
 
   const response = await fetch(`resources/stale-script.py?token=` + request_token);
+  // Wait until resource is completely fetched to allow caching before next fetch.
+  const body = await response.text();
   const response2 = await fetch(`resources/stale-script.py?token=` + request_token);
 
   assert_equals(response.headers.get('Unique-Id'), response2.headers.get('Unique-Id'));
+  const body2 = await response2.text();
+  assert_equals(body, body2);
 
   while(true) {
     const revalidation_check = await fetch(`resources/stale-script.py?query&token=` + request_token);


### PR DESCRIPTION
Wait for resource to be fetched completely before comparing headers, since
some implementations only cache when the complete resource is fetched, rather
than just the first response, and this test relies on caching the first fetch.