### PR TITLE
Update test for registerProtocolHandler() to include otpauth

### DIFF
--- a/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol.https.html
+++ b/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol.https.html
@@ -108,6 +108,7 @@ test(() => {
   'moz-icon',
   'opera',
   'operamail',
+  'otpauth',
   'res',
   'resource',
   'shttp',


### PR DESCRIPTION
This adds otpauth as discussed in [whatwg/html#5551](https://github.com/whatwg/html/pull/5551)