### PR TITLE
[wptrunner/chromium] Produce full logs and screenshots

### DIFF
--- a/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
@@ -139,7 +139,7 @@ def test_subtest_messages(capfd):
                        message="t1_b_message")
     logger.test_end("t1", status="PASS", expected="PASS")
     logger.test_start("t2")
-    # Currently, subtests with empty messages will be ignored
+    # Subtests with empty messages should not be ignored.
     logger.test_status("t2", status="PASS", subtest="t2_a")
     # A test-level message will also be appended
     logger.test_end("t2", status="TIMEOUT", expected="PASS",
@@ -157,11 +157,17 @@ def test_subtest_messages(capfd):
     output_json = json.load(output)
 
     t1_artifacts = output_json["tests"]["t1"]["artifacts"]
-    assert t1_artifacts["log"] == ["[FAIL expected PASS] t1_a: t1_a_message\n"
-                                   "[PASS] t1_b: t1_b_message\n"]
+    assert t1_artifacts["log"] == [
+        "Test: [FAIL expected PASS]\n"
+        "[FAIL expected PASS] t1_a: t1_a_message\n"
+        "[PASS] t1_b: t1_b_message\n"
+    ]
     assert t1_artifacts["wpt_subtest_failure"] == ["true"]
     t2_artifacts = output_json["tests"]["t2"]["artifacts"]
-    assert t2_artifacts["log"] == ["[TIMEOUT expected PASS] t2_message\n"]
+    assert t2_artifacts["log"] == [
+        "Test: [TIMEOUT expected PASS]: t2_message\n"
+        "[PASS] t2_a\n"
+    ]
     assert "wpt_subtest_failure" not in t2_artifacts.keys()
 
 
@@ -204,9 +210,12 @@ def test_subtest_failure(capfd):
 
     test_obj = output_json["tests"]["t1"]
     t1_artifacts = test_obj["artifacts"]
-    assert t1_artifacts["log"] == ["[FAIL expected PASS] t1_a: t1_a_message\n"
-                                   "[PASS] t1_b: t1_b_message\n"
-                                   "[TIMEOUT expected PASS] t1_c: t1_c_message\n"]
+    assert t1_artifacts["log"] == [
+        "Test: [FAIL expected PASS]\n"
+        "[FAIL expected PASS] t1_a: t1_a_message\n"
+        "[PASS] t1_b: t1_b_message\n"
+        "[TIMEOUT expected PASS] t1_c: t1_c_message\n"
+    ]
     assert t1_artifacts["wpt_subtest_failure"] == ["true"]
     # The status of the test in the output is a failure because subtests failed,
     # despite the harness reporting that the test passed. But the harness status
@@ -258,9 +267,12 @@ def test_expected_subtest_failure(capfd):
 
     test_obj = output_json["tests"]["t1"]
     t1_log = test_obj["artifacts"]["log"]
-    assert t1_log == ["[FAIL] t1_a: t1_a_message\n"
-                      "[PASS] t1_b: t1_b_message\n"
-                      "[TIMEOUT] t1_c: t1_c_message\n"]
+    assert t1_log == [
+        "Test: [PASS]\n"
+        "[FAIL] t1_a: t1_a_message\n"
+        "[PASS] t1_b: t1_b_message\n"
+        "[TIMEOUT] t1_c: t1_c_message\n"
+    ]
     # The status of the test in the output is a pass because the subtest
     # failures were all expected.
     assert test_obj["actual"] == "PASS"
@@ -303,7 +315,10 @@ def test_unexpected_subtest_pass(capfd):
 
     test_obj = output_json["tests"]["t1"]
     t1_artifacts = test_obj["artifacts"]
-    assert t1_artifacts["log"] == ["[PASS expected FAIL] t1_a: t1_a_message\n"]
+    assert t1_artifacts["log"] == [
+        "Test: [FAIL expected PASS]\n"
+        "[PASS expected FAIL] t1_a: t1_a_message\n"
+    ]
     assert t1_artifacts["wpt_subtest_failure"] == ["true"]
     # Since the subtest status is unexpected, we fail the test. But we report
     # wpt_actual_status as an artifact
@@ -518,3 +533,38 @@ def test_known_intermittent_empty(capfd):
     # anywhere.
     assert test_obj["actual"] == "PASS"
     assert test_obj["expected"] == "PASS"
+
+
+def test_reftest_screenshots(capfd):
+    # reftest_screenshots, if present, should be plumbed into artifacts.
+
+    # Set up the handler.
+    output = StringIO()
+    logger = structuredlog.StructuredLogger("test_a")
+    logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
+
+    # Run a reftest with reftest_screenshots.
+    logger.suite_start(["t1"], run_info={}, time=123)
+    logger.test_start("t1")
+    logger.test_end("t1", status="FAIL", expected="PASS", extra={
+        "reftest_screenshots": [
+            {"url": "foo.html", "hash": "HASH1", "screenshot": "DATA1"},
+            "!=",
+            {"url": "foo-ref.html", "hash": "HASH2", "screenshot": "DATA2"},
+        ]
+    })
+    logger.suite_end()
+
+    # check nothing got output to stdout/stderr
+    # (note that mozlog outputs exceptions during handling to stderr!)
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    # check the actual output of the formatter
+    output.seek(0)
+    output_json = json.load(output)
+
+    test_obj = output_json["tests"]["t1"]
+    assert test_obj["artifacts"]["foo.html"] == ["DATA1"]
+    assert test_obj["artifacts"]["foo-ref.html"] == ["DATA2"]


### PR DESCRIPTION
1. artifacts["log"] now contains the full logs, including the harness
   status and passing subtests.
2. Base64-encoded reftest screenshots, if present, are now stored in
   artifacts[url].

This is a bit of a prototype; I'm running the full suite to determine how much bigger the JSON output will be, but please take a first pass.