### PR TITLE
Python 3: Convert text to byte string to support PY2 and PY3

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -488,7 +488,7 @@ class OutputHandler(object):
 
     def __call__(self, line):
         """Write a line of output from the firefox process to the log"""
-        if "GLib-GObject-CRITICAL" in line:
+        if b"GLib-GObject-CRITICAL" in line:
             return
         if line:
             if not self.setup_ran:


### PR DESCRIPTION
In Python 2, both text and bytes are str type while in Python 3
they are different types.