### PR TITLE
Correct CSS2/css1/c414-flt-fit-000.xht and reference

### DIFF
--- a/css/CSS2/css1/c414-flt-fit-000-ref.xht
+++ b/css/CSS2/css1/c414-flt-fit-000-ref.xht
@@ -11,6 +11,7 @@
   <style type="text/css"><![CDATA[
   table
   {
+  font: 16px monospace;
   border-collapse: separate;
   border: blue solid medium;
   border-spacing: 0px;
@@ -33,7 +34,6 @@
 
   td
   {
-  color: navy;
   padding: 0;
   }
   ]]></style>

--- a/css/CSS2/css1/c414-flt-fit-000.xht
+++ b/css/CSS2/css1/c414-flt-fit-000.xht
@@ -10,8 +10,8 @@
   <link rel="match" href="c414-flt-fit-000-ref.xht" />
 
   <style type="text/css"><![CDATA[
-   div { border: solid blue; padding: 1em; width: 14em; margin: 10px; }
-   div p { margin: 0; width: 5em; float: left; color: navy; }
+   div { font: 16px monospace; border: solid blue; padding: 1em; width: 14em; margin: 10px; }
+   div p { margin: 0; width: 5em; float: left; }
   ]]></style>
 
  </head>
@@ -22,7 +22,7 @@
    <p> 2 </p>
    <p> 4 </p>
        3
-       5&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;&#xA0;
+       5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <!-- the font is set to monospace so we know how wide a nbsp is -->
   </div>
  </body>
 </html>


### PR DESCRIPTION
The reference did not match the test, as it did not have navy everywhere the test had it. This fixes this by removing the navy from both test and reference, as it served no purpose.

Additionally, the test depended upon the width of the nbsp relative to the em-square; having observed this varying, this is now fixed by making the table monospace in both test and reference.

Closes #8834. cc/ @TalbotG given he made most of the review comments before (I don't this contains anything you disagreed with, though?). Note that unlike #8834, this *doesn't* change any width given browsers seem to be interoperable with what the test already had (and @TalbotG believed correct).