### PR TITLE
Fix module script referrer port

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html
@@ -13,18 +13,18 @@
 
 import { referrer as referrerSame } from "./resources/referrer-checker.py?name=same";
 
-import { referrer as referrerRemote } from "http://{{domains[www1]}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/module/resources/referrer-checker.py?name=remote";
+import { referrer as referrerRemote } from "http://{{domains[www1]}}:{{ports[http][1]}}/html/semantics/scripting-1/the-script-element/module/resources/referrer-checker.py?name=remote";
 
 import { referrer as referrerSameSame } from "./resources/import-referrer-checker.sub.js?name=same_same";
 
 import { referrer as referrerSameRemote } from "./resources/import-remote-origin-referrer-checker.sub.js?name=same_remote";
 
-import { referrer as referrerRemoteRemote } from "http://{{domains[www1]}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker.sub.js?name=remote_remote";
+import { referrer as referrerRemoteRemote } from "http://{{domains[www1]}}:{{ports[http][1]}}/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker.sub.js?name=remote_remote";
 
-import { referrer as referrerRemoteSame } from "http://{{domains[www1]}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/module/resources/import-same-origin-referrer-checker-from-remote-origin.sub.js?name=remote_same";
+import { referrer as referrerRemoteSame } from "http://{{domains[www1]}}:{{ports[http][1]}}/html/semantics/scripting-1/the-script-element/module/resources/import-same-origin-referrer-checker-from-remote-origin.sub.js?name=remote_same";
 
 const origin = (new URL(location.href)).origin + "/";
-const remoteOrigin = "http://{{domains[www1]}}:{{ports[http][0]}}/";
+const remoteOrigin = "http://{{domains[www1]}}:{{ports[http][1]}}/";
 
 test(t => {
   assert_equals(

--- a/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html
@@ -13,18 +13,18 @@
 
 import { referrer as referrerSame } from "./resources/referrer-checker.py?name=same";
 
-import { referrer as referrerRemote } from "http://{{domains[www1]}}:{{ports[http][1]}}/html/semantics/scripting-1/the-script-element/module/resources/referrer-checker.py?name=remote";
+import { referrer as referrerRemote } from "http://{{domains[www1]}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/module/resources/referrer-checker.py?name=remote";
 
 import { referrer as referrerSameSame } from "./resources/import-referrer-checker.sub.js?name=same_same";
 
 import { referrer as referrerSameRemote } from "./resources/import-remote-origin-referrer-checker.sub.js?name=same_remote";
 
-import { referrer as referrerRemoteRemote } from "http://{{domains[www1]}}:{{ports[http][1]}}/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker.sub.js?name=remote_remote";
+import { referrer as referrerRemoteRemote } from "http://{{domains[www1]}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker.sub.js?name=remote_remote";
 
-import { referrer as referrerRemoteSame } from "http://{{domains[www1]}}:{{ports[http][1]}}/html/semantics/scripting-1/the-script-element/module/resources/import-same-origin-referrer-checker-from-remote-origin.sub.js?name=remote_same";
+import { referrer as referrerRemoteSame } from "http://{{domains[www1]}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/module/resources/import-same-origin-referrer-checker-from-remote-origin.sub.js?name=remote_same";
 
 const origin = (new URL(location.href)).origin + "/";
-const remoteOrigin = "http://{{domains[www1]}}:{{ports[http][1]}}/";
+const remoteOrigin = new URL("http://{{domains[www1]}}:{{ports[http][0]}}/").origin + "/";
 
 test(t => {
   assert_equals(


### PR DESCRIPTION
The [`origin-when-cross-origin`](https://github.com/web-platform-tests/wpt/blob/master/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html) module script descendant test requires maintaining a variable `remoteOrigin`, whose value is the "cross-origin" origin that we're using to host remote-origin scripts for the test. It is initialized as:

> const remoteOrigin = "http://{{domains[www1]}}:{{ports[http][0]}}/";

The problematic bit is `ports[http][0]`. When running this locally, it is not port `80`, so tests such as [this one](https://github.com/web-platform-tests/wpt/blob/master/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html#L73-L78) report a referrer with a non-`80` port, and the comparison works.

However on sites like `wpt.live`, this test seems to fail (in Chrome, whose implementation is spec-conformant, and obviously in any browser that isn't). It is because `referrerOrigin` contains the port number `:80`, but the generated `Referer` from the browser never contains the port number `:80` if that's where the site is hosted. There are two solutions:

 - Definitely use a non-`80` port-number (which is what this PR does)
 - Detect if `{{ports[http][0]}} == 80`, and strip the `:80` from `referrerOrigin`
    - This seemed complex, so I didn't do it

Anne, do you know why browsers do not include `:80` in the `Referer`? I couldn't find it from an admittedly cursory search through Fetch and Referrer Policy.