### PR TITLE
Update Safari Technology Preview to 105

### DIFF
--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask 'safari-technology-preview' do
   if MacOS.version <= :mojave
-    version '104,061-96689-20200407-7f675598-e07d-46db-8b24-b10c33a006ba'
-    sha256 'bc1b0a79f99022aae802bbb1e83a6a13613a339115063489fc240567b1b5d81d'
+    version '105,001-02874-20200422-3f38295f-da03-425d-9100-ae835120f1c7'
+    sha256 'ce15f783b3e46c0e1267196956d79ea416a14005b6f733c68be5104ea57da20e'
   else
-    version '104,061-96685-20200407-907fca12-9ba9-4bfa-8b8c-d5bf101d534b'
-    sha256 '3dcfde56386f38984c9ede1d67714c43699c5cafece9608ee2730484bffdcf9c'
+    version '105,001-00430-20200422-c04186cc-77e2-42a7-a3c8-6881c4447f31'
+    sha256 '443675a62bbe054216129bdd5c91da57c18b3be6b61455ea16f27d35a9be7996'
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 105, 15610.1.10)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=1718&view=logs