### PR TITLE
COOP+COEP: adopt step_wait & friends

### DIFF
--- a/html/cross-origin-embedder-policy/none.https.html
+++ b/html/cross-origin-embedder-policy/none.https.html
@@ -46,11 +46,11 @@ async_test(t => {
   t.add_cleanup(() => w.close());
 
   w.onload = t.step_func(() => {
+    assert_true(w.location.href.endsWith("?to=navigate-require-corp.sub.html"));
     w.history.back();
-    t.step_timeout(() => {
-      assert_not_equals(w.document, null);
+    t.wait_for_callback(() => w.location.href.endsWith("/navigate-require-corp.sub.html"), () => {
       t.done();
-    }, 1500);
+    });
   });
 }, `"none" top-level: navigating a frame back from "require-corp" should succeed`);
 

--- a/html/cross-origin-embedder-policy/none.https.html
+++ b/html/cross-origin-embedder-policy/none.https.html
@@ -48,9 +48,7 @@ async_test(t => {
   w.onload = t.step_func(() => {
     assert_true(w.location.href.endsWith("?to=navigate-require-corp.sub.html"));
     w.history.back();
-    t.wait_for_callback(() => w.location.href.endsWith("/navigate-require-corp.sub.html"), () => {
-      t.done();
-    });
+    t.step_wait_func_done(() => w.location.href.endsWith("/navigate-require-corp.sub.html"));
   });
 }, `"none" top-level: navigating a frame back from "require-corp" should succeed`);
 

--- a/html/cross-origin-embedder-policy/require-corp-about-blank.html
+++ b/html/cross-origin-embedder-policy/require-corp-about-blank.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
@@ -10,15 +11,13 @@ promise_test(t => {
 
 promise_test(async t => {
   let iframe = document.createElement("iframe");
-  let iframe_loaded =  new Promise(resolve => iframe.onload = resolve);
+  let iframe_loaded =  new Promise(resolve => iframe.onload = t.step_func(resolve));
   iframe.src = "about:blank";
   document.body.appendChild(iframe);
 
   // The about:blank document can load.
   await iframe_loaded;
   assert_not_equals(iframe.contentDocument, null);
-
-  t.done();
 }, "about:blank can always be embedded by a 'require-corp' document");
 
 promise_test(async t => {
@@ -26,7 +25,7 @@ promise_test(async t => {
   let iframe_B = document.createElement("iframe");
   iframe_B.src = "about:blank";
   iframe_C.src = "/common/blank.html";
-  let iframe_B_loaded = new Promise(resolve => iframe_B.onload = resolve);
+  let iframe_B_loaded = new Promise(resolve => iframe_B.onload = t.step_func(resolve));
   document.body.appendChild(iframe_B);
 
   // The about:blank frame must be able to load.
@@ -34,16 +33,16 @@ promise_test(async t => {
   assert_not_equals(iframe_B.contentDocument, null);
   iframe_B.contentDocument.body.appendChild(iframe_C);
 
-  t.step_timeout(() => {
-    // The document nested under about:blank must not load because it does not
-    // specify the Cross-Origin-Embedder-Policy: require-corp header.
-    // An error page must be displayed instead.
-    // See https://github.com/whatwg/html/issues/125 for why a timeout is used
-    // here. Long term all network error handling should be similar and have a
-    // reliable event.
-    assert_equals(iframe_C.contentDocument, null);
-    t.done();
-  }, 500);
+
+  // The document nested under about:blank must not load because it does not
+  // specify the Cross-Origin-Embedder-Policy: require-corp header.
+  // An error page must be displayed instead.
+  // See https://github.com/whatwg/html/issues/125 for why a timeout is used
+  // here. Long term all network error handling should be similar and have a
+  // reliable event.
+  assert_equals(iframe_C.contentWindow.location.href, "about:blank");
+  assert_not_equals(iframe_C.contentDocument, null);
+  await t.wait_for(() => iframe_C.contentDocument === null);
 }, "A(B(C)) A=require-corp, B=about:blank, C=no-require-corp => C can't load");
 
 </script>

--- a/html/cross-origin-embedder-policy/require-corp-about-blank.html
+++ b/html/cross-origin-embedder-policy/require-corp-about-blank.html
@@ -11,7 +11,7 @@ promise_test(t => {
 
 promise_test(async t => {
   let iframe = document.createElement("iframe");
-  let iframe_loaded =  new Promise(resolve => iframe.onload = t.step_func(resolve));
+  let iframe_loaded =  new Promise(resolve => iframe.onload = resolve);
   iframe.src = "about:blank";
   document.body.appendChild(iframe);
 
@@ -25,7 +25,7 @@ promise_test(async t => {
   let iframe_B = document.createElement("iframe");
   iframe_B.src = "about:blank";
   iframe_C.src = "/common/blank.html";
-  let iframe_B_loaded = new Promise(resolve => iframe_B.onload = t.step_func(resolve));
+  let iframe_B_loaded = new Promise(resolve => iframe_B.onload = resolve);
   document.body.appendChild(iframe_B);
 
   // The about:blank frame must be able to load.
@@ -42,7 +42,7 @@ promise_test(async t => {
   // reliable event.
   assert_equals(iframe_C.contentWindow.location.href, "about:blank");
   assert_not_equals(iframe_C.contentDocument, null);
-  await t.wait_for(() => iframe_C.contentDocument === null);
+  await t.step_wait(() => iframe_C.contentDocument === null);
 }, "A(B(C)) A=require-corp, B=about:blank, C=no-require-corp => C can't load");
 
 </script>

--- a/html/cross-origin-embedder-policy/require-corp-about-srcdoc.html
+++ b/html/cross-origin-embedder-policy/require-corp-about-srcdoc.html
@@ -4,13 +4,13 @@
 
 promise_test(t => {
   return new Promise(resolve => {
-    window.addEventListener("DOMContentLoaded", resolve);
+    window.addEventListener("DOMContentLoaded", t.step_func(resolve));
   });
 }, "Wait for the DOM to be built.");
 
 promise_test(async t => {
   let iframe = document.createElement("iframe");
-  let iframe_loaded =  new Promise(resolve => iframe.onload = resolve);
+  let iframe_loaded =  new Promise(resolve => iframe.onload = t.step_func(resolve));
   iframe.srcdoc = "loaded document";
   document.body.appendChild(iframe);
 
@@ -18,8 +18,6 @@ promise_test(async t => {
   await iframe_loaded;
   assert_not_equals(iframe.contentDocument, null);
   assert_equals(iframe.contentDocument.body.innerText, "loaded document");
-
-  t.done();
 }, "about:srcdoc can always be embedded by a 'require-corp' document");
 
 promise_test(async t => {
@@ -27,7 +25,7 @@ promise_test(async t => {
   let iframe_B = document.createElement("iframe");
   iframe_B.srcdoc = "dummy content";
   iframe_C.src = "/common/blank.html";
-  let iframe_B_loaded = new Promise(resolve => iframe_B.onload = resolve);
+  let iframe_B_loaded = new Promise(resolve => iframe_B.onload = t.step_func(resolve));
   document.body.appendChild(iframe_B);
 
   // The about:srcdoc frame must be able to load.
@@ -36,17 +34,15 @@ promise_test(async t => {
   assert_equals(iframe_B.contentDocument.body.innerText, "dummy content");
   iframe_B.contentDocument.body.appendChild(iframe_C);
 
-
-  t.step_timeout(() => {
-    // The document nested under about:srcdoc must not load because it does not
-    // specify the Cross-Origin-Embedder-Policy: require-corp header.
-    // An error page must be displayed instead.
-    // See https://github.com/whatwg/html/issues/125 for why a timeout is used
-    // here. Long term all network error handling should be similar and have a
-    // reliable event.
-    assert_equals(iframe_C.contentDocument, null);
-    t.done();
-  }, 500);
+  // The document nested under about:srcdoc must not load because it does not
+  // specify the Cross-Origin-Embedder-Policy: require-corp header.
+  // An error page must be displayed instead.
+  // See https://github.com/whatwg/html/issues/125 for why a timeout is used
+  // here. Long term all network error handling should be similar and have a
+  // reliable event.
+  assert_equals(iframe_C.contentWindow.location.href, "about:blank");
+  assert_not_equals(iframe_C.contentDocument, null);
+  await t.wait_for(() => iframe_C.contentDocument === null);
 }, "A(B(C)) A=require-corp, B=about:srcdoc, C=no-require-corp => C can't load");
 
 </script>

--- a/html/cross-origin-embedder-policy/require-corp-about-srcdoc.html
+++ b/html/cross-origin-embedder-policy/require-corp-about-srcdoc.html
@@ -4,13 +4,13 @@
 
 promise_test(t => {
   return new Promise(resolve => {
-    window.addEventListener("DOMContentLoaded", t.step_func(resolve));
+    window.addEventListener("DOMContentLoaded", resolve);
   });
 }, "Wait for the DOM to be built.");
 
 promise_test(async t => {
   let iframe = document.createElement("iframe");
-  let iframe_loaded =  new Promise(resolve => iframe.onload = t.step_func(resolve));
+  let iframe_loaded =  new Promise(resolve => iframe.onload = resolve);
   iframe.srcdoc = "loaded document";
   document.body.appendChild(iframe);
 
@@ -25,7 +25,7 @@ promise_test(async t => {
   let iframe_B = document.createElement("iframe");
   iframe_B.srcdoc = "dummy content";
   iframe_C.src = "/common/blank.html";
-  let iframe_B_loaded = new Promise(resolve => iframe_B.onload = t.step_func(resolve));
+  let iframe_B_loaded = new Promise(resolve => iframe_B.onload = resolve);
   document.body.appendChild(iframe_B);
 
   // The about:srcdoc frame must be able to load.
@@ -42,7 +42,7 @@ promise_test(async t => {
   // reliable event.
   assert_equals(iframe_C.contentWindow.location.href, "about:blank");
   assert_not_equals(iframe_C.contentDocument, null);
-  await t.wait_for(() => iframe_C.contentDocument === null);
+  await t.step_wait(() => iframe_C.contentDocument === null);
 }, "A(B(C)) A=require-corp, B=about:srcdoc, C=no-require-corp => C can't load");
 
 </script>

--- a/html/cross-origin-embedder-policy/require-corp.https.html
+++ b/html/cross-origin-embedder-policy/require-corp.https.html
@@ -13,16 +13,13 @@ const BASE = new URL("resources", location).pathname;
 async_test(t => {
   const frame = document.createElement("iframe");
   t.add_cleanup(() => frame.remove());
-  t.step_timeout(() => {
-    // Make sure the iframe didn't load. See https://github.com/whatwg/html/issues/125 for why a
-    // timeout is used here. Long term all network error handling should be similar and have a
-    // reliable event.
-    assert_equals(frame.contentDocument, null);
-    t.done();
-  }, 2000);
   frame.src = "/common/blank.html";
   document.body.append(frame);
+  // Make sure the iframe didn't load. See https://github.com/whatwg/html/issues/125 for why a
+  // timeout is used here. Long term all network error handling should be similar and have a
+  // reliable event.
   assert_equals(frame.contentDocument.body.localName, "body");
+  t.wait_for_callback(() => frame.contentDocument === null, () => t.done());
 }, `"require-corp" top-level: navigating a frame to "none" should fail`);
 
 async_test(t => {
@@ -33,10 +30,7 @@ async_test(t => {
     assert_not_equals(frame.contentDocument, null);
     let payload = event.data;
     assert_equals(payload, "loaded");
-    t.step_timeout(() => {
-      assert_equals(frame.contentDocument, null);
-      t.done();
-    }, 2000);
+    t.wait_for_callback(() => frame.contentDocument === null, () => t.done());
   });
   frame.src = `resources/navigate-require-corp.sub.html?channelName=${bc.name}&to=/common/blank.html`;
   document.body.append(frame);
@@ -143,25 +137,24 @@ promise_test(t => {
 async_test(t => {
   let w = window.open();
   const frame = w.document.createElement("iframe");
-  t.add_cleanup(() => w.close());
-  t.step_timeout(() => {
-    // Make sure the iframe didn't load. See
-    // https://github.com/whatwg/html/issues/125 for why a timeout is
-    // used here. Long term all network error handling should be similar
-    // and have a reliable event.
-    assert_equals(frame.contentDocument, null);
-    t.done();
-  }, 2000);
+  t.add_cleanup(() => {
+    w.close();
+    frame.remove();
+  });
   frame.src = "/common/blank.html";
   document.body.append(frame);
+  // Make sure the iframe didn't load. See https://github.com/whatwg/html/issues/125 for why a
+  // timeout is used here. Long term all network error handling should be similar and have a
+  // reliable event.
   assert_equals(frame.contentDocument.body.localName, "body");
+  t.wait_for_callback(() => frame.contentDocument === null, () => t.done());
 }, `"require-corp" top-level: navigating an iframe to a page without CORP, through a WindowProxy, should fail`);
 
 async_test(t => {
   const frame = document.createElement("iframe");
   const id = token();
   t.add_cleanup(() => frame.remove());
-  window.addEventListener('message', t.step_func((e) => {
+  window.addEventListener('message', t.step_func(e => {
     if (e.data === id) {
       // Loaded!
       t.done();
@@ -177,9 +170,9 @@ async_test(t => {
   const id = token();
   t.add_cleanup(() => frame.remove());
   let loaded = false;
-  window.addEventListener('message', t.step_func((e) => {
+  window.addEventListener('message', t.step_func(e => {
     if (e.data === id) {
-        loaded = true;
+      loaded = true;
     }
   }));
   t.step_timeout(() => {

--- a/html/cross-origin-embedder-policy/require-corp.https.html
+++ b/html/cross-origin-embedder-policy/require-corp.https.html
@@ -19,7 +19,7 @@ async_test(t => {
   // timeout is used here. Long term all network error handling should be similar and have a
   // reliable event.
   assert_equals(frame.contentDocument.body.localName, "body");
-  t.wait_for_callback(() => frame.contentDocument === null, () => t.done());
+  t.step_wait_func_done(() => frame.contentDocument === null);
 }, `"require-corp" top-level: navigating a frame to "none" should fail`);
 
 async_test(t => {
@@ -30,7 +30,7 @@ async_test(t => {
     assert_not_equals(frame.contentDocument, null);
     let payload = event.data;
     assert_equals(payload, "loaded");
-    t.wait_for_callback(() => frame.contentDocument === null, () => t.done());
+    t.step_wait_func_done(() => frame.contentDocument === null);
   });
   frame.src = `resources/navigate-require-corp.sub.html?channelName=${bc.name}&to=/common/blank.html`;
   document.body.append(frame);
@@ -147,14 +147,14 @@ async_test(t => {
   // timeout is used here. Long term all network error handling should be similar and have a
   // reliable event.
   assert_equals(frame.contentDocument.body.localName, "body");
-  t.wait_for_callback(() => frame.contentDocument === null, () => t.done());
+  t.step_wait_func_done(() => frame.contentDocument === null);
 }, `"require-corp" top-level: navigating an iframe to a page without CORP, through a WindowProxy, should fail`);
 
 async_test(t => {
   const frame = document.createElement("iframe");
   const id = token();
   t.add_cleanup(() => frame.remove());
-  window.addEventListener('message', t.step_func(e => {
+  window.addEventListener('message', t.step_func((e) => {
     if (e.data === id) {
       // Loaded!
       t.done();
@@ -170,7 +170,7 @@ async_test(t => {
   const id = token();
   t.add_cleanup(() => frame.remove());
   let loaded = false;
-  window.addEventListener('message', t.step_func(e => {
+  window.addEventListener('message', t.step_func((e) => {
     if (e.data === id) {
       loaded = true;
     }

--- a/html/cross-origin-opener-policy/coop-sandbox.https.html
+++ b/html/cross-origin-opener-policy/coop-sandbox.https.html
@@ -20,6 +20,8 @@
   <\/script>`;
     document.body.append(frame);
     addEventListener('load', t.step_func(() => {
+      // This uses a timeout to give some time for incorrect implementations to broadcast. A
+      // theoretical testdriver.js API for browsing contexts could be used to speed this up.
       t.step_timeout(() => {
         t.done()
       }, 1500);
@@ -38,7 +40,6 @@ async_test(t => {
     assert_equals(payload.name, frame.name, "name");
     t.done();
   });
-  t.step_timeout(t.unreached_func("Timed out while waiting for iframe's message"), 1500);
   t.add_cleanup(() => frame.remove());
   document.body.append(frame);
 }, `Iframe with sandbox and COOP must load.`);

--- a/html/cross-origin-opener-policy/popup-same-origin-non-initial-about-blank.https.html
+++ b/html/cross-origin-opener-policy/popup-same-origin-non-initial-about-blank.https.html
@@ -5,13 +5,15 @@
 <script>
 async_test(t => {
   const popup = window.open("resources/coop-coep.py?coop=same-origin&coep=&navigate=about:blank");
+  t.add_cleanup(() => popup.close());
   assert_equals(window, popup.opener);
-  window.onload = t.step_func(() => {
-    t.step_timeout(() => {
-      assert_equals(popup.location.href, "about:blank");
-      popup.close();
+
+  popup.onload = t.step_func(() => {
+    assert_true(popup.location.href.endsWith("&navigate=about:blank"));
+    // Use wait_for_callback as about:blank cannot message back.
+    t.wait_for_callback(() => popup.location.href === "about:blank", () => {
       t.done();
-    }, 1500);
+    });
   });
 }, "Navigating a popup to about:blank");
 </script>

--- a/html/cross-origin-opener-policy/popup-same-origin-non-initial-about-blank.https.html
+++ b/html/cross-origin-opener-policy/popup-same-origin-non-initial-about-blank.https.html
@@ -11,9 +11,7 @@ async_test(t => {
   popup.onload = t.step_func(() => {
     assert_true(popup.location.href.endsWith("&navigate=about:blank"));
     // Use wait_for_callback as about:blank cannot message back.
-    t.wait_for_callback(() => popup.location.href === "about:blank", () => {
-      t.done();
-    });
+    t.step_wait_func_done(() => popup.location.href === "about:blank");
   });
 }, "Navigating a popup to about:blank");
 </script>


### PR DESCRIPTION
This is on top of #24030 and requires that to land first. Apart from adopting those utility functions for a number of tests it also does some cleanup.