### PR TITLE
Correct name of lint.ignore file in docs

### DIFF
--- a/docs/writing-tests/general-guidelines.md
+++ b/docs/writing-tests/general-guidelines.md
@@ -175,7 +175,7 @@ see the [lint-tool documentation][lint-tool].
 
 But in the unusual case of error reports for things essential to a certain
 test or that for other exceptional reasons shouldn't prevent a merge of a
-test, update and commit the `lint.ignorelist` file in the web-platform-tests
+test, update and commit the `lint.ignore` file in the web-platform-tests
 root directory to suppress the error reports. For details on doing that,
 see the [lint-tool documentation][lint-tool].
 

--- a/docs/writing-tests/lint-tool.md
+++ b/docs/writing-tests/lint-tool.md
@@ -11,14 +11,14 @@ web-platform-tests working directory like this:
 The lint tool is also run automatically for every submitted pull request,
 and reviewers will not merge branches with tests that have lint errors, so
 you must either [fix all lint errors](#fixing-lint-errors), or you must
-[add an exception](#updating-the-ignorelist) to suppress the errors.
+[add an exception](#updating-the-ignored-files) to suppress the errors.
 
 ## Fixing lint errors
 
 You must fix any errors the lint tool reports, unless an error is for something
 essential to a certain test or that for some other exceptional reason shouldn't
 prevent the test from being merged; in those cases you can [add an
-exception](#updating-the-ignorelist) to suppress the errors. In all other
+exception](#updating-the-ignored-files) to suppress the errors. In all other
 cases, follow the instructions below to fix all errors reported.
 
 <!--
@@ -30,12 +30,12 @@ cases, follow the instructions below to fix all errors reported.
 .. wpt-lint-rules:: tools.lint.rules
 ```
 
-## Updating the ignorelist
+## Updating the ignored files
 
 Normally you must [fix all lint errors](#fixing-lint-errors). But in the
 unusual case of error reports for things essential to certain tests or that
 for other exceptional reasons shouldn't prevent a merge of a test, you can
-update and commit the `lint.ignorelist` file in the web-platform-tests root
+update and commit the `lint.ignore` file in the web-platform-tests root
 directory to suppress errors the lint tool would report for a test file.
 
 To add a test file or directory to the list, use the following format:
@@ -45,7 +45,7 @@ ERROR TYPE:file/name/pattern
 ```
 
 For example, to ignore all `TRAILING WHITESPACE` errors in the file
-`example/file.html`, add the following line to the `lint.ignorelist` file:
+`example/file.html`, add the following line to the `lint.ignore` file:
 
 ```
 TRAILING WHITESPACE:example/file.html
@@ -53,7 +53,7 @@ TRAILING WHITESPACE:example/file.html
 
 To ignore errors for an entire directory rather than just one file, use the `*`
 wildcard. For example, to ignore all `TRAILING WHITESPACE` errors in the
-`example` directory, add the following line to the `lint.ignorelist` file:
+`example` directory, add the following line to the `lint.ignore` file:
 
 ```
 TRAILING WHITESPACE:example/*
@@ -71,7 +71,7 @@ ERROR TYPE:file/name/pattern:line_number
 ```
 
 For example, to ignore the `TRAILING WHITESPACE` error for just line 128 of the
-file `example/file.html`, add the following to the `lint.ignorelist` file:
+file `example/file.html`, add the following to the `lint.ignore` file:
 
 ```
 TRAILING WHITESPACE:example/file.html:128


### PR DESCRIPTION
In https://github.com/web-platform-tests/wpt/pull/24158 the docs were
updated, but I got the filename wrong - it's lint.ignore, not lint.ignorelist.