### PR TITLE
[Azure Pipelines] tweak job and display names

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -81,7 +81,7 @@ jobs:
     name: test_jobs
     displayName: 'Run ./wpt test-jobs'
 
-- job: infrastructure_macOS
+- job: infrastructure_mac
   displayName: 'infrastructure/ tests: macOS'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_infrastructure']
@@ -114,7 +114,7 @@ jobs:
       artifactName: 'infrastructure'
     condition: always()
 
-- job: tools_unittest_macOS
+- job: tools_unittest_mac
   displayName: 'tools/ unittests: macOS'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
@@ -132,8 +132,8 @@ jobs:
       directory: tools/
       toxenv: py27
 
-- job: tools_unittest_macOS_py36
-  displayName: 'tools/ unittests: macOS (Python 3.6)'
+- job: tools_unittest_mac_py36
+  displayName: 'tools/ unittests: macOS + Python 3.6'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
@@ -148,8 +148,8 @@ jobs:
       directory: tools/
       toxenv: py36
 
-- job: tools_unittest_macOS_py38
-  displayName: 'tools/ unittests: macOS (Python 3.8)'
+- job: tools_unittest_mac_py38
+  displayName: 'tools/ unittests: macOS + Python 3.8'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
@@ -164,7 +164,7 @@ jobs:
       directory: tools/
       toxenv: py38
 
-- job: wptrunner_unittest_macOS
+- job: wptrunner_unittest_mac
   displayName: 'tools/wptrunner/ unittests: macOS'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
@@ -182,8 +182,8 @@ jobs:
       directory: tools/wptrunner/
       toxenv: py27
 
-- job: wptrunner_unittest_macOS_py36
-  displayName: 'tools/wptrunner/ unittests: macOS (Python 3.6)'
+- job: wptrunner_unittest_mac_py36
+  displayName: 'tools/wptrunner/ unittests: macOS + Python 3.6'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
@@ -198,8 +198,8 @@ jobs:
       directory: tools/wptrunner/
       toxenv: py36
 
-- job: wptrunner_unittest_macOS_py38
-  displayName: 'tools/wptrunner/ unittests: macOS (Python 3.8)'
+- job: wptrunner_unittest_mac_py38
+  displayName: 'tools/wptrunner/ unittests: macOS + Python 3.8'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
@@ -214,7 +214,7 @@ jobs:
       directory: tools/wptrunner/
       toxenv: py38
 
-- job: wpt_integration_macOS
+- job: wpt_integration_mac
   displayName: 'tools/wpt/ tests: macOS'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
@@ -236,8 +236,8 @@ jobs:
       directory: tools/wpt/
       toxenv: py27
 
-- job: wpt_integration_macOS_py36
-  displayName: 'tools/wpt/ tests: macOS (Python 3.6)'
+- job: wpt_integration_mac_py36
+  displayName: 'tools/wpt/ tests: macOS + Python 3.6'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
@@ -256,8 +256,8 @@ jobs:
       directory: tools/wpt/
       toxenv: py36
 
-- job: wpt_integration_macOS_py38
-  displayName: 'tools/wpt/ tests: macOS (Python 3.8)'
+- job: wpt_integratio_mac_py38
+  displayName: 'tools/wpt/ tests: macOS + Python 3.8'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
@@ -295,7 +295,7 @@ jobs:
       toxenv: py27
 
 - job: tools_unittest_win_py36
-  displayName: 'tools/ unittests: Windows (Python 3.6)'
+  displayName: 'tools/ unittests: Windows + Python 3.6'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
@@ -314,7 +314,7 @@ jobs:
       toxenv: py36
 
 - job: tools_unittest_win_py38
-  displayName: 'tools/ unittests: Windows (Python 3.8)'
+  displayName: 'tools/ unittests: Windows + Python 3.8'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
@@ -349,7 +349,7 @@ jobs:
       toxenv: py27
 
 - job: wptrunner_unittest_win_py36
-  displayName: 'tools/wptrunner/ unittests: Windows (Python 3.6)'
+  displayName: 'tools/wptrunner/ unittests: Windows + Python 3.6'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
@@ -366,7 +366,7 @@ jobs:
       toxenv: py36
 
 - job: wptrunner_unittest_win_py38
-  displayName: 'tools/wptrunner/ unittests: Windows (Python 3.8)'
+  displayName: 'tools/wptrunner/ unittests: Windows + Python 3.8'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
@@ -407,7 +407,7 @@ jobs:
       toxenv: py27
 
 - job: wpt_integration_win_py36
-  displayName: 'tools/wpt/ tests: Windows (Python 3.6)'
+  displayName: 'tools/wpt/ tests: Windows + Python 3.6'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
@@ -429,7 +429,7 @@ jobs:
       toxenv: py36
 
 - job: wpt_integration_win_py38
-  displayName: 'tools/wpt/ tests: Windows (Python 3.8)'
+  displayName: 'tools/wpt/ tests: Windows + Python 3.8'
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:


### PR DESCRIPTION
Non-lowercase macOS in the job names looks out of place now, so use _mac
to match _win.

Parenthesis in display names aren't great because in the GitHub Checks
API integration, the check name is "$pipelineName ($jobName)", leading
to check names like "Azure Pipelines (tools/ unittests: macOS (Python 3.6))".

(The pipeline name is indeed "Azure Pipelines".)