### PR TITLE
Fix a dialog focus test that expects a wrong element to be focused

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/show-modal-focusing-steps.html
+++ b/html/semantics/interactive-elements/the-dialog-element/show-modal-focusing-steps.html
@@ -10,10 +10,11 @@ promise_test(() => {
         outerButton = document.getElementById('outer-button');
         assert_equals(document.activeElement, outerButton);
 
-        // Test that focus goes to body if the dialog has no focusable elements, including itself
+        // dialog element itself should be focused when no descendant
+        // element matches the requirements.
         var outerDialog = document.getElementById('outer-dialog');
         outerDialog.showModal();
-        assert_equals(document.activeElement, document.body);
+        assert_equals(document.activeElement, outerDialog);
 
         // Test that an autofocus element in the dialog gets focus.
         var dialog = document.getElementById('dialog');


### PR DESCRIPTION
Per spec, when there are no descendant elements that match
the requirement, the dialog element itself should be focused.

Please feel free to correct me if I am wrong here. 