### PR TITLE
Make canvas test generation python3 compatible

### DIFF
--- a/html/canvas/tools/gentestutils.py
+++ b/html/canvas/tools/gentestutils.py
@@ -348,7 +348,7 @@ def genTestUtils(TESTOUTPUTDIR, IMAGEOUTPUTDIR, TEMPLATEFILE, NAME2DIRFILE, ISOF
             scripts += '<script src="%s"></script>\n' % (s)
 
         variants = test.get('script-variants', {})
-        script_variants = [(v, '<script src="%s"></script>\n' % (s)) for (v, s) in variants.iteritems()]
+        script_variants = [(v, '<script src="%s"></script>\n' % (s)) for (v, s) in variants.items()]
         if not script_variants:
             script_variants = [('', '')]
 

--- a/html/canvas/tools/tests2d-offscreen.yaml
+++ b/html/canvas/tools/tests2d-offscreen.yaml
@@ -694,7 +694,9 @@
     # The ones that change the output when src = (0,0,0,0):
     ops_trans = [ 'source-in', 'destination-in', 'source-out', 'destination-atop', 'copy' ];
 
-    def calc_output((RA, GA, BA, aA), (RB, GB, BB, aB), FA_code, FB_code):
+    def calc_output(A, B, FA_code, FB_code):
+        RA, GA, BA, aA = A
+        RB, GB, BB, aB = B
         rA, gA, bA = RA*aA, GA*aA, BA*aA
         rB, gB, bB = RB*aB, GB*aB, BB*aB
 
@@ -719,9 +721,11 @@
 
         return (RO, GO, BO, aO)
 
-    def to_test((r,g,b,a)):
+    def to_test(color):
+        r, g, b, a = color
         return '%d,%d,%d,%d' % (round(r), round(g), round(b), round(a*255))
-    def to_cairo((r,g,b,a)):
+    def to_cairo(color):
+        r, g, b, a = color
         return '%f,%f,%f,%f' % (r/255., g/255., b/255., a)
 
     for (name, src, dest) in [

--- a/html/canvas/tools/tests2d.yaml
+++ b/html/canvas/tools/tests2d.yaml
@@ -5561,7 +5561,6 @@
     cr.set_source_rgb(1, 1, 0)
     cr.rectangle(0, 25, 1, 25)
     cr.fill()
-    foo = 12
     for x in range(1, 100):
         sigma = x/2.0
         filter = []

--- a/html/canvas/tools/tests2d.yaml
+++ b/html/canvas/tools/tests2d.yaml
@@ -5591,7 +5591,7 @@
     import math
     sigma = 100.0/2
     filter = []
-    for i in range(-200, 200):
+    for i in range(-200, 100):
         filter.append(math.exp(-i*i / (2*sigma*sigma)) / (math.sqrt(2*math.pi)*sigma))
     accum = [0]
     for f in filter:

--- a/html/canvas/tools/tests2d.yaml
+++ b/html/canvas/tools/tests2d.yaml
@@ -1053,7 +1053,9 @@
     # The ones that change the output when src = (0,0,0,0):
     ops_trans = [ 'source-in', 'destination-in', 'source-out', 'destination-atop', 'copy' ];
 
-    def calc_output((RA, GA, BA, aA), (RB, GB, BB, aB), FA_code, FB_code):
+    def calc_output(A, B, FA_code, FB_code):
+        (RA, GA, BA, aA) = A
+        (RB, GB, BB, aB) = B
         rA, gA, bA = RA*aA, GA*aA, BA*aA
         rB, gB, bB = RB*aB, GB*aB, BB*aB
 
@@ -1078,9 +1080,11 @@
 
         return (RO, GO, BO, aO)
 
-    def to_test((r,g,b,a)):
+    def to_test(color):
+        r, g, b, a = color
         return '%d,%d,%d,%d' % (round(r), round(g), round(b), round(a*255))
-    def to_cairo((r,g,b,a)):
+    def to_cairo(color):
+        r, g, b, a = color
         return '%f,%f,%f,%f' % (r/255., g/255., b/255., a)
 
     for (name, src, dest) in [
@@ -5557,9 +5561,12 @@
     cr.set_source_rgb(1, 1, 0)
     cr.rectangle(0, 25, 1, 25)
     cr.fill()
+    foo = 12
     for x in range(1, 100):
         sigma = x/2.0
-        filter = [math.exp(-i*i / (2*sigma*sigma)) / (math.sqrt(2*math.pi)*sigma) for i in range(-24, 26)]
+        filter = []
+        for i in range(-24, 26):
+            filter.append(math.exp(-i*i / (2*sigma*sigma)) / (math.sqrt(2*math.pi)*sigma))
         accum = [0]
         for f in filter:
             accum.append(accum[-1] + f)
@@ -5584,7 +5591,9 @@
     size 100 50
     import math
     sigma = 100.0/2
-    filter = [math.exp(-i*i / (2*sigma*sigma)) / (math.sqrt(2*math.pi)*sigma) for i in range(-200, 100)]
+    filter = []
+    for i in range(-200, 200):
+        filter.append(math.exp(-i*i / (2*sigma*sigma)) / (math.sqrt(2*math.pi)*sigma))
     accum = [0]
     for f in filter:
         accum.append(accum[-1] + f)


### PR DESCRIPTION
The canvas version of `gentests.py` needs some changes so that it works with python3. 

There's an odd gotcha with the combination of `eval` scoping and list comprehensions in python3 that I've punted around.
https://stackoverflow.com/questions/36616739/python-how-can-i-run-eval-in-the-local-scope-of-a-function
https://stackoverflow.com/questions/53123062/scope-within-eval-in-list-comprehension-with-method

In the long run we should perhaps move away from `eval`. It seems that best practices are resoundingly against it.