### PR TITLE
Strict referrer policy on insecure descendant script from secure module script

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/referrer-strict-policies.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/referrer-strict-policies.sub.html
@@ -9,7 +9,7 @@
 <body>
 <script type="module">
 
-// "name" parameter is necessary for bypassing the module map.
+// "name" parameter is necessary for bypassing the module map in descendant import.
 
 import { referrer as insecureImport } from "./resources/import-referrer-checker-insecure.sub.js?name=insecure_import";
 import { referrer as secureImport } from "https://{{domains[www]}}:{{ports[https][0]}}/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker-insecure.sub.js?name=secure_import";
@@ -20,16 +20,16 @@ test(t => {
   assert_equals(
       insecureImport, origin,
       "A document with the strict-origin referrer policy served over HTTP, " +
-      "imports an module script over HTTPS, that imports a descendant script " +
-      "over HTTP. The request for the descendant script is sent with no " +
-      "`Referer` header");
+      "imports an module script over HTTP, that imports a descendant script " +
+      "over HTTP. The request for the descendant script is sent with a " +
+      "`Referer` header with the page's origin");
 
   assert_equals(
       secureImport, "",
       "A document with the strict-origin referrer policy served over HTTP, " +
-      "imports an module script over HTTP, that imports a descendant script " +
-      "over HTTP. The request for the descendant script is sent with a " +
-      "`Referer` header with the page's origin");
+      "imports an module script over HTTPS, that imports a descendant script " +
+      "over HTTP. The request for the descendant script is sent with no " +
+      "`Referer` header");
 }, "The strict-* referrer policies compare the trustworthiness of a " +
    "request's referrer string against its URL");
 

--- a/html/semantics/scripting-1/the-script-element/module/referrer-strict-policies.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/referrer-strict-policies.sub.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Referrer with the strict-origin referrer policy</title>
+<meta name="referrer" content="strict-origin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script type="module">
+
+// "name" parameter is necessary for bypassing the module map.
+
+import { referrer as insecureImport } from "./resources/import-referrer-checker-insecure.sub.js?name=insecure_import";
+import { referrer as secureImport } from "https://{{domains[www]}}:{{ports[https][0]}}/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker-insecure.sub.js?name=secure_import";
+
+const origin = (new URL(location.href)).origin + "/";
+
+test(t => {
+  assert_equals(
+      insecureImport, origin,
+      "A document with the strict-origin referrer policy served over HTTP, " +
+      "imports an module script over HTTPS, that imports a descendant script " +
+      "over HTTP. The request for the descendant script is sent with no " +
+      "`Referer` header");
+
+  assert_equals(
+      secureImport, "",
+      "A document with the strict-origin referrer policy served over HTTP, " +
+      "imports an module script over HTTP, that imports a descendant script " +
+      "over HTTP. The request for the descendant script is sent with a " +
+      "`Referer` header with the page's origin");
+}, "The strict-* referrer policies compare the trustworthiness of a " +
+   "request's referrer string against its URL");
+
+</script>
+</body>
+</html>

--- a/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker-insecure.sub.js
+++ b/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker-insecure.sub.js
@@ -1,0 +1,2 @@
+import { referrer as referrerImport } from 'http://{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/module/resources/referrer-checker.py?name={{GET[name]}}';
+export const referrer = referrerImport;

--- a/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker-insecure.sub.js
+++ b/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker-insecure.sub.js
@@ -1,2 +1,1 @@
-import { referrer as referrerImport } from 'http://{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/module/resources/referrer-checker.py?name={{GET[name]}}';
-export const referrer = referrerImport;
+export { referrer } from 'http://{{host}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/module/resources/referrer-checker.py?name={{GET[name]}}';

--- a/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker-insecure.sub.js.headers
+++ b/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker-insecure.sub.js.headers
@@ -1,0 +1,1 @@
+Access-Control-Allow-Origin: *

--- a/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker.sub.js
+++ b/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker.sub.js
@@ -1,2 +1,1 @@
-import { referrer as referrerImport } from './referrer-checker.py?name={{GET[name]}}';
-export const referrer = referrerImport;
+export { referrer } from './referrer-checker.py?name={{GET[name]}}';

--- a/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker.sub.js
+++ b/html/semantics/scripting-1/the-script-element/module/resources/import-referrer-checker.sub.js
@@ -1,1 +1,2 @@
-export { referrer } from './referrer-checker.py?name={{GET[name]}}';
+import { referrer as referrerImport } from './referrer-checker.py?name={{GET[name]}}';
+export const referrer = referrerImport;


### PR DESCRIPTION
This adds a test for the second bullet point of https://github.com/w3c/webappsec-referrer-policy/pull/135#issue-416916261.