### PR TITLE
Wasm: ensure expected results are booleans

### DIFF
--- a/wasm/jsapi/memory/grow.any.js
+++ b/wasm/jsapi/memory/grow.any.js
@@ -1,14 +1,14 @@
 // META: global=jsshell
 
-function assert_ArrayBuffer(actual, expected, message) {
+function assert_ArrayBuffer(actual, { size=0, shared=false, detached=false }, message) {
   // https://github.com/WebAssembly/spec/issues/840
   // See https://github.com/whatwg/html/issues/5380 for why not `self.SharedArrayBuffer`
   const isShared = !("isView" in actual.constructor);
-  assert_equals(isShared, expected.shared, `${message}: constructor`);
-  const sharedString = expected.shared ? "Shared" : "";
+  assert_equals(isShared, shared, `${message}: constructor`);
+  const sharedString = shared ? "Shared" : "";
   assert_equals(actual.toString(), `[object ${sharedString}ArrayBuffer]`, `${message}: toString()`);
   assert_equals(Object.getPrototypeOf(actual).toString(), `[object ${sharedString}ArrayBuffer]`, `${message}: prototype toString()`);
-  if (expected.detached) {
+  if (detached) {
     // https://github.com/tc39/ecma262/issues/678
     let byteLength;
     try {
@@ -18,8 +18,8 @@ function assert_ArrayBuffer(actual, expected, message) {
     }
     assert_equals(byteLength, 0, `${message}: detached size`);
   } else {
-    assert_equals(actual.byteLength, 0x10000 * expected.size, `${message}: size`);
-    if (expected.size > 0) {
+    assert_equals(actual.byteLength, 0x10000 * size, `${message}: size`);
+    if (size > 0) {
       const array = new Uint8Array(actual);
       assert_equals(array[0], 0, `${message}: first element`);
       assert_equals(array[array.byteLength - 1], 0, `${message}: last element`);


### PR DESCRIPTION
Follow-up to 6a1b15e5d699a00d58844b53e8c18d368169018d.

Apologies for missing that the previous version wasn't working at all.