### PR TITLE
Add test that inactivate/activate a transceiver and ensure corresponding track stays live

### DIFF
--- a/webrtc/receiver-track-live.html
+++ b/webrtc/receiver-track-live.html
@@ -10,8 +10,8 @@
 <body>
     <video id="video" controls autoplay playsinline></video>
     <script>
-    var pc1, pc2;
-    var localTrack, remoteTrack;
+    let pc1, pc2;
+    let localTrack, remoteTrack;
     promise_test(async (test) => {
         const localStream = await navigator.mediaDevices.getUserMedia({audio: true});
         localTrack = localStream.getAudioTracks()[0];
@@ -40,7 +40,7 @@
 
         // Let's remove ssrc lines
         let sdpLines = offer.sdp.split("\r\n");
-        offer.sdp = sdpLines.filter(line => line && line.length && !line.startsWith("a=ssrc")).join("\r\n") + "\r\n";
+        offer.sdp = sdpLines.filter(line => line && !line.startsWith("a=ssrc")).join("\r\n") + "\r\n";
 
         await pc2.setRemoteDescription(offer);
         let answer = await pc2.createAnswer();

--- a/webrtc/receiver-track-live.html
+++ b/webrtc/receiver-track-live.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Remote tracks should not get ended except for stop/close</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="RTCPeerConnection-helper.js"></script>
+</head>
+<body>
+    <video id="video" controls autoplay playsinline></video>
+    <script>
+    var pc1, pc2;
+    var localTrack, remoteTrack;
+    promise_test(async (test) => {
+        const localStream = await navigator.mediaDevices.getUserMedia({audio: true});
+        localTrack = localStream.getAudioTracks()[0];
+
+        pc1 = new RTCPeerConnection();
+        pc1.addTrack(localTrack, localStream);
+        pc2 = new RTCPeerConnection();
+
+        let trackPromise = new Promise(resolve => {
+            pc2.ontrack = e => resolve(e.track);
+        });
+
+        exchangeIceCandidates(pc1, pc2);
+        await exchangeOfferAnswer(pc1, pc2);
+
+        remoteTrack = await trackPromise;
+        video.srcObject = new MediaStream([remoteTrack]);
+        await video.play();
+    }, "Setup audio call");
+
+    promise_test(async (test) => {
+        pc1.getTransceivers()[0].direction = "inactive";
+
+        let offer = await pc1.createOffer();
+        await pc1.setLocalDescription(offer);
+
+        // Let's remove ssrc lines
+        let sdpLines = offer.sdp.split("\r\n");
+        offer.sdp = sdpLines.filter(line => line && line.length && !line.startsWith("a=ssrc")).join("\r\n") + "\r\n";
+
+        await pc2.setRemoteDescription(offer);
+        let answer = await pc2.createAnswer();
+        await pc2.setLocalDescription(answer);
+        await pc1.setRemoteDescription(answer);
+
+        assert_equals(remoteTrack.readyState, "live");
+    }, "Inactivate the audio transceiver");
+
+    promise_test(async (test) => {
+        pc1.getTransceivers()[0].direction = "sendonly";
+
+        await exchangeOfferAnswer(pc1, pc2);
+
+        assert_equals(remoteTrack.readyState, "live");
+    }, "Reactivate the audio transceiver");
+
+    promise_test(async (test) => {
+        pc1.close();
+        pc2.close();
+        localTrack.stop();
+    }, "Clean-up");
+    </script>
+</body>
+</html>


### PR DESCRIPTION
In addition to the direction, we remove the ssrcs when setting direction to inactive, which triggers the remote track to get ended on Chrome and Safari. Firefox keeps the track as live.