### PR TITLE
Rename variable to avoid mypy type error

### DIFF
--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -994,7 +994,7 @@ class SourceFile(object):
             cached_properties = self.__dict__["__cached_properties__"]
             for key in cached_properties:
                 if key in self.__dict__:
-                    del self.__dict__[str(key)]
+                    del self.__dict__[key]
             del self.__dict__["__cached_properties__"]
 
         return rv

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -993,7 +993,7 @@ class SourceFile(object):
         if drop_cached and "__cached_properties__" in self.__dict__:
             cached_properties = self.__dict__["__cached_properties__"]
             for key in cached_properties:
-                if str(key) in self.__dict__:
+                if key in self.__dict__:
                     del self.__dict__[str(key)]
             del self.__dict__["__cached_properties__"]
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -991,12 +991,10 @@ class SourceFile(object):
         self.items_cache = rv
 
         if drop_cached and "__cached_properties__" in self.__dict__:
-            # __cached_properties__ comes from the @cached_property decorator,
-            # and is a set filled with 'func.__name__', which are 'str' types.
-            cached_properties = self.__dict__["__cached_properties__"]  # type: Set[str]
-            for key in cached_properties:
-                if key in self.__dict__:
-                    del self.__dict__[key]
+            cached_properties = self.__dict__["__cached_properties__"]
+            for prop in cached_properties:
+                if prop in self.__dict__:
+                    del self.__dict__[prop]
             del self.__dict__["__cached_properties__"]
 
         return rv

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -991,7 +991,9 @@ class SourceFile(object):
         self.items_cache = rv
 
         if drop_cached and "__cached_properties__" in self.__dict__:
-            cached_properties = self.__dict__["__cached_properties__"]
+            # __cached_properties__ comes from the @cached_property decorator,
+            # and is a set filled with 'func.__name__', which are 'str' types.
+            cached_properties = self.__dict__["__cached_properties__"]  # type: Set[str]
             for key in cached_properties:
                 if key in self.__dict__:
                     del self.__dict__[key]


### PR DESCRIPTION
Reusing variables can cause a mypy type error (https://github.com/python/mypy/issues/1174).
This previously went unnoticed because the previous and current use of `key` was `str`, but in
https://github.com/web-platform-tests/wpt/pull/23644 the previous use was retyped to `Text`
and as such caused a unicode-vs-str type error in mypy.