### PR TITLE
Add test cases for URLSearchParams parsing %

### DIFF
--- a/url/urlencoded-parser.any.js
+++ b/url/urlencoded-parser.any.js
@@ -28,7 +28,11 @@
   { "input": '%a=a', "output": [['%a', 'a']] },
   { "input": '%a_=a', "output": [['%a_', 'a']] },
   { "input": '%61=a', "output": [['a', 'a']] },
-  { "input": '%61+%4d%4D=', "output": [['a MM', '']] }
+  { "input": '%61+%4d%4D=', "output": [['a MM', '']] },
+  { "input": "id=0&value=%", "output": [['id', '0'], ['value', '%']] },
+  { "input": "b=%2sf%2a", "output": [['b', '%2sf*']]},
+  { "input": "b=%2%2af%2a", "output": [['b', '%2*f*']]},
+  { "input": "b=%%2a", "output": [['b', '%*']]}
 ].forEach((val) => {
   test(() => {
     let sp = new URLSearchParams(val.input),

--- a/url/urlsearchparams-constructor.any.js
+++ b/url/urlsearchparams-constructor.any.js
@@ -56,6 +56,28 @@ test(function() {
     assert_false(params.has('c'), 'Search params object did not have the name "c"');
     assert_true(params.has(' c'), 'Search params object has name " c"');
     assert_true(params.has('møø'), 'Search params object has name "møø"');
+
+    params = new URLSearchParams('id=0&value=%');
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_true(params.has('id'), 'Search params object has name "id"');
+    assert_true(params.has('value'), 'Search params object has name "value"');
+    assert_equals(params.get('id'), '0');
+    assert_equals(params.get('value'), '%');
+
+    params = new URLSearchParams('b=%2sf%2a');
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_true(params.has('b'), 'Search params object has name "b"');
+    assert_equals(params.get('b'), '%2sf*');
+
+    params = new URLSearchParams('b=%2%2af%2a');
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_true(params.has('b'), 'Search params object has name "b"');
+    assert_equals(params.get('b'), '%2*f*');
+
+    params = new URLSearchParams('b=%%2a');
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_true(params.has('b'), 'Search params object has name "b"');
+    assert_equals(params.get('b'), '%*');
 }, 'URLSearchParams constructor, string.');
 
 test(function() {

--- a/url/urlsearchparams-stringifier.any.js
+++ b/url/urlsearchparams-stringifier.any.js
@@ -78,6 +78,9 @@ test(function() {
     params.delete('a');
     params.append('a%b', 'c');
     assert_equals(params + '', 'a%25b=c');
+
+    params = new URLSearchParams('id=0&value=%')
+    assert_equals(params + '', 'id=0&value=%25')
 }, 'Serialize %');
 
 test(function() {
@@ -107,6 +110,15 @@ test(function() {
     // The lone '=' _does_ survive the roundtrip.
     params = new URLSearchParams('a=&a=b');
     assert_equals(params.toString(), 'a=&a=b');
+
+    params = new URLSearchParams('b=%2sf%2a');
+    assert_equals(params.toString(), 'b=%252sf*');
+
+    params = new URLSearchParams('b=%2%2af%2a');
+    assert_equals(params.toString(), 'b=%252*f*');
+
+    params = new URLSearchParams('b=%%2a');
+    assert_equals(params.toString(), 'b=%25*');
 }, 'URLSearchParams.toString');
 
 test(() => {


### PR DESCRIPTION
This adds test cases from https://github.com/nodejs/node/issues/33892 since it was mentioned it might be good to have these here. 

Let me know if there are any changes that need to be made, I tested these locally against Firefox and Chrome and they look to be passing ok