### PR TITLE
Add test to fire scrollend events for user scrolls

### DIFF
--- a/dom/events/scrolling/scroll_support.js
+++ b/dom/events/scrolling/scroll_support.js
@@ -83,3 +83,18 @@ function touchScrollInTarget(pixels_to_scroll, target, direction, pause_time_in_
 function touchFlingInTarget(pixels_to_scroll, target, direction) {
   touchScrollInTarget(pixels_to_scroll, target, direction, 0 /* pause_time */);
 }
+
+async function mouseActionsInTarget(target, origin, delta, pause_time_in_ms = 100) {
+  return new test_driver.Actions()
+    .addPointer("pointer1", "mouse")
+    .pointerMove(origin.x, origin.y, { origin: target })
+    .pointerDown()
+    .pointerMove(origin.x + delta.x, origin.y + delta.y, { origin: target })
+    .pointerMove(origin.x + delta.x * 2, origin.y + delta.y * 2, { origin: target })
+    .send()
+    .then(() => {
+      setTimeout(() => {
+        return new test_driver.Actions().pointerUp().send();
+      }, pause_time_in_ms);     
+    });
+}

--- a/dom/events/scrolling/scroll_support.js
+++ b/dom/events/scrolling/scroll_support.js
@@ -91,10 +91,7 @@ async function mouseActionsInTarget(target, origin, delta, pause_time_in_ms = 10
     .pointerDown()
     .pointerMove(origin.x + delta.x, origin.y + delta.y, { origin: target })
     .pointerMove(origin.x + delta.x * 2, origin.y + delta.y * 2, { origin: target })
-    .send()
-    .then(() => {
-      setTimeout(() => {
-        return new test_driver.Actions().pointerUp().send();
-      }, pause_time_in_ms);     
-    });
+    .pause(pause_time_in_ms)
+    .pointerUp()
+    .send();
 }

--- a/dom/events/scrolling/scroll_support.js
+++ b/dom/events/scrolling/scroll_support.js
@@ -84,7 +84,7 @@ function touchFlingInTarget(pixels_to_scroll, target, direction) {
   touchScrollInTarget(pixels_to_scroll, target, direction, 0 /* pause_time */);
 }
 
-async function mouseActionsInTarget(target, origin, delta, pause_time_in_ms = 100) {
+function mouseActionsInTarget(target, origin, delta, pause_time_in_ms = 100) {
   return new test_driver.Actions()
     .addPointer("pointer1", "mouse")
     .pointerMove(origin.x, origin.y, { origin: target })

--- a/dom/events/scrolling/scrollend-event-for-user-scroll.html
+++ b/dom/events/scrolling/scrollend-event-for-user-scroll.html
@@ -44,7 +44,7 @@ function resetTargetScrollState() {
 
 function checkFinalPosition(target, position, pause_time_in_ms) {
     return new Promise((resolve, reject) => {
-        setTimeout(() => {
+        step_timeout(() => {
             resolve();
             assert_equals(position.x, target.scrollLeft);
             assert_equals(position.y, target.scrollTop);

--- a/dom/events/scrolling/scrollend-event-for-user-scroll.html
+++ b/dom/events/scrolling/scrollend-event-for-user-scroll.html
@@ -62,11 +62,10 @@ function runTest() {
         await waitForCompositorCommit();
         scrollend_arrived = false;
 
-        // Perform drag actiion on target div and wait for target_div to get scrollend event.
+        // Perform drag action on target div and wait for target_div to get scrollend event.
         var origin = { x: target_div.offsetWidth / 2, y: target_div.offsetHeight - 50 };
         var delta = { x: 0, y: 40 };
         await mouseActionsInTarget(target_div, origin, delta, 300);
-        assert_false(scrollend_arrived);
         await waitFor(() => { return scrollend_arrived; },
             'target_div did not receive scrollend event after dragging scroll on target.');
         assert_true(target_div.scrollTop > 0);
@@ -82,7 +81,9 @@ function runTest() {
         scrollend_arrived = false;
 
         // Hit the scrollbar of target div and wait for target_div to get scrollend event.
-        var origin = {x: target_div.offsetWidth - 5, y: target_div.offsetHeight - 50};
+        var scrollbar_width = target_div.offsetWidth - target_div.clientWidth;
+        assert_true(scrollbar_width > 0, "This test requires scrollbar.");
+        var origin = {x: target_div.offsetWidth - scrollbar_width / 2, y: target_div.offsetHeight - 50};
         var delta = {x: 0, y: 0};
         await mouseActionsInTarget(target_div, origin, delta, 100);
         await waitFor(() => { return scrollend_arrived; },
@@ -99,8 +100,11 @@ function runTest() {
         await waitForCompositorCommit();
         scrollend_arrived = false;
 
+
         // Drag the thumb of target div.
-        var origin = { x: target_div.offsetWidth - 5, y: 50 };
+        var scrollbar_width = target_div.offsetWidth - target_div.clientWidth;
+        assert_true(scrollbar_width > 0, "This test requires scrollbar.");
+        var origin = { x: target_div.offsetWidth - scrollbar_width / 2, y: 50 };
         var delta = { x: 0, y: 20 };
         await mouseActionsInTarget(target_div, origin, delta, 100);
         await waitFor(() => { return scrollend_arrived; },

--- a/dom/events/scrolling/scrollend-event-for-user-scroll.html
+++ b/dom/events/scrolling/scrollend-event-for-user-scroll.html
@@ -25,7 +25,6 @@
         <div id="innerDiv">
         </div>
     </div>
-    <div id="log"></div>
 </body>
 
 <script>

--- a/dom/events/scrolling/scrollend-event-for-user-scroll.html
+++ b/dom/events/scrolling/scrollend-event-for-user-scroll.html
@@ -42,7 +42,7 @@ function resetTargetScrollState() {
     target_div.scrollLeft = 0;
 }
 
-function checkFinialPosition(target, position, pause_time_in_ms) {
+function checkFinalPosition(target, position, pause_time_in_ms) {
     return new Promise((resolve, reject) => {
         setTimeout(() => {
             resolve();
@@ -69,7 +69,7 @@ function runTest() {
         await waitFor(() => { return scrollend_arrived; },
             'target_div did not receive scrollend event after dragging scroll on target.');
         assert_true(target_div.scrollTop > 0);
-        await checkFinialPosition(target_div, {x: target_div.scrollLeft, y: target_div.scrollTop}, 300);
+        await checkFinalPosition(target_div, {x: target_div.scrollLeft, y: target_div.scrollTop}, 300);
     }, 'Tests that the target_div gets scrollend event when dragging scroll on target.');
 
     promise_test(async (t) => {
@@ -89,7 +89,7 @@ function runTest() {
         await waitFor(() => { return scrollend_arrived; },
             'target_div did not receive scrollend event after clicking scrollbar on target.');
         assert_true(target_div.scrollTop > 0);
-        await checkFinialPosition(target_div, { x: target_div.scrollLeft, y: target_div.scrollTop }, 300);
+        await checkFinalPosition(target_div, { x: target_div.scrollLeft, y: target_div.scrollTop }, 300);
     }, 'Tests that the target_div gets scrollend event when click scrollbar on target.');
 
     promise_test(async (t) => {
@@ -110,7 +110,7 @@ function runTest() {
         await waitFor(() => { return scrollend_arrived; },
             'target_div did not receive scrollend event after dragging the thumb of target.');
         assert_true(target_div.scrollTop > 0);
-        await checkFinialPosition(target_div, { x: target_div.scrollLeft, y: target_div.scrollTop }, 300);
+        await checkFinalPosition(target_div, { x: target_div.scrollLeft, y: target_div.scrollTop }, 300);
     }, 'Tests that the target_div gets scrollend event when drag the thumb of target.');
 
     promise_test(async (t) => {
@@ -131,7 +131,7 @@ function runTest() {
         await waitFor(() => { return scrollend_arrived; },
             'target_div did not receive scrollend event after sending DOWN key to target.');
         assert_true(target_div.scrollTop > 0);
-        await checkFinialPosition(target_div, { x: target_div.scrollLeft, y: target_div.scrollTop }, 300);
+        await checkFinalPosition(target_div, { x: target_div.scrollLeft, y: target_div.scrollTop }, 300);
     }, 'Tests that the target_div gets scrollend event when send DOWN key to target.');
 }
 </script>

--- a/dom/events/scrolling/scrollend-event-for-user-scroll.html
+++ b/dom/events/scrolling/scrollend-event-for-user-scroll.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="scroll_support.js"></script>
+<style>
+    #targetDiv {
+        width: 200px;
+        height: 200px;
+        overflow: scroll;
+    }
+
+    #innerDiv {
+        width: 400px;
+        height: 400px;
+    }
+</style>
+</head>
+<body style="margin:0" onload=runTest()>
+    <div id="targetDiv">
+        <div id="innerDiv">
+        </div>
+    </div>
+    <div id="log"></div>
+</body>
+
+<script>
+var target_div = document.getElementById('targetDiv');
+var scrollend_arrived = false;
+
+function onScrollEnd(event) {
+    assert_false(event.cancelable);
+    assert_false(event.bubbles);
+    scrollend_arrived = true;
+}
+
+function resetTargetScrollState() {
+    target_div.scrollTop = 0;
+    target_div.scrollLeft = 0;
+}
+
+function checkFinialPosition(target, position, pause_time_in_ms) {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            resolve();
+            assert_equals(position.x, target.scrollLeft);
+            assert_equals(position.y, target.scrollTop);
+        }, pause_time_in_ms);
+    });
+}
+
+target_div.addEventListener("scrollend", onScrollEnd);
+
+function runTest() {
+    promise_test(async (t) => {
+        // Make sure that no scrollend event is sent to window.
+        window.addEventListener("scrollend",
+            t.unreached_func("window got unexpected scrollend event."));
+        await waitForCompositorCommit();
+        scrollend_arrived = false;
+
+        // Perform drag actiion on target div and wait for target_div to get scrollend event.
+        var origin = { x: target_div.offsetWidth / 2, y: target_div.offsetHeight - 50 };
+        var delta = { x: 0, y: 40 };
+        await mouseActionsInTarget(target_div, origin, delta, 300);
+        assert_false(scrollend_arrived);
+        await waitFor(() => { return scrollend_arrived; },
+            'target_div did not receive scrollend event after dragging scroll on target.');
+        assert_true(target_div.scrollTop > 0);
+        await checkFinialPosition(target_div, {x: target_div.scrollLeft, y: target_div.scrollTop}, 300);
+    }, 'Tests that the target_div gets scrollend event when dragging scroll on target.');
+
+    promise_test(async (t) => {
+        resetTargetScrollState();
+        // Make sure that no scrollend event is sent to window.
+        window.addEventListener("scrollend",
+            t.unreached_func("window got unexpected scrollend event."));
+        await waitForCompositorCommit();
+        scrollend_arrived = false;
+
+        // Hit the scrollbar of target div and wait for target_div to get scrollend event.
+        var origin = {x: target_div.offsetWidth - 5, y: target_div.offsetHeight - 50};
+        var delta = {x: 0, y: 0};
+        await mouseActionsInTarget(target_div, origin, delta, 100);
+        await waitFor(() => { return scrollend_arrived; },
+            'target_div did not receive scrollend event after clicking scrollbar on target.');
+        assert_true(target_div.scrollTop > 0);
+        await checkFinialPosition(target_div, { x: target_div.scrollLeft, y: target_div.scrollTop }, 300);
+    }, 'Tests that the target_div gets scrollend event when click scrollbar on target.');
+
+    promise_test(async (t) => {
+        resetTargetScrollState();
+        // Make sure that no scrollend event is sent to window.
+        window.addEventListener("scrollend",
+            t.unreached_func("window got unexpected scrollend event."));
+        await waitForCompositorCommit();
+        scrollend_arrived = false;
+
+        // Drag the thumb of target div.
+        var origin = { x: target_div.offsetWidth - 5, y: 50 };
+        var delta = { x: 0, y: 20 };
+        await mouseActionsInTarget(target_div, origin, delta, 100);
+        await waitFor(() => { return scrollend_arrived; },
+            'target_div did not receive scrollend event after dragging the thumb of target.');
+        assert_true(target_div.scrollTop > 0);
+        await checkFinialPosition(target_div, { x: target_div.scrollLeft, y: target_div.scrollTop }, 300);
+    }, 'Tests that the target_div gets scrollend event when drag the thumb of target.');
+
+    promise_test(async (t) => {
+        resetTargetScrollState();
+        // Make sure that no scrollend event is sent to window.
+        window.addEventListener("scrollend",
+            t.unreached_func("window got unexpected scrollend event."));
+        await waitForCompositorCommit();
+        scrollend_arrived = false;
+
+        // Hit and active the target div.
+        var origin = { x: target_div.offsetWidth / 2, y: target_div.offsetHeight / 2};
+        var delta = { x: 0, y: 0 };
+        await mouseActionsInTarget(target_div, origin, delta, 100);
+        // Send DOWN key to the target div.
+        window.test_driver.send_keys(target_div, '\ue015');
+
+        await waitFor(() => { return scrollend_arrived; },
+            'target_div did not receive scrollend event after sending DOWN key to target.');
+        assert_true(target_div.scrollTop > 0);
+        await checkFinialPosition(target_div, { x: target_div.scrollLeft, y: target_div.scrollTop }, 300);
+    }, 'Tests that the target_div gets scrollend event when send DOWN key to target.');
+}
+</script>
+</html>


### PR DESCRIPTION
Hi,
This patch adds scrollend event tests to user scrolls: dragging scroll, pressing scrollbar scroll, dragging scrollbar thumb scroll, and sending DOWN key scroll.