### PR TITLE
Fix //fetch/metadata/preload.https.sub.html

### DIFF
--- a/fetch/metadata/preload.https.sub.html
+++ b/fetch/metadata/preload.https.sub.html
@@ -22,7 +22,7 @@
       if (as !== undefined) {
         e.setAttribute("as", as);
       }
-      e.onload = e.onerror = t.step_func_done(e => {
+      e.onload = e.onerror = t.step_func(e => {
         fetch("/fetch/metadata/resources/record-header.py?retrieve=true&file=" + key)
           .then(t.step_func(response => response.text()))
           .then(t.step_func(text => assert_header_equals(text, expected)))

--- a/fetch/metadata/preload.https.sub.html
+++ b/fetch/metadata/preload.https.sub.html
@@ -25,7 +25,7 @@
       e.onload = e.onerror = t.step_func(e => {
         fetch("/fetch/metadata/resources/record-header.py?retrieve=true&file=" + key)
           .then(t.step_func(response => response.text()))
-          .then(t.step_func_done(text => assert_header_equals(text, expected)))
+          .then(t.step_func_done(text => assert_header_equals(text, expected, `preload ${as} ${host}`)))
           .catch(t.unreached_func());
       });
 

--- a/fetch/metadata/preload.https.sub.html
+++ b/fetch/metadata/preload.https.sub.html
@@ -25,8 +25,7 @@
       e.onload = e.onerror = t.step_func(e => {
         fetch("/fetch/metadata/resources/record-header.py?retrieve=true&file=" + key)
           .then(t.step_func(response => response.text()))
-          .then(t.step_func(text => assert_header_equals(text, expected)))
-          .then(t.step_func_done(_ => resolve()))
+          .then(t.step_func_done(text => assert_header_equals(text, expected)))
           .catch(t.unreached_func());
       });
 


### PR DESCRIPTION
We're currently exiting the test before `fetch()` resolves due to using
`step_func_done()` rather than `step_func()`.