### PR TITLE
[Azure Pipelines] drop the `sudo safaridriver --enable` workaround

### DIFF
--- a/tools/ci/azure/com.apple.Safari.plist
+++ b/tools/ci/azure/com.apple.Safari.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>AllowRemoteAutomation</key>
-	<true/>
-</dict>
-</plist>

--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -12,9 +12,6 @@ steps:
     displayName: 'Install Safari Technology Preview'
 - ${{ if eq(parameters.channel, 'stable') }}:
   - script: |
-      # Workaround for `sudo safardriver --enable` not working:
-      # https://github.com/web-platform-tests/wpt/issues/19845
-      mkdir -p ~/Library/WebDriver/
-      cp tools/ci/azure/com.apple.Safari.plist ~/Library/WebDriver/
+      sudo safaridriver --enable
       defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically 1
     displayName: 'Configure Safari'


### PR DESCRIPTION
This delightful workaround was added in https://github.com/web-platform-tests/wpt/pull/19846,
but is happily no longer needed.

See https://github.com/web-platform-tests/wpt/issues/19845.