### PR TITLE
Fix stash ID in //fetch/metadata/preload.https.sub.html

### DIFF
--- a/fetch/metadata/preload.https.sub.html
+++ b/fetch/metadata/preload.https.sub.html
@@ -12,7 +12,7 @@
 
   function create_test(host, as, expected) {
     async_test(t => {
-      let nonce = "{{uuid()}}";
+      let nonce = token();
       let key = as + nonce;
 
       let e = document.createElement('link');


### PR DESCRIPTION
`"{{uuid()}}"` is locked in when the page is generated, meaning that the generated
subtests were all using the same random string for their stash storage. Which was
dumb and my fault. This patch generates new stash IDs at runtime via `token()`.

h/t @jgraham in https://bugzilla.mozilla.org/show_bug.cgi?id=1635614.