### PR TITLE
Support async iterable declarations in idlharness

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2654,6 +2654,8 @@ IdlInterface.prototype.test_member_async_iterable = function(member)
             });
         } else {
             assert_equals(proto["values"], proto[Symbol.asyncIterator], "values method should be the same as @@asyncIterator method");
+            assert_false("entries" in proto, "should not have an entries method");
+            assert_false("keys" in proto, "should not have a keys method");
         }
     }.bind(this), this.name + " interface: async iterable<" + member.idlType.map(function(t) { return t.idlType; }).join(", ") + ">");
 };

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2597,23 +2597,34 @@ IdlInterface.prototype.test_member_iterable = function(member)
     {
         var isPairIterator = member.idlType.length === 2;
         var proto = this.get_interface_object().prototype;
-        var descriptor = Object.getOwnPropertyDescriptor(proto, Symbol.iterator);
+        var iteratorDesc = Object.getOwnPropertyDescriptor(proto, Symbol.iterator);
 
-        assert_true(descriptor.writable, "@@iterator property should be writable");
-        assert_true(descriptor.configurable, "@@iterator property should be configurable");
-        assert_false(descriptor.enumerable, "@@iterator property should not be enumerable");
-        assert_equals(typeof descriptor.value, "function", "@@iterator property should be a function");
-        assert_equals(descriptor.value.length, 0, "@@iterator function object length should be 0");
-        assert_equals(descriptor.value.name, isPairIterator ? "entries" : "values", "@@iterator function object should have the right name");
+        assert_true(iteratorDesc.writable, "@@iterator property should be writable");
+        assert_true(iteratorDesc.configurable, "@@iterator property should be configurable");
+        assert_false(iteratorDesc.enumerable, "@@iterator property should not be enumerable");
+        assert_equals(typeof iteratorDesc.value, "function", "@@iterator property should be a function");
+        assert_equals(iteratorDesc.value.length, 0, "@@iterator function object length should be 0");
+        assert_equals(iteratorDesc.value.name, isPairIterator ? "entries" : "values", "@@iterator function object should have the right name");
 
         if (isPairIterator) {
             assert_equals(proto["entries"], proto[Symbol.iterator], "entries method should be the same as @@iterator method");
+            [
+                ["entries", 0],
+                ["keys", 0],
+                ["values", 0],
+                ["forEach", 1]
+            ].forEach(([property, length]) => {
+                var desc = Object.getOwnPropertyDescriptor(proto, property);
+                assert_equals(typeof desc.value, "function", property + " property should be a function");
+                assert_equals(desc.value.length, length, property + " function object length should be " + length);
+                assert_equals(desc.value.name, property, property + " function object should have the right name");
+            });
         } else {
             assert_equals(proto[Symbol.iterator], Array.prototype[Symbol.iterator], "@@iterator method should be the same as Array prototype's");
-            ["entries", "keys", "values", "forEach", Symbol.iterator].forEach(function(property) {
+            ["entries", "keys", "values", "forEach", Symbol.iterator].forEach(property => {
                 var propertyName = property === Symbol.iterator ? "@@iterator" : property;
                 assert_equals(proto[property], Array.prototype[property], propertyName + " method should be the same as Array prototype's");
-            }.bind(this));
+            });
         }
     }.bind(this), this.name + " interface: iterable<" + member.idlType.map(function(t) { return t.idlType; }).join(", ") + ">");
 };

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2777,9 +2777,9 @@ IdlInterface.prototype.test_members = function()
 
         case "iterable":
             if (member.async) {
-              this.test_member_async_iterable(member);
+                this.test_member_async_iterable(member);
             } else {
-              this.test_member_iterable(member);
+                this.test_member_iterable(member);
             }
             break;
         default:


### PR DESCRIPTION
Currently, the idlharness incorrectly interprets [async iterable declarations](https://heycam.github.io/webidl/#es-asynchronous-iterable) (as used in the Streams spec) as if they were [regular iterables](https://heycam.github.io/webidl/#es-iterable). This PR fixes that by adding separate testing logic for such async iterable declarations.

I also added tests for the `entries`, `keys`, `values` and `forEach` methods of pair iterable declarations, to match the new tests for the methods on asynchronous pair iterables.

Fixes #24174 