### PR TITLE
[webrtc] remove unnecessary `ctx.getImageData()` call

### DIFF
--- a/webrtc/RTCPeerConnection-helper.js
+++ b/webrtc/RTCPeerConnection-helper.js
@@ -598,7 +598,6 @@ const trackFactories = {
       if (signal !== null) {
         ctx.fillStyle = `rgb(${signal}, ${signal}, ${signal})`;
         ctx.fillRect(10, 10, 20, 20);
-        let pixel = ctx.getImageData(15, 15, 1, 1);
       }
     }, 100);
 


### PR DESCRIPTION
See https://github.com/web-platform-tests/wpt/pull/22779#discussion_r407830942