### PR TITLE
Install py-taskcluster in the Dockerfile

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -56,7 +56,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.37
+            image: webplatformtests/wpt:0.38
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -56,7 +56,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.38
+            image: webplatformtests/wpt:0.41
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.37
+    image: webplatformtests/wpt:0.38
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.38
+    image: webplatformtests/wpt:0.41
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get -qqy install \
 RUN apt-get -y autoremove
 
 RUN pip install --upgrade pip
+RUN pip install taskcluster
 RUN pip install virtualenv
 
 ENV TZ "UTC"


### PR DESCRIPTION
This is required for the proposed Taskcluster sink-task, which will utilize the taskcluster
APIs to inspect the state of other tasks.