### PR TITLE
XPathNSResolver: Add non-string return value test

### DIFF
--- a/domxpath/resolver-callback-interface.html
+++ b/domxpath/resolver-callback-interface.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <title>XPathNSResolver implements callback interface</title>
+<link rel="help" href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator">
+<link rel="help" href="https://heycam.github.io/webidl/#call-a-user-objects-operation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel="help" href="https://heycam.github.io/webidl/#call-a-user-objects-operation">
+<script src="resources/invalid_namespace_test.js"></script>
 <div id=log></div>
 <script>
 "use strict";
-setup({ allow_uncaught_exception: true });
 
 test(() => {
   let resolverCalls = 0;
@@ -32,24 +33,6 @@ test(() => {
   assert_equals(resolverCalls, 2);
 }, "callable resolver: result is not cached");
 
-const uncaught_error_test = async (t, resolver) => {
-  const timeout = () => {
-    return new Promise(resolve => {
-      t.step_timeout(resolve, 0);
-    });
-  };
-
-  const eventWatcher = new EventWatcher(t, window, "error", timeout);
-  const errorPromise = eventWatcher.wait_for("error");
-
-  assert_throws_dom("NAMESPACE_ERR", () => {
-    document.evaluate("/foo:bar", document.documentElement, resolver);
-  });
-
-  const event = await errorPromise;
-  throw event.error;
-};
-
 promise_test(t => {
   const testError = { name: "test" };
   const resolver = () => {
@@ -57,7 +40,7 @@ promise_test(t => {
   };
 
   return promise_rejects_exactly(t, testError,
-    uncaught_error_test(t, resolver)
+    invalid_namespace_test(t, resolver)
   );
 }, "callable resolver: abrupt completion from Call");
 
@@ -124,7 +107,7 @@ promise_test(t => {
   };
 
   return promise_rejects_exactly(t, testError,
-    uncaught_error_test(t, resolver)
+    invalid_namespace_test(t, resolver)
   );
 }, "object resolver: abrupt completion from Get");
 
@@ -134,13 +117,13 @@ promise_test(t => {
   };
 
   return promise_rejects_js(t, TypeError,
-    uncaught_error_test(t, resolver)
+    invalid_namespace_test(t, resolver)
   );
 }, "object resolver: 'lookupNamespaceURI' is thruthy and not callable");
 
 promise_test(t => {
   return promise_rejects_js(t, TypeError,
-    uncaught_error_test(t, {})
+    invalid_namespace_test(t, {})
   );
 }, "object resolver: 'lookupNamespaceURI' is falsy and not callable");
 </script>

--- a/domxpath/resolver-non-string-result.html
+++ b/domxpath/resolver-non-string-result.html
@@ -10,11 +10,11 @@
 "use strict";
 
 promise_test(t => {
-  return invalid_namespace_test(t, () => null);
+  return invalid_namespace_test(t, () => undefined);
 }, "undefined");
 
 promise_test(t => {
-  return invalid_namespace_test(t, () => undefined);
+  return invalid_namespace_test(t, () => null);
 }, "null");
 
 test(t => {

--- a/domxpath/resolver-non-string-result.html
+++ b/domxpath/resolver-non-string-result.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>XPathNSResolver non-string return value</title>
+<link rel="help" href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/invalid_namespace_test.js"></script>
+<div id=log></div>
+<script>
+"use strict";
+
+promise_test(t => {
+  return invalid_namespace_test(t, () => null);
+}, "undefined");
+
+promise_test(t => {
+  return invalid_namespace_test(t, () => undefined);
+}, "null");
+
+test(t => {
+  let resolverCalls = 0;
+
+  document.evaluate("/foo:bar", document.documentElement, () => {
+    resolverCalls++;
+    return 0;
+  });
+
+  assert_equals(resolverCalls, 1);
+}, "number");
+
+test(t => {
+  let resolverCalls = 0;
+
+  document.evaluate("/foo:bar", document.documentElement, () => {
+    resolverCalls++;
+    return false;
+  });
+
+  assert_equals(resolverCalls, 1);
+}, "boolean");
+
+promise_test(t => {
+  return promise_rejects_js(t, TypeError,
+    invalid_namespace_test(t, () => Symbol())
+  );
+}, "symbol");
+
+promise_test(t => {
+  const testError = { name: "test" };
+  const resolverResult = {
+    toString: () => { throw testError; },
+    valueOf: t.unreached_func("`valueOf` should not be called."),
+  };
+
+  return promise_rejects_exactly(t, testError,
+    invalid_namespace_test(t, () => resolverResult)
+  );
+}, "object coercion (abrupt completion)");
+</script>
+</body>

--- a/domxpath/resources/invalid_namespace_test.js
+++ b/domxpath/resources/invalid_namespace_test.js
@@ -1,0 +1,23 @@
+"use strict";
+setup({ allow_uncaught_exception: true });
+
+const invalid_namespace_test = (t, resolver) => {
+  const result = new Promise((resolve, reject) => {
+    const handler = event => {
+      reject(event.error);
+    };
+
+    window.addEventListener("error", handler);
+    t.add_cleanup(() => {
+      window.removeEventListener("error", handler);
+    });
+
+    t.step_timeout(resolve, 10);
+  });
+
+  assert_throws_dom("NAMESPACE_ERR", () => {
+    document.evaluate("/foo:bar", document.documentElement, resolver);
+  });
+
+  return result;
+};

--- a/domxpath/resources/invalid_namespace_test.js
+++ b/domxpath/resources/invalid_namespace_test.js
@@ -12,7 +12,7 @@ const invalid_namespace_test = (t, resolver) => {
       window.removeEventListener("error", handler);
     });
 
-    t.step_timeout(resolve, 10);
+    t.step_timeout(resolve, 0);
   });
 
   assert_throws_dom("NAMESPACE_ERR", () => {


### PR DESCRIPTION
Safari and Firefox treat `undefined` return value as failure, throwing an error, while Chrome seems to ignore it.

_cc_ @tkent-google