### PR TITLE
50% top margin resolves against width, not height. Use 50vh

### DIFF
--- a/css/css-masking/clip-path/reference/clip-path-ref-bottom-green-ref.html
+++ b/css/css-masking/clip-path/reference/clip-path-ref-bottom-green-ref.html
@@ -13,7 +13,7 @@
     </style>
 </head>
 <body>
-    <div style="width: 100%; height: 50%; margin-top: 50%; background-color: green; position: absolute;"></div>
+    <div style="width: 100%; height: 50%; margin-top: 50vh; background-color: green; position: absolute;"></div>
     <p style="position: absolute;">The test passes if the top half of the site is white and the bottom half of the site is green.</p>
 </body>
 </html>


### PR DESCRIPTION
As the subject says. A 50% margin-top will resolve against the width, not the height, so it's not halfway down the page. Use 50vh instead.