### PR TITLE
Allow hiding test state for first-contentful-paint tests

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -489,6 +489,10 @@ with some existing test framework that has its own timeout mechanism).
 `allow_uncaught_exception` - don't treat an uncaught exception as an error;
 needed when e.g. testing the `window.onerror` handler.
 
+`hide_test_state` - hide the test state output while the test is
+running; This is helpful when the output of the test state may interfere
+the test results.
+
 `timeout_multiplier` - Multiplier to apply to per-test timeouts.
 
 `single_test` - Test authors may set this property to `true` to enable [the

--- a/paint-timing/basetest.html
+++ b/paint-timing/basetest.html
@@ -8,6 +8,7 @@
 <div id="main"></div>
 
 <script>
+setup({"hide_test_state": true});
 async_test(function(t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     t.step(function() {

--- a/paint-timing/border-image.html
+++ b/paint-timing/border-image.html
@@ -14,6 +14,7 @@
 </style>
 <div id='bordered'></div>
 <script>
+setup({"hide_test_state": true});
 promise_test(async t => {
   const onload = new Promise(r => window.addEventListener('load', r));
   await onload;

--- a/paint-timing/buffered-flag.window.js
+++ b/paint-timing/buffered-flag.window.js
@@ -1,3 +1,4 @@
+setup({"hide_test_state": true});
 async_test(t => {
   assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
   // First observer creates second in callback to ensure the entry has been dispatched by the time

--- a/paint-timing/child-painting-first-image.html
+++ b/paint-timing/child-painting-first-image.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     window.addEventListener('message', t.step_func(e => {

--- a/paint-timing/fcp-only/fcp-canvas-context.html
+++ b/paint-timing/fcp-only/fcp-canvas-context.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <canvas id="canvas" width="50" height="50"></canvas>
 <script>
+  setup({"hide_test_state": true});
   promise_test(async t => {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     await new Promise(r => window.addEventListener('load', r));

--- a/paint-timing/fcp-only/fcp-gradient.html
+++ b/paint-timing/fcp-only/fcp-gradient.html
@@ -15,6 +15,7 @@
 <script src="../resources/utils.js"></script>
 <div id="main"></div>
 <script>
+  setup({"hide_test_state": true});
   promise_test(async t => {
       assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
       await new Promise(r => window.addEventListener('load', r));

--- a/paint-timing/fcp-only/fcp-text-input.html
+++ b/paint-timing/fcp-only/fcp-text-input.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <input id="input" type="text" />
 <script>
+  setup({"hide_test_state": true});
   promise_test(async t => {
       assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
       await new Promise(r => window.addEventListener('load', r));

--- a/paint-timing/fcp-only/fcp-video-frame.html
+++ b/paint-timing/fcp-only/fcp-video-frame.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <video id="video" autoplay></video>
 <script>
+  setup({"hide_test_state": true});
   promise_test(async t => {
       assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
       await new Promise(r => window.addEventListener('load', r));

--- a/paint-timing/fcp-only/fcp-video-poster.html
+++ b/paint-timing/fcp-only/fcp-video-poster.html
@@ -8,6 +8,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <video id="video" width="50" height="50"></video>
 <script>
+  setup({"hide_test_state": true});
   promise_test(async t => {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     await new Promise(r => window.addEventListener('load', r));

--- a/paint-timing/fcp-only/fcp-with-rtl.html
+++ b/paint-timing/fcp-only/fcp-with-rtl.html
@@ -18,6 +18,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="text">TEXT</div>
 <script>
+  setup({"hide_test_state": true});
   promise_test(async t => {
       assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
       await new Promise(r => window.addEventListener('load', r));

--- a/paint-timing/first-contentful-bg-image.html
+++ b/paint-timing/first-contentful-bg-image.html
@@ -10,6 +10,7 @@
 
 <footer>
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const body = document.getElementsByTagName('body')[0];

--- a/paint-timing/first-contentful-canvas.html
+++ b/paint-timing/first-contentful-canvas.html
@@ -8,6 +8,7 @@
 <canvas id="canvas" width="200" height="200" ></canvas>
 
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const canvas = document.getElementById("canvas");

--- a/paint-timing/first-contentful-image.html
+++ b/paint-timing/first-contentful-image.html
@@ -8,6 +8,7 @@
 <div id="image"></div>
 
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const img = document.createElement("IMG");

--- a/paint-timing/first-contentful-paint.html
+++ b/paint-timing/first-contentful-paint.html
@@ -9,6 +9,7 @@
 <div id="image"></div>
 
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const bufferedEntries = performance.getEntriesByType('paint');

--- a/paint-timing/first-contentful-svg.html
+++ b/paint-timing/first-contentful-svg.html
@@ -8,6 +8,7 @@
 <div id="svg"></div>
 
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const img = document.createElement("IMG");

--- a/paint-timing/first-image-child.html
+++ b/paint-timing/first-image-child.html
@@ -9,6 +9,7 @@
 <iframe src='resources/subframe-sending-paint.html' id='child-iframe'></iframe>
 <img src='resources/circles.png'/>
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
 

--- a/paint-timing/first-paint-bg-color.html
+++ b/paint-timing/first-paint-bg-color.html
@@ -10,6 +10,7 @@
 
 <footer>
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     document.body.style.backgroundColor = "#AA0000";

--- a/paint-timing/first-paint-only.html
+++ b/paint-timing/first-paint-only.html
@@ -8,6 +8,7 @@
 <div id="main"></div>
 
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     const div = document.createElement("div");

--- a/paint-timing/input-text.html
+++ b/paint-timing/input-text.html
@@ -7,6 +7,7 @@
   <input type="text" id='myInput'>
 </form>
 <script>
+setup({"hide_test_state": true});
 promise_test(async t => {
   const onload = new Promise(r => window.addEventListener('load', r));
   await onload;

--- a/paint-timing/mask-image.html
+++ b/paint-timing/mask-image.html
@@ -13,6 +13,7 @@
 </style>
 <div id='masked'></div>
 <script>
+setup({"hide_test_state": true});
 promise_test(async t => {
   const onload = new Promise(r => window.addEventListener('load', r));
   await onload;

--- a/paint-timing/paint-visited.html
+++ b/paint-timing/paint-visited.html
@@ -20,6 +20,7 @@ window.onload = function() {
   history.replaceState({}, "", "./");
   history.replaceState({}, "", current_url);
 }
+setup({"hide_test_state": true});
 async_test(function(t) {
   assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
   function testPaintEntries() {

--- a/paint-timing/replaced-content-image.html
+++ b/paint-timing/replaced-content-image.html
@@ -10,6 +10,7 @@
 </style>
 <img></img>
 <script>
+setup({"hide_test_state": true});
 promise_test(async t => {
   const onload = new Promise(r => window.addEventListener('load', r));
   await onload;

--- a/paint-timing/resources/utils.js
+++ b/paint-timing/resources/utils.js
@@ -33,6 +33,7 @@ async function assertFirstContentfulPaint(t) {
 }
 
 async function test_fcp(label) {
+  setup({"hide_test_state": true});
   const style = document.createElement('style');
   document.head.appendChild(style);
   await promise_test(async t => {

--- a/paint-timing/sibling-painting-first-image.html
+++ b/paint-timing/sibling-painting-first-image.html
@@ -5,6 +5,7 @@
  <!-- This iframe will have a sibling that paints, we want to ensure it does not detect that paint. -->
 <iframe id="listening-iframe" src="resources/subframe-sending-paint.html"></iframe>
 <script>
+setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
     let paintingIframeHasDispatchedEntries = false;

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2510,6 +2510,7 @@ policies and contribution forms [3].
         this.test_done_callbacks = [];
         this.all_done_callbacks = [];
 
+        this.hide_test_state = false;
         this.pending_remotes = [];
 
         this.status = new TestsStatus();
@@ -2557,6 +2558,8 @@ policies and contribution forms [3].
                     if (this.timeout_length) {
                          this.timeout_length *= this.timeout_multiplier;
                     }
+                } else if (p == "hide_test_state") {
+                    this.hide_test_state = value;
                 }
             }
         }
@@ -3063,7 +3066,7 @@ policies and contribution forms [3].
             this.phase = this.HAVE_RESULTS;
         }
         var done_count = tests.tests.length - tests.num_pending;
-        if (this.output_node) {
+        if (this.output_node && !tests.hide_test_state) {
             if (done_count < 100 ||
                 (done_count < 1000 && done_count % 100 === 0) ||
                 done_count % 1000 === 0) {


### PR DESCRIPTION
The testharness' `show_status` function call interfere
the tests result because it would display a text to the document
while the tests are running.

The issue is this text could be considered as the first-contentful-paint,
which is not what we expect.

We fix it by adding a new setup property to not displaying this text.

This PR intends to fix #24089 