### PR TITLE
[ci/tc] Fix a unit test

### DIFF
--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -46,7 +46,9 @@ def test_verify_payload():
     r.raise_for_status()
     create_task_schema = r.json()
 
-    r = requests.get("https://raw.githubusercontent.com/taskcluster/taskcluster/master/workers/docker-worker/schemas/v1/payload.json")
+    # TODO(Hexcles): Change it to https://community-tc.services.mozilla.com/references/schemas/docker-worker/v1/payload.json
+    # after the next Community-TC release (see https://bugzilla.mozilla.org/show_bug.cgi?id=1639732)..
+    r = requests.get("https://raw.githubusercontent.com/taskcluster/taskcluster/3ed511ef9119da54fc093e976b7b5955874c9b54/workers/docker-worker/schemas/v1/payload.json")
     r.raise_for_status()
     payload_schema = r.json()
 

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -48,7 +48,9 @@ def test_verify_payload():
 
     # TODO(Hexcles): Change it to https://community-tc.services.mozilla.com/references/schemas/docker-worker/v1/payload.json
     # after the next Community-TC release (see https://bugzilla.mozilla.org/show_bug.cgi?id=1639732)..
-    r = requests.get("https://raw.githubusercontent.com/taskcluster/taskcluster/3ed511ef9119da54fc093e976b7b5955874c9b54/workers/docker-worker/schemas/v1/payload.json")
+    r = requests.get(
+        "https://raw.githubusercontent.com/taskcluster/taskcluster/"
+        "3ed511ef9119da54fc093e976b7b5955874c9b54/workers/docker-worker/schemas/v1/payload.json")
     r.raise_for_status()
     payload_schema = r.json()
 


### PR DESCRIPTION
The payload schema for docker-worker has been moved and will be released
officially in the next TC release. For now, pin it to a known good
version.