### PR TITLE
Update Safari Technology Preview to 106

### DIFF
--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask 'safari-technology-preview' do
   if MacOS.version <= :mojave
-    version '105,001-02874-20200422-3f38295f-da03-425d-9100-ae835120f1c7'
-    sha256 'ce15f783b3e46c0e1267196956d79ea416a14005b6f733c68be5104ea57da20e'
+    version '106,001-05966-20200513-86571be6-878e-411b-a5b9-65a971573fae'
+    sha256 '8518c8917a9172aeb75deeb61060d353229760fd54dc85bd38a0897cc1d12105'
   else
-    version '105,001-00430-20200422-c04186cc-77e2-42a7-a3c8-6881c4447f31'
-    sha256 '443675a62bbe054216129bdd5c91da57c18b3be6b61455ea16f27d35a9be7996'
+    version '106,001-05890-20200513-321a69b4-de58-440e-8182-8ac03d65f6ce'
+    sha256 'f3c073d9b60ff6d11f82abbc6cc131e5913e6d0f2a11f0968ae77db1b51e1e35'
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 106, 15610.1.12.2)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=1742&view=logs