### PR TITLE
[css-transforms] correctly mark css-transform-scale-001.html as manual

### DIFF
--- a/css/css-transforms/css-transform-scale-001-manual.html
+++ b/css/css-transforms/css-transform-scale-001-manual.html
@@ -9,7 +9,6 @@
     <!-- See also: http://www.w3.org/wiki/CSS/Selectors/pseudo-classes/:hover -->
     <link rel="match" href="reference/css-transform-scale-ref-001.html">
     <meta name="assert" content="When the element is hovered over, the transform scales the element to twice its size in both the X and Y directions and moves its origin to the top left corner.">
-    <meta name="flag" content="interactive">
     <style type="text/css">
         .container {
             position: absolute;


### PR DESCRIPTION
This should have been <meta name="flags" content="interact"> to work,
but that is deprecated in favor of naming tests -manual:
https://web-platform-tests.org/writing-tests/css-metadata.html#requirement-flags