### PR TITLE
[taskcluster] Actually use the new image in tests

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: harjgam/web-platform-tests:0.34
+    image: webplatformtests/wpt:0.36
     maxRunTime: 7200
     artifacts:
       public/results:
@@ -103,8 +103,6 @@ components:
     env:
       TOXENV: py36
       PY_COLORS: 0
-    install:
-      - python3-pip
 
   tox-python38:
     env:

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -13,5 +13,6 @@ docker build --pull -t <tag> .
 docker push <tag>
 ```
 
-Then update `.taskcluster.yml` in the top-level directory to point to the new
-image you have uploaded.
+Then update the following Taskcluster configurations to use the new image:
+* `.taskcluster.yml` (the decision task)
+* `tools/ci/tc/tasks/test.yml` (all the other tasks)


### PR DESCRIPTION
This is a follow-up to #23190. I forgot that tools/ci/tc/tasks/test.yml
existed, so we really only updated the image of the decision task.

Drive-by:
* Update README to document this.
* Remove python3-pip from `install` as it's now included in the image.