### PR TITLE
Actually remove six from Dockerfile

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.40
+            image: webplatformtests/wpt:0.41
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.40
+    image: webplatformtests/wpt:0.41
     maxRunTime: 7200
     artifacts:
       public/results:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -57,10 +57,6 @@ RUN pip2 install virtualenv
 RUN pip3 install --upgrade pip
 RUN pip3 install virtualenv
 
-# Ensure we have up-to-date six
-RUN pip2 install --upgrade six
-RUN pip3 install --upgrade six
-
 ENV TZ "UTC"
 RUN echo "${TZ}" > /etc/timezone \
   && dpkg-reconfigure --frontend noninteractive tzdata


### PR DESCRIPTION
With #24484 removing the dependency on system six, we are now able to
remove it from the Docker image, which was introduced in #23733.

Removing this has the benefit of avoiding introducing accidental
dependency.