### PR TITLE
[idlharness] Remove old names for legacy extended attributes

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1343,8 +1343,7 @@ function IdlInterface(obj, is_callback, is_mixin)
 
     /** An array of IdlInterfaceMembers. */
     this.members = obj.members.map(function(m){return new IdlInterfaceMember(m); });
-    if (this.has_extended_attribute("Unforgeable") ||
-        this.has_extended_attribute("LegacyUnforgeable")) {
+    if (this.has_extended_attribute("LegacyUnforgeable")) {
         this.members
             .filter(function(m) { return m.special !== "static" && (m.type == "attribute" || m.type == "operation"); })
             .forEach(function(m) { return m.isUnforgeable = true; });
@@ -1806,10 +1805,9 @@ IdlInterface.prototype.test_self = function()
         }.bind(this), this.name + " interface: legacy window alias");
     }
 
-    if (this.has_extended_attribute("NamedConstructor") ||
-        this.has_extended_attribute("LegacyFactoryFunction")) {
+    if (this.has_extended_attribute("LegacyFactoryFunction")) {
         var constructors = this.extAttrs
-            .filter(function(attr) { return attr.name == "NamedConstructor" || attr.name == "LegacyFactoryFunction"; });
+            .filter(function(attr) { return attr.name == "LegacyFactoryFunction"; });
         if (constructors.length !== 1) {
             throw new IdlHarnessError("Internal error: missing support for multiple LegacyFactoryFunction extended attributes");
         }
@@ -2383,8 +2381,7 @@ IdlInterface.prototype.test_member_attribute = function(member)
                 "The prototype object must have a property " +
                 format_value(member.name));
 
-            if (!member.has_extended_attribute("LenientThis") &&
-                !member.has_extended_attribute("LegacyLenientThis")) {
+            if (!member.has_extended_attribute("LegacyLenientThis")) {
                 if (member.idlType.generic !== "Promise") {
                     // this.get_interface_object() returns a thing in our global
                     assert_throws_js(TypeError, function() {
@@ -3113,8 +3110,7 @@ IdlInterface.prototype.do_interface_attribute_asserts = function(obj, member, a_
         // "If the attribute was specified with the [LegacyLenientThis] extended
         // attribute, then return undefined.
         // "Otherwise, throw a TypeError."
-        if (!member.has_extended_attribute("LenientThis") &&
-            !member.has_extended_attribute("LegacyLenientThis")) {
+        if (!member.has_extended_attribute("LegacyLenientThis")) {
             if (member.idlType.generic !== "Promise") {
                 assert_throws_js(globalOf(desc.get).TypeError, function() {
                     desc.get.call({});
@@ -3143,7 +3139,6 @@ IdlInterface.prototype.do_interface_attribute_asserts = function(obj, member, a_
     // TODO: Test calling setter on the interface prototype (should throw
     // TypeError in most cases).
     if (member.readonly
-    && !member.has_extended_attribute("LenientSetter")
     && !member.has_extended_attribute("LegacyLenientSetter")
     && !member.has_extended_attribute("PutForwards")
     && !member.has_extended_attribute("Replaceable"))
@@ -3167,8 +3162,7 @@ IdlInterface.prototype.do_interface_attribute_asserts = function(obj, member, a_
             // "If the attribute is declared with a [Replaceable] extended
             // attribute, then: ..."
             // "If validThis is false, then return."
-            if (!member.has_extended_attribute("LenientThis") &&
-                !member.has_extended_attribute("LegacyLenientThis")) {
+            if (!member.has_extended_attribute("LegacyLenientThis")) {
                 assert_throws_js(globalOf(desc.set).TypeError, function() {
                     desc.set.call({});
                 }.bind(this), "calling setter on wrong object type must throw TypeError");
@@ -3208,8 +3202,7 @@ function IdlInterfaceMember(obj)
         this.extAttrs = [];
     }
 
-    this.isUnforgeable = this.has_extended_attribute("Unforgeable") ||
-        this.has_extended_attribute("LegacyUnforgeable");
+    this.isUnforgeable = this.has_extended_attribute("LegacyUnforgeable");
     this.isUnscopable = this.has_extended_attribute("Unscopable");
 }
 

--- a/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
+++ b/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
@@ -45,7 +45,7 @@ idlArray.add_idls(
   void Lies();
 };
 namespace bar {
-  [Unforgeable]
+  [LegacyUnforgeable]
   void Truth();
 };
 namespace baz {


### PR DESCRIPTION
The following attributes don't seem to have code relating to them in
idlharness:
  - OverrideBuiltins / LegacyOverrideBuiltIns
  - TreatNonObjectAsNull / LegacyTreatNonObjectAsNull
  - TreatNullAs=EmptyString / LegacyNullToEmptyString

Finally, didn't touch NoInterfaceObject yet as there appear to be no
specs that mention it or its replacement LegacyNoInterfaceObject in
interfaces/*.idl.

See https://github.com/web-platform-tests/wpt/issues/23148