### PR TITLE
Test both negotiated & non-negotiated datachannels

### DIFF
--- a/webrtc/RTCDataChannel-bufferedAmount.html
+++ b/webrtc/RTCDataChannel-bufferedAmount.html
@@ -62,20 +62,19 @@ const unicodeBuffer = Uint8Array.of(
   0xe4, 0xb8, 0x96, 0xe7, 0x95, 0x8c,
   0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd);
 
+for (const options of [{}, {negotiated: true, id: 0}]) {
+
+const datachannel = `${options.negotiated? "negotiated " : ""}datachannel`;
+
 /*
   Ensure .bufferedAmount is 0 initially for both sides.
  */
 promise_test(async (t) => {
-  const pc1 = new RTCPeerConnection();
-  const pc2 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
-
-  const [dc1, dc2] = await createDataChannelPair(pc1, pc2);
+  const [dc1, dc2] = await createDataChannelPair(t, options);
 
   assert_equals(dc1.bufferedAmount, 0, 'Expect bufferedAmount to be 0');
   assert_equals(dc2.bufferedAmount, 0, 'Expect bufferedAmount to be 0');
-}, 'bufferedAmount initial value should be 0 for both peers');
+}, `${datachannel} bufferedAmount initial value should be 0 for both peers`);
 
 /*
   6.2.  send()
@@ -86,12 +85,7 @@ promise_test(async (t) => {
           by the number of bytes needed to express data as UTF-8.
  */
 promise_test(async (t) => {
-  const pc1 = new RTCPeerConnection();
-  const pc2 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
-
-  const [dc1, dc2] = await createDataChannelPair(pc1, pc2);
+  const [dc1, dc2] = await createDataChannelPair(t, options);
 
   dc1.send(unicodeString);
   assert_equals(dc1.bufferedAmount, unicodeBuffer.byteLength,
@@ -100,7 +94,8 @@ promise_test(async (t) => {
   await awaitMessage(dc2);
   assert_equals(dc1.bufferedAmount, 0,
     'Expect sender bufferedAmount to be reduced after message is sent');
-}, 'bufferedAmount should increase to byte length of encoded unicode string sent');
+}, `${datachannel} bufferedAmount should increase to byte length of encoded` +
+   `unicode string sent`);
 
 /*
   6.2. send()
@@ -111,12 +106,7 @@ promise_test(async (t) => {
           ArrayBuffer in bytes.
  */
 promise_test(async (t) => {
-  const pc1 = new RTCPeerConnection();
-  const pc2 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
-
-  const [dc1, dc2] = await createDataChannelPair(pc1, pc2);
+  const [dc1, dc2] = await createDataChannelPair(t, options);
 
   dc1.send(helloBuffer.buffer);
   assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
@@ -125,7 +115,7 @@ promise_test(async (t) => {
   await awaitMessage(dc2);
   assert_equals(dc1.bufferedAmount, 0,
     'Expect sender bufferedAmount to be reduced after message is sent');
-}, 'bufferedAmount should increase to byte length of buffer sent');
+}, `${datachannel} bufferedAmount should increase to byte length of buffer sent`);
 
 /*
   6.2. send()
@@ -135,12 +125,7 @@ promise_test(async (t) => {
           the bufferedAmount attribute by the size of data, in bytes.
  */
 promise_test(async (t) => {
-  const pc1 = new RTCPeerConnection();
-  const pc2 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
-
-  const [dc1, dc2] = await createDataChannelPair(pc1, pc2);
+  const [dc1, dc2] = await createDataChannelPair(t, options);
 
   dc1.send(helloBlob);
   assert_equals(dc1.bufferedAmount, helloBlob.size,
@@ -149,28 +134,21 @@ promise_test(async (t) => {
   await awaitMessage(dc2);
   assert_equals(dc1.bufferedAmount, 0,
     'Expect sender bufferedAmount to be reduced after message is sent');
-}, 'bufferedAmount should increase to size of blob sent');
+}, `${datachannel} bufferedAmount should increase to size of blob sent`);
 
 // Test sending 3 messages: helloBuffer, unicodeString, helloBlob
 promise_test(async (t) => {
   const resolver = new Resolver();
-  const pc1 = new RTCPeerConnection();
-  const pc2 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
-
   let messageCount = 0;
 
-  const [dc1, dc2] = await createDataChannelPair(pc1, pc2);
-  const onMessage = t.step_func(() => {
+  const [dc1, dc2] = await createDataChannelPair(t, options);
+  dc2.onmessage = t.step_func(() => {
     if (++messageCount === 3) {
       assert_equals(dc1.bufferedAmount, 0,
         'Expect sender bufferedAmount to be reduced after message is sent');
       resolver.resolve();
     }
   });
-
-  dc2.addEventListener('message', onMessage);
 
   dc1.send(helloBuffer);
   assert_equals(dc1.bufferedAmount, helloString.length,
@@ -187,15 +165,10 @@ promise_test(async (t) => {
     'Expect bufferedAmount to be the total length of all messages queued to send');
 
   await resolver;
-}, 'bufferedAmount should increase by byte length for each message sent');
+}, `${datachannel} bufferedAmount should increase by byte length for each message sent`);
 
 promise_test(async (t) => {
-  const pc1 = new RTCPeerConnection();
-  const pc2 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
-
-  const [dc1] = await createDataChannelPair(pc1, pc2);
+  const [dc1] = await createDataChannelPair(t, options);
 
   dc1.send(helloBuffer.buffer);
   assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
@@ -204,15 +177,12 @@ promise_test(async (t) => {
   dc1.close();
   assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
     'Expect bufferedAmount to not decrease immediately after closing the channel');
-}, 'bufferedAmount should not decrease immediately after initiating closure');
+}, `${datachannel} bufferedAmount should not decrease immediately after initiating closure`);
 
 promise_test(async (t) => {
   const pc1 = new RTCPeerConnection();
-  const pc2 = new RTCPeerConnection();
   t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
-
-  const [dc1] = await createDataChannelPair(pc1, pc2);
+  const [dc1] = await createDataChannelPair(t, options, pc1);
 
   dc1.send(helloBuffer.buffer);
   assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
@@ -221,36 +191,35 @@ promise_test(async (t) => {
   pc1.close();
   assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
     'Expect bufferedAmount to not decrease after closing the peer connection');
-}, 'bufferedAmount should not decrease after closing the peer connection');
+}, `${datachannel} bufferedAmount should not decrease after closing the peer connection`);
 
   promise_test(async t => {
-    const [channel1, channel2] = await createDataChannelPair();
+    const [channel1, channel2] = await createDataChannelPair(t, options);
     channel1.addEventListener('bufferedamountlow', t.step_func_done(() => {
       assert_true(channel1.bufferedAmount <= channel1.bufferedAmountLowThreshold);
     }));
     const eventWatcher = new EventWatcher(t, channel1, ['bufferedamountlow']);
     channel1.send(helloString);
     await eventWatcher.wait_for(['bufferedamountlow']);
-  }, 'Data channel bufferedamountlow event fires after send() is complete');
+  }, `${datachannel} bufferedamountlow event fires after send() is complete`);
 
   promise_test(async t => {
-    const [channel1, channel2] = await createDataChannelPair();
+    const [channel1, channel2] = await createDataChannelPair(t, options);
     channel1.send(helloString);
     assert_equals(channel1.bufferedAmount, helloString.length);
     await awaitMessage(channel2);
     assert_equals(channel1.bufferedAmount, 0);
-  }, 'Data channel bufferedamount is data.length on send(data)');
+  }, `${datachannel} bufferedamount is data.length on send(data)`);
 
   promise_test(async t => {
-    const [channel1, channel2] = await createDataChannelPair();
+    const [channel1, channel2] = await createDataChannelPair(t, options);
     channel1.send(helloString);
     assert_equals(channel1.bufferedAmount, helloString.length);
     assert_equals(channel1.bufferedAmount, helloString.length);
-  }, 'Data channel bufferedamount returns the same amount if no more data is' +
-     ' sent on the channel');
+  }, `${datachannel} bufferedamount returns the same amount if no more data is`);
 
   promise_test(async t => {
-    const [channel1, channel2] = await createDataChannelPair();
+    const [channel1, channel2] = await createDataChannelPair(t, options);
     let eventFireCount = 0;
     channel1.addEventListener('bufferedamountlow', t.step_func(() => {
       assert_true(channel1.bufferedAmount <= channel1.bufferedAmountLowThreshold);
@@ -262,11 +231,11 @@ promise_test(async (t) => {
     channel1.send(helloString);
     assert_equals(channel1.bufferedAmount, 2 * helloString.length);
     await eventWatcher.wait_for(['bufferedamountlow']);
-  }, 'Data channel bufferedamountlow event fires only once after multiple' +
-    ' consecutive send() calls');
+  }, `${datachannel} bufferedamountlow event fires only once after multiple` +
+     ` consecutive send() calls`);
 
   promise_test(async t => {
-    const [channel1, channel2] = await createDataChannelPair();
+    const [channel1, channel2] = await createDataChannelPair(t, options);
     const eventWatcher = new EventWatcher(t, channel1, ['bufferedamountlow']);
     channel1.send(helloString);
     assert_equals(channel1.bufferedAmount, helloString.length);
@@ -276,6 +245,6 @@ promise_test(async (t) => {
     assert_equals(channel1.bufferedAmount, helloString.length);
     await eventWatcher.wait_for(['bufferedamountlow']);
     assert_equals(await awaitMessage(channel2), helloString);
-  }, 'Data channel bufferedamountlow event fires after each sent message');
-
+  }, `${datachannel} bufferedamountlow event fires after each sent message`);
+}
 </script>

--- a/webrtc/RTCDataChannel-bufferedAmount.html
+++ b/webrtc/RTCDataChannel-bufferedAmount.html
@@ -63,135 +63,134 @@ const unicodeBuffer = Uint8Array.of(
   0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd);
 
 for (const options of [{}, {negotiated: true, id: 0}]) {
+  const mode = `${options.negotiated? "negotiated " : ""}datachannel`;
 
-const datachannel = `${options.negotiated? "negotiated " : ""}datachannel`;
+  /*
+    Ensure .bufferedAmount is 0 initially for both sides.
+   */
+  promise_test(async (t) => {
+    const [dc1, dc2] = await createDataChannelPair(t, options);
 
-/*
-  Ensure .bufferedAmount is 0 initially for both sides.
- */
-promise_test(async (t) => {
-  const [dc1, dc2] = await createDataChannelPair(t, options);
+    assert_equals(dc1.bufferedAmount, 0, 'Expect bufferedAmount to be 0');
+    assert_equals(dc2.bufferedAmount, 0, 'Expect bufferedAmount to be 0');
+  }, `${mode} bufferedAmount initial value should be 0 for both peers`);
 
-  assert_equals(dc1.bufferedAmount, 0, 'Expect bufferedAmount to be 0');
-  assert_equals(dc2.bufferedAmount, 0, 'Expect bufferedAmount to be 0');
-}, `${datachannel} bufferedAmount initial value should be 0 for both peers`);
+  /*
+    6.2.  send()
+      3.  Execute the sub step that corresponds to the type of the methods argument:
 
-/*
-  6.2.  send()
-    3.  Execute the sub step that corresponds to the type of the methods argument:
+          string object
+            Let data be the object and increase the bufferedAmount attribute
+            by the number of bytes needed to express data as UTF-8.
+   */
+  promise_test(async (t) => {
+    const [dc1, dc2] = await createDataChannelPair(t, options);
 
-        string object
-          Let data be the object and increase the bufferedAmount attribute
-          by the number of bytes needed to express data as UTF-8.
- */
-promise_test(async (t) => {
-  const [dc1, dc2] = await createDataChannelPair(t, options);
+    dc1.send(unicodeString);
+    assert_equals(dc1.bufferedAmount, unicodeBuffer.byteLength,
+      'Expect bufferedAmount to be the byte length of the unicode string');
 
-  dc1.send(unicodeString);
-  assert_equals(dc1.bufferedAmount, unicodeBuffer.byteLength,
-    'Expect bufferedAmount to be the byte length of the unicode string');
+    await awaitMessage(dc2);
+    assert_equals(dc1.bufferedAmount, 0,
+      'Expect sender bufferedAmount to be reduced after message is sent');
+  }, `${mode} bufferedAmount should increase to byte length of encoded` +
+     `unicode string sent`);
 
-  await awaitMessage(dc2);
-  assert_equals(dc1.bufferedAmount, 0,
-    'Expect sender bufferedAmount to be reduced after message is sent');
-}, `${datachannel} bufferedAmount should increase to byte length of encoded` +
-   `unicode string sent`);
+  /*
+    6.2. send()
+      3.  Execute the sub step that corresponds to the type of the methods argument:
+          ArrayBuffer object
+            Let data be the data stored in the buffer described by the ArrayBuffer
+            object and increase the bufferedAmount attribute by the length of the
+            ArrayBuffer in bytes.
+   */
+  promise_test(async (t) => {
+    const [dc1, dc2] = await createDataChannelPair(t, options);
 
-/*
-  6.2. send()
-    3.  Execute the sub step that corresponds to the type of the methods argument:
-        ArrayBuffer object
-          Let data be the data stored in the buffer described by the ArrayBuffer
-          object and increase the bufferedAmount attribute by the length of the
-          ArrayBuffer in bytes.
- */
-promise_test(async (t) => {
-  const [dc1, dc2] = await createDataChannelPair(t, options);
+    dc1.send(helloBuffer.buffer);
+    assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
+      'Expect bufferedAmount to increase to byte length of sent buffer');
 
-  dc1.send(helloBuffer.buffer);
-  assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
-    'Expect bufferedAmount to increase to byte length of sent buffer');
+    await awaitMessage(dc2);
+    assert_equals(dc1.bufferedAmount, 0,
+      'Expect sender bufferedAmount to be reduced after message is sent');
+  }, `${mode} bufferedAmount should increase to byte length of buffer sent`);
 
-  await awaitMessage(dc2);
-  assert_equals(dc1.bufferedAmount, 0,
-    'Expect sender bufferedAmount to be reduced after message is sent');
-}, `${datachannel} bufferedAmount should increase to byte length of buffer sent`);
+  /*
+    6.2. send()
+      3.  Execute the sub step that corresponds to the type of the methods argument:
+          Blob object
+            Let data be the raw data represented by the Blob object and increase
+            the bufferedAmount attribute by the size of data, in bytes.
+   */
+  promise_test(async (t) => {
+    const [dc1, dc2] = await createDataChannelPair(t, options);
 
-/*
-  6.2. send()
-    3.  Execute the sub step that corresponds to the type of the methods argument:
-        Blob object
-          Let data be the raw data represented by the Blob object and increase
-          the bufferedAmount attribute by the size of data, in bytes.
- */
-promise_test(async (t) => {
-  const [dc1, dc2] = await createDataChannelPair(t, options);
+    dc1.send(helloBlob);
+    assert_equals(dc1.bufferedAmount, helloBlob.size,
+      'Expect bufferedAmount to increase to size of sent blob');
 
-  dc1.send(helloBlob);
-  assert_equals(dc1.bufferedAmount, helloBlob.size,
-    'Expect bufferedAmount to increase to size of sent blob');
+    await awaitMessage(dc2);
+    assert_equals(dc1.bufferedAmount, 0,
+      'Expect sender bufferedAmount to be reduced after message is sent');
+  }, `${mode} bufferedAmount should increase to size of blob sent`);
 
-  await awaitMessage(dc2);
-  assert_equals(dc1.bufferedAmount, 0,
-    'Expect sender bufferedAmount to be reduced after message is sent');
-}, `${datachannel} bufferedAmount should increase to size of blob sent`);
+  // Test sending 3 messages: helloBuffer, unicodeString, helloBlob
+  promise_test(async (t) => {
+    const resolver = new Resolver();
+    let messageCount = 0;
 
-// Test sending 3 messages: helloBuffer, unicodeString, helloBlob
-promise_test(async (t) => {
-  const resolver = new Resolver();
-  let messageCount = 0;
+    const [dc1, dc2] = await createDataChannelPair(t, options);
+    dc2.onmessage = t.step_func(() => {
+      if (++messageCount === 3) {
+        assert_equals(dc1.bufferedAmount, 0,
+          'Expect sender bufferedAmount to be reduced after message is sent');
+        resolver.resolve();
+      }
+    });
 
-  const [dc1, dc2] = await createDataChannelPair(t, options);
-  dc2.onmessage = t.step_func(() => {
-    if (++messageCount === 3) {
-      assert_equals(dc1.bufferedAmount, 0,
-        'Expect sender bufferedAmount to be reduced after message is sent');
-      resolver.resolve();
-    }
-  });
+    dc1.send(helloBuffer);
+    assert_equals(dc1.bufferedAmount, helloString.length,
+      'Expect bufferedAmount to be the total length of all messages queued to send');
 
-  dc1.send(helloBuffer);
-  assert_equals(dc1.bufferedAmount, helloString.length,
-    'Expect bufferedAmount to be the total length of all messages queued to send');
+    dc1.send(unicodeString);
+    assert_equals(dc1.bufferedAmount,
+      helloString.length + unicodeBuffer.byteLength,
+      'Expect bufferedAmount to be the total length of all messages queued to send');
 
-  dc1.send(unicodeString);
-  assert_equals(dc1.bufferedAmount,
-    helloString.length + unicodeBuffer.byteLength,
-    'Expect bufferedAmount to be the total length of all messages queued to send');
+    dc1.send(helloBlob);
+    assert_equals(dc1.bufferedAmount,
+      helloString.length*2 + unicodeBuffer.byteLength,
+      'Expect bufferedAmount to be the total length of all messages queued to send');
 
-  dc1.send(helloBlob);
-  assert_equals(dc1.bufferedAmount,
-    helloString.length*2 + unicodeBuffer.byteLength,
-    'Expect bufferedAmount to be the total length of all messages queued to send');
+    await resolver;
+  }, `${mode} bufferedAmount should increase by byte length for each message sent`);
 
-  await resolver;
-}, `${datachannel} bufferedAmount should increase by byte length for each message sent`);
+  promise_test(async (t) => {
+    const [dc1] = await createDataChannelPair(t, options);
 
-promise_test(async (t) => {
-  const [dc1] = await createDataChannelPair(t, options);
+    dc1.send(helloBuffer.buffer);
+    assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
+      'Expect bufferedAmount to increase to byte length of sent buffer');
 
-  dc1.send(helloBuffer.buffer);
-  assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
-    'Expect bufferedAmount to increase to byte length of sent buffer');
+    dc1.close();
+    assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
+      'Expect bufferedAmount to not decrease immediately after closing the channel');
+  }, `${mode} bufferedAmount should not decrease immediately after initiating closure`);
 
-  dc1.close();
-  assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
-    'Expect bufferedAmount to not decrease immediately after closing the channel');
-}, `${datachannel} bufferedAmount should not decrease immediately after initiating closure`);
+  promise_test(async (t) => {
+    const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    const [dc1] = await createDataChannelPair(t, options, pc1);
 
-promise_test(async (t) => {
-  const pc1 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  const [dc1] = await createDataChannelPair(t, options, pc1);
+    dc1.send(helloBuffer.buffer);
+    assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
+      'Expect bufferedAmount to increase to byte length of sent buffer');
 
-  dc1.send(helloBuffer.buffer);
-  assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
-    'Expect bufferedAmount to increase to byte length of sent buffer');
-
-  pc1.close();
-  assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
-    'Expect bufferedAmount to not decrease after closing the peer connection');
-}, `${datachannel} bufferedAmount should not decrease after closing the peer connection`);
+    pc1.close();
+    assert_equals(dc1.bufferedAmount, helloBuffer.byteLength,
+      'Expect bufferedAmount to not decrease after closing the peer connection');
+  }, `${mode} bufferedAmount should not decrease after closing the peer connection`);
 
   promise_test(async t => {
     const [channel1, channel2] = await createDataChannelPair(t, options);
@@ -201,7 +200,7 @@ promise_test(async (t) => {
     const eventWatcher = new EventWatcher(t, channel1, ['bufferedamountlow']);
     channel1.send(helloString);
     await eventWatcher.wait_for(['bufferedamountlow']);
-  }, `${datachannel} bufferedamountlow event fires after send() is complete`);
+  }, `${mode} bufferedamountlow event fires after send() is complete`);
 
   promise_test(async t => {
     const [channel1, channel2] = await createDataChannelPair(t, options);
@@ -209,14 +208,14 @@ promise_test(async (t) => {
     assert_equals(channel1.bufferedAmount, helloString.length);
     await awaitMessage(channel2);
     assert_equals(channel1.bufferedAmount, 0);
-  }, `${datachannel} bufferedamount is data.length on send(data)`);
+  }, `${mode} bufferedamount is data.length on send(data)`);
 
   promise_test(async t => {
     const [channel1, channel2] = await createDataChannelPair(t, options);
     channel1.send(helloString);
     assert_equals(channel1.bufferedAmount, helloString.length);
     assert_equals(channel1.bufferedAmount, helloString.length);
-  }, `${datachannel} bufferedamount returns the same amount if no more data is`);
+  }, `${mode} bufferedamount returns the same amount if no more data is`);
 
   promise_test(async t => {
     const [channel1, channel2] = await createDataChannelPair(t, options);
@@ -231,7 +230,7 @@ promise_test(async (t) => {
     channel1.send(helloString);
     assert_equals(channel1.bufferedAmount, 2 * helloString.length);
     await eventWatcher.wait_for(['bufferedamountlow']);
-  }, `${datachannel} bufferedamountlow event fires only once after multiple` +
+  }, `${mode} bufferedamountlow event fires only once after multiple` +
      ` consecutive send() calls`);
 
   promise_test(async t => {
@@ -245,6 +244,6 @@ promise_test(async (t) => {
     assert_equals(channel1.bufferedAmount, helloString.length);
     await eventWatcher.wait_for(['bufferedamountlow']);
     assert_equals(await awaitMessage(channel2), helloString);
-  }, `${datachannel} bufferedamountlow event fires after each sent message`);
+  }, `${mode} bufferedamountlow event fires after each sent message`);
 }
 </script>

--- a/webrtc/RTCDataChannel-close.html
+++ b/webrtc/RTCDataChannel-close.html
@@ -9,95 +9,92 @@
 'use strict';
 
 for (const options of [{}, {negotiated: true, id: 0}]) {
+  const mode = `${options.negotiated? "negotiated " : ""}datachannel`;
 
-const datachannel = `${options.negotiated? "negotiated " : ""}datachannel`;
-
-promise_test(async t => {
-  const [channel1, channel2] = await createDataChannelPair(t, options);
-  const haveClosed = new Promise(r => channel2.onclose = r);
-  let closingSeen = false;
-  channel1.onclosing = t.unreached_func();
-  channel2.onclosing = () => {
-    assert_equals(channel2.readyState, 'closing');
-    closingSeen = true;
-  };
-  channel2.addEventListener('error', t.unreached_func());
-  channel1.close();
-  await haveClosed;
-  assert_equals(channel2.readyState, 'closed');
-  assert_true(closingSeen, 'Closing event was seen');
-}, `Close ${datachannel} causes onclosing and onclose to be called`);
-
-promise_test(async t => {
-  // This is the same test as above, but using addEventListener
-  // rather than the "onclose" attribute.
-  const [channel1, channel2] = await createDataChannelPair(t, options);
-  const haveClosed = new Promise(r => channel2.addEventListener('close', r));
-  let closingSeen = false;
-  channel1.addEventListener('closing', t.unreached_func());
-  channel2.addEventListener('closing', () => {
-    assert_equals(channel2.readyState, 'closing');
-    closingSeen = true;
-  });
-  channel2.addEventListener('error', t.unreached_func());
-  channel1.close();
-  await haveClosed;
-  assert_equals(channel2.readyState, 'closed');
-  assert_true(closingSeen, 'Closing event was seen');
-}, `Close ${datachannel} causes closing and close event to be called`);
-
-promise_test(async t => {
-  const pc1 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  const [channel1, channel2] = await createDataChannelPair(t, options, pc1);
-  const events = [];
-  let error = null;
-  channel2.addEventListener('error', t.step_func(event => {
-    events.push('error');
-    assert_true(event instanceof RTCErrorEvent);
-    error = event.error;
-  }));
-  const haveClosed = new Promise(r => channel2.addEventListener('close', () => {
-    events.push('close');
-    r();
-  }));
-  pc1.close();
-  await haveClosed;
-  // Error should fire before close.
-  assert_array_equals(events, ['error', 'close']);
-  assert_true(error instanceof RTCError);
-  assert_equals(error.name, 'OperationError');
-}, `Close peerconnection causes close event and error to be called on ${datachannel}`);
-
-promise_test(async t => {
-  let pc1 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  let [channel1, channel2] = await createDataChannelPair(t, options, pc1);
-  // The expected sequence of events when closing a DC is that
-  // channel1 goes to closing, channel2 fires onclose, and when
-  // the close is confirmed, channel1 fires onclose.
-  // After that, no more events should fire.
-  channel1.onerror = t.unreached_func();
-  let close2Handler = new Promise(resolve => {
-    channel2.onclose = event => {
-      resolve();
+  promise_test(async t => {
+    const [channel1, channel2] = await createDataChannelPair(t, options);
+    const haveClosed = new Promise(r => channel2.onclose = r);
+    let closingSeen = false;
+    channel1.onclosing = t.unreached_func();
+    channel2.onclosing = () => {
+      assert_equals(channel2.readyState, 'closing');
+      closingSeen = true;
     };
-  });
-  let close1Handler = new Promise(resolve => {
-    channel1.onclose = event => {
-      resolve();
-    };
-  });
-  channel1.close();
-  await close2Handler;
-  await close1Handler;
-  channel1.onclose = t.unreached_func();
-  channel2.onclose = t.unreached_func();
-  channel2.onerror = t.unreached_func();
-  pc1.close();
-  await new Promise(resolve => t.step_timeout(resolve, 10));
-}, `Close peerconnection after ${datachannel} close causes no events`);
+    channel2.addEventListener('error', t.unreached_func());
+    channel1.close();
+    await haveClosed;
+    assert_equals(channel2.readyState, 'closed');
+    assert_true(closingSeen, 'Closing event was seen');
+  }, `Close ${mode} causes onclosing and onclose to be called`);
 
+  promise_test(async t => {
+    // This is the same test as above, but using addEventListener
+    // rather than the "onclose" attribute.
+    const [channel1, channel2] = await createDataChannelPair(t, options);
+    const haveClosed = new Promise(r => channel2.addEventListener('close', r));
+    let closingSeen = false;
+    channel1.addEventListener('closing', t.unreached_func());
+    channel2.addEventListener('closing', () => {
+      assert_equals(channel2.readyState, 'closing');
+      closingSeen = true;
+    });
+    channel2.addEventListener('error', t.unreached_func());
+    channel1.close();
+    await haveClosed;
+    assert_equals(channel2.readyState, 'closed');
+    assert_true(closingSeen, 'Closing event was seen');
+  }, `Close ${mode} causes closing and close event to be called`);
+
+  promise_test(async t => {
+    const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    const [channel1, channel2] = await createDataChannelPair(t, options, pc1);
+    const events = [];
+    let error = null;
+    channel2.addEventListener('error', t.step_func(event => {
+      events.push('error');
+      assert_true(event instanceof RTCErrorEvent);
+      error = event.error;
+    }));
+    const haveClosed = new Promise(r => channel2.addEventListener('close', () => {
+      events.push('close');
+      r();
+    }));
+    pc1.close();
+    await haveClosed;
+    // Error should fire before close.
+    assert_array_equals(events, ['error', 'close']);
+    assert_true(error instanceof RTCError);
+    assert_equals(error.name, 'OperationError');
+  }, `Close peerconnection causes close event and error to be called on ${mode}`);
+
+  promise_test(async t => {
+    let pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    let [channel1, channel2] = await createDataChannelPair(t, options, pc1);
+    // The expected sequence of events when closing a DC is that
+    // channel1 goes to closing, channel2 fires onclose, and when
+    // the close is confirmed, channel1 fires onclose.
+    // After that, no more events should fire.
+    channel1.onerror = t.unreached_func();
+    let close2Handler = new Promise(resolve => {
+      channel2.onclose = event => {
+        resolve();
+      };
+    });
+    let close1Handler = new Promise(resolve => {
+      channel1.onclose = event => {
+        resolve();
+      };
+    });
+    channel1.close();
+    await close2Handler;
+    await close1Handler;
+    channel1.onclose = t.unreached_func();
+    channel2.onclose = t.unreached_func();
+    channel2.onerror = t.unreached_func();
+    pc1.close();
+    await new Promise(resolve => t.step_timeout(resolve, 10));
+  }, `Close peerconnection after ${mode} close causes no events`);
 }
-
 </script>

--- a/webrtc/RTCDataChannel-close.html
+++ b/webrtc/RTCDataChannel-close.html
@@ -8,10 +8,12 @@
 <script>
 'use strict';
 
+for (const options of [{}, {negotiated: true, id: 0}]) {
+
+const datachannel = `${options.negotiated? "negotiated " : ""}datachannel`;
+
 promise_test(async t => {
-  const pc1 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  const [channel1, channel2] = await createDataChannelPair(pc1);
+  const [channel1, channel2] = await createDataChannelPair(t, options);
   const haveClosed = new Promise(r => channel2.onclose = r);
   let closingSeen = false;
   channel1.onclosing = t.unreached_func();
@@ -24,14 +26,12 @@ promise_test(async t => {
   await haveClosed;
   assert_equals(channel2.readyState, 'closed');
   assert_true(closingSeen, 'Closing event was seen');
-}, 'Close datachannel causes onclosing and onclose to be called');
+}, `Close ${datachannel} causes onclosing and onclose to be called`);
 
 promise_test(async t => {
   // This is the same test as above, but using addEventListener
   // rather than the "onclose" attribute.
-  const pc1 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  const [channel1, channel2] = await createDataChannelPair(pc1);
+  const [channel1, channel2] = await createDataChannelPair(t, options);
   const haveClosed = new Promise(r => channel2.addEventListener('close', r));
   let closingSeen = false;
   channel1.addEventListener('closing', t.unreached_func());
@@ -44,12 +44,12 @@ promise_test(async t => {
   await haveClosed;
   assert_equals(channel2.readyState, 'closed');
   assert_true(closingSeen, 'Closing event was seen');
-}, 'Close datachannel causes closing and close event to be called');
+}, `Close ${datachannel} causes closing and close event to be called`);
 
 promise_test(async t => {
   const pc1 = new RTCPeerConnection();
   t.add_cleanup(() => pc1.close());
-  const [channel1, channel2] = await createDataChannelPair(pc1);
+  const [channel1, channel2] = await createDataChannelPair(t, options, pc1);
   const events = [];
   let error = null;
   channel2.addEventListener('error', t.step_func(event => {
@@ -67,12 +67,12 @@ promise_test(async t => {
   assert_array_equals(events, ['error', 'close']);
   assert_true(error instanceof RTCError);
   assert_equals(error.name, 'OperationError');
-}, 'Close peerconnection causes close event and error to be called');
+}, `Close peerconnection causes close event and error to be called on ${datachannel}`);
 
 promise_test(async t => {
   let pc1 = new RTCPeerConnection();
   t.add_cleanup(() => pc1.close());
-  let [channel1, channel2] = await createDataChannelPair(pc1);
+  let [channel1, channel2] = await createDataChannelPair(t, options, pc1);
   // The expected sequence of events when closing a DC is that
   // channel1 goes to closing, channel2 fires onclose, and when
   // the close is confirmed, channel1 fires onclose.
@@ -96,6 +96,8 @@ promise_test(async t => {
   channel2.onerror = t.unreached_func();
   pc1.close();
   await new Promise(resolve => t.step_timeout(resolve, 10));
-}, 'Close peerconnection after DC close causes no events');
+}, `Close peerconnection after ${datachannel} close causes no events`);
+
+}
 
 </script>

--- a/webrtc/RTCDataChannel-send-blob-order.html
+++ b/webrtc/RTCDataChannel-send-blob-order.html
@@ -26,6 +26,6 @@ for (const options of [{}, {negotiated: true, id: 0}]) {
 
     e = await new Promise(r => channel2.onmessage = r);
     assert_equals(e.data.byteLength, data2Size);
-  }, '${datachannel} should send data following the order of the send call');
+  }, `${datachannel} should send data following the order of the send call`);
 }
 </script>

--- a/webrtc/RTCDataChannel-send-blob-order.html
+++ b/webrtc/RTCDataChannel-send-blob-order.html
@@ -7,7 +7,7 @@
 <script>
 
 for (const options of [{}, {negotiated: true, id: 0}]) {
-  const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
+  const mode = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
   promise_test(async t => {
     const data1 = new Blob(['blob']);
@@ -26,6 +26,6 @@ for (const options of [{}, {negotiated: true, id: 0}]) {
 
     e = await new Promise(r => channel2.onmessage = r);
     assert_equals(e.data.byteLength, data2Size);
-  }, `${datachannel} should send data following the order of the send call`);
+  }, `${mode} should send data following the order of the send call`);
 }
 </script>

--- a/webrtc/RTCDataChannel-send-blob-order.html
+++ b/webrtc/RTCDataChannel-send-blob-order.html
@@ -5,13 +5,17 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="RTCPeerConnection-helper.js"></script>
 <script>
-promise_test(async t => {
+
+for (const options of [{}, {negotiated: true, id: 0}]) {
+  const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
+
+  promise_test(async t => {
     const data1 = new Blob(['blob']);
     const data1Size = data1.size;
     const data2 = new ArrayBuffer(8);
     const data2Size = data2.byteLength;
 
-    const [channel1, channel2] = await createDataChannelPair();
+    const [channel1, channel2] = await createDataChannelPair(t, options);
     channel2.binaryType = "arraybuffer";
 
     channel1.send(data1);
@@ -22,5 +26,6 @@ promise_test(async t => {
 
     e = await new Promise(r => channel2.onmessage = r);
     assert_equals(e.data.byteLength, data2Size);
-}, 'Data channel should send data following the order of the send call');
+  }, '${datachannel} should send data following the order of the send call');
+}
 </script>

--- a/webrtc/RTCDataChannel-send.html
+++ b/webrtc/RTCDataChannel-send.html
@@ -6,60 +6,59 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="RTCPeerConnection-helper.js"></script>
 <script>
-  'use strict';
+'use strict';
 
-  // Test is based on the following editor draft:
-  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+// Test is based on the following editor draft:
+// https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
-  // The following helper functions are called from RTCPeerConnection-helper.js:
-  //  createDataChannelPair
-  //  awaitMessage
-  //  blobToArrayBuffer
-  //  assert_equals_typed_array
+// The following helper functions are called from RTCPeerConnection-helper.js:
+//  createDataChannelPair
+//  awaitMessage
+//  blobToArrayBuffer
+//  assert_equals_typed_array
 
-  /*
-    6.2.  RTCDataChannel
-      interface RTCDataChannel : EventTarget {
-        ...
-        readonly  attribute RTCDataChannelState readyState;
-        readonly  attribute unsigned long       bufferedAmount;
-                  attribute EventHandler        onmessage;
-                  attribute DOMString           binaryType;
+/*
+  6.2.  RTCDataChannel
+    interface RTCDataChannel : EventTarget {
+      ...
+      readonly  attribute RTCDataChannelState readyState;
+      readonly  attribute unsigned long       bufferedAmount;
+                attribute EventHandler        onmessage;
+                attribute DOMString           binaryType;
 
-        void send(USVString data);
-        void send(Blob data);
-        void send(ArrayBuffer data);
-        void send(ArrayBufferView data);
-      };
-   */
+      void send(USVString data);
+      void send(Blob data);
+      void send(ArrayBuffer data);
+      void send(ArrayBufferView data);
+    };
+ */
 
-  // Simple ASCII encoded string
-  const helloString = 'hello';
-  // ASCII encoded buffer representation of the string
-  const helloBuffer = Uint8Array.of(0x68, 0x65, 0x6c, 0x6c, 0x6f);
-  const helloBlob = new Blob([helloBuffer]);
+// Simple ASCII encoded string
+const helloString = 'hello';
+// ASCII encoded buffer representation of the string
+const helloBuffer = Uint8Array.of(0x68, 0x65, 0x6c, 0x6c, 0x6f);
+const helloBlob = new Blob([helloBuffer]);
 
-  // Unicode string with multiple code units
-  const unicodeString = '世界你好';
-  // UTF-8 encoded buffer representation of the string
-  const unicodeBuffer = Uint8Array.of(
-    0xe4, 0xb8, 0x96, 0xe7, 0x95, 0x8c,
-    0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd);
+// Unicode string with multiple code units
+const unicodeString = '世界你好';
+// UTF-8 encoded buffer representation of the string
+const unicodeBuffer = Uint8Array.of(
+  0xe4, 0xb8, 0x96, 0xe7, 0x95, 0x8c,
+  0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd);
 
-  /*
-      6.2.  send()
-        2.  If channel's readyState attribute is connecting, throw an InvalidStateError.
-   */
-  test(t => {
-    const pc = new RTCPeerConnection();
-    const channel = pc.createDataChannel('test');
-    assert_equals(channel.readyState, 'connecting');
-    assert_throws_dom('InvalidStateError', () => channel.send(helloString));
-  }, 'Calling send() when data channel is in connecting state should throw InvalidStateError');
+/*
+    6.2.  send()
+      2.  If channel's readyState attribute is connecting, throw an InvalidStateError.
+ */
+test(t => {
+  const pc = new RTCPeerConnection();
+  const channel = pc.createDataChannel('test');
+  assert_equals(channel.readyState, 'connecting');
+  assert_throws_dom('InvalidStateError', () => channel.send(helloString));
+}, 'Calling send() when data channel is in connecting state should throw InvalidStateError');
 
 for (const options of [{}, {negotiated: true, id: 0}]) {
-
-const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
+  const mode = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
   /*
     6.2.  send()
@@ -86,7 +85,7 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
       assert_equals(message, helloString);
     });
-  }, `${datachannel} should be able to send simple string and receive as string`);
+  }, `${mode} should be able to send simple string and receive as string`);
 
   promise_test(t => {
     return createDataChannelPair(t, options)
@@ -99,7 +98,7 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
       assert_equals(message, unicodeString);
     });
-  }, `${datachannel} should be able to send unicode string and receive as unicode string`);
+  }, `${mode} should be able to send unicode string and receive as unicode string`);
   promise_test(t => {
     return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
@@ -112,7 +111,7 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
       assert_equals(message, helloString);
     });
-  }, `${datachannel} should ignore binaryType and always receive string message as string`);
+  }, `${mode} should ignore binaryType and always receive string message as string`);
 
   /*
     6.2. send()
@@ -147,7 +146,7 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, `${datachannel} should be able to send Uint8Array message and receive as ArrayBuffer`);
+  }, `${mode} should be able to send Uint8Array message and receive as ArrayBuffer`);
 
   /*
     6.2. send()
@@ -169,7 +168,7 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, `${datachannel} should be able to send ArrayBuffer message and receive as ArrayBuffer`);
+  }, `${mode} should be able to send ArrayBuffer message and receive as ArrayBuffer`);
 
   /*
     6.2. send()
@@ -190,7 +189,7 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, `${datachannel} should be able to send Blob message and receive as ArrayBuffer`);
+  }, `${mode} should be able to send Blob message and receive as ArrayBuffer`);
 
   /*
     [WebSocket]
@@ -217,7 +216,7 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, `${datachannel} should be able to send ArrayBuffer message and receive as Blob`);
+  }, `${mode} should be able to send ArrayBuffer message and receive as Blob`);
 
   /*
     6.2.  RTCDataChannel
@@ -247,7 +246,7 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, `${datachannel} binaryType should receive message as Blob by default`);
+  }, `${mode} binaryType should receive message as Blob by default`);
 
   // Test sending 3 messages: helloBuffer, unicodeString, helloBlob
   async_test(t => {
@@ -277,7 +276,7 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
 
     }).catch(t.step_func(err =>
       assert_unreached(`Unexpected promise rejection: ${err}`)));
-  }, `${datachannel} sending multiple messages with different types should succeed and be received`);
+  }, `${mode} sending multiple messages with different types should succeed and be received`);
 
   /*
     [Deferred]
@@ -302,23 +301,22 @@ const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
     }, 'Calling send() when data channel is in closing state should succeed');
   */
 
-promise_test(async t => {
-  let pc1 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  let [channel1, channel2] = await createDataChannelPair(t, options, pc1);
-  let message = 'hello888'; // 8 bytes
-  while (message.length <= pc1.sctp.maxMessageSize) {
-    channel1.send(message);
-    let received_message = await awaitMessage(channel2);
-    assert_equals(received_message.length, message.length, "Size mismatch");
-    // Double size
-    message = message + message;
-  }
-  // "send" method step 4:
-  // If the byte size of "data" exceeds the value of maxMessageSize, throw
-  // a TypeError.
-  assert_throws_js(TypeError, () => channel1.send(message));
-}, `${datachannel} send() up to max size should succeed, above max size should fail`);
-
+  promise_test(async t => {
+    let pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    let [channel1, channel2] = await createDataChannelPair(t, options, pc1);
+    let message = 'hello888'; // 8 bytes
+    while (message.length <= pc1.sctp.maxMessageSize) {
+      channel1.send(message);
+      let received_message = await awaitMessage(channel2);
+      assert_equals(received_message.length, message.length, "Size mismatch");
+      // Double size
+      message = message + message;
+    }
+    // "send" method step 4:
+    // If the byte size of "data" exceeds the value of maxMessageSize, throw
+    // a TypeError.
+    assert_throws_js(TypeError, () => channel1.send(message));
+  }, `${mode} send() up to max size should succeed, above max size should fail`);
 }
 </script>

--- a/webrtc/RTCDataChannel-send.html
+++ b/webrtc/RTCDataChannel-send.html
@@ -57,6 +57,10 @@
     assert_throws_dom('InvalidStateError', () => channel.send(helloString));
   }, 'Calling send() when data channel is in connecting state should throw InvalidStateError');
 
+for (const options of [{}, {negotiated: true, id: 0}]) {
+
+const datachannel = `${options.negotiated? "Negotiated d" : "D"}atachannel`;
+
   /*
     6.2.  send()
       3.  Execute the sub step that corresponds to the type of the methods argument:
@@ -72,7 +76,7 @@
             attribute to data.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
       channel1.send(helloString);
       return awaitMessage(channel2)
@@ -82,10 +86,10 @@
 
       assert_equals(message, helloString);
     });
-  }, 'Data channel should be able to send simple string and receive as string');
+  }, `${datachannel} should be able to send simple string and receive as string`);
 
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
       channel1.send(unicodeString);
       return awaitMessage(channel2)
@@ -95,9 +99,9 @@
 
       assert_equals(message, unicodeString);
     });
-  }, 'Data channel should be able to send unicode string and receive as unicode string');
+  }, `${datachannel} should be able to send unicode string and receive as unicode string`);
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel1.send(helloString);
@@ -108,7 +112,7 @@
 
       assert_equals(message, helloString);
     });
-  }, 'Data channel should ignore binaryType and always receive string message as string');
+  }, `${datachannel} should ignore binaryType and always receive string message as string`);
 
   /*
     6.2. send()
@@ -132,7 +136,7 @@
         Float32Array or Float64Array or DataView) ArrayBufferView;
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel1.send(helloBuffer);
@@ -143,7 +147,7 @@
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, 'Data channel should be able to send Uint8Array message and receive as ArrayBuffer');
+  }, `${datachannel} should be able to send Uint8Array message and receive as ArrayBuffer`);
 
   /*
     6.2. send()
@@ -154,7 +158,7 @@
             ArrayBuffer in bytes.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel1.send(helloBuffer.buffer);
@@ -165,7 +169,7 @@
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, 'Data channel should be able to send ArrayBuffer message and receive as ArrayBuffer');
+  }, `${datachannel} should be able to send ArrayBuffer message and receive as ArrayBuffer`);
 
   /*
     6.2. send()
@@ -175,7 +179,7 @@
             the bufferedAmount attribute by the size of data, in bytes.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel1.send(helloBlob);
@@ -186,7 +190,7 @@
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, 'Data channel should be able to send Blob message and receive as ArrayBuffer');
+  }, `${datachannel} should be able to send Blob message and receive as ArrayBuffer`);
 
   /*
     [WebSocket]
@@ -196,7 +200,7 @@
             to a new Blob object that represents data as its raw data.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'blob';
       channel1.send(helloBuffer);
@@ -213,7 +217,7 @@
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, 'Data channel should be able to send ArrayBuffer message and receive as Blob');
+  }, `${datachannel} should be able to send ArrayBuffer message and receive as Blob`);
 
   /*
     6.2.  RTCDataChannel
@@ -224,7 +228,7 @@
         be initialized to the string "blob".
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
       assert_equals(channel2.binaryType, 'blob',
         'Expect initial binaryType value to be blob');
@@ -243,7 +247,7 @@
 
       assert_equals_typed_array(messageBuffer, helloBuffer.buffer);
     });
-  }, 'Data channel binaryType should receive message as Blob by default');
+  }, `${datachannel} binaryType should receive message as Blob by default`);
 
   // Test sending 3 messages: helloBuffer, unicodeString, helloBlob
   async_test(t => {
@@ -262,7 +266,7 @@
       }
     });
 
-    createDataChannelPair()
+    createDataChannelPair(t, options)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel2.addEventListener('message', onMessage);
@@ -273,7 +277,7 @@
 
     }).catch(t.step_func(err =>
       assert_unreached(`Unexpected promise rejection: ${err}`)));
-  }, 'Sending multiple messages with different types should succeed and be received');
+  }, `${datachannel} sending multiple messages with different types should succeed and be received`);
 
   /*
     [Deferred]
@@ -301,7 +305,7 @@
 promise_test(async t => {
   let pc1 = new RTCPeerConnection();
   t.add_cleanup(() => pc1.close());
-  let [channel1, channel2] = await createDataChannelPair(pc1);
+  let [channel1, channel2] = await createDataChannelPair(t, options, pc1);
   let message = 'hello888'; // 8 bytes
   while (message.length <= pc1.sctp.maxMessageSize) {
     channel1.send(message);
@@ -314,5 +318,7 @@ promise_test(async t => {
   // If the byte size of "data" exceeds the value of maxMessageSize, throw
   // a TypeError.
   assert_throws_js(TypeError, () => channel1.send(message));
-}, 'Calling send() up to max size should succeed, above max size should fail');
+}, `${datachannel} send() up to max size should succeed, above max size should fail`);
+
+}
 </script>

--- a/webrtc/RTCIceTransport.html
+++ b/webrtc/RTCIceTransport.html
@@ -123,7 +123,7 @@
     const pc2 = new RTCPeerConnection();
     t.add_cleanup(() => pc2.close());
 
-    return createDataChannelPair(pc1, pc2)
+    return createDataChannelPair(t, {}, pc1, pc2)
     .then(([channel1, channel2]) => {
       // Send a ping message and wait for it just to make sure
       // that the connection is fully working before testing

--- a/webrtc/RTCPeerConnection-createDataChannel.html
+++ b/webrtc/RTCPeerConnection-createDataChannel.html
@@ -666,33 +666,46 @@ promise_test(async t => {
 }, 'Reusing a data channel id that is in use (after setRemoteDescription, negotiated via DCEP) ' +
   'should throw OperationError');
 
+
+for (const options of [{}, {negotiated: true, id: 0}]) {
+
+const datachannel = `${options.negotiated? "negotiated " : ""}datachannel`;
+
 // Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1441723
 promise_test(async t => {
   const pc1 = new RTCPeerConnection();
-  const pc2 = new RTCPeerConnection();
   t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
 
-  await createDataChannelPair(pc1, pc2);
+  await createDataChannelPair(t, options, pc1);
 
   const dc = pc1.createDataChannel('');
   assert_equals(dc.readyState, 'connecting', 'Channel should be in the connecting state');
-}, 'New data channel should be in the connecting state after creation (after connection ' +
-  'establishment)');
+}, `New ${datachannel} should be in the connecting state after creation ` +
+   `(after connection establishment)`);
 
 promise_test(async t => {
   const pc1 = new RTCPeerConnection();
-  const pc2 = new RTCPeerConnection();
   t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
   const stream = await getNoiseStream({audio: true, video: true});
   t.add_cleanup(() => stopTracks(stream));
   const audio = stream.getAudioTracks()[0];
   const video = stream.getVideoTracks()[0];
   pc1.addTrack(audio, stream);
   pc1.addTrack(video, stream);
-  await createDataChannelPair(pc1, pc2);
-}, 'addTrack, then createDataChannel, should negotiate properly');
+  await createDataChannelPair(t, options, pc1);
+}, `addTrack, then creating ${datachannel}, should negotiate properly`);
+
+promise_test(async t => {
+  const pc1 = new RTCPeerConnection({bundlePolicy: "max-bundle"});
+  t.add_cleanup(() => pc1.close());
+  const stream = await getNoiseStream({audio: true, video: true});
+  t.add_cleanup(() => stopTracks(stream));
+  const audio = stream.getAudioTracks()[0];
+  const video = stream.getVideoTracks()[0];
+  pc1.addTrack(audio, stream);
+  pc1.addTrack(video, stream);
+  await createDataChannelPair(t, options, pc1);
+}, `addTrack, then creating ${datachannel}, should negotiate properly when max-bundle is used`);
 
 promise_test(async t => {
   const pc1 = new RTCPeerConnection({bundlePolicy: "max-bundle"});
@@ -705,27 +718,14 @@ promise_test(async t => {
   const video = stream.getVideoTracks()[0];
   pc1.addTrack(audio, stream);
   pc1.addTrack(video, stream);
-  await createDataChannelPair(pc1, pc2);
-}, 'addTrack, then createDataChannel, should negotiate properly when max-bundle is used');
-
-promise_test(async t => {
-  const pc1 = new RTCPeerConnection({bundlePolicy: "max-bundle"});
-  const pc2 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
-  const stream = await getNoiseStream({audio: true, video: true});
-  t.add_cleanup(() => stopTracks(stream));
-  const audio = stream.getAudioTracks()[0];
-  const video = stream.getVideoTracks()[0];
-  pc1.addTrack(audio, stream);
-  pc1.addTrack(video, stream);
-  const [dc1, dc2] = await createDataChannelPair(pc1, pc2);
+  const [dc1, dc2] = await createDataChannelPair(t, options, pc1, pc2);
 
   pc2.getTransceivers()[0].stop();
   const dc1Closed = new Promise(r => dc1.onclose = r);
   await exchangeOfferAnswer(pc1, pc2);
   await dc1Closed;
-}, 'Stopping the bundle-tag when there is a DataChannel in the bundle should kill the DataChannel');
+}, `Stopping the bundle-tag when there is a ${datachannel} in the bundle ` +
+   `should kill the DataChannel`);
 
 /*
   Untestable
@@ -748,4 +748,5 @@ promise_test(async t => {
   Tested in RTCDataChannel-dcep.html
     - Transmission of '.label' and further options
 */
+}
 </script>

--- a/webrtc/RTCPeerConnection-createDataChannel.html
+++ b/webrtc/RTCPeerConnection-createDataChannel.html
@@ -668,64 +668,64 @@ promise_test(async t => {
 
 
 for (const options of [{}, {negotiated: true, id: 0}]) {
+  const mode = `${options.negotiated? "negotiated " : ""}datachannel`;
 
-const datachannel = `${options.negotiated? "negotiated " : ""}datachannel`;
+  // Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1441723
+  promise_test(async t => {
+    const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
 
-// Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1441723
-promise_test(async t => {
-  const pc1 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
+    await createDataChannelPair(t, options, pc1);
 
-  await createDataChannelPair(t, options, pc1);
+    const dc = pc1.createDataChannel('');
+    assert_equals(dc.readyState, 'connecting', 'Channel should be in the connecting state');
+  }, `New ${mode} should be in the connecting state after creation ` +
+     `(after connection establishment)`);
 
-  const dc = pc1.createDataChannel('');
-  assert_equals(dc.readyState, 'connecting', 'Channel should be in the connecting state');
-}, `New ${datachannel} should be in the connecting state after creation ` +
-   `(after connection establishment)`);
+  promise_test(async t => {
+    const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    const stream = await getNoiseStream({audio: true, video: true});
+    t.add_cleanup(() => stopTracks(stream));
+    const audio = stream.getAudioTracks()[0];
+    const video = stream.getVideoTracks()[0];
+    pc1.addTrack(audio, stream);
+    pc1.addTrack(video, stream);
+    await createDataChannelPair(t, options, pc1);
+  }, `addTrack, then creating ${mode}, should negotiate properly`);
 
-promise_test(async t => {
-  const pc1 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  const stream = await getNoiseStream({audio: true, video: true});
-  t.add_cleanup(() => stopTracks(stream));
-  const audio = stream.getAudioTracks()[0];
-  const video = stream.getVideoTracks()[0];
-  pc1.addTrack(audio, stream);
-  pc1.addTrack(video, stream);
-  await createDataChannelPair(t, options, pc1);
-}, `addTrack, then creating ${datachannel}, should negotiate properly`);
+  promise_test(async t => {
+    const pc1 = new RTCPeerConnection({bundlePolicy: "max-bundle"});
+    t.add_cleanup(() => pc1.close());
+    const stream = await getNoiseStream({audio: true, video: true});
+    t.add_cleanup(() => stopTracks(stream));
+    const audio = stream.getAudioTracks()[0];
+    const video = stream.getVideoTracks()[0];
+    pc1.addTrack(audio, stream);
+    pc1.addTrack(video, stream);
+    await createDataChannelPair(t, options, pc1);
+  }, `addTrack, then creating ${mode}, should negotiate properly when max-bundle is used`);
 
-promise_test(async t => {
-  const pc1 = new RTCPeerConnection({bundlePolicy: "max-bundle"});
-  t.add_cleanup(() => pc1.close());
-  const stream = await getNoiseStream({audio: true, video: true});
-  t.add_cleanup(() => stopTracks(stream));
-  const audio = stream.getAudioTracks()[0];
-  const video = stream.getVideoTracks()[0];
-  pc1.addTrack(audio, stream);
-  pc1.addTrack(video, stream);
-  await createDataChannelPair(t, options, pc1);
-}, `addTrack, then creating ${datachannel}, should negotiate properly when max-bundle is used`);
+  promise_test(async t => {
+    const pc1 = new RTCPeerConnection({bundlePolicy: "max-bundle"});
+    const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    t.add_cleanup(() => pc2.close());
+    const stream = await getNoiseStream({audio: true, video: true});
+    t.add_cleanup(() => stopTracks(stream));
+    const audio = stream.getAudioTracks()[0];
+    const video = stream.getVideoTracks()[0];
+    pc1.addTrack(audio, stream);
+    pc1.addTrack(video, stream);
+    const [dc1, dc2] = await createDataChannelPair(t, options, pc1, pc2);
 
-promise_test(async t => {
-  const pc1 = new RTCPeerConnection({bundlePolicy: "max-bundle"});
-  const pc2 = new RTCPeerConnection();
-  t.add_cleanup(() => pc1.close());
-  t.add_cleanup(() => pc2.close());
-  const stream = await getNoiseStream({audio: true, video: true});
-  t.add_cleanup(() => stopTracks(stream));
-  const audio = stream.getAudioTracks()[0];
-  const video = stream.getVideoTracks()[0];
-  pc1.addTrack(audio, stream);
-  pc1.addTrack(video, stream);
-  const [dc1, dc2] = await createDataChannelPair(t, options, pc1, pc2);
-
-  pc2.getTransceivers()[0].stop();
-  const dc1Closed = new Promise(r => dc1.onclose = r);
-  await exchangeOfferAnswer(pc1, pc2);
-  await dc1Closed;
-}, `Stopping the bundle-tag when there is a ${datachannel} in the bundle ` +
-   `should kill the DataChannel`);
+    pc2.getTransceivers()[0].stop();
+    const dc1Closed = new Promise(r => dc1.onclose = r);
+    await exchangeOfferAnswer(pc1, pc2);
+    await dc1Closed;
+  }, `Stopping the bundle-tag when there is a ${mode} in the bundle ` +
+     `should kill the DataChannel`);
+}
 
 /*
   Untestable
@@ -748,5 +748,4 @@ promise_test(async t => {
   Tested in RTCDataChannel-dcep.html
     - Transmission of '.label' and further options
 */
-}
 </script>


### PR DESCRIPTION
Fixes `createDataChannelPair()` helper to test both negotiated and non-negotiated datachannels.

cc @alvestrand 