### PR TITLE
Update two SVG tests to be consistent between browsers

### DIFF
--- a/svg/import/pservers-grad-08-b-manual.svg
+++ b/svg/import/pservers-grad-08-b-manual.svg
@@ -75,11 +75,11 @@
       <!-- ====================================================================== -->
       <!-- Gradient on fill of text                                      ======== -->
       <!-- ====================================================================== -->
-      <text font-family="Blocky" font-size="68" fill="url(#Gradient)" x="20" y="70">Gradient on fill</text>
+      <text font-family="Blocky, sans-serif" font-size="68" fill="url(#Gradient)" x="20" y="70">Gradient on fill</text>
       <!-- ====================================================================== -->
       <!-- Gradient on stroke of text                                    ======== -->
       <!-- ====================================================================== -->
-      <text font-family="Blocky" x="20" y="160" font-size="55" fill="none" stroke="url(#Gradient)" stroke-width="3">Gradient on stroke</text>
+      <text font-family="Blocky, sans-serif" x="20" y="160" font-size="55" fill="none" stroke="url(#Gradient)" stroke-width="3">Gradient on stroke</text>
 
     </g>
       <g font-family="SVGFreeSansASCII,sans-serif" font-size="28">

--- a/svg/import/text-altglyph-01-b-manual.svg
+++ b/svg/import/text-altglyph-01-b-manual.svg
@@ -100,7 +100,7 @@
           <glyphRef xlink:href="#Y1"/>
         </altGlyphDef>
       </defs>
-      <g font-family="HappySad" font-size="60" fill="none" stroke-width="5">
+      <g font-family="HappySad, sans-serif" font-size="60" fill="none" stroke-width="5">
         <text x="140" y="190" stroke="fuchsia">
 <altGlyph xlink:href="#Hsmile">H</altGlyph>
 <altGlyph xlink:href="#Asmile">A</altGlyph>


### PR DESCRIPTION
`svg/import/pservers-grad-08-b-manual.svg`:
This test renders some text using a font that doesn't contain the space glyph.
However, the content contains the space character, and doesn't specify a fallback
font. This means that different browsers on the same OS will pick different
fallback fonts, causing different renderings. Instead, the test should be updated
to specify a fallback font, which makes browsers render it consistently.

`svg/import/text-altglyph-01-b-manual.svg`:
Similarly, this test renders text with a font that doesn't support those characters.
(It does it using <altGlyph>, but support for <altGlyph> has been removed in SVG 2.0 
and neither Safari nor Firefox support it.) A fallback font should be supplied to the 
test to get consistent renderings across browsers.