### PR TITLE
IDL test: Remove title argument for registerProtocolHandler()

### DIFF
--- a/interfaces/html.idl
+++ b/interfaces/html.idl
@@ -1969,7 +1969,7 @@ interface mixin NavigatorLanguage {
 };
 
 interface mixin NavigatorContentUtils {
-  [SecureContext] void registerProtocolHandler(DOMString scheme, USVString url, DOMString title);
+  [SecureContext] void registerProtocolHandler(DOMString scheme, USVString url);
   [SecureContext] void unregisterProtocolHandler(DOMString scheme, USVString url);
 };
 


### PR DESCRIPTION
This was discussed in [1] and test added in [2]. This commit updates
the corresponding IDL test.

[1] https://github.com/whatwg/html/pull/5425
[2] https://github.com/web-platform-tests/wpt/pull/22678