### PR TITLE
Improve web engine detection in webxr_util.js

### DIFF
--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -10,19 +10,21 @@
 // Debugging message helper, by default does nothing. Implementations can
 // override this.
 var xr_debug = function(name, msg) {}
+var isChromiumBased = 'MojoInterfaceInterceptor' in self;
+var isWebKitBased = 'internals' in self && 'xrTest' in internals;
 
 function xr_promise_test(name, func, properties) {
   promise_test(async (t) => {
     // Perform any required test setup:
     xr_debug(name, 'setup');
 
-    if (window.XRTest === undefined) {
+    if (isChromiumBased) {
       // Chrome setup
       await loadChromiumResources;
       xr_debug = navigator.xr.test.Debug;
     }
 
-    if (self.internals && internals.xrTest && navigator.xr) {
+    if (isWebKitBased) {
       // WebKit setup
       await setupWebKitWebXRTestAPI;
     }
@@ -161,7 +163,7 @@ function forEachWebxrObject(callback) {
 
 // Code for loading test API in Chromium.
 let loadChromiumResources = Promise.resolve().then(() => {
-  if (!('MojoInterfaceInterceptor' in self)) {
+  if (!isChromiumBased) {
     // Do nothing on non-Chromium-based browsers or when the Mojo bindings are
     // not present in the global namespace.
     return;
@@ -206,7 +208,7 @@ let loadChromiumResources = Promise.resolve().then(() => {
 });
 
 let setupWebKitWebXRTestAPI = Promise.resolve().then(() => {
-  if (!self.internals || !internals.xrTest) {
+  if (!isWebKitBased) {
     // Do nothing on non-WebKit-based browsers.
     return;
   }

--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -18,15 +18,15 @@ function xr_promise_test(name, func, properties) {
     // Perform any required test setup:
     xr_debug(name, 'setup');
 
-    if (isChromiumBased) {
-      // Chrome setup
-      await loadChromiumResources;
-      xr_debug = navigator.xr.test.Debug;
-    }
-
-    if (isWebKitBased) {
-      // WebKit setup
-      await setupWebKitWebXRTestAPI;
+    if (!navigator.xr.test) {
+      if (isChromiumBased) {
+        // Chrome setup
+        await loadChromiumResources;
+        xr_debug = navigator.xr.test.Debug;
+      } else if (isWebKitBased) {
+        // WebKit setup
+        await setupWebKitWebXRTestAPI;
+      }
     }
 
     // Ensure that any devices are disconnected when done. If this were done in

--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -21,9 +21,8 @@ function xr_promise_test(name, func, properties) {
     if (!navigator.xr.test) {
         if (isChromiumBased) {
           // Chrome setup
-          loadChromiumResources().then(() => {
-            xr_debug = navigator.xr.test.Debug;
-          });
+          await loadChromiumResources();
+          xr_debug = navigator.xr.test.Debug;
         } else if (isWebKitBased) {
           // WebKit setup
           await setupWebKitWebXRTestAPI();

--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -18,15 +18,15 @@ function xr_promise_test(name, func, properties) {
     // Perform any required test setup:
     xr_debug(name, 'setup');
 
-    if (!navigator.xr.test) {
-        if (isChromiumBased) {
-          // Chrome setup
-          await loadChromiumResources();
-          xr_debug = navigator.xr.test.Debug;
-        } else if (isWebKitBased) {
-          // WebKit setup
-          await setupWebKitWebXRTestAPI();
-        }
+    if (isChromiumBased) {
+      // Chrome setup
+      await loadChromiumResources;
+      xr_debug = navigator.xr.test.Debug;
+    }
+
+    if (isWebKitBased) {
+      // WebKit setup
+      await setupWebKitWebXRTestAPI;
     }
 
     // Ensure that any devices are disconnected when done. If this were done in
@@ -162,7 +162,13 @@ function forEachWebxrObject(callback) {
 }
 
 // Code for loading test API in Chromium.
-function loadChromiumResources() {
+let loadChromiumResources = Promise.resolve().then(() => {
+  if (!isChromiumBased) {
+    // Do nothing on non-Chromium-based browsers or when the Mojo bindings are
+    // not present in the global namespace.
+    return;
+  }
+
   let chromiumResources = [
     '/gen/layout_test_data/mojo/public/js/mojo_bindings.js',
     '/gen/mojo/public/mojom/base/time.mojom.js',
@@ -188,23 +194,28 @@ function loadChromiumResources() {
   }
 
   let chain = Promise.resolve();
-  chromiumResources.forEach(path => {
-    let script = document.createElement('script');
-    script.src = path;
-    script.async = false;
-    chain = chain.then(() => new Promise(resolve => {
-      script.onload = () => resolve();
-    }));
-    document.head.appendChild(script);
+    chromiumResources.forEach(path => {
+      let script = document.createElement('script');
+      script.src = path;
+      script.async = false;
+      chain = chain.then(() => new Promise(resolve => {
+                           script.onload = () => resolve();
+                         }));
+      document.head.appendChild(script);
   });
-  return chain;
-}
 
-function setupWebKitWebXRTestAPI() {
-  return new Promise(resolve => {
-    // WebKit setup. The internals object is used by the WebKit test runner
-    // to provide JS access to internal APIs. In this case it's used to
-    // ensure that XRTest is only exposed to wpt tests.
-    navigator.xr.test = internals.xrTest;
-  });
-}
+  return chain;
+});
+
+let setupWebKitWebXRTestAPI = Promise.resolve().then(() => {
+  if (!isWebKitBased) {
+    // Do nothing on non-WebKit-based browsers.
+    return;
+  }
+
+  // WebKit setup. The internals object is used by the WebKit test runner
+  // to provide JS access to internal APIs. In this case it's used to
+  // ensure that XRTest is only exposed to wpt tests.
+  navigator.xr.test = internals.xrTest;
+  return Promise.resolve();
+});


### PR DESCRIPTION
The problem is that although is initialized to an empty function it's later redeclared to some chromium specific entity
```
    if (window.XRTest === undefined) {
       // Chrome setup
       await loadChromiumResources;
       xr_debug = navigator.xr.test.Debug;
     }
```
The if condition is true also for WebKit based browsers (actually I guess for any other)