### PR TITLE
[WebDriver] Add test for triple click

### DIFF
--- a/webdriver/tests/perform_actions/pointer_tripleclick.py
+++ b/webdriver/tests/perform_actions/pointer_tripleclick.py
@@ -8,6 +8,11 @@ lots_of_text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 
 
 
 def test_tripleclick_at_coordinates(session, mouse_chain):
+    """
+        This test does a triple click on a coordinate. On desktop platforms
+        this will select a paragraph. On mobile this will not have the same
+        desired outcome as taps are handled differently on mobile.
+    """
     session.url = inline("""<div>
           {}
         </div>""".format(lots_of_text))

--- a/webdriver/tests/perform_actions/pointer_tripleclick.py
+++ b/webdriver/tests/perform_actions/pointer_tripleclick.py
@@ -1,0 +1,31 @@
+from tests.perform_actions.support.refine import filter_dict, get_events
+from tests.support.asserts import assert_move_to_coordinates
+from tests.support.inline import inline
+
+lots_of_text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor "\
+               "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud "\
+               " exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+
+
+def test_tripleclick_at_coordinates(session, mouse_chain):
+    session.url = inline("""<div>
+          {}
+        </div>""".format(lots_of_text))
+    div = session.find.css("div", all=False)
+    div_rect = div.rect
+    div_centre = {
+        "x": div_rect["x"] + div_rect["width"]/2,
+        "y": div_rect["y"] + div_rect["height"]/2
+    }
+    mouse_chain \
+        .pointer_move(div_centre["x"], div_centre["y"]) \
+        .click() \
+        .pause(0) \
+        .click() \
+        .pause(0) \
+        .click() \
+        .perform()
+    
+    actual_text = session.execute_script("return document.getSelection().toString();")
+
+    assert lots_of_text == actual_text

--- a/webdriver/tests/perform_actions/pointer_tripleclick.py
+++ b/webdriver/tests/perform_actions/pointer_tripleclick.py
@@ -20,9 +20,7 @@ def test_tripleclick_at_coordinates(session, mouse_chain):
     mouse_chain \
         .pointer_move(div_centre["x"], div_centre["y"]) \
         .click() \
-        .pause(0) \
         .click() \
-        .pause(0) \
         .click() \
         .perform()
 

--- a/webdriver/tests/perform_actions/pointer_tripleclick.py
+++ b/webdriver/tests/perform_actions/pointer_tripleclick.py
@@ -25,7 +25,7 @@ def test_tripleclick_at_coordinates(session, mouse_chain):
         .pause(0) \
         .click() \
         .perform()
-    
+
     actual_text = session.execute_script("return document.getSelection().toString();")
 
     assert lots_of_text == actual_text


### PR DESCRIPTION
This test does a triple-click and then checks that the entire paragraph
has been selected.

This currently fails in all drivers.