### PR TITLE
Add unicode tests for base64 decoding

### DIFF
--- a/fetch/data-urls/resources/base64.json
+++ b/fetch/data-urls/resources/base64.json
@@ -50,6 +50,8 @@
   ["abc=d", null],
   ["abc=d=", null],
   ["ab\u000Bcd", null],
+  ["ab\u3000cd", null],
+  ["ab\u3001cd", null],
   ["ab\tcd", [105, 183, 29]],
   ["ab\ncd", [105, 183, 29]],
   ["ab\fcd", [105, 183, 29]],


### PR DESCRIPTION
This change adds a unicode whitespace and a unicode
non-whitespace subtest.