### PR TITLE
[canvas] make paths to /css/css-images/ resources absolute

### DIFF
--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-bitmap-orientation-none.tentative.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-bitmap-orientation-none.tentative.html
@@ -8,7 +8,7 @@
 <link rel="match" href="reference/drawImage-from-bitmap-orientation-none-ref.html">
   <script>
     image = new Image();
-    image.src = "../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg";
+    image.src = "/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg";
 
     let imageLoadPromise = new Promise(resolve => {
       image.onload = resolve;
@@ -25,7 +25,7 @@
   </script>
 </head>
 <body>
-  <img id="img-element" src="../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
   <canvas id="bitmap-canvas" style="image-orientation: none;"></canvas>
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-bitmap-swap-width-height-orientation-none.tentative.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-bitmap-swap-width-height-orientation-none.tentative.html
@@ -8,7 +8,7 @@
 <link rel="match" href="reference/drawImage-from-bitmap-swap-width-height-orientation-none-ref.html">
   <script>
     image = new Image();
-    image.src = "../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg";
+    image.src = "/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg";
 
     let imageLoadPromise = new Promise(resolve => {
       image.onload = resolve;
@@ -26,7 +26,7 @@
   </script>
 </head>
 <body>
-  <img id="img-element" src="../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
   <canvas id="bitmap-canvas" style="image-orientation: none;"></canvas>
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-bitmap-swap-width-height.tentative.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-bitmap-swap-width-height.tentative.html
@@ -8,7 +8,7 @@
 <link rel="match" href="reference/drawImage-from-bitmap-swap-width-height-ref.html">
   <script>
     image = new Image();
-    image.src = "../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg";
+    image.src = "/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg";
 
     let imageLoadPromise = new Promise(resolve => {
       image.onload = resolve;
@@ -26,7 +26,7 @@
   </script>
 </head>
 <body>
-  <img id="img-element" src="../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
   <canvas id="bitmap-canvas"></canvas>
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-bitmap.tentative.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-bitmap.tentative.html
@@ -8,7 +8,7 @@
 <link rel="match" href="reference/drawImage-from-bitmap-ref.html">
   <script>
     image = new Image();
-    image.src = "../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg";
+    image.src = "/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg";
 
     let imageLoadPromise = new Promise(resolve => {
       image.onload = resolve;
@@ -25,7 +25,7 @@
   </script>
 </head>
 <body>
-  <img id="img-element" src="../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
   <canvas id="bitmap-canvas"></canvas>
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-element-orientation-none.tentative.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-element-orientation-none.tentative.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body>
-  <img id="img-element" src="../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
   <canvas id="bitmap-canvas" style="image-orientation: none;"></canvas>
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-element-swap-width-height-orientation-none.tentative.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-element-swap-width-height-orientation-none.tentative.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body>
-  <img id="img-element" src="../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
   <canvas id="bitmap-canvas" style="image-orientation: none;"></canvas>
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-element-swap-width-height.tentative.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-element-swap-width-height.tentative.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body>
-  <img id="img-element" src="../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
   <canvas id="bitmap-canvas"></canvas>
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-element.tentative.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/drawImage-from-element.tentative.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body>
-  <img id="img-element" src="../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
   <canvas id="bitmap-canvas"></canvas>
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-bitmap-orientation-none-ref.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-bitmap-orientation-none-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 </head>
 <body>
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
-  <img id="img-element" style="image-orientation: none;" src="../../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" style="image-orientation: none;" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-bitmap-ref.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-bitmap-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 </head>
 <body>
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-bitmap-swap-width-height-orientation-none-ref.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-bitmap-swap-width-height-orientation-none-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 </head>
 <body>
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
-  <img id="img-element" style="image-orientation: none;" src="../../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" style="image-orientation: none;" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-bitmap-swap-width-height-ref.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-bitmap-swap-width-height-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 </head>
 <body>
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-blob-ref.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-blob-ref.html
@@ -5,6 +5,6 @@
 <title>createImageBitmap and drawImage from a blob with image orientation: from-image, reference</title>
 </head>
 <body>
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-element-orientation-none-ref.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-element-orientation-none-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 </head>
 <body>
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
-  <img id="img-element" style="image-orientation: none;" src="../../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" style="image-orientation: none;" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-element-ref.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-element-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 </head>
 <body>
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-3-lr.jpg">
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-element-swap-width-height-orientation-none-ref.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-element-swap-width-height-orientation-none-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 </head>
 <body>
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
-  <img id="img-element" style="image-orientation: none;" src="../../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" style="image-orientation: none;" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
 </body>
 </html>

--- a/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-element-swap-width-height-ref.html
+++ b/html/canvas/element/drawing-images-to-the-canvas/image-orientation/reference/drawImage-from-element-swap-width-height-ref.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 </head>
 <body>
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
-  <img id="img-element" src="../../../../css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
+  <img id="img-element" src="/css/css-images/image-orientation/support/exif-orientation-7-rl.jpg">
 </body>
 </html>


### PR DESCRIPTION
Some of these relative paths broke in https://github.com/web-platform-tests/wpt/pull/23070.

There are already a lot of absolute paths elsewhere here, so just make
these absolute too to fix the problem.