### PR TITLE
WebIDL: Fix class string of null-prototype instance test

### DIFF
--- a/WebIDL/ecmascript-binding/class-string-iterator-prototype-object.any.js
+++ b/WebIDL/ecmascript-binding/class-string-iterator-prototype-object.any.js
@@ -39,6 +39,17 @@ test(() => {
   assert_equals(Object.prototype.toString.call(iterator), "[object Object]");
 }, "Object.prototype.toString applied to a null-prototype instance");
 
+test(t => {
+  const proto = Object.getPrototypeOf(iteratorProto);
+  t.add_cleanup(() => {
+    Object.setPrototypeOf(iteratorProto, proto);
+  });
+
+  Object.setPrototypeOf(iteratorProto, null);
+
+  assert_equals(Object.prototype.toString.call(iteratorProto), "[object URLSearchParams Iterator]");
+}, "Object.prototype.toString applied after nulling the prototype");
+
 // This test must be last.
 test(() => {
   delete iteratorProto[Symbol.toStringTag];

--- a/WebIDL/ecmascript-binding/class-string-iterator-prototype-object.any.js
+++ b/WebIDL/ecmascript-binding/class-string-iterator-prototype-object.any.js
@@ -31,16 +31,13 @@ test(t => {
 // was no @@toStringTag, it would fall back to a magic class string. This tests that the bug is
 // fixed.
 
-test(t => {
-  const proto = Object.getPrototypeOf(iteratorProto);
-  t.add_cleanup(() => {
-    Object.setPrototypeOf(iteratorProto, proto);
-  });
+test(() => {
+  const iterator = (new URLSearchParams()).keys();
+  assert_equals(Object.prototype.toString.call(iterator), "[object URLSearchParams Iterator]");
 
-  Object.setPrototypeOf(iteratorProto, null);
-
-  assert_equals(Object.prototype.toString.call(iteratorProto), "[object Object]");
-}, "Object.prototype.toString applied after nulling the prototype");
+  Object.setPrototypeOf(iterator, null);
+  assert_equals(Object.prototype.toString.call(iterator), "[object Object]");
+}, "Object.prototype.toString applied to a null-prototype instance");
 
 // This test must be last.
 test(() => {


### PR DESCRIPTION
Follow-up of #23140.
Spec: heycam/webidl#357.

_cc_ @domenic 