### PR TITLE
location.replace with invalid urls should throw

### DIFF
--- a/html/browsers/history/the-location-interface/location_replace.html
+++ b/html/browsers/history/the-location-interface/location_replace.html
@@ -15,6 +15,12 @@
       assert_equals((href + "#x"), location.href, "location href");
 
     }, "location replace");
+
+    test(function () {
+      var href = location.href;
+      assert_throws_dom('SYNTAX_ERR', function() { location.replace("//"); });
+      assert_equals(location.href, href);
+    }, "URL that fails to parse");
     </script>
   </body>
 </html>


### PR DESCRIPTION
Add a subtest to verify that location.replace throws SyntaxError if
the resulting url is not valid.