### PR TITLE
[WIP] [Taskcluster] Split out wptrunner_unittest into its own category

### DIFF
--- a/tools/ci/ci_tools_unittest.sh
+++ b/tools/ci/ci_tools_unittest.sh
@@ -18,19 +18,16 @@ run_applicable_tox () {
     export TOXENV="$OLD_TOXENV"
 }
 
-if ./wpt test-jobs --includes tools_unittest; then
+if [ "$0" == "tools_unittest" ]; then
     pip install --user -U tox codecov
     cd tools
     run_applicable_tox
     cd $WPT_ROOT
-else
-    echo "Skipping tools unittest"
 fi
 
-if ./wpt test-jobs --includes wptrunner_unittest; then
+if [ "$0" == "wptrunner_unittest" ]; then
+    pip install --user -U tox codecov
     cd tools/wptrunner
     run_applicable_tox
     cd $WPT_ROOT
-else
-    echo "Skipping wptrunner unittest"
 fi

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -312,7 +312,7 @@ tasks:
         - tox-python2
       description: >-
         Unit tests for tools running under Python 2.7, excluding wptrunner
-      command: ./tools/ci/ci_tools_unittest.sh
+      command: ./tools/ci/ci_tools_unittest.sh tools_unittest
       env:
         HYPOTHESIS_PROFILE: ci
       schedule-if:
@@ -326,7 +326,7 @@ tasks:
         - wpt-base
         - trigger-pr
         - tox-python3
-      command: ./tools/ci/ci_tools_unittest.sh
+      command: ./tools/ci/ci_tools_unittest.sh tools_unittest
       env:
         HYPOTHESIS_PROFILE: ci
       schedule-if:
@@ -340,12 +340,54 @@ tasks:
         - wpt-base
         - trigger-pr
         - tox-python38
-      command: ./tools/ci/ci_tools_unittest.sh
+      command: ./tools/ci/ci_tools_unittest.sh tools_unittest
       env:
         HYPOTHESIS_PROFILE: ci
       schedule-if:
         run-job:
           - tools_unittest
+
+  - tools/wptrunner/ unittests (Python 2):
+      description: >-
+        Unit tests for wptrunner, running under Python 2.7
+      use:
+        - wpt-base
+        - trigger-pr
+        - tox-python2
+      command: ./tools/ci/ci_tools_unittest.sh wptrunner_unittest
+      env:
+        HYPOTHESIS_PROFILE: ci
+      schedule-if:
+        run-job:
+          - wptrunner_unittest
+
+  - tools/wptrunner/ unittests (Python 3.6):
+      description: >-
+        Unit tests for wptrunner, running under Python 3.6
+      use:
+        - wpt-base
+        - trigger-pr
+        - tox-python36
+      command: ./tools/ci/ci_tools_unittest.sh wptrunner_unittest
+      env:
+        HYPOTHESIS_PROFILE: ci
+      schedule-if:
+        run-job:
+          - wptrunner_unittest
+
+  - tools/wptrunner/ unittests (Python 3.8):
+      description: >-
+        Unit tests for wptrunner, running under Python 3.8
+      use:
+        - wpt-base
+        - trigger-pr
+        - tox-python38
+      command: ./tools/ci/ci_tools_unittest.sh wptrunner_unittest
+      env:
+        HYPOTHESIS_PROFILE: ci
+      schedule-if:
+        run-job:
+          - wptrunner_unittest
 
   - tools/ integration tests (Python 2):
       description: >-


### PR DESCRIPTION
Previously we claimed in the description that we didn't run wptrunner
unittests, but we actually did as long as `wptrunner_unittest` was one
of the WPT jobs reported. This would always be true for any task that
ran `tools_unittest`, because they have the same regex (all changes
under tools/)!

To align with Azure, and stop the description being a lie, this commit
splits out the wptrunner_unittests into their own Taskcluster tasks.