### PR TITLE
[wptserve] Handle non-ASCII query params correctly in Python 3

### DIFF
--- a/tools/wptserve/tests/functional/test_request.py
+++ b/tools/wptserve/tests/functional/test_request.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+from six import PY3
 
 wptserve = pytest.importorskip("wptserve")
 from .base import TestUsingServer
@@ -117,7 +118,7 @@ class TestRequest(TestUsingServer):
     def test_non_ascii_in_headers(self):
         @wptserve.handlers.handler
         def handler(request, response):
-            return request.headers["foo"]
+            return request.headers[b"foo"]
 
         route = ("GET", "/test/test_unicode_in_headers", handler)
         self.server.router.register(*route)
@@ -131,6 +132,45 @@ class TestRequest(TestUsingServer):
         # returned in verbatim.
         encoded_text = u"どうも".encode("shift-jis")
         resp = self.request(route[1], headers={"foo": encoded_text})
+        self.assertEqual(encoded_text, resp.read())
+
+    def test_non_ascii_in_GET_params(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            return request.GET[b"foo"]
+
+        route = ("GET", "/test/test_unicode_in_get", handler)
+        self.server.router.register(*route)
+
+        # We intentionally choose an encoding that's not the default UTF-8.
+        encoded_text = u"どうも".encode("shift-jis")
+        if PY3:
+            from urllib.parse import quote_from_bytes
+            quoted = quote_from_bytes(encoded_text)
+        else:
+            from urllib import quote
+            quoted = quote(encoded_text)
+        resp = self.request(route[1], query="foo="+quoted)
+        self.assertEqual(encoded_text, resp.read())
+
+    def test_non_ascii_in_POST_params(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            return request.POST[b"foo"]
+
+        route = ("POST", "/test/test_unicode_in_POST", handler)
+        self.server.router.register(*route)
+
+        # We intentionally choose an encoding that's not the default UTF-8.
+        encoded_text = u"どうも".encode("shift-jis")
+        if PY3:
+            from urllib.parse import quote_from_bytes
+            # After urlencoding, the string should only contain ASCII.
+            quoted = quote_from_bytes(encoded_text).encode("ascii")
+        else:
+            from urllib import quote
+            quoted = quote(encoded_text)
+        resp = self.request(route[1], method="POST", body=b"foo="+quoted)
         self.assertEqual(encoded_text, resp.read())
 
 

--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -294,7 +294,12 @@ class Request(object):
     @property
     def GET(self):
         if self._GET is None:
-            params = parse_qsl(self.url_parts.query, keep_blank_values=True)
+            kwargs = {
+                "keep_blank_values": True,
+            }
+            if PY3:
+                kwargs["encoding"] = "iso-8859-1"
+            params = parse_qsl(self.url_parts.query, **kwargs)
             self._GET = MultiDict()
             for key, value in params:
                 self._GET.add(isomorphic_encode(key), isomorphic_encode(value))


### PR DESCRIPTION
In Python 3, parse_qsl automatically does string decoding and the
default encoding is UTF-8 instead of the isomorphic latin-1 that we
assumed. We need to explicitly set the encoding, similar to
cgi.FieldStorage. A test case is added (which would crash due to
UnicodeError in Python 3 without this fix).

Also add a similar test for POST.