### PR TITLE
Cleanup newline-removal in manifest_build.py

### DIFF
--- a/tools/ci/manifest_build.py
+++ b/tools/ci/manifest_build.py
@@ -108,9 +108,6 @@ def get_pr(owner, repo, sha):
 
 def create_release(manifest_path, owner, repo, sha, tag, body):
     logger.info("Creating a release for tag='%s', target_commitish='%s'" % (tag, sha))
-    tag = tag.strip()
-    sha = sha.strip()
-
     create_url = "https://api.github.com/repos/%s/%s/releases" % (owner, repo)
     create_data = {"tag_name": tag,
                    "target_commitish": sha,
@@ -177,7 +174,7 @@ def main():
     owner, repo = os.environ["GITHUB_REPOSITORY"].split("/", 1)
 
     git = get_git_cmd(wpt_root)
-    head_rev = git("rev-parse", "HEAD")
+    head_rev = git("rev-parse", "HEAD").strip()
     body = git("show", "--no-patch", "--format=%B", "HEAD")
 
     if dry_run:


### PR DESCRIPTION
This is a small follow-up to d7423b4ef835ac579b2aa6cbd0e88e47ed1c82cd,
which was an attempt at a hotfix that turned out to be the problem. To
tidy up the code, trim the sha at retrieval time and don't trim the tag
(which turned out not to have a newline in it).