### PR TITLE
Sync Mozilla CSS tests as of 2020-05-21

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
@@ -1,4 +1,3 @@
-
 == contain-paint-clip-001.html contain-paint-clip-001-ref.html
 == contain-paint-clip-002.html contain-paint-clip-002-ref.html
 == contain-paint-clip-003.html contain-paint-clip-003-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-004-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-004-ref.html
@@ -8,12 +8,10 @@
   <title>Reference: Testing percentage gap resolution in flex containers</title>
   <link rel="author" title="Mihir Iyer" href="mailto:miyer@mozilla.com">
   <meta charset="utf-8">
-</html>
   <style>
     .flexContainer {
       display: flex;
       border: 2px solid black;
-      row-gap: 20px;
       column-gap: 10px;
       align-content: start;
       justify-content: start;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-004.html
@@ -9,7 +9,9 @@
   <link rel="author" title="Mihir Iyer" href="mailto:miyer@mozilla.com">
   <link rel="help" href="https://drafts.csswg.org/css-align/#column-row-gap">
   <link rel="match" href="flexbox-column-row-gap-004-ref.html">
+  <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/5081">
   <meta charset="utf-8">
+  <meta name="assert" content="% row-gaps in a flexbox with indefinite block size are treated as 'normal'." />
   <style>
     .flexContainer {
       display: flex;

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
@@ -190,7 +190,7 @@
 == flexbox-mbp-horiz-002b.xhtml            flexbox-mbp-horiz-002-ref.xhtml
 == flexbox-mbp-horiz-002v.xhtml            flexbox-mbp-horiz-002-ref.xhtml
 == flexbox-mbp-horiz-003.xhtml             flexbox-mbp-horiz-003-ref.xhtml
-== flexbox-mbp-horiz-003v.xhtml            flexbox-mbp-horiz-003-ref.xhtml
+== flexbox-mbp-horiz-003v.xhtml flexbox-mbp-horiz-003-ref.xhtml
 == flexbox-mbp-horiz-003-reverse.xhtml     flexbox-mbp-horiz-003-reverse-ref.xhtml
 == flexbox-mbp-horiz-004.xhtml             flexbox-mbp-horiz-004-ref.xhtml
 


### PR DESCRIPTION
Sync Mozilla CSS tests as of https://hg.mozilla.org/mozilla-central/rev/2d00a1a6495c9b0350c4a7d601df64b49355e701 .

This contains changes from [bug 1639627](https://bugzilla.mozilla.org/show_bug.cgi?id=1639627) by @dholbert, reviewed by @aethanyc.