### PR TITLE
[wptserve] Fix an exception handler in stash

### DIFF
--- a/tools/wptserve/wptserve/stash.py
+++ b/tools/wptserve/wptserve/stash.py
@@ -162,7 +162,7 @@ class Stash(object):
         if internal_key in self.data:
             raise StashError("Tried to overwrite existing shared stash value "
                              "for key %s (old value was %s, new value is %s)" %
-                             (internal_key, self.data[str(internal_key)], value))
+                             (internal_key, self.data[internal_key], value))
         else:
             self.data[internal_key] = value
 


### PR DESCRIPTION
internal_key is a tuple whose items are guaranteed to be strings.
It should be used as the key directly.