### PR TITLE
[WIP] Alternative approach for testdriver integration

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -234,7 +234,7 @@
               state,
               oneRealm: one_realm,
             };
-            return window.test_driver_internal.set_permission(permission_params);
+            return window.test_driver_internal.post('permissions', permission_params);
         },
 
         /**

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -126,6 +126,15 @@
         return pending_promise;
     };
 
+    window.test_driver_internal.post = function(endpoint, params) {
+        const pending_promise = new Promise(function(resolve, reject) {
+            pending_resolve = resolve;
+            pending_reject = reject;
+        });
+        window.__wptrunner_message_queue.push({"type": "post", "endpoint": endpoint, params});
+        return pending_promise;
+    }
+
     window.test_driver_internal.set_permission = function(permission_params) {
         const pending_promise = new Promise(function(resolve, reject) {
             pending_resolve = resolve;


### PR DESCRIPTION
**NOTE**: This is a less-than half-baked idea, just throwing it in a PR to share with folks.

The goal would be to reduce
https://github.com/web-platform-tests/wpt/blob/master/docs/writing-tests/testdriver-extension-tutorial.md
down to:

```
  test_driver.set_permission = function(params) {
    test_driver_internal.post('permission', params);
  }
```

Or even remove it completely in favor of tests directly calling `post`.