### PR TITLE
IDL: Handle ArrayBufferView in attribute types

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1209,6 +1209,10 @@ IdlArray.prototype.assert_type_is = function(value, type)
             assert_regexp_match(value, /^([\x00-\ud7ff\ue000-\uffff]|[\ud800-\udbff][\udc00-\udfff])*$/);
             return;
 
+        case "ArrayBufferView":
+            assert_true(ArrayBuffer.isView(value));
+            return;
+
         case "object":
             assert_in_array(typeof value, ["object", "function"], "wrong type: not object or function");
             return;


### PR DESCRIPTION
Streams appears to be the first specification [to use the `ArrayBufferView` type in an attribute position](https://github.com/web-platform-tests/wpt/blob/a16dbbde7c098577d8a7f51cc9bf4c80499dd05d/interfaces/streams.idl#L104). `idlharness` did not handle that yet, so this PR fixes it.

Follow-up on #24267.