### PR TITLE
Add MathML tests for presentational hints

### DIFF
--- a/mathml/relations/css-styling/presentational-hints-001-ref.html
+++ b/mathml/relations/css-styling/presentational-hints-001-ref.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>presentational hints</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  @font-face {
+    font-family: DoubleStruck;
+    src: url("/fonts/math/mathvariant-double-struck.woff");
+  }
+  @font-face {
+    font-family: Italic;
+    src: url("/fonts/math/mathvariant-italic.woff");
+  }
+  math {
+      font: 25px/1 Ahem;
+  }
+</style>
+<body>
+  <p>dir:
+    <math style="direction: ltr;">
+      <mtext>X</mtext>
+      <mtext>p</mtext>
+    </math>
+  </p>
+  <p>mathcolor:
+    <math style="color: green;">
+      <mtext>X</mtext>
+      <mtext>p</mtext>
+    </math>
+  </p>
+  <p>mathbackground:
+    <math style="background: green;">
+      <mtext>X</mtext>
+      <mtext>p</mtext>
+  </p>
+  <p>mathsize:
+    <math>
+      <mtext style="font-size: 100%">X</mtext>
+    </math>
+  </p>
+  <p>mathvariant:
+    <math style="font-family: DoubleStruck, Italic;">
+      <mtext style="text-transform: math-italic">&#x628;</mtext>
+    </math>
+  </p>
+  <p>displaystyle:
+    <math style="math-style: inline">
+      <munder>
+        <mo movablelimits="true">X</mo>
+        <mo>X</mo>
+      </munder>
+    </math>
+  </p>
+  <p>scriptlevel:
+    <math>
+      <mtext style="font-size: scriptlevel(0);">X</mtext>
+    </math>
+  </p>
+</body>
+</html>

--- a/mathml/relations/css-styling/presentational-hints-001.html
+++ b/mathml/relations/css-styling/presentational-hints-001.html
@@ -11,7 +11,7 @@
 <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-displaystyle-and-scriptlevel-attributes">
 <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-mathvariant-attribute">
 <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-mathvariant-attribute">
-<link rel="match" href="presentational-hints-ref.html"/>
+<link rel="match" href="presentational-hints-001-ref.html"/>
 <link rel="stylesheet" href="/fonts/ahem.css">
 <meta name="assert" content="Verify that local author style wins over presentation hints attributes">
 <style>

--- a/mathml/relations/css-styling/presentational-hints-001.html
+++ b/mathml/relations/css-styling/presentational-hints-001.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>presentational hints</title>
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#attributes-common-to-html-and-mathml-elements">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#css-styling">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#double-struck-mappings">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#legacy-mathml-style-attributes">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#new-text-transform-values">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-displaystyle-and-scriptlevel-attributes">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-mathvariant-attribute">
+<link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-mathvariant-attribute">
+<link rel="match" href="presentational-hints-ref.html"/>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<meta name="assert" content="Verify that local author style wins over presentation hints attributes">
+<style>
+  @font-face {
+    font-family: DoubleStruck;
+    src: url("/fonts/math/mathvariant-double-struck.woff");
+  }
+  @font-face {
+    font-family: Italic;
+    src: url("/fonts/math/mathvariant-italic.woff");
+  }
+  math {
+      font: 25px/1 Ahem;
+  }
+</style>
+<body>
+  <p>dir:
+    <math dir="rtl" style="direction: ltr;">
+      <mtext>X</mtext>
+      <mtext>p</mtext>
+    </math>
+  </p>
+  <p>mathcolor:
+    <math mathcolor="red" style="color: green;">
+      <mtext>X</mtext>
+      <mtext>p</mtext>
+    </math>
+  </p>
+  <p>mathbackground:
+    <math mathbackground="red" style="background: green;">
+      <mtext>X</mtext>
+      <mtext>p</mtext>
+  </p>
+  <p>mathsize:
+    <math>
+      <mtext mathsize="300%" style="font-size: 100%">X</mtext>
+    </math>
+  </p>
+  <p>mathvariant:
+    <math style="font-family: DoubleStruck, Italic;">
+      <mtext mathvariant="double-struck"
+             style="text-transform: math-italic">&#x628;</mtext>
+    </math>
+  </p>
+  <p>displaystyle:
+    <math displaystyle="true" style="math-style: inline">
+      <munder>
+        <mo movablelimits="true">X</mo>
+        <mo>X</mo>
+      </munder>
+    </math>
+  </p>
+  <p>scriptlevel:
+    <math>
+      <mtext scriptlevel="1" style="font-size: scriptlevel(0);">X</mtext>
+    </math>
+  </p>
+</body>
+</html>


### PR DESCRIPTION
presentational hints are author-level zero-specifity
style attribute is author-level + infinite specificity

So style wins over mapped attributes.

https://www.w3.org/TR/css-cascade-3/#cascading
https://html.spec.whatwg.org/multipage/rendering.html#presentational-hints

https://github.com/mathml-refresh/mathml/issues/215