### PR TITLE
Test the sourceText of event handlers

### DIFF
--- a/html/webappapis/scripting/events/event-handler-sourcetext.html
+++ b/html/webappapis/scripting/events/event-handler-sourcetext.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test the sourceText of event handlers</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/5500">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+test(() => {
+  const el = document.createElement("div");
+  el.setAttribute("onclick", "foo");
+  assert_equals(el.onclick.toString(), "function onclick(event) {\nfoo\n}");
+}, "non-error event handler");
+
+test(() => {
+  const el = document.createElement("div");
+  el.setAttribute("onerror", "foo");
+  assert_equals(el.onerror.toString(), "function onerror(event) {\nfoo\n}");
+}, "error event handler not on body");
+
+test(() => {
+  const el = document.createElement("body");
+  el.setAttribute("onerror", "foo");
+  assert_equals(el.onerror.toString(), "function onerror(event, source, lineno, colno, error) {\nfoo\n}");
+}, "error event handler on disconnected body");
+
+test(() => {
+  const el = document.createElement("frameset");
+  el.setAttribute("onerror", "foo");
+  assert_equals(el.onerror.toString(), "function onerror(event, source, lineno, colno, error) {\nfoo\n}");
+}, "error event handler on disconnected frameset");
+
+test(() => {
+  document.body.setAttribute("onerror", "foo");
+  assert_equals(window.onerror.toString(), "function onerror(event, source, lineno, colno, error) {\nfoo\n}");
+}, "error event handler on connected body, reflected to Window");
+</script>


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/5514.

Note that stable Chrome fails this but Chrome Canary passes this, since https://bugs.chromium.org/p/chromium/issues/detail?id=1077133 was recently fixed.