### PR TITLE
Add another variant that explicitly uses minmax(0, 1fr), rather than relying on the auto size.

### DIFF
--- a/css/css-grid/layout-algorithm/flex-and-intrinsic-sizes-001.html
+++ b/css/css-grid/layout-algorithm/flex-and-intrinsic-sizes-001.html
@@ -45,6 +45,12 @@ div { font: 10px/1 Ahem; }
 </div>
 
 <div class="container">
+  <div class="grid min-content" data-expected-width="30" data-expected-height="20" style="grid-template-columns:minmax(0, 1fr);">
+    <div>XXX XXX</div>
+  </div>
+</div>
+
+<div class="container">
   <div class="grid max-content" data-expected-width="70" data-expected-height="10">
     <div>XXX XXX</div>
   </div>


### PR DESCRIPTION
Tests <https://github.com/w3c/csswg-drafts/issues/3683> a little more precisely.