### PR TITLE
Add a new test for updateRenderState()

### DIFF
--- a/webxr/render_state_update.https.html
+++ b/webxr/render_state_update.https.html
@@ -28,10 +28,7 @@ let testBaseLayer = function(session, fakeDeviceController, t, sessionObjects) {
       navigator.xr.requestSession('immersive-ar').then((tempSession) => {
         assert(tempSession);
         assert_not_equals(session, tempSession);
-        session.updateRenderState({ baseLayer : new XRWebGLLayer(tempSession, sessionObjects.gl), });
-        assert_unreached("updateRenderState should fail when baseLayer is created with a different session");
-      }).catch(err => {
-        assert_equals(err.name, 'InvalidStateError');
+        assert_throws_dom('InvalidStateError', () => session.updateRenderState({ baseLayer : new XRWebGLLayer(tempSession, sessionObjects.gl), }));
       });
       resolve();
     });

--- a/webxr/render_state_update.https.html
+++ b/webxr/render_state_update.https.html
@@ -10,14 +10,9 @@ let fakeDeviceInitParams = TRACKED_IMMERSIVE_DEVICE;
 
 let testSessionEnded = function(session, fakeDeviceController, t) {
   return new Promise((resolve, reject) => {
-      resolve(session.end().then(() => {
-          try {
-              session.updateRenderState({});
-              assert_unreached("updateRenderState should fail when created with an ended session");
-          } catch (err) {
-              assert_equals(err.name, 'InvalidStateError');
-          }
-      }));
+    resolve(session.end().then(() => {
+      assert_throws_dom('InvalidStateError', () => session.updateRenderState({}));
+    }));
   });
 };
 
@@ -25,8 +20,7 @@ let testSessionEnded = function(session, fakeDeviceController, t) {
 let testBaseLayer = function(session, fakeDeviceController, t, sessionObjects) {
   return new Promise((resolve, reject) => {
     navigator.xr.test.simulateUserActivation(() => {
-      navigator.xr.requestSession('immersive-ar').then((tempSession) => {
-        assert(tempSession);
+      navigator.xr.requestSession('inline').then((tempSession) => {
         assert_not_equals(session, tempSession);
         assert_throws_dom('InvalidStateError', () => session.updateRenderState({ baseLayer : new XRWebGLLayer(tempSession, sessionObjects.gl), }));
       });
@@ -37,12 +31,7 @@ let testBaseLayer = function(session, fakeDeviceController, t, sessionObjects) {
 
 let testFieldOfView = function(session, fakeDeviceController, t) {
   return new Promise((resolve, reject) => {
-    try {
-      session.updateRenderState({ inlineVerticalFieldOfView : Math.PI, });
-      assert_unreached("updateRenderState should fail when specifying an inlineVerticalFieldOfView with immersive sessions");
-    } catch (err) {
-      assert_equals(err.name, 'InvalidStateError');
-    }
+    assert_throws_dom('InvalidStateError', () => session.updateRenderState({ inlineVerticalFieldOfView : Math.PI, }));
     resolve();
   });
 };

--- a/webxr/render_state_update.https.html
+++ b/webxr/render_state_update.https.html
@@ -11,7 +11,9 @@ let fakeDeviceInitParams = TRACKED_IMMERSIVE_DEVICE;
 let testSessionEnded = function(session, fakeDeviceController, t) {
   return new Promise((resolve, reject) => {
     resolve(session.end().then(() => {
-      assert_throws_dom('InvalidStateError', () => session.updateRenderState({}));
+      t.step(() => {
+        assert_throws_dom('InvalidStateError', () => session.updateRenderState({}));
+      });
     }));
   });
 };
@@ -21,8 +23,10 @@ let testBaseLayer = function(session, fakeDeviceController, t, sessionObjects) {
   return new Promise((resolve, reject) => {
     navigator.xr.test.simulateUserActivation(() => {
       navigator.xr.requestSession('inline').then((tempSession) => {
-        assert_not_equals(session, tempSession);
-        assert_throws_dom('InvalidStateError', () => session.updateRenderState({ baseLayer : new XRWebGLLayer(tempSession, sessionObjects.gl), }));
+        t.step(() => {
+          assert_not_equals(session, tempSession);
+          assert_throws_dom('InvalidStateError', () => session.updateRenderState({ baseLayer : new XRWebGLLayer(tempSession, sessionObjects.gl), }));
+        });
       });
       resolve();
     });
@@ -31,7 +35,9 @@ let testBaseLayer = function(session, fakeDeviceController, t, sessionObjects) {
 
 let testFieldOfView = function(session, fakeDeviceController, t) {
   return new Promise((resolve, reject) => {
-    assert_throws_dom('InvalidStateError', () => session.updateRenderState({ inlineVerticalFieldOfView : Math.PI, }));
+    t.step(() => {
+      assert_throws_dom('InvalidStateError', () => session.updateRenderState({ inlineVerticalFieldOfView : Math.PI, }));
+    });
     resolve();
   });
 };
@@ -52,16 +58,18 @@ let testParams = function(session, fakeDeviceController, t, sessionObjects) {
     let gl = sessionObjects.gl;
     try {
       gl.makeXRCompatible().then(() => {
-        let fov = Math.PI;
-        let near = 0.2;
-        let far = 0.8;
-        let layer = new XRWebGLLayer(session, gl);
-        session.updateRenderState({ inlineVerticalFieldOfView: fov, depthNear: near, depthFar: far, baseLayer: layer });
-        // The update can only happen between frame boundaries, updateRenderState only queues changes.
-        assert_not_equals(session.renderState.inlineVerticalFieldOfView, fov);
-        assert_not_equals(session.renderState.depthNear, near);
-        assert_not_equals(session.renderState.depthFar, far);
-        assert_not_equals(session.renderState.baseLayer, layer);
+        t.step(() => {
+          let fov = Math.PI;
+          let near = 0.2;
+          let far = 0.8;
+          let layer = new XRWebGLLayer(session, gl);
+          session.updateRenderState({ inlineVerticalFieldOfView: fov, depthNear: near, depthFar: far, baseLayer: layer });
+          // The update can only happen between frame boundaries, updateRenderState only queues changes.
+          assert_not_equals(session.renderState.inlineVerticalFieldOfView, fov);
+          assert_not_equals(session.renderState.depthNear, near);
+          assert_not_equals(session.renderState.depthFar, far);
+          assert_not_equals(session.renderState.baseLayer, layer);
+        });
       });
     } catch (err) {
       assert_unreached("updateRenderState should not fail when all params are specified");

--- a/webxr/render_state_update.https.html
+++ b/webxr/render_state_update.https.html
@@ -64,7 +64,7 @@ let testParams = function(session, fakeDeviceController, t, sessionObjects) {
         assert_not_equals(session.renderState.baseLayer, layer);
       });
     } catch (err) {
-      assert_unreached("updateRenderState should not fail (actually not do anything) with no params");
+      assert_unreached("updateRenderState should not fail when all params are specified");
     }
     resolve();
   });

--- a/webxr/render_state_update.https.html
+++ b/webxr/render_state_update.https.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/webxr_util.js"></script>
+<script src="resources/webxr_test_constants.js"></script>
+<canvas />
+
+<script>
+let fakeDeviceInitParams = TRACKED_IMMERSIVE_DEVICE;
+
+let testSessionEnded = function(session, fakeDeviceController, t) {
+  return new Promise((resolve, reject) => {
+      resolve(session.end().then(() => {
+          try {
+              session.updateRenderState({});
+              assert_unreached("updateRenderState should fail when created with an ended session");
+          } catch (err) {
+              assert_equals(err.name, 'InvalidStateError');
+          }
+      }));
+  });
+};
+
+
+let testBaseLayer = function(session, fakeDeviceController, t, sessionObjects) {
+  return new Promise((resolve, reject) => {
+    navigator.xr.test.simulateUserActivation(() => {
+      navigator.xr.requestSession('immersive-ar').then((tempSession) => {
+        assert(tempSession);
+        assert_not_equals(session, tempSession);
+        session.updateRenderState({ baseLayer : new XRWebGLLayer(tempSession, sessionObjects.gl), });
+        assert_unreached("updateRenderState should fail when baseLayer is created with a different session");
+      }).catch(err => {
+        assert_equals(err.name, 'InvalidStateError');
+      });
+      resolve();
+    });
+  });
+};
+
+let testFieldOfView = function(session, fakeDeviceController, t) {
+  return new Promise((resolve, reject) => {
+    try {
+      session.updateRenderState({ inlineVerticalFieldOfView : Math.PI, });
+      assert_unreached("updateRenderState should fail when specifying an inlineVerticalFieldOfView with immersive sessions");
+    } catch (err) {
+      assert_equals(err.name, 'InvalidStateError');
+    }
+    resolve();
+  });
+};
+
+let testNoParams = function(session, fakeDeviceController, t) {
+  return new Promise((resolve, reject) => {
+    try {
+      session.updateRenderState({});
+    } catch (err) {
+      assert_unreached("updateRenderState should not fail (actually not do anything) with no params");
+    }
+    resolve();
+  });
+};
+
+let testParams = function(session, fakeDeviceController, t, sessionObjects) {
+  return new Promise((resolve, reject) => {
+    let gl = sessionObjects.gl;
+    try {
+      gl.makeXRCompatible().then(() => {
+        let fov = Math.PI;
+        let near = 0.2;
+        let far = 0.8;
+        let layer = new XRWebGLLayer(session, gl);
+        session.updateRenderState({ inlineVerticalFieldOfView: fov, depthNear: near, depthFar: far, baseLayer: layer });
+        // The update can only happen between frame boundaries, updateRenderState only queues changes.
+        assert_not_equals(session.renderState.inlineVerticalFieldOfView, fov);
+        assert_not_equals(session.renderState.depthNear, near);
+        assert_not_equals(session.renderState.depthFar, far);
+        assert_not_equals(session.renderState.baseLayer, layer);
+      });
+    } catch (err) {
+      assert_unreached("updateRenderState should not fail (actually not do anything) with no params");
+    }
+    resolve();
+  });
+};
+
+let testName = "updateRenderState handles appropriately ended sessions";
+xr_session_promise_test(testName, testSessionEnded, fakeDeviceInitParams, 'immersive-vr');
+
+testName = "updateRenderState handles appropriately baseLayers created with different sessions";
+xr_session_promise_test(testName, testBaseLayer, fakeDeviceInitParams, 'immersive-vr');
+
+testName = "updateRenderState handles appropriately immersive sessions with specified inlineVerticalFieldOfView";
+xr_session_promise_test(testName, testFieldOfView, fakeDeviceInitParams, 'immersive-vr');
+
+testName = "updateRenderState handles appropriately XRRenderStateInit with no params";
+xr_session_promise_test(testName, testNoParams, fakeDeviceInitParams, 'immersive-vr');
+
+testName = "updateRenderState handles appropriately XRRenderStateInit params";
+xr_session_promise_test(testName, testParams, fakeDeviceInitParams, 'inline');
+
+</script>


### PR DESCRIPTION
This PR adds a new test for the updateRenderState() algorithm described https://immersive-web.github.io/webxr/#dom-xrsession-updaterenderstate.