### PR TITLE
[taskcluster] Fix unit tests

### DIFF
--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -43,10 +43,11 @@ def test_verify_payload():
     from tools.ci.tc.decision import decide
 
     create_task_schema = requests.get(
-        "https://raw.githubusercontent.com/taskcluster/taskcluster/blob/master/services/queue/schemas/v1/create-task-request.yml")
+        "https://raw.githubusercontent.com/taskcluster/taskcluster/master/services/queue/schemas/v1/create-task-request.yml")
     create_task_schema = yaml.safe_load(create_task_schema.content)
 
-    payload_schema = requests.get("https://raw.githubusercontent.com/taskcluster/docker-worker/master/schemas/v1/payload.json").json()
+    payload_schema = requests.get(
+        "https://raw.githubusercontent.com/taskcluster/taskcluster/master/workers/docker-worker/schemas/v1/payload.json").json()
 
     jobs = ["lint",
             "manifest_upload",

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -42,12 +42,13 @@ def test_verify_payload():
     """Verify that the decision task produces tasks with a valid payload"""
     from tools.ci.tc.decision import decide
 
-    create_task_schema = requests.get(
-        "https://raw.githubusercontent.com/taskcluster/taskcluster/master/services/queue/schemas/v1/create-task-request.yml")
-    create_task_schema = yaml.safe_load(create_task_schema.content)
+    r = requests.get("https://community-tc.services.mozilla.com/schemas/queue/v1/create-task-request.json")
+    r.raise_for_status()
+    create_task_schema = r.json()
 
-    payload_schema = requests.get(
-        "https://raw.githubusercontent.com/taskcluster/taskcluster/master/workers/docker-worker/schemas/v1/payload.json").json()
+    r = requests.get("https://raw.githubusercontent.com/taskcluster/taskcluster/master/workers/docker-worker/schemas/v1/payload.json")
+    r.raise_for_status()
+    payload_schema = r.json()
 
     jobs = ["lint",
             "manifest_upload",


### PR DESCRIPTION
Each of the two schemas has its own problem.

* `create-task-request`: this never worked. We tried to build the JSON schema ourselves from the YAML source without fetching the other included templates, which would produce an incomplete schema. However, we happened to use an incorrect URL (404) without checking the status code so we built an empty schema that would validate any valid JSON... Change to use the canonical, published schema instead.
* `docker-worker/.../payload.json`: the repository has been archived and merged into the main `taskcluster` monorepo. Fix the URL.