### PR TITLE
[css-backgrounds] Remove some invalid uses of <meta name="flag">

### DIFF
--- a/css/css-backgrounds/css-border-radius-001.html
+++ b/css/css-backgrounds/css-border-radius-001.html
@@ -5,8 +5,6 @@
     <link rel="author" title="tmd" href="mailto:weisong4413@126.com">
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-radius">
     <link rel="match" href="reference/css-border-radius-ref-001.html">
-    <meta name="assert" content="">
-    <meta name="flag" content="border-radius">
     <style type="text/css">
 		.redSquare{
             position: absolute;

--- a/css/css-backgrounds/css-border-radius-002.html
+++ b/css/css-backgrounds/css-border-radius-002.html
@@ -6,7 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-radius">
     <link rel="match" href="reference/css-border-radius-ref-002.html">
     <meta name="assert" content="if there is more then one graph and one color">
-    <meta name="flag" content="border-radius">
     <style type="text/css">
         .redSquare {
             position: absolute;

--- a/css/css-backgrounds/css-box-shadow-001.html
+++ b/css/css-backgrounds/css-box-shadow-001.html
@@ -6,8 +6,6 @@
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-box-shadow">
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-radius">
     <link rel="match" href="reference/css-box-shadow-ref-001.html">
-    <meta name="assert" content="">
-    <meta name="flag" content="box-shadow">
     <style type="text/css">
 		.greenSquare-shadow{
             position: absolute;


### PR DESCRIPTION
Found because "flag" should be "flags", but the flags in question
aren't and never were valid:
https://github.com/web-platform-tests/wpt/issues/23253#issuecomment-620190373