### PR TITLE
css-sizing/percentage-height-in-flexbox.html: start the test with signal window.onload

### DIFF
--- a/css/css-sizing/percentage-height-in-flexbox.html
+++ b/css/css-sizing/percentage-height-in-flexbox.html
@@ -22,24 +22,29 @@
   display:block;
 }
 </style>
+<script>
+setup({explicit_done: true});
+function doTest() {
+  test(() => {
+    let target = document.querySelector("#target");
+    assert_equals(target.offsetWidth, target.offsetHeight);
+    assert_equals(target.offsetWidth, target.parentNode.offsetWidth);
+    assert_equals(target.offsetHeight, target.parentNode.offsetHeight);
+  }, '#target offsetSize matches #container offsetSize' );
+  test(() => {
+    document.querySelector("#container").style.height = "100px";
+    let target = document.querySelector("#target");
+    assert_equals(target.offsetWidth, target.offsetHeight);
+    assert_equals(target.offsetWidth, target.parentNode.offsetWidth);
+    assert_equals(target.offsetHeight, target.parentNode.offsetHeight);
+  }, '#target offsetSize matches #container offsetSize after resize' );
+  done();
+}
+</script>
+<body onload="doTest()">
 <div id="outer">
   <div id="container">
     <img id="target" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
   </div>
 </div>
-<script>
-test(() => {
-  let target = document.querySelector("#target");
-  assert_equals(target.offsetWidth, target.offsetHeight);
-  assert_equals(target.offsetWidth, target.parentNode.offsetWidth);
-  assert_equals(target.offsetHeight, target.parentNode.offsetHeight);
-}, '#target offsetSize matches #container offsetSize' );
-test(() => {
-  document.querySelector("#container").style.height = "100px";
-  let target = document.querySelector("#target");
-  assert_equals(target.offsetWidth, target.offsetHeight);
-  assert_equals(target.offsetWidth, target.parentNode.offsetWidth);
-  assert_equals(target.offsetHeight, target.parentNode.offsetHeight);
-}, '#target offsetSize matches #container offsetSize after resize' );
-
-</script>
+</body>


### PR DESCRIPTION

 * There was a race condition in this test, since the image has to be loaded before the test starts. But before this patch the test was not ensuring this happened and that caused flakiness on WebKit browsers.

 * To fix that we start the test with window.onload signal and we also make the test explicit about when it finish.