### PR TITLE
Exclude tentative files from the spec-link lint

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -467,6 +467,7 @@ def check_parsed(repo_root, path, f):
 
         if (source_file.type != "support" and
             not source_file.name_is_reference and
+            not source_file.name_is_tentative and
             not source_file.spec_links):
             return [rules.MissingLink.error(path)]
 

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -796,6 +796,20 @@ def test_css_missing_file_manual():
     ]
 
 
+def test_css_missing_file_tentative():
+    code = b"""\
+<html xmlns="http://www.w3.org/1999/xhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</html>
+"""
+
+    # The tentative flag covers tests that make assertions 'not yet required by
+    # any specification', so they need not have a specification link.
+    errors = check_file_contents("", "css/foo/bar.tentative.html", six.BytesIO(code))
+    assert not errors
+
+
 @pytest.mark.parametrize("filename", [
     "foo.worker.js",
     "foo.any.js",

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -409,11 +409,11 @@ class SourceFile(object):
 
     @property
     def name_is_tentative(self):
+        # type: () -> bool
         """Check if the file name matches the conditions for the file to be a
-        tentative file
+        tentative file.
 
         See https://web-platform-tests.org/writing-tests/file-names.html#test-features"""
-        # type: () -> bool
         return "tentative" in self.meta_flags
 
     @property

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -408,6 +408,15 @@ class SourceFile(object):
         return self.type_flag == "crash" or "crashtests" in self.dir_path.split(os.path.sep)
 
     @property
+    def name_is_tentative(self):
+        """Check if the file name matches the conditions for the file to be a
+        tentative file
+
+        See https://web-platform-tests.org/writing-tests/file-names.html#test-features"""
+        # type: () -> bool
+        return "tentative" in self.meta_flags
+
+    @property
     def markup_type(self):
         # type: () -> Optional[Text]
         """Return the type of markup contained in a file, based on its extension,

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -127,7 +127,7 @@ def test_name_is_tentative():
     assert s.name_is_tentative
 
     s = create("css/css-ui/appearance-revert-001.html")
-    assert not s._name_is_tentative
+    assert not s.name_is_tentative
 
 
 def test_worker():

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -122,6 +122,14 @@ def test_name_is_reference(rel_path):
     assert items(s) == []
 
 
+def test_name_is_tentative():
+    s = create("css/css-ui/appearance-revert-001.tentative.html")
+    assert s.name_is_tentative
+
+    s = create("css/css-ui/appearance-revert-001.html")
+    assert not s._name_is_tentative
+
+
 def test_worker():
     s = create("html/test.worker.js")
     assert not s.name_is_non_test


### PR DESCRIPTION
The tenative file flag 'indicates that a test makes assertions not yet
required by any specification, or in contradiction to some
specification'. As such, tests that have this file flag may not have a
specification section to link to, so they should be excluded.