### PR TITLE
[lint] Allow multiple --ignore-glob in `wpt lint`

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -867,8 +867,8 @@ def create_parser():
     parser.add_argument("--repo-root", type=ensure_text,
                         help="The WPT directory. Use this "
                         "option if the lint script exists outside the repository")
-    parser.add_argument("--ignore-glob", type=ensure_text,
-                        help="Additional file glob to ignore.")
+    parser.add_argument("--ignore-glob", type=ensure_text, action="append",
+                        help="Additional file glob to ignore (repeat to add more)")
     parser.add_argument("--all", action="store_true", help="If no paths are passed, try to lint the whole "
                         "working directory, not just files that changed")
     return parser
@@ -894,12 +894,12 @@ def main(**kwargs_str):
 
     paths = lint_paths(kwargs, repo_root)
 
-    ignore_glob = kwargs.get("ignore_glob") or ""
+    ignore_glob = kwargs.get("ignore_glob", [])
 
     return lint(repo_root, paths, output_format, ignore_glob)
 
 
-def lint(repo_root, paths, output_format, ignore_glob=""):
+def lint(repo_root, paths, output_format, ignore_glob=None):
     # type: (Text, List[Text], Text, Text) -> int
     error_count = defaultdict(int)  # type: Dict[Text, int]
     last = None
@@ -908,7 +908,7 @@ def lint(repo_root, paths, output_format, ignore_glob=""):
         ignorelist, skipped_files = parse_ignorelist(f)
 
     if ignore_glob:
-        skipped_files.add(ignore_glob)
+        skipped_files |= set(ignore_glob)
 
     output_errors = {"json": output_errors_json,
                      "markdown": output_errors_markdown,

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -900,7 +900,7 @@ def main(**kwargs_str):
 
 
 def lint(repo_root, paths, output_format, ignore_glob=None):
-    # type: (Text, List[Text], Text, Text) -> int
+    # type: (Text, List[Text], Text, Optional[List]) -> int
     error_count = defaultdict(int)  # type: Dict[Text, int]
     last = None
 

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -464,7 +464,10 @@ def test_ignore_glob(caplog):
     # clean.
     with _mock_lint("check_path") as mocked_check_path:
         with _mock_lint("check_file_contents") as mocked_check_file_contents:
-            rv = lint(_dummy_repo, ["ref/absolute.html", "ref/existent_relative.html"], "normal", ["*solu*"])
+            rv = lint(_dummy_repo,
+                      ["broken.html", "ref/absolute.html", "ref/existent_relative.html"],
+                      "normal",
+                      ["broken*", "*solu*"])
             assert rv == 0
             # Also confirm that only one file is checked
             assert mocked_check_path.call_count == 1
@@ -473,10 +476,11 @@ def test_ignore_glob(caplog):
     # However, linting the same two files without ignore_glob yields lint errors.
     with _mock_lint("check_path") as mocked_check_path:
         with _mock_lint("check_file_contents") as mocked_check_file_contents:
-            rv = lint(_dummy_repo, ["ref/absolute.html", "ref/existent_relative.html"], "normal")
-            assert rv == 1
-            assert mocked_check_path.call_count == 2
-            assert mocked_check_file_contents.call_count == 2
+            rv = lint(_dummy_repo, ["broken.html", "ref/absolute.html", "ref/existent_relative.html"], "normal")
+            assert rv == 2
+            assert mocked_check_path.call_count == 3
+            assert mocked_check_file_contents.call_count == 3
+            assert "TRAILING WHITESPACE" in caplog.text
             assert "ABSOLUTE-URL-REF" in caplog.text
 
 
@@ -526,7 +530,7 @@ def test_main_with_args():
                                           [os.path.relpath(os.path.join(os.getcwd(), x), repo_root)
                                            for x in ['a', 'b', 'c']],
                                           "normal",
-                                          str())
+                                          None)
     finally:
         sys.argv = orig_argv
 
@@ -538,7 +542,7 @@ def test_main_no_args():
         with _mock_lint('lint', return_value=True) as m:
             with _mock_lint('changed_files', return_value=['foo', 'bar']):
                 lint_mod.main(**vars(create_parser().parse_args()))
-                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", str())
+                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", None)
     finally:
         sys.argv = orig_argv
 
@@ -550,6 +554,6 @@ def test_main_all():
         with _mock_lint('lint', return_value=True) as m:
             with _mock_lint('all_filesystem_paths', return_value=['foo', 'bar']):
                 lint_mod.main(**vars(create_parser().parse_args()))
-                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", str())
+                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", None)
     finally:
         sys.argv = orig_argv

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -464,7 +464,7 @@ def test_ignore_glob(caplog):
     # clean.
     with _mock_lint("check_path") as mocked_check_path:
         with _mock_lint("check_file_contents") as mocked_check_file_contents:
-            rv = lint(_dummy_repo, ["ref/absolute.html", "ref/existent_relative.html"], "normal", "*solu*")
+            rv = lint(_dummy_repo, ["ref/absolute.html", "ref/existent_relative.html"], "normal", ["*solu*"])
             assert rv == 0
             # Also confirm that only one file is checked
             assert mocked_check_path.call_count == 1


### PR DESCRIPTION
Needed by https://crbug.com/1103374 to add additional globs in Chromium