### PR TITLE
Test `this` value of non-function callback interfaces

### DIFF
--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -172,6 +172,24 @@ test(function()
     assert_node(walker.currentNode, { type: Element, id: 'root' });
 }, 'Testing with filter object that throws');
 
+test(() =>
+{
+    let thisValue, nodeArgID;
+    const filter = {
+        acceptNode(node) {
+            thisValue = this;
+            nodeArgID = node.id;
+            return NodeFilter.FILTER_ACCEPT;
+        },
+    };
+
+    const walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
+    walker.nextNode();
+
+    assert_equals(thisValue, filter);
+    assert_equals(nodeArgID, 'A1');
+}, 'Testing with filter object: this value and `node` argument');
+
 </script>
 </body>
 </html>

--- a/domxpath/resolver-callback-interface.html
+++ b/domxpath/resolver-callback-interface.html
@@ -77,6 +77,22 @@ test(() => {
 }, "object resolver");
 
 test(() => {
+  let thisValue, prefixArg;
+  const resolver = {
+    lookupNamespaceURI(prefix) {
+      thisValue = this;
+      prefixArg = prefix;
+      return "";
+    },
+  };
+
+  document.evaluate("/foo:bar", document.documentElement, resolver);
+
+  assert_equals(thisValue, resolver);
+  assert_equals(prefixArg, "foo");
+}, "object resolver: this value and `prefix` argument");
+
+test(() => {
   let resolverCalls = 0;
   const lookupNamespaceURI = () => {
     resolverCalls++;


### PR DESCRIPTION
[`EventListener`](https://dom.spec.whatwg.org/#callbackdef-eventlistener) is already covered by [`/dom/events/EventListener-handleEvent.html`](https://github.com/web-platform-tests/wpt/blob/cb40575e1a57892476f3e326355674d492dedbd2/dom/events/EventListener-handleEvent.html#L21).

WebKit bug: ["acceptNode" method is called with incorrect `this` value](https://bugs.webkit.org/show_bug.cgi?id=213716).