### PR TITLE
Fix idlharness timeout when enumerability checks fail

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2393,12 +2393,12 @@ IdlInterface.prototype.test_member_attribute = function(member)
                 } else {
                     promise_rejects_js(a_test, TypeError,
                                     this.get_interface_object().prototype[member.name])
-                        .then(function() {
+                        .then(a_test.step_func(function() {
                             // do_interface_attribute_asserts must be the last
                             // thing we do, since it will call done() on a_test.
                             this.do_interface_attribute_asserts(this.get_interface_object().prototype,
                                                                 member, a_test);
-                        }.bind(this));
+                        }.bind(this)));
                 }
             } else {
                 assert_equals(this.get_interface_object().prototype[member.name], undefined,


### PR DESCRIPTION
Exceptions caused by failed enumerability asserts were not caught,
causing the test to neither fail nor done() to be called, resulting in
the test timing out.

Use step_func() to ensure exceptions from these asserts() are caught.