### PR TITLE
Use requestSkipAnimationFrame to avoid races in tests

### DIFF
--- a/webxr/dom-overlay/ar_dom_overlay.https.html
+++ b/webxr/dom-overlay/ar_dom_overlay.https.html
@@ -137,7 +137,7 @@ let testInput = function(overlayElement, session, fakeDeviceController, t) {
   session.requestReferenceSpace('viewer').then(function(viewerSpace) {
     // Press the primary input button and then release it a short time later.
     debug('got viewerSpace');
-    session.requestAnimationFrame((time, xrFrame) => {
+    requestSkipAnimationFrame(session, (time, xrFrame) => {
       debug('got rAF 1');
       input_source.setOverlayPointerPosition(inner_a.offsetLeft + 1,
                                              inner_a.offsetTop + 1);
@@ -202,7 +202,7 @@ let testCrossOriginContent = function(overlayElement, session, fakeDeviceControl
       fakeDeviceController.simulateInputSourceConnection(SCREEN_CONTROLLER);
   session.requestReferenceSpace('viewer').then(function(viewerSpace) {
     // Press the primary input button and then release it a short time later.
-    session.requestAnimationFrame((time, xrFrame) => {
+    requestSkipAnimationFrame(session, (time, xrFrame) => {
       debug('got rAF 1');
       input_source.setOverlayPointerPosition(iframe.offsetLeft + 1,
                                              iframe.offsetTop + 1);

--- a/webxr/events_input_sources_change.https.html
+++ b/webxr/events_input_sources_change.https.html
@@ -101,9 +101,9 @@ let testFunction = function(session, fakeDeviceController, t) {
 
   // Make our input source disappear after one frame, and wait an additional
   // frame for that disappearance to propogate.
-  session.requestAnimationFrame((time, xrFrame) => {
+  requestSkipAnimationFrame(session, (time, xrFrame) => {
     input_source.disconnect();
-    session.requestAnimationFrame((time, xrFrame) => {});
+    requestSkipAnimationFrame(session, (time, xrFrame) => {});
   });
 
   return eventPromise;

--- a/webxr/events_input_sources_change.https.html
+++ b/webxr/events_input_sources_change.https.html
@@ -103,7 +103,7 @@ let testFunction = function(session, fakeDeviceController, t) {
   // frame for that disappearance to propogate.
   requestSkipAnimationFrame(session, (time, xrFrame) => {
     input_source.disconnect();
-    requestSkipAnimationFrame(session, (time, xrFrame) => {});
+    session.requestAnimationFrame((time, xrFrame) => {});
   });
 
   return eventPromise;

--- a/webxr/events_referenceSpace_reset_immersive.https.html
+++ b/webxr/events_referenceSpace_reset_immersive.https.html
@@ -40,7 +40,7 @@ let testFunction = function(session, fakeDeviceController, t) {
   fakeDeviceController.simulateResetPose();
 
   // The triggered resetPose event should arrive after the next Animation Frame
-  session.requestAnimationFrame(() => {});
+  requestSkipAnimationFrame(session, () => {});
 
   return resetPromise;
 };

--- a/webxr/events_session_select.https.html
+++ b/webxr/events_session_select.https.html
@@ -92,7 +92,7 @@ let testFunction = function(session, fakeDeviceController, t) {
       currentReferenceSpace = referenceSpace;
 
       // Press the primary input button and then release it a short time later.
-      session.requestAnimationFrame((time, xrFrame) => {
+      requestSkipAnimationFrame(session, (time, xrFrame) => {
         input_source.startSelection();
 
           session.requestAnimationFrame((time, xrFrame) => {

--- a/webxr/events_session_select_subframe.https.html
+++ b/webxr/events_session_select_subframe.https.html
@@ -51,10 +51,10 @@ let testFunction = function(session, fakeDeviceController, t) {
   let input_source = fakeDeviceController.simulateInputSourceConnection(VALID_CONTROLLER);
 
   // Press the primary input button and then release it a short time later.
-  session.requestAnimationFrame((time, xrFrame) => {
+  requestSkipAnimationFrame(session, (time, xrFrame) => {
     input_source.simulateSelect();
 
-    session.requestAnimationFrame((time, xrFrame) => {
+    requestSkipAnimationFrame(session, (time, xrFrame) => {
       // Need to process one more frame to allow select to propegate.
     });
   });

--- a/webxr/events_session_select_subframe.https.html
+++ b/webxr/events_session_select_subframe.https.html
@@ -54,7 +54,7 @@ let testFunction = function(session, fakeDeviceController, t) {
   requestSkipAnimationFrame(session, (time, xrFrame) => {
     input_source.simulateSelect();
 
-    requestSkipAnimationFrame(session, (time, xrFrame) => {
+    session.requestAnimationFrame((time, xrFrame) => {
       // Need to process one more frame to allow select to propegate.
     });
   });

--- a/webxr/events_session_squeeze.https.html
+++ b/webxr/events_session_squeeze.https.html
@@ -114,7 +114,7 @@ let testFunction = function(session, fakeDeviceController, t) {
       currentReferenceSpace = referenceSpace;
 
       //Simulate a grip starting then release it a short time later.
-      session.requestAnimationFrame((time, xrFrame) => {
+      requestSkipAnimationFrame(session, (time, xrFrame) => {
         input_source.updateButtonState(pressed_grip_button);
 
           session.requestAnimationFrame((time, xrFrame) => {

--- a/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html
+++ b/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html
@@ -132,7 +132,7 @@ let testFunction = function(session, fakeDeviceController, t) {
   // 5. Waits for all of the input events to finish propagating, then ends the
   // session, at which point the controller should be disconnected.
   return new Promise((resolve) => {
-    session.requestAnimationFrame(() => {
+    requestSkipAnimationFrame(session, () => {
       input_source.setSupportedButtons([]);
       session.requestAnimationFrame(() => {
         input_source.setSupportedButtons(gamepadButtons);

--- a/webxr/gamepads-module/xrInputSource_gamepad_input_registered.https.html
+++ b/webxr/gamepads-module/xrInputSource_gamepad_input_registered.https.html
@@ -69,7 +69,7 @@ let testFunction = function(session, fakeDeviceController, t) {
   //    updated values make their way to the WebXR gamepad and that it does not
   //    fire an inputsourceschange event).
   return new Promise((resolve) => {
-    session.requestAnimationFrame(() => {
+    requestSkipAnimationFrame(session, () => {
       // Make sure the exposed gamepad has the number of buttons and axes we
       // requested.
       // 3 Buttons: trigger, grip, touchpad

--- a/webxr/getInputPose_handedness.https.html
+++ b/webxr/getInputPose_handedness.https.html
@@ -75,7 +75,7 @@ let testFunction =
     }
 
     // Handedness only updates during an XR frame.
-    session.requestAnimationFrame(CheckNone);
+    requestSkipAnimationFrame(session, CheckNone);
   });
 
 xr_session_promise_test(

--- a/webxr/getInputPose_pointer.https.html
+++ b/webxr/getInputPose_pointer.https.html
@@ -88,7 +88,7 @@ let testFunction =
       }
 
       // Can only request input poses in an xr frame.
-      session.requestAnimationFrame(CheckInvalidGrip);
+      requestSkipAnimationFrame(session, CheckInvalidGrip);
     });
   });
 

--- a/webxr/getViewerPose_emulatedPosition.https.html
+++ b/webxr/getViewerPose_emulatedPosition.https.html
@@ -45,7 +45,7 @@
             resolve();
           }
 
-          session.requestAnimationFrame(CheckPositionNotEmulated);
+          requestSkipAnimationFrame(session, CheckPositionNotEmulated);
         }));
     };
 

--- a/webxr/hit-test/ar_hittest_subscription_inputSources.https.html
+++ b/webxr/hit-test/ar_hittest_subscription_inputSources.https.html
@@ -56,7 +56,7 @@ let testFunctionGenerator = function(ray, expectedPoses, inputFromPointer, nextF
 
       const input_source_controller = fakeDeviceController.simulateInputSourceConnection(screen_controller_init);
 
-      session.requestAnimationFrame((time, frame) => {
+      requestSkipAnimationFrame(session, (time, frame) => {
         t.step(() => {
           assert_equals(session.inputSources.length, 1);
         });

--- a/webxr/hit-test/ar_hittest_subscription_transientInputSources.https.html
+++ b/webxr/hit-test/ar_hittest_subscription_transientInputSources.https.html
@@ -57,7 +57,7 @@ let testFunctionGenerator = function(ray, expectedPoses, inputFromPointer, nextF
 
       const input_source_controller = fakeDeviceController.simulateInputSourceConnection(screen_controller_init);
 
-      session.requestAnimationFrame((time, frame) => {
+      requestSkipAnimationFrame(session, (time, frame) => {
         debug('rAF 1');
         t.step(() => {
           assert_equals(session.inputSources.length, 1);

--- a/webxr/resources/webxr_util.js
+++ b/webxr/resources/webxr_util.js
@@ -44,6 +44,18 @@ function xr_promise_test(name, func, properties) {
   }, name, properties);
 }
 
+// A utility function for waiting one animation frame before running the callback
+//
+// This is only needed after calling FakeXRDevice methods outside of an animation frame
+//
+// This is so that we can paper over the potential race allowed by the "next animation frame"
+// concept https://immersive-web.github.io/webxr-test-api/#xrsession-next-animation-frame
+function requestSkipAnimationFrame(session, callback) {
+ session.requestAnimationFrame(() => {
+  session.requestAnimationFrame(callback);
+ });
+}
+
 // A test function which runs through the common steps of requesting a session.
 // Calls the passed in test function with the session, the controller for the
 // device, and the test object.

--- a/webxr/xrBoundedReferenceSpace_updates.https.html
+++ b/webxr/xrBoundedReferenceSpace_updates.https.html
@@ -49,7 +49,7 @@ let testFunction = function(session, fakeDeviceController, t) {
 
           // Now set the bounds explicitly and check again on the next frame.
           fakeDeviceController.setBoundsGeometry(VALID_BOUNDS);
-          session.requestAnimationFrame(onFrame);
+          requestSkipAnimationFrame(session, onFrame);
         });
     });
 };

--- a/webxr/xrInputSource_add_remove.https.html
+++ b/webxr/xrInputSource_add_remove.https.html
@@ -21,7 +21,7 @@ let testFunction = (session, fakeDeviceController, t) => new Promise((resolve) =
 
     let input_source_1 = fakeDeviceController.simulateInputSourceConnection(RIGHT_CONTROLLER);
 
-    session.requestAnimationFrame((time, xrFrame) => {
+    requestSkipAnimationFrame(session, (time, xrFrame) => {
       let input_sources = session.inputSources;
 
       t.step( () => {
@@ -37,7 +37,7 @@ let testFunction = (session, fakeDeviceController, t) => new Promise((resolve) =
         profiles: []
       });
 
-      session.requestAnimationFrame((time, xrFrame) => {
+      requestSkipAnimationFrame(session, (time, xrFrame) => {
         let input_sources = session.inputSources;
 
         t.step( () => {

--- a/webxr/xrInputSource_add_remove.https.html
+++ b/webxr/xrInputSource_add_remove.https.html
@@ -37,7 +37,7 @@ let testFunction = (session, fakeDeviceController, t) => new Promise((resolve) =
         profiles: []
       });
 
-      requestSkipAnimationFrame(session, (time, xrFrame) => {
+      session.requestAnimationFrame((time, xrFrame) => {
         let input_sources = session.inputSources;
 
         t.step( () => {

--- a/webxr/xrInputSource_emulatedPosition.https.html
+++ b/webxr/xrInputSource_emulatedPosition.https.html
@@ -53,7 +53,7 @@ let testFunction =
       }
 
       // Can only request input poses in an xr frame.
-      session.requestAnimationFrame(CheckPositionNotEmulated);
+      requestSkipAnimationFrame(session, CheckPositionNotEmulated);
     });
   });
 

--- a/webxr/xrInputSource_profiles.https.html
+++ b/webxr/xrInputSource_profiles.https.html
@@ -22,7 +22,7 @@ let testFunction = function(session, fakeDeviceController, t) {
   // Input events and state changes need one frame to propagate, which is why we
   // are requesting an animation frame before checking the profiles list.
   return new Promise((resolve) => {
-    session.requestAnimationFrame(() => {
+    requestSkipAnimationFrame(session, () => {
       let profiles = session.inputSources[0].profiles;
       t.step(() => {
         assert_equals(profiles.length, 2);

--- a/webxr/xrInputSource_sameObject.https.html
+++ b/webxr/xrInputSource_sameObject.https.html
@@ -18,7 +18,7 @@ let testFunction = function(session, fakeDeviceController, t) {
       profiles: ["foo", "bar"]
     });
 
-    session.requestAnimationFrame((time, xrFrame) => {
+    requestSkipAnimationFrame(session, (time, xrFrame) => {
       let source = session.inputSources[0];
       let targetRaySpace = source.targetRaySpace;
       let gripSpace = source.gripSpace;

--- a/webxr/xrPose_transform_sameObject.https.html
+++ b/webxr/xrPose_transform_sameObject.https.html
@@ -19,7 +19,7 @@ let testFunction = function(session, fakeDeviceController, t) {
     });
 
     session.requestReferenceSpace('local').then((referenceSpace) => {
-      session.requestAnimationFrame((time, xrFrame) => {
+      requestSkipAnimationFrame(session, (time, xrFrame) => {
         let source = session.inputSources[0];
         let input_pose = xrFrame.getPose(source.targetRaySpace, referenceSpace);
 

--- a/webxr/xrReferenceSpace_originOffset.https.html
+++ b/webxr/xrReferenceSpace_originOffset.https.html
@@ -126,7 +126,7 @@ let testFunction =
       }
 
       // Can only request input poses in an xr frame.
-      session.requestAnimationFrame(OnFrame);
+      requestSkipAnimationFrame(session, OnFrame);
     });
   });
 

--- a/webxr/xrReferenceSpace_originOffsetBounded.https.html
+++ b/webxr/xrReferenceSpace_originOffsetBounded.https.html
@@ -67,7 +67,7 @@ function testFunction(session, fakeDeviceController, t) {
   });
 
   return new Promise((resolve, reject) => {
-    session.requestAnimationFrame((time, frame) => {
+    requestSkipAnimationFrame(session, (time, frame) => {
       let input_source = session.inputSources[0];
 
       session.requestReferenceSpace('bounded-floor').then((referenceSpace) => {

--- a/webxr/xrSession_input_events_end.https.html
+++ b/webxr/xrSession_input_events_end.https.html
@@ -42,7 +42,7 @@ let testFunction = function(session, fakeDeviceController, t, sessionObjects) {
       profiles: [],
       selectionClicked: true
     });
-    session.requestAnimationFrame(() => {});
+    requestSkipAnimationFrame(session, () => {});
   }
 
   function sessionEndTest(endEvent, eventOrder) {

--- a/webxr/xrSession_sameObject.https.html
+++ b/webxr/xrSession_sameObject.https.html
@@ -18,7 +18,7 @@ let testFunction = function(session, fakeDeviceController, t) {
       profiles: ["foo", "bar"]
     });
 
-    session.requestAnimationFrame((time, xrFrame) => {
+    requestSkipAnimationFrame(session, (time, xrFrame) => {
       let renderState = session.renderState;
       let sources = session.inputSources;
 

--- a/webxr/xrStationaryReferenceSpace_floorlevel_updates.https.html
+++ b/webxr/xrStationaryReferenceSpace_floorlevel_updates.https.html
@@ -36,9 +36,7 @@ let testFunction = function(session, fakeDeviceController, t) {
 
           // Need to request one animation frame for the new stage transform to
           // propagate before we check that it's what we expect.
-          session.requestAnimationFrame(() => {
-            session.requestAnimationFrame(onFrame);
-          });
+          requestSkipAnimationFrame(session, onFrame);
         });
       }
 
@@ -58,9 +56,7 @@ let testFunction = function(session, fakeDeviceController, t) {
 
       // Need to wait one frame for the removal to propagate before we check that
       // everything is at the expected emulated position.
-      session.requestAnimationFrame(() => {
-        session.requestAnimationFrame(onFirstFrame);
-      });
+      requestSkipAnimationFrame(session, onFirstFrame);
     }));
 };
 


### PR DESCRIPTION
See https://github.com/immersive-web/webxr-test-api/issues/64 : the current usage is racy, tests should requestSkipAnimationFrame() after manipulating fakeDeviceController outside of the rAF loop.

Would like to allow https://chromium-review.googlesource.com/c/chromium/src/+/2173519 to land and sync before landing this, to avoid manifest merge conflicts and further headaches for Alex :smile:

fixes https://github.com/servo/servo/issues/26347