### PR TITLE
Update docker image to webplatformtests/wpt:0.36

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -56,7 +56,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: hexcles/web-platform-tests:0.35
+            image: webplatformtests/wpt:0.36
             maxRunTime: 7200
             artifacts:
               public/results:


### PR DESCRIPTION
This incorporates the change in
https://github.com/web-platform-tests/wpt/pull/23190, as well as
switching to the new dockerhub organization.