### PR TITLE
Add "quic" property to manifest and add "--include-quic" switch to wptrunner

### DIFF
--- a/docs/writing-tests/server-features.md
+++ b/docs/writing-tests/server-features.md
@@ -18,9 +18,11 @@ To make writing such tests possible, we are using a number of
 server-side components designed to make it easy to manipulate the
 precise details of the response:
 
-* *wptserve*, a custom Python HTTP server.
+* *wptserve*, a custom Python HTTP server
 
 * *pywebsocket*, an existing websockets server
+
+* *tools/quic*, a custom Python 3 QUIC server using `aioquic`
 
 wptserve is a Python-based web server. By default it serves static
 files in the test suite. For more sophisticated requirements, several
@@ -116,7 +118,8 @@ The server also provides the ability to write [Python
 data and can manipulate the content and timing of the response. Responses are
 also influenced by [the `pipe` query string parameter](server-pipes).
 
-### Writing tests for HTTP/2.0
+
+### Tests Requiring HTTP/2.0
 
 The server now has a prototype HTTP/2.0 server which gives you access to
 some of the HTTP/2.0 specific functionality. Currently, the server is off
@@ -126,4 +129,27 @@ API are documented in [Writing H2 Tests](h2tests).
 
 > <b>Important:</b> The HTTP/2.0 server requires you to have Python 2.7.10+
 and OpenSSL 1.0.2+. This is because HTTP/2.0 is negotiated using the
-[TLS ALPN](https://tools.ietf.org/html/rfc7301) extension, which is only supported in [OpenSSL 1.0.2](https://www.openssl.org/news/openssl-1.0.2-notes.html) and up.
+[TLS ALPN](https://tools.ietf.org/html/rfc7301) extension, which is only
+supported in
+[OpenSSL 1.0.2](https://www.openssl.org/news/openssl-1.0.2-notes.html) and up.
+
+
+### Tests Requiring QUIC
+
+We do not support loading a test over QUIC yet, but a test can establish a QUIC
+connection to the test server (e.g. for WebTransport, similar to WebSocket).
+Since the QUIC server is not yet enabled by default, tests must explicitly
+declare that they need access to the QUIC server:
+
+* For HTML tests (including testharness.js and reference tests), add the
+  following element:
+```html
+<meta name="quic" content="true">
+```
+* For JavaScript tests (auto-generated tests), add the following comment:
+```js
+// META: quic=true
+```
+
+The QUIC server is not yet enabled by default, so QUIC tests will be skipped
+unless `--enable-quic` is specified to `./wpt run`.

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -191,6 +191,11 @@ class TestharnessTest(URLManifestItem):
         return self._extras.get("jsshell")
 
     @property
+    def quic(self):
+        # type: () -> Optional[bool]
+        return self._extras.get("quic")
+
+    @property
     def script_metadata(self):
         # type: () -> Optional[Text]
         return self._extras.get("script_metadata")
@@ -204,6 +209,8 @@ class TestharnessTest(URLManifestItem):
             rv[-1]["testdriver"] = self.testdriver
         if self.jsshell:
             rv[-1]["jsshell"] = True
+        if self.quic is not None:
+            rv[-1]["quic"] = self.quic
         if self.script_metadata:
             rv[-1]["script_metadata"] = [(k.decode('utf8'), v.decode('utf8')) for (k,v) in self.script_metadata]
         return rv

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -675,6 +675,36 @@ class SourceFile(object):
         return bool(self.testdriver_nodes)
 
     @cached_property
+    def quic_nodes(self):
+        # type: () -> List[ElementTree.Element]
+        """List of ElementTree Elements corresponding to nodes in a test that
+        specify whether it needs QUIC server."""
+        assert self.root is not None
+        return self.root.findall(".//{http://www.w3.org/1999/xhtml}meta[@name='quic']")
+
+    @cached_property
+    def quic(self):
+        # type: () -> Optional[bool]
+        """Boolean indicating whether a test requires QUIC server
+
+        Determined by <meta> elements (`quic_nodes()`) and "// META" comments
+        (`script_metadata()`).
+        """
+        if self.script_metadata:
+            if any(m == (b"quic", b"true") for m in self.script_metadata):
+                return True
+
+        if self.root is None:
+            return None
+
+        if self.quic_nodes:
+            quic_str = self.quic_nodes[0].attrib.get("content", "false")  # type: Text
+            if quic_str.lower() == "true":
+                return True
+
+        return None
+
+    @cached_property
     def reftest_nodes(self):
         # type: () -> List[ElementTree.Element]
         """List of ElementTree Elements corresponding to nodes representing a
@@ -850,6 +880,7 @@ class SourceFile(object):
                     global_variant_url(self.rel_url, suffix) + variant,
                     timeout=self.timeout,
                     jsshell=jsshell,
+                    quic=self.quic,
                     script_metadata=self.script_metadata
                 )
                 for (suffix, jsshell) in sorted(global_suffixes(globals))
@@ -866,6 +897,7 @@ class SourceFile(object):
                     self.url_base,
                     test_url + variant,
                     timeout=self.timeout,
+                    quic=self.quic,
                     script_metadata=self.script_metadata
                 )
                 for variant in self.test_variants
@@ -881,6 +913,7 @@ class SourceFile(object):
                     self.url_base,
                     test_url + variant,
                     timeout=self.timeout,
+                    quic=self.quic,
                     script_metadata=self.script_metadata
                 )
                 for variant in self.test_variants
@@ -917,6 +950,7 @@ class SourceFile(object):
                     self.url_base,
                     url,
                     timeout=self.timeout,
+                    quic=self.quic,
                     testdriver=testdriver,
                     script_metadata=self.script_metadata
                 ))
@@ -930,6 +964,7 @@ class SourceFile(object):
                     self.rel_url,
                     references=self.references,
                     timeout=self.timeout,
+                    quic=self.quic,
                     viewport_size=self.viewport_size,
                     dpi=self.dpi,
                     fuzzy=self.fuzzy

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -53,7 +53,9 @@ class TestEnvironmentError(Exception):
 class TestEnvironment(object):
     """Context manager that owns the test environment i.e. the http and
     websockets servers"""
-    def __init__(self, test_paths, testharness_timeout_multipler, pause_after_test, debug_info, options, ssl_config, env_extras):
+    def __init__(self, test_paths, testharness_timeout_multipler,
+                 pause_after_test, debug_info, options, ssl_config, env_extras,
+                 enable_quic=False):
         self.test_paths = test_paths
         self.server = None
         self.config_ctx = None
@@ -69,6 +71,7 @@ class TestEnvironment(object):
         self.env_extras = env_extras
         self.env_extras_cms = None
         self.ssl_config = ssl_config
+        self.enable_quic = enable_quic
 
     def __enter__(self):
         self.config_ctx = self.build_config()
@@ -130,6 +133,8 @@ class TestEnvironment(object):
             "wss": [8889],
             "h2": [9000],
         }
+        if self.enable_quic:
+            config.ports["quic"] = [10000]
 
         if os.path.exists(override_path):
             with open(override_path) as f:

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -168,6 +168,7 @@ class TestLoader(object):
                  total_chunks=1,
                  chunk_number=1,
                  include_https=True,
+                 include_quic=False,
                  skip_timeout=False,
                  skip_implementation_status=None,
                  chunker_kwargs=None):
@@ -181,6 +182,7 @@ class TestLoader(object):
         self.tests = None
         self.disabled_tests = None
         self.include_https = include_https
+        self.include_quic = include_quic
         self.skip_timeout = skip_timeout
         self.skip_implementation_status = skip_implementation_status
 
@@ -266,6 +268,8 @@ class TestLoader(object):
         for test_path, test_type, test in self.iter_tests():
             enabled = not test.disabled()
             if not self.include_https and test.environment["protocol"] == "https":
+                enabled = False
+            if not self.include_quic and test.environment["quic"]:
                 enabled = False
             if self.skip_timeout and test.expected() == "TIMEOUT":
                 enabled = False

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -141,6 +141,10 @@ scheme host and port.""")
                                       action="append",
                                       choices=["not-implementing", "backlog", "implementing"],
                                       help="Skip tests that have the given implementation status")
+    # TODO: Remove this when QUIC is enabled by default.
+    test_selection_group.add_argument("--enable-quic", action="store_true", default=False,
+                                      help="Enable tests that require QUIC server (default: false)")
+
     test_selection_group.add_argument("--tag", action="append", dest="tags",
                                       help="Labels applied to tests to include in the run. "
                                            "Labels starting dir: are equivalent to top-level directories.")

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -78,6 +78,7 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, chunker_kw
                                         total_chunks=kwargs["total_chunks"],
                                         chunk_number=kwargs["this_chunk"],
                                         include_https=ssl_enabled,
+                                        include_quic=kwargs["enable_quic"],
                                         skip_timeout=kwargs["skip_timeout"],
                                         skip_implementation_status=kwargs["skip_implementation_status"],
                                         chunker_kwargs=chunker_kwargs)
@@ -211,7 +212,8 @@ def run_tests(config, test_paths, product, **kwargs):
                                  kwargs["debug_info"],
                                  product.env_options,
                                  ssl_config,
-                                 env_extras) as test_environment:
+                                 env_extras,
+                                 kwargs["enable_quic"]) as test_environment:
             recording.set(["startup", "ensure_environment"])
             try:
                 test_environment.ensure_started()


### PR DESCRIPTION
With these two changes, `./wpt run` can skip tests that require QUIC by default, unless `--include-quic` is given (tested manually using `--list-disabled`). The flag is also plumbed all the way to `TestEnvironment` and to `wpt serve` (via `config`). A future change in `wpt serve` will start the QUIC server based on this flag.

Probably easier to review the two commits separately.

RFC: https://github.com/web-platform-tests/rfcs/blob/master/rfcs/quic.md

Tracking issue: #19114