### PR TITLE
IDL: Add missing step_func

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2393,12 +2393,12 @@ IdlInterface.prototype.test_member_attribute = function(member)
                 } else {
                     promise_rejects_js(a_test, TypeError,
                                     this.get_interface_object().prototype[member.name])
-                        .then(function() {
+                        .then(a_test.step_func(function() {
                             // do_interface_attribute_asserts must be the last
                             // thing we do, since it will call done() on a_test.
                             this.do_interface_attribute_asserts(this.get_interface_object().prototype,
                                                                 member, a_test);
-                        }.bind(this));
+                        }.bind(this)));
                 }
             } else {
                 assert_equals(this.get_interface_object().prototype[member.name], undefined,


### PR DESCRIPTION
`do_interface_attribute_asserts` can throw an assertion error synchronously, which must fail the test. However, when this method is called [from a promise callback in `test_member_attribute`](https://github.com/web-platform-tests/wpt/blob/cb40575e1a57892476f3e326355674d492dedbd2/resources/idlharness.js#L2396-L2401), such an error would instead reject an (unhandled) promise, keeping the test running indefinitely.

Fix it by wrapping the promise callback inside a `step_func()`.