### PR TITLE
Enforce string prefixes in Python handlers

### DIFF
--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -127,6 +127,12 @@ class ParseFailed(Rule):
         examine the file to find the causes of any parse errors, and fix them.
     """
 
+class StringPrefix(Rule):
+    name = "STRING-PREFIX"
+    description = "Missing string type prefix in Python script handler files"
+    to_fix = """
+        ensure text strings are prefixed with 'u' and bytes with 'b'
+    """
 
 class ContentManual(Rule):
     name = "CONTENT-MANUAL"

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -359,23 +359,26 @@ class RoutesBuilder(object):
         self.mountpoint_routes[url_base] = []
 
         routes = [
-            ("GET", "*.worker.html", WorkersHandler),
-            ("GET", "*.window.html", WindowHandler),
-            ("GET", "*.any.html", AnyHtmlHandler),
-            ("GET", "*.any.sharedworker.html", SharedWorkersHandler),
-            ("GET", "*.any.serviceworker.html", ServiceWorkersHandler),
-            ("GET", "*.any.worker.js", AnyWorkerHandler),
-            ("GET", "*.asis", handlers.AsIsHandler),
-            ("GET", "/.well-known/origin-policy", handlers.PythonScriptHandler),
-            ("*", "*.py", handlers.PythonScriptHandler),
-            ("GET", "*", handlers.FileHandler)
+            ("GET", "*.worker.html", WorkersHandler, None),
+            ("GET", "*.window.html", WindowHandler, None),
+            ("GET", "*.any.html", AnyHtmlHandler, None),
+            ("GET", "*.any.sharedworker.html", SharedWorkersHandler, None),
+            ("GET", "*.any.serviceworker.html", ServiceWorkersHandler, None),
+            ("GET", "*.any.worker.js", AnyWorkerHandler, None),
+            ("GET", "*.asis", handlers.AsIsHandler, None),
+            ("GET", "/.well-known/origin-policy", handlers.PythonScriptHandler,
+             {"require_string_prefix": True}),
+            ("*", "*.py", handlers.PythonScriptHandler, {"require_string_prefix": True}),
+            ("GET", "*", handlers.FileHandler, None)
         ]
 
-        for (method, suffix, handler_cls) in routes:
+        for (method, suffix, handler_cls, handler_kwargs) in routes:
+            if handler_kwargs is None:
+                handler_kwargs = {}
             self.mountpoint_routes[url_base].append(
                 (method,
                  "%s%s" % (url_base if url_base != "/" else "", suffix),
-                 handler_cls(base_path=path, url_base=url_base)))
+                 handler_cls(base_path=path, url_base=url_base, **handler_kwargs)))
 
     def add_file_mount_point(self, file_url, base_path):
         assert file_url.startswith("/")


### PR DESCRIPTION
Enforce that all strings are written as either `u""` or `b""` so that the data type of literals doesn't vary between Py2 and Py3.