### PR TITLE
Test frameElement access from siblings

### DIFF
--- a/html/browsers/windows/nested-browsing-contexts/frameElement-siblings.sub.html
+++ b/html/browsers/windows/nested-browsing-contexts/frameElement-siblings.sub.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>window.frameElement access to a same-origin-domain sibling</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe src="//{{hosts[][]}}:{{ports[http][0]}}/html/browsers/windows/nested-browsing-contexts/resources/frameElement-sibling-accessed.html"></iframe>
+<iframe src="//{{hosts[][www]}}:{{ports[http][0]}}/html/browsers/windows/nested-browsing-contexts/resources/frameElement-sibling-accessor.html"></iframe>
+
+<script>
+"use strict";
+setup({ explicit_done: true });
+
+window.onload = () => {
+  promise_test(async () => {
+    frames[1].postMessage({}, "*");
+    const result = await waitForMessage();
+
+    assert_equals(result, "SecurityError");
+  }, "it must give a \"SecurityError\" DOMException if the pages are different-origin domain");
+
+  promise_test(async () => {
+    document.domain = document.domain;
+
+    frames[0].postMessage({ newDocumentDomain: document.domain }, "*");
+    assert_equals(await waitForMessage(), "done");
+
+    frames[1].postMessage({ newDocumentDomain: document.domain }, "*");
+    const result = await waitForMessage();
+
+    assert_equals(result, "HTMLIFrameElement");
+  }, "it must return the iframe element if the pages are same-origin domain");
+
+  done();
+};
+
+function waitForMessage() {
+  return new Promise(resolve => {
+    window.addEventListener("message", e => resolve(e.data), { once: true });
+  });
+}
+</script>

--- a/html/browsers/windows/nested-browsing-contexts/resources/frameElement-sibling-accessed.html
+++ b/html/browsers/windows/nested-browsing-contexts/resources/frameElement-sibling-accessed.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>This page will set its document.domain on request so that its sibling can access it</title>
+
+<h1>I did get loaded</h1>
+
+<script>
+"use strict";
+
+window.onmessage = e => {
+  const { newDocumentDomain } = e.data;
+  document.domain = newDocumentDomain;
+
+  parent.postMessage("done", "*");
+};
+</script>

--- a/html/browsers/windows/nested-browsing-contexts/resources/frameElement-sibling-accessor.html
+++ b/html/browsers/windows/nested-browsing-contexts/resources/frameElement-sibling-accessor.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>This page will attempt to access the frameElement of its sibling and report the results on request</title>
+
+<h1>I did get loaded</h1>
+
+<script>
+"use strict";
+
+window.onmessage = e => {
+  const { newDocumentDomain } = e.data;
+  if (newDocumentDomain) {
+    document.domain = newDocumentDomain;
+  }
+
+  const siblingWindow = parent.frames[0];
+
+  try {
+    const { frameElement } = siblingWindow;
+
+    let result = "something wierd happened";
+    if (frameElement === null) {
+      result = "null";
+    } else if (frameElement.constructor) {
+      result = frameElement.constructor.name;
+    }
+
+    parent.postMessage(result, "*");
+  } catch (e) {
+    parent.postMessage(e.name, "*");
+  }
+};
+</script>


### PR DESCRIPTION
I was working on similar tests for origin isolation and couldn't get them to pass. So I decided to do a reduced test case. Well, this one passes in Chrome and Firefox at least. I thought we should keep it around.