### PR TITLE
[webdriver] normalize and fix links to the WebDriver spec

### DIFF
--- a/css/compositing/test-plan/test-plan.html
+++ b/css/compositing/test-plan/test-plan.html
@@ -214,9 +214,7 @@ table.simple {
 					is to ensure that most tests are automatable (i.e. they're either
 					reftests or use <code>testharness.js</code>). Even where manual tests
 					are absolutely necessary they should be written so that they can be
-					easily automated – as there are on-going efforts to make
-					WebDriver [<cite><a class="bibref" href="#bib-webdriver">webdriver</a></cite>] automated tests a first class citizen in W3C
-					testing. This means that even if a manual test requires user
+					easily automated. This means that even if a manual test requires user
 					interaction, the validation or PASS/FAIL conditions should still be
 					clear enough as to allow automatic validation if said interaction is
 					later automated.

--- a/docs/writing-tests/testdriver-extension-tutorial.md
+++ b/docs/writing-tests/testdriver-extension-tutorial.md
@@ -9,7 +9,7 @@ We assume the following in this writeup:
 
 ## Introduction!
 
-Let's implement window resizing. We can do this via the [Set Window Rect](https://w3c.github.io/webdriver/webdriver-spec.html#dfn-set-window-rect) command in WebDriver.
+Let's implement window resizing. We can do this via the [Set Window Rect](https://w3c.github.io/webdriver/#set-window-rect) command in WebDriver.
 
 First, we need to think of what the API will look like a little. We will be using WebDriver and Marionette for this, so we can look and see that they take in x, y coordinates, width and height integers.
 
@@ -30,7 +30,7 @@ window.test_driver = {
     * Triggers browser window to be resized and relocated
     *
     * This matches the behaviour of the {@link
-    * https://w3c.github.io/webdriver/webdriver-spec.html#dfn-set-window-rect|WebDriver
+    * https://w3c.github.io/webdriver/#set-window-rect|WebDriver
     * Set Window Rect command}.
     *
     * @param {Integer} x - The x coordinate of the top left of the window
@@ -56,7 +56,7 @@ window.test_driver_internal = {
      * Triggers browser window to be resized and relocated
      *
      * This matches the behaviour of the {@link
-     * https://w3c.github.io/webdriver/webdriver-spec.html#dfn-set-window-rect|WebDriver
+     * https://w3c.github.io/webdriver/#set-window-rect|WebDriver
      * Set Window Rect command}.
      *
      * @param {Integer} x - The x coordinate of the top left of the window
@@ -325,7 +325,7 @@ class GetWindowRectAction(object):
         return self.protocol.get_window_rect.get_window_rect()
 ```
 
-The WebDriver command will return a [WindowRect object](https://www.w3.org/TR/webdriver1/#dfn-window-rect), which is a dictionary with keys `x`, `y`, `width`, and `height`.
+The WebDriver command will return a [WindowRect object](https://w3c.github.io/webdriver/#dfn-window-rect), which is a dictionary with keys `x`, `y`, `width`, and `height`.
 ```python
 class WebDriverGetWindowRectProtocolPart(GetWindowRectProtocolPart):
     def get_window_rect(self):

--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -124,7 +124,7 @@ Note that if the element that the keys need to be sent to does not have
 a unique ID, the document must not have any DOM mutations made
 between the function being called and the promise settling.
 
-To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a [list for code points to special keys in the spec](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
+To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a [list for code points to special keys in the spec](https://w3c.github.io/webdriver/#keyboard-actions).
 For example, to send the tab key you would send "\uE004".
 
 [activation]: https://html.spec.whatwg.org/multipage/interaction.html#activation

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -87,7 +87,7 @@
          * Triggers a user-initiated click
          *
          * This matches the behaviour of the {@link
-         * https://w3c.github.io/webdriver/webdriver-spec.html#element-click|WebDriver
+         * https://w3c.github.io/webdriver/#element-click|WebDriver
          * Element Click command}.
          *
          * @param {Element} element - element to be clicked
@@ -126,7 +126,7 @@
          * Send keys to an element
          *
          * This matches the behaviour of the {@link
-         * https://w3c.github.io/webdriver/webdriver-spec.html#element-send-keys|WebDriver
+         * https://w3c.github.io/webdriver/#element-send-keys|WebDriver
          * Send Keys command}.
          *
          * @param {Element} element - element to send keys to

--- a/tools/webdriver/README.md
+++ b/tools/webdriver/README.md
@@ -1,7 +1,7 @@
 # WebDriver client for Python
 
 This package provides Python bindings
-that conform to the [W3C WebDriver standard](https://w3c.github.io/webdriver/webdriver-spec.html),
+that conform to the [W3C WebDriver standard](https://w3c.github.io/webdriver/),
 which specifies a remote control protocol for web browsers.
 
 These bindings are written with determining

--- a/webdriver/README.md
+++ b/webdriver/README.md
@@ -2,7 +2,7 @@
 
 Herein lies a set of conformance tests
 for the W3C web browser automation specification
-known as [WebDriver](http://w3c.github.io/webdriver/webdriver-spec.html).
+known as [WebDriver](http://w3c.github.io/webdriver/).
 The purpose of these tests is determine implementation compliance
 so that different driver implementations can determine
 whether they meet the recognized standard.

--- a/webdriver/tests/get_named_cookie/get.py
+++ b/webdriver/tests/get_named_cookie/get.py
@@ -28,7 +28,7 @@ def test_get_named_session_cookie(session, url):
     assert isinstance(cookie, dict)
 
     # table for cookie conversion
-    # https://w3c.github.io/webdriver/webdriver-spec.html#dfn-table-for-cookie-conversion
+    # https://w3c.github.io/webdriver/#dfn-table-for-cookie-conversion
     assert "name" in cookie
     assert isinstance(cookie["name"], text_type)
     assert "value" in cookie

--- a/webdriver/tests/perform_actions/support/keys.py
+++ b/webdriver/tests/perform_actions/support/keys.py
@@ -26,7 +26,7 @@ class Keys(object):
     """
     Set of special keys codes.
 
-    See also https://w3c.github.io/webdriver/#h-keyboard-actions
+    See also https://w3c.github.io/webdriver/#keyboard-actions
     """
 
     NULL = u"\ue000"


### PR DESCRIPTION
Spotted while looking for incoming links to the spec:
https://github.com/w3c/webdriver/issues/1462#issuecomment-637441468

(#dfn-set-window-rect changed to #set-window-rect for consistency, not
to enable the ID to be changed.)