### PR TITLE
html: Remove Promise.resolve in bailout-side-effects-ignore-opens-during-unload.window.html

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-ignore-opens-during-unload.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-side-effects-ignore-opens-during-unload.window.js
@@ -6,19 +6,11 @@ for (const ev of ["unload", "beforeunload", "pagehide"]) {
     t.add_cleanup(() => iframe.remove());
     iframe.src = "/common/blank.html";
     iframe.onload = t.step_func(() => {
-      iframe.contentWindow.addEventListener(ev, t.step_func(() => {
-        // Here, the entry settings object could still be the iframe's. Delay
-        // it in such a way that ensures the entry settings object is the
-        // top-level page's, but without delaying too much that the
-        // ignore-opens-during-unload counter becomes decremented. A microtask
-        // is perfect as it's executed immediately in "clean up after running
-        // script".
-        Promise.resolve().then(t.step_func_done(() => {
-          const origURL = iframe.contentDocument.URL;
-          assertDocumentIsReadyForSideEffectsTest(iframe.contentDocument, `ignore-opens-during-unload counter is greater than 0 during ${ev} event`);
-          assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
-          assertOpenHasNoSideEffects(iframe.contentDocument, origURL, `ignore-opens-during-unload counter is greater than 0 during ${ev} event`);
-        }));
+      iframe.contentWindow.addEventListener(ev, t.step_func_done(() => {
+        const origURL = iframe.contentDocument.URL;
+        assertDocumentIsReadyForSideEffectsTest(iframe.contentDocument, `ignore-opens-during-unload counter is greater than 0 during ${ev} event`);
+        assert_equals(iframe.contentDocument.open(), iframe.contentDocument);
+        assertOpenHasNoSideEffects(iframe.contentDocument, origURL, `ignore-opens-during-unload counter is greater than 0 during ${ev} event`);
       }));
       iframe.src = "about:blank";
     });


### PR DESCRIPTION
The call was originally to mitigate a Chrome bug involving incorrectly set entry realm, but it turns out to not actually work per spec. After this PR, Firefox and Chrome would both pass this test, as they have fixed their own respective issues.

Fixes: #14909