### PR TITLE
Replace assert_precondition in webrtc

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -763,5 +763,3 @@ ASSERT-PRECONDITION: infrastructure/expected-fail/precondition.html
 ASSERT-PRECONDITION: infrastructure/expected-fail/precondition-in-setup.html
 ASSERT-PRECONDITION: infrastructure/expected-fail/precondition-in-promise.html
 ASSERT-PRECONDITION: resources/testharness.js
-ASSERT-PRECONDITION: webrtc/protocol/crypto-suite.https.html
-ASSERT-PRECONDITION: webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html

--- a/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html
+++ b/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html
@@ -88,7 +88,7 @@ async function checkAbsCaptureTimeAndExchangeAnswer(caller, callee,
   if (answer.sdp.match(extmap) == null) {
     // We expect that absolute capture time RTP header extension is answered.
     // But if not, there is no need to proceed with the test.
-    assert_precondition(!absCaptureTimeAnswered, 'Absolute capture time RTP ' +
+    assert_implements(!absCaptureTimeAnswered, 'Absolute capture time RTP ' +
         'header extension is not answered');
   } else {
     if (!absCaptureTimeAnswered) {

--- a/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html
+++ b/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html
@@ -88,7 +88,7 @@ async function checkAbsCaptureTimeAndExchangeAnswer(caller, callee,
   if (answer.sdp.match(extmap) == null) {
     // We expect that absolute capture time RTP header extension is answered.
     // But if not, there is no need to proceed with the test.
-    assert_implements(!absCaptureTimeAnswered, 'Absolute capture time RTP ' +
+    assert_false(absCaptureTimeAnswered, 'Absolute capture time RTP ' +
         'header extension is not answered');
   } else {
     if (!absCaptureTimeAnswered) {

--- a/webrtc/protocol/crypto-suite.https.html
+++ b/webrtc/protocol/crypto-suite.https.html
@@ -45,7 +45,7 @@ const acceptableValues = {
 };
 
 function verifyStat(name, transportStats) {
-  assert_precondition(typeof transportStats !== 'undefined');
+  assert_implements(typeof transportStats !== 'undefined');
   assert_true(name in transportStats, 'Value present:');
   assert_true(acceptableValues[name].has(transportStats[name]));
 }

--- a/webrtc/protocol/crypto-suite.https.html
+++ b/webrtc/protocol/crypto-suite.https.html
@@ -45,7 +45,7 @@ const acceptableValues = {
 };
 
 function verifyStat(name, transportStats) {
-  assert_implements(typeof transportStats !== 'undefined');
+  assert_true(typeof transportStats !== 'undefined');
   assert_true(name in transportStats, 'Value present:');
   assert_true(acceptableValues[name].has(transportStats[name]));
 }


### PR DESCRIPTION
assert_precondition is deprecated (see
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/assert_precondition_rename.md).