### PR TITLE
Streams: remove obsolete test for @@asyncIterator === values

### DIFF
--- a/streams/readable-streams/async-iterator.any.js
+++ b/streams/readable-streams/async-iterator.any.js
@@ -16,10 +16,6 @@ function assert_iter_result(iterResult, value, done, message) {
 }
 
 test(() => {
-  assert_equals(ReadableStream.prototype[Symbol.asyncIterator], ReadableStream.prototype.values);
-}, '@@asyncIterator() method is === to values() method');
-
-test(() => {
   const s = new ReadableStream();
   const it = s.values();
   const proto = Object.getPrototypeOf(it);


### PR DESCRIPTION
[As noted](https://github.com/web-platform-tests/wpt/pull/24266#pullrequestreview-435085684) in #24266, [this Streams test](https://github.com/web-platform-tests/wpt/blob/887350c2f46def5b01c4dd1f8d2eee35dfb9c5bb/streams/readable-streams/async-iterator.any.js#L18-L20) is now covered by [the new `async iterable` tests](https://github.com/web-platform-tests/wpt/blob/6c7192b5706688f0c721ee5ad1f4c17f59a32300/resources/idlharness.js#L2657) from the WebIDL harness. Therefore, we can remove the Streams-specific test.