### PR TITLE
Fix mobile table

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -5,3 +5,7 @@ div.body {
 #video-introduction-transcript iframe {
   max-width: 100%;
 }
+
+.table-container {
+  overflow: auto;
+}

--- a/docs/writing-tests/making-a-testing-plan.md
+++ b/docs/writing-tests/making-a-testing-plan.md
@@ -482,6 +482,8 @@ use [git](https://git-scm.com) to perform more powerful searches.
 The following table lists some common search criteria and examples of how they
 can be expressed using regular expressions:
 
+<div class="table-container">
+
 ```eval_rst
 ================================= ================== ==========================
 Criteria                          Example match      Example regular expression
@@ -493,6 +495,8 @@ HTML attributes                   ``<div foo=3>``    ``<[a-zA-Z][^>]*\sfoo(\s|>|
 CSS property name                 ``style="foo: 4"`` ``([{;=\"']|\s|^)foo\s+:``
 ================================= ================== ==========================
 ```
+
+</div>
 
 Bear in mind that searches like this are not necessarily exhaustive. Depending
 on the feature, it may be difficult (or even impossible) to write a query that


### PR DESCRIPTION
fixes #20014 

wrap this particular table in a div that will scroll if necessary when it overflows, instead of causing the window itself to scroll.

[edit] oh weird, I'm seeing that the css file is not in master anymore? I wonder if it was removed? I'll have to look into what happened.