### PR TITLE
Don't assert there is no viewport override for reftests.

### DIFF
--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -556,8 +556,7 @@ class ReftestTest(Test):
         return metadata
 
     def get_viewport_size(self, override):
-        assert override is None
-        return None
+        return override
 
     @property
     def id(self):


### PR DESCRIPTION
Servo has reftests that provide a viewport override. This change allows us to continue running those tests and unbreaks our nightly sync process.