### PR TITLE
[css-grid] Fix grid-items-sizing-alignment-001.html for WebKit

### DIFF
--- a/css/css-grid/grid-items/grid-items-sizing-alignment-001-ref.html
+++ b/css/css-grid/grid-items/grid-items-sizing-alignment-001-ref.html
@@ -2,6 +2,11 @@
 <meta charset="utf-8">
 <title>CSS Reftest Reference: Grid Item Sizing</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<style>
+  button {
+    margin: 0; /* Prevent WebKit from adding some margin */
+  }
+</style>
 
 <p>Test passes if it has the same output than the reference.</p>
 

--- a/css/css-grid/grid-items/grid-items-sizing-alignment-001.html
+++ b/css/css-grid/grid-items/grid-items-sizing-alignment-001.html
@@ -11,6 +11,9 @@
     grid-auto-rows: 200px;
     grid-template-columns: repeat(3, 200px);
   }
+  button {
+    margin: 0; /* Prevent WebKit from adding some margin */
+  }
 </style>
 
 <p>Test passes if it has the same output than the reference.</p>


### PR DESCRIPTION
WebKit adds some margin to buttons when they have an intrinsic size.
This is making this test fail, since some buttons have an 'auto' width
and height in the test, but have explicit lengths in the reference.

This behavior doesn't seem relevant to the test, so just explicitly
setting 'margin: 0' to disable it.

Fixes https://webkit.org/b/169271