### PR TITLE
Update Safari Technology Preview to 109

### DIFF
--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask 'safari-technology-preview' do
-  if MacOS.version <= :mojave
-    version '108,001-15210-20200610-d35e22e0-d9fa-4503-9988-cf7b2b554e15'
-    sha256 '0299fd2f2836b170a8b633b00d289bcc6913716042e82251af4fa1d5394b87d5'
+  if MacOS.version <= :catalina
+    version '109,001-21354-20200624-98a4e372-cb40-4d35-9b8c-8b8abcde5272'
+    sha256 '4dff98feb0723d0408a313d3b195ac4448a6d9c9dda8d88e6efd03114585d162'
   else
-    version '108,001-16091-20200610-09f04256-ae36-4930-b7c4-b1333f8d8e5f'
-    sha256 '22a4d9ca7fb39227cbf4a83be13ad05973171cf88eb6bcc2fac4556a36017357'
+    version '109,001-01921-20200624-789b06ac-f1c4-43e7-9e02-636204e11bb1'
+    sha256 '169d1eb786eb4bf8ef03392aa42c4a3738db0355e28c991627ce6ca279a70088'
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
@@ -13,7 +13,7 @@ cask 'safari-technology-preview' do
   homepage 'https://developer.apple.com/safari/download/'
 
   auto_updates true
-  depends_on macos: '>= :mojave'
+  depends_on macos: '>= :catalina'
 
   pkg 'Safari Technology Preview.pkg'
 


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 109, 15610.1.17.2)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=1940&view=logs