### PR TITLE
Streams: fix IDL tests

### DIFF
--- a/streams/idlharness.any.js
+++ b/streams/idlharness.any.js
@@ -29,8 +29,9 @@ idl_test(
 
     try {
       const stream = new ReadableStream({
-        pull() {
-          self.readableStreamByobRequest = controller.byobRequest;
+        pull(c) {
+          self.readableStreamByobRequest = c.byobRequest;
+          c.enqueue(new Uint8Array(0));
         },
         type: 'bytes'
       });

--- a/streams/idlharness.any.js
+++ b/streams/idlharness.any.js
@@ -59,7 +59,7 @@ idl_test(
     idl_array.add_objects({
       ReadableStream: ["new ReadableStream()"],
       ReadableStreamDefaultReader: ["(new ReadableStream()).getReader()"],
-      ReadableStreamBYOBReader: ["(new ReadableStream({ type: 'bytes' })).getReader('byob')"],
+      ReadableStreamBYOBReader: ["(new ReadableStream({ type: 'bytes' })).getReader({ mode: 'byob' })"],
       ReadableStreamDefaultController: ["self.readableStreamDefaultController"],
       ReadableByteStreamController: ["self.readableByteStreamController"],
       ReadableStreamBYOBRequest: ["self.readableStreamByobRequest"],

--- a/streams/idlharness.any.js
+++ b/streams/idlharness.any.js
@@ -28,17 +28,20 @@ idl_test(
     } catch {}
 
     try {
+      let resolvePullCalledPromise;
+      const pullCalledPromise = new Promise(resolve => {
+        resolvePullCalledPromise = resolve;
+      });
       const stream = new ReadableStream({
         pull(c) {
           self.readableStreamByobRequest = c.byobRequest;
-          c.enqueue(new Uint8Array(0));
+          resolvePullCalledPromise();
         },
         type: 'bytes'
       });
-
       const reader = stream.getReader({ mode: 'byob' });
-
-      await reader.read(new Uint8Array(1));
+      reader.read(new Uint8Array(1));
+      await pullCalledPromise;
     } catch {}
 
     try {


### PR DESCRIPTION
The new IDL harness tests for Streams (#22982) did not correctly instantiate all tested interfaces. This PR fixes them.