### PR TITLE
Correction to textpath-selection-011.html test

### DIFF
--- a/css/css-pseudo/textpath-selection-011.html
+++ b/css/css-pseudo/textpath-selection-011.html
@@ -9,6 +9,7 @@
   <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-styling">
   <link rel="help" href="https://www.w3.org/TR/fill-stroke-3/#fill-shorthand">
   <link rel="help" href="https://www.w3.org/TR/fill-stroke-3/#stroke-shorthand">
+  <link rel="match" href="textpath-selection-011-ref.html">
 
   <meta content="svg" name="flags">
   <meta content="This test checks that an SVG application with a text following a text path can be selected and then be styled." name="assert">


### PR DESCRIPTION
textpath-selection-011.html test was missing
`<link rel="match" href="textpath-selection-011-ref.html">`
@fantasai , we both missed this in
https://github.com/web-platform-tests/wpt/pull/20033

Approving this will fix the missing link reported in
https://drafts.csswg.org/bikeshed/css-pseudo-4/