### PR TITLE
[wptserve] Fix RequestHeaders.get in Python 3

### DIFF
--- a/tools/wptserve/tests/test_request.py
+++ b/tools/wptserve/tests/test_request.py
@@ -1,0 +1,78 @@
+import mock
+from six import binary_type
+
+from wptserve.request import Request, RequestHeaders
+
+
+class MockHTTPMessage(dict):
+    """A minimum (and not completely correctly) mock of HTTPMessage for testing.
+
+    Constructing HTTPMessage is annoying and different in Python 2 and 3. This
+    only implements the parts used by RequestHeaders.
+
+    Requirements for construction:
+    * Keys are header names and MUST be lower-case.
+    * Values are lists of header values (even if there's only one).
+    * Keys and values should be native strings to match stdlib's behaviours.
+    """
+    def __getitem__(self, key):
+        assert isinstance(key, str)
+        values = dict.__getitem__(self, key.lower())
+        assert isinstance(values, list)
+        return values[0]
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def getallmatchingheaders(self, key):
+        values = dict.__getitem__(self, key.lower())
+        return ["{}: {}\n".format(key, v) for v in values]
+
+
+def test_request_headers_get():
+    raw_headers = MockHTTPMessage({
+        'x-foo': ['foo'],
+        'x-bar': ['bar1', 'bar2'],
+    })
+    headers = RequestHeaders(raw_headers)
+    assert headers['x-foo'] == b'foo'
+    assert headers['X-Bar'] == b'bar1, bar2'
+    assert headers.get('x-bar') == b'bar1, bar2'
+
+
+def test_request_headers_encoding():
+    raw_headers = MockHTTPMessage({
+        'x-foo': ['foo'],
+        'x-bar': ['bar1', 'bar2'],
+    })
+    headers = RequestHeaders(raw_headers)
+    assert isinstance(headers['x-foo'], binary_type)
+    assert isinstance(headers['x-bar'], binary_type)
+    assert isinstance(headers.get_list('x-bar')[0], binary_type)
+
+
+def test_request_url_from_server_address():
+    request_handler = mock.Mock()
+    request_handler.server.scheme = 'http'
+    request_handler.server.server_address = ('localhost', '8000')
+    request_handler.path = '/demo'
+    request_handler.headers = MockHTTPMessage()
+
+    request = Request(request_handler)
+    assert request.url == 'http://localhost:8000/demo'
+    assert isinstance(request.url, str)
+
+
+def test_request_url_from_host_header():
+    request_handler = mock.Mock()
+    request_handler.server.scheme = 'http'
+    request_handler.server.server_address = ('localhost', '8000')
+    request_handler.path = '/demo'
+    request_handler.headers = MockHTTPMessage({'host': ['web-platform.test:8001']})
+
+    request = Request(request_handler)
+    assert request.url == 'http://web-platform.test:8001/demo'
+    assert isinstance(request.url, str)

--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -268,6 +268,7 @@ class Request(object):
         if self.request_path.startswith(scheme + "://"):
             self.url = self.request_path
         else:
+            # TODO(#23362): Stop using native strings for URLs.
             self.url = "%s://%s:%s%s" % (
                 scheme, host, port, self.request_path)
         self.url_parts = urlsplit(self.url)
@@ -318,7 +319,6 @@ class Request(object):
         if self._cookies is None:
             parser = BaseCookie()
             cookie_headers = self.headers.get("cookie", b"")
-            # FIXME: cookies should probably be decoded in UTF-8?
             if PY3:
                 cookie_headers = cookie_headers.decode("iso-8859-1")
             parser.load(cookie_headers)

--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -248,8 +248,12 @@ class Request(object):
         self.protocol_version = request_handler.protocol_version
         self.method = request_handler.command
 
+        # Keys and values in raw headers are native strings.
+        self._headers = None
+        self.raw_headers = request_handler.headers
+
         scheme = request_handler.server.scheme
-        host = request_handler.headers.get("Host")
+        host = self.raw_headers.get("Host")
         port = request_handler.server.server_address[1]
 
         if host is None:
@@ -262,22 +266,16 @@ class Request(object):
         self.url_base = "/"
 
         if self.request_path.startswith(scheme + "://"):
-            self.url = request_handler.path
+            self.url = self.request_path
         else:
-            self.url = "%s://%s:%s%s" % (scheme,
-                                      host,
-                                      port,
-                                      self.request_path)
+            self.url = "%s://%s:%s%s" % (
+                scheme, host, port, self.request_path)
         self.url_parts = urlsplit(self.url)
-
-        self.raw_headers = request_handler.headers
 
         self.request_line = request_handler.raw_requestline
 
-        self._headers = None
-
         self.raw_input = InputFile(request_handler.rfile,
-                                   int(self.headers.get("Content-Length", 0)))
+                                   int(self.raw_headers.get("Content-Length", 0)))
 
         self._body = None
 
@@ -303,9 +301,10 @@ class Request(object):
     @property
     def POST(self):
         if self._POST is None:
-            #Work out the post parameters
+            # Work out the post parameters
             pos = self.raw_input.tell()
             self.raw_input.seek(0)
+            # FIXME: specify encoding in Python 3.
             fs = cgi.FieldStorage(fp=self.raw_input,
                                   environ={"REQUEST_METHOD": self.method},
                                   headers=self.raw_headers,
@@ -319,6 +318,7 @@ class Request(object):
         if self._cookies is None:
             parser = BaseCookie()
             cookie_headers = self.headers.get("cookie", b"")
+            # FIXME: cookies should probably be decoded in UTF-8?
             if PY3:
                 cookie_headers = cookie_headers.decode("iso-8859-1")
             parser.load(cookie_headers)
@@ -400,7 +400,6 @@ class RequestHeaders(dict):
                 headers = [_maybe_encode(items[header])]
             dict.__setitem__(self, key, headers)
 
-
     def __getitem__(self, key):
         """Get all headers of a certain (case-insensitive) name. If there is
         more than one, the values are returned comma separated"""
@@ -409,7 +408,7 @@ class RequestHeaders(dict):
         if len(values) == 1:
             return values[0]
         else:
-            return ", ".join(values)
+            return b", ".join(values)
 
     def __setitem__(self, name, value):
         raise Exception
@@ -450,6 +449,7 @@ class RequestHeaders(dict):
     def itervalues(self):
         for item in self:
             yield self[item]
+
 
 class CookieValue(object):
     """Representation of cookies.


### PR DESCRIPTION
When there are multiple headers with the same name, this method would
crash in Python 3 when attempting to join them.

Drive-by:
* Clean up Request.__init__ to make the logic clearer and an unnecessary
  access to the headers property.
* Add some FIXMEs for more potential Py3 issues.
* Add some tests to make sure Request.url can be constructed correctly
  as it uses some native strings intentionally.
