### PR TITLE
Fix html/coep/require-corp.https.html flakiness

### DIFF
--- a/html/cross-origin-embedder-policy/require-corp.https.html
+++ b/html/cross-origin-embedder-policy/require-corp.https.html
@@ -27,7 +27,6 @@ async_test(t => {
   t.add_cleanup(() => frame.remove());
   const bc = new BroadcastChannel(token());
   bc.onmessage = t.step_func((event) => {
-    assert_not_equals(frame.contentDocument, null);
     let payload = event.data;
     assert_equals(payload, "loaded");
     t.step_wait_func_done(() => frame.contentDocument === null);


### PR DESCRIPTION
The test case asserts that frame.contentDocument is not null, by
assuming that the message arrives at the parent frame before the
child frame navigates out, which actually is not guaranteed. Remove
the assertion.