### PR TITLE
Change 'window.load() event' to 'window load event' for correctness

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy.tentative.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy.tentative.html
@@ -37,20 +37,20 @@
 
   const below_viewport_iframe_onload = t_below_viewport.step_func_done(() => {
     assert_true(has_window_loaded,
-                "The window.load() event should have fired before " +
+                "The window load event should have fired before " +
                 "the below-viewport iframe loads");
   });
 
   // Must make this accessible to the srcdoc iframe's body.
   window.below_viewport_srcdoc_iframe_subresource_onload = t_below_viewport_srcdoc.step_func(() => {
     assert_true(has_window_loaded,
-                "The window.load() event should have fired before " +
+                "The window load event should have fired before " +
                 "the below-viewport srcdoc iframe's subresource loads");
   });
 
   const below_viewport_srcdoc_iframe_onload = t_below_viewport_srcdoc.step_func_done(() => {
     assert_true(has_window_loaded,
-                "The window.load() event should have fired before " +
+                "The window load event should have fired before " +
                 "the below-viewport srcdoc iframe loads");
   });
 </script>
@@ -77,7 +77,7 @@
 
   <!-- This async script loads very slowly in order to ensure that, if the
        below_viewport* elements have started loading, it has a chance to finish
-       loading before window.load() happens, so that the test will dependably
+       loading before window load event fires, so that the test will dependably
        fail in that case instead of potentially passing depending on how long
        different resource fetches take. -->
   <script async src="/common/slow.py"></script>

--- a/html/semantics/embedded-content/the-img-element/image-loading-lazy-below-viewport-dynamic.html
+++ b/html/semantics/embedded-content/the-img-element/image-loading-lazy-below-viewport-dynamic.html
@@ -18,7 +18,7 @@
 
   window.addEventListener("load", t.step_func(function() {
     assert_false(has_window_loaded,
-                 "The window.load() event should only fire once.");
+                 "The window load event should only fire once.");
     has_window_loaded = true;
   }));
 
@@ -26,7 +26,7 @@
     assert_false(has_below_viewport_loaded,
                "The in_viewport element should load only once.");
     assert_true(has_window_loaded,
-                "The window.load() event should have fired before " +
+                "The window load event should have fired before " +
                 "below_viewport loaded.");
     has_below_viewport_loaded = true;
   });
@@ -38,7 +38,7 @@
        loading="lazy" onload="below_viewport_img_onload();">
   <script>
     assert_false(has_window_loaded,
-                "The window.load() event should not fire before " +
+                "The window load event should not fire before " +
                 "changing below_viewport to loading='eager'.");
     document.getElementById("below_viewport").loading = 'eager';
   </script>

--- a/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-viewport-dynamic.html
+++ b/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-viewport-dynamic.html
@@ -20,13 +20,13 @@
     assert_false(has_in_viewport_loaded,
                "The in_viewport element should load only once.");
     assert_true(has_window_loaded,
-               "The window.load() event should fire before in_viewport image loads.");
+               "The window load event should fire before in_viewport image loads.");
     has_in_viewport_loaded = true;
   });
 
   window.addEventListener("load", t.step_func(function() {
     assert_false(has_window_loaded,
-                 "The window.load() event should only fire once.");
+                 "The window load event should only fire once.");
     has_window_loaded = true;
   }));
 </script>

--- a/html/semantics/embedded-content/the-img-element/image-loading-lazy-multicol.html
+++ b/html/semantics/embedded-content/the-img-element/image-loading-lazy-multicol.html
@@ -20,7 +20,7 @@
 
   window.addEventListener("load", t.step_func_done(function() {
     assert_true(has_in_viewport_loaded, "The in_viewport element should have loaded before window.load().");
-    assert_false(has_window_loaded, "The window.load() event should only fire once.");
+    assert_false(has_window_loaded, "The window load event should only fire once.");
     has_window_loaded = true;
   }));
 
@@ -37,7 +37,7 @@
   <!--
     This async script loads very slowly in order to ensure that, if the
     below_viewport element has started loading, it has a chance to finish
-    loading before window.load() happens, so that the test will dependably fail
+    loading before window load event fires, so that the test will dependably fail
     in that case instead of potentially passing depending on how long different
     resource fetches take.
   -->


### PR DESCRIPTION
I noticed this while reviewing https://github.com/web-platform-tests/wpt/pull/24361 (cc @domfarolino @scott-little )