### PR TITLE
Add python3 and python3-pip to the docker image

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -56,7 +56,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: hexcles/web-platform-tests:0.35
+            image: webplatformtests/wpt:0.36
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get -qqy update \
     pulseaudio \
     python \
     python-pip \
+    python3 \
+    python3-pip \
     qemu-kvm \
     tzdata \
     sudo \

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,8 +1,12 @@
 This docker images is used for testing Chrome, Firefox, WebKitGTK and running
 other tasks on Taskcluster. When any of the files in this directory change, the
-images must be updated as well. To do this, assuming you have docker installed:
+images must be updated as well. Doing this requires you be part of the
+'webplatformtests' organization on dockerhub; ping @Hexcles or @stephenmcgruer
+if you aren't.
 
-In this directory, run
+In this directory, run the following, where `<tag>` is of the form
+`webplatformtests/wpt:{current-version + 0.1}`:
+
 ```sh
 # --pull forces Docker to get the newest base image.
 docker build --pull -t <tag> .

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,11 +1,11 @@
 This docker images is used for testing Chrome, Firefox, WebKitGTK and running
 other tasks on Taskcluster. When any of the files in this directory change, the
 images must be updated as well. Doing this requires you be part of the
-'webplatformtests' organization on dockerhub; ping @Hexcles or @stephenmcgruer
-if you aren't.
+'webplatformtests' organization on Docker Hub; ping @Hexcles or @stephenmcgruer
+if you are not a member.
 
 In this directory, run the following, where `<tag>` is of the form
-`webplatformtests/wpt:{current-version + 0.1}`:
+`webplatformtests/wpt:{current-version + 0.01}`:
 
 ```sh
 # --pull forces Docker to get the newest base image.
@@ -13,3 +13,5 @@ docker build --pull -t <tag> .
 docker push <tag>
 ```
 
+Then update `.taskcluster.yml` in the top-level directory to point to the new
+image you have uploaded.


### PR DESCRIPTION
These dependencies are required to run the CI system under Python 3, including making `distutils` available.

See https://github.com/web-platform-tests/wpt/pull/23182#issuecomment-617997827