### PR TITLE
Add another https port, 8444

### DIFF
--- a/common/get-host-info.sub.js
+++ b/common/get-host-info.sub.js
@@ -7,6 +7,7 @@ function get_host_info() {
   var HTTP_PORT = '{{ports[http][0]}}';
   var HTTP_PORT2 = '{{ports[http][1]}}';
   var HTTPS_PORT = '{{ports[https][0]}}';
+  var HTTPS_PORT2 = '{{ports[https][1]}}';
   var PROTOCOL = self.location.protocol;
   var IS_HTTPS = (PROTOCOL == "https:");
   var HTTP_PORT_ELIDED = HTTP_PORT == "80" ? "" : (":" + HTTP_PORT);

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -514,7 +514,7 @@ def make_hosts_file(config, host):
 def start_servers(host, ports, paths, routes, bind_address, config, **kwargs):
     servers = defaultdict(list)
     for scheme, ports in ports.items():
-        assert len(ports) == {"http": 2}.get(scheme, 1)
+        assert len(ports) == {"http": 2, "https": 2}.get(scheme, 1)
 
         # If trying to start HTTP/2.0 server, check compatibility
         if scheme == 'h2' and not http2_compatible():
@@ -822,7 +822,7 @@ class ConfigBuilder(config.ConfigBuilder):
         "server_host": None,
         "ports": {
             "http": [8000, "auto"],
-            "https": [8443],
+            "https": [8443, 8444],
             "ws": ["auto"],
             "wss": ["auto"],
         },

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -128,7 +128,7 @@ class TestEnvironment(object):
 
         ports = {
             "http": [8000, 8001],
-            "https": [8443],
+            "https": [8443, 8444],
             "ws": [8888],
             "wss": [8889],
             "h2": [9000],


### PR DESCRIPTION
This is required to test origin isolation
(https://github.com/WICG/origin-isolation), which includes guarantees
that two origins with the same host but different ports are treated as
isolated.

Fixes https://github.com/web-platform-tests/wpt/issues/23579