### PR TITLE
[Sauce] Remove workaround that manually sets selenium version for edge

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -69,9 +69,6 @@ def get_capabilities(**kwargs):
         "prerun": prerun_script.get(browser_name)
     }
 
-    if browser_name == 'MicrosoftEdge':
-        capabilities['selenium-version'] = '2.4.8'
-
     return capabilities
 
 


### PR DESCRIPTION
This appears to be a leftover from the previous use of the sauce runner,
assumedly when there was some bug that required a specific version of
selenium to be used (it was sadly undocumented).

Fixes https://github.com/web-platform-tests/wpt/issues/23895