### PR TITLE
Use atomic_writes package to update manifest

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -2,6 +2,7 @@ import io
 import itertools
 import json
 import os
+from atomicwrites import atomic_write
 from copy import deepcopy
 from multiprocessing import Pool, cpu_count
 from six import (
@@ -411,7 +412,7 @@ def write(manifest, manifest_path):
     dir_name = os.path.dirname(manifest_path)
     if not os.path.exists(dir_name):
         os.makedirs(dir_name)
-    with open(manifest_path, "w") as f:
+    with atomic_write(manifest_path, overwrite=True) as f:
         # Use ',' instead of the default ', ' separator to prevent trailing
         # spaces: https://docs.python.org/2/library/json.html#json.dump
         json.dump(manifest.to_json(caller_owns_obj=True), f,


### PR DESCRIPTION
This should avoid creating an invalid manifest due to partial write.
It turns out we vendored the dependency already for wdspec tests, so
should have done this some time ago :)