### PR TITLE
Add tests for transferable streams

### DIFF
--- a/streams/transferable/readable-stream.html
+++ b/streams/transferable/readable-stream.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/test-utils.js"></script>
+<script>
+'use strict';
+
+promise_test(async () => {
+  const rs = await createTransferredReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.close();
+    }
+  });
+  const reader = rs.getReader();
+  {
+    const {value, done} = await reader.read();
+    assert_false(done, 'should not be done yet');
+    assert_equals(value, 'a', 'first chunk should be a');
+  }
+  {
+    const {done} = await reader.read();
+    assert_true(done, 'should be done now');
+  }
+}, 'sending one chunk through a transferred stream should work');
+
+promise_test(async () => {
+  let controller;
+  const rs = await createTransferredReadableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  for (let i = 0; i < 10; ++i) {
+    controller.enqueue(i);
+  }
+  controller.close();
+  const reader = rs.getReader();
+  for (let i = 0; i < 10; ++i) {
+    const {value, done} = await reader.read();
+    assert_false(done, 'should not be done yet');
+    assert_equals(value, i, 'chunk content should match index');
+  }
+  const {done} = await reader.read();
+  assert_true(done, 'should be done now');
+}, 'sending ten chunks through a transferred stream should work');
+
+promise_test(async () => {
+  let controller;
+  const rs = await createTransferredReadableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const reader = rs.getReader();
+  for (let i = 0; i < 10; ++i) {
+    controller.enqueue(i);
+    const {value, done} = await reader.read();
+    assert_false(done, 'should not be done yet');
+    assert_equals(value, i, 'chunk content should match index');
+  }
+  controller.close();
+  const {done} = await reader.read();
+  assert_true(done, 'should be done now');
+}, 'sending ten chunks one at a time should work');
+
+promise_test(async () => {
+  let controller;
+  const rs = await createTransferredReadableStream({
+    start() {
+      this.counter = 0;
+    },
+    pull(controller) {
+      controller.enqueue(this.counter);
+      ++this.counter;
+      if (this.counter === 10)
+        controller.close();
+    }
+  });
+  const reader = rs.getReader();
+  for (let i = 0; i < 10; ++i) {
+    const {value, done} = await reader.read();
+    assert_false(done, 'should not be done yet');
+    assert_equals(value, i, 'chunk content should match index');
+  }
+  const {done} = await reader.read();
+  assert_true(done, 'should be done now');
+}, 'sending ten chunks on demand should work');
+
+promise_test(async () => {
+  const rs = recordingReadableStream({}, { highWaterMark: 0 });
+  await delay(0);
+  assert_array_equals(rs.events, [], 'pull() should not have been called');
+  // Eat the message so it can't interfere with other tests.
+  addEventListener('message', () => {}, {once: true});
+  // The transfer is done manually to verify that it is posting the stream that
+  // relieves backpressure, not receiving it.
+  postMessage(rs, '*', [rs]);
+  await delay(0);
+  assert_array_equals(rs.events, ['pull'], 'pull() should have been called');
+}, 'transferring a stream should relieve backpressure');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream({
+    pull(controller) {
+      controller.enqueue('a');
+    }
+  }, { highWaterMark: 2 });
+  await delay(0);
+  assert_array_equals(rs.events, ['pull', 'pull', 'pull'],
+                      'pull() should have been called three times');
+}, 'transferring a stream should add one chunk to the queue size');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array(1024));
+      controller.enqueue(new Uint8Array(1024));
+    }
+  }, new ByteLengthQueuingStrategy({highWaterMark: 512}));
+  await delay(0);
+  // At this point the queue contains 1024/512 bytes and 1/1 chunk, so it's full
+  // and pull() is not called.
+  assert_array_equals(rs.events, [], 'pull() should not have been called');
+  const reader = rs.getReader();
+  const {value, done} = await reader.read();
+  assert_false(done, 'we should not be done');
+  assert_equals(value.byteLength, 1024, 'expected chunk should be returned');
+  // Now the queue contains 0/512 bytes and 1/1 chunk, so pull() is called. If
+  // the implementation erroneously counted the extra queue space in bytes, then
+  // the queue would contain 1024/513 bytes and pull() wouldn't be called.
+  assert_array_equals(rs.events, ['pull'], 'pull() should have been called');
+}, 'the extra queue from transferring is counted in chunks');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream();
+  rs.cancel('message');
+  await delay(0);
+  assert_array_equals(rs.events, ['pull', 'cancel', 'message'],
+                      'cancel() should have been called');
+  const reader = rs.getReader();
+  // Check the stream really got closed.
+  await reader.closed;
+}, 'cancel should be propagated to the original');
+
+promise_test(async () => {
+  let resolveCancelCalled;
+  const cancelCalled = new Promise(resolve => {
+    resolveCancelCalled = resolve;
+  });
+  const rs = await recordingTransferredReadableStream({
+    cancel() {
+      resolveCancelCalled();
+    }
+  });
+  const reader = rs.getReader();
+  const readPromise = reader.read();
+  reader.cancel('done');
+  const { done } = await readPromise;
+  assert_true(done, 'should be done');
+  await cancelCalled;
+  assert_array_equals(rs.events, ['pull', 'cancel', 'done'],
+                      'events should match');
+}, 'cancel should abort a pending read()');
+
+promise_test(async () => {
+  let cancelComplete = false;
+  const rs = await createTransferredReadableStream({
+    async cancel() {
+      await flushAsyncEvents();
+      cancelComplete = true;
+    }
+  });
+  await rs.cancel();
+  assert_false(cancelComplete,
+               'cancel() on the underlying sink should not have completed');
+}, 'stream cancel should not wait for underlying source cancel');
+
+promise_test(async t => {
+  const rs = await recordingTransferredReadableStream();
+  const reader = rs.getReader();
+  let serializationHappened = false;
+  rs.controller.enqueue({
+    get getter() {
+      serializationHappened = true;
+      return 'a';
+    }
+  });
+  await flushAsyncEvents();
+  assert_false(serializationHappened,
+               'serialization should not have happened yet');
+  const {value, done} = await reader.read();
+  assert_false(done, 'should not be done');
+  assert_equals(value.getter, 'a', 'getter should be a');
+  assert_true(serializationHappened,
+              'serialization should have happened');
+}, 'serialization should not happen until the value is read');
+
+promise_test(async t => {
+  const rs = await recordingTransferredReadableStream();
+  const reader = rs.getReader();
+  rs.controller.enqueue(new ReadableStream());
+  await promise_rejects_dom(t, 'DataCloneError', reader.read(),
+                            'closed promise should reject');
+  assert_throws_js(TypeError, () => rs.controller.enqueue(),
+                   'original stream should be errored');
+}, 'transferring a non-serializable chunk should error both sides');
+
+promise_test(async () => {
+  const rs = await createTransferredReadableStream({
+    start(controller) {
+      controller.error('foo');
+    }
+  });
+  const reader = rs.getReader();
+  let threw = false;
+  try {
+    await reader.read();
+  } catch (e) {
+    threw = true;
+    assert_equals(e, 'foo', 'error should be passed through');
+  }
+  assert_true(threw, 'reader.read() should throw');
+}, 'errors should be passed through');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream();
+  await delay(0);
+  const reader = rs.getReader();
+  reader.cancel();
+  rs.controller.error();
+  const {done} = await reader.read();
+  assert_true(done, 'should be done');
+  assert_throws_js(TypeError, () => rs.controller.enqueue(),
+                   'enqueue should throw');
+}, 'race between cancel() and error() should leave sides in different states');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream();
+  await delay(0);
+  const reader = rs.getReader();
+  reader.cancel();
+  rs.controller.close();
+  const {done} = await reader.read();
+  assert_true(done, 'should be done');
+}, 'race between cancel() and close() should be benign');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream();
+  await delay(0);
+  const reader = rs.getReader();
+  reader.cancel();
+  rs.controller.enqueue('a');
+  const {done} = await reader.read();
+  assert_true(done, 'should be done');
+}, 'race between cancel() and enqueue() should be benign');
+
+</script>

--- a/streams/transferable/readable-stream.html
+++ b/streams/transferable/readable-stream.html
@@ -209,21 +209,15 @@ promise_test(async t => {
                    'original stream should be errored');
 }, 'transferring a non-serializable chunk should error both sides');
 
-promise_test(async () => {
+promise_test(async t => {
   const rs = await createTransferredReadableStream({
     start(controller) {
       controller.error('foo');
     }
   });
   const reader = rs.getReader();
-  let threw = false;
-  try {
-    await reader.read();
-  } catch (e) {
-    threw = true;
-    assert_equals(e, 'foo', 'error should be passed through');
-  }
-  assert_true(threw, 'reader.read() should throw');
+  return promise_rejects_exactly(t, 'foo', reader.read(),
+                                 'error should be passed through');
 }, 'errors should be passed through');
 
 promise_test(async () => {

--- a/streams/transferable/reason.html
+++ b/streams/transferable/reason.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+<script>
+'use strict';
+
+// Chrome used to special-case the reason for cancel() and abort() in order to
+// handle exceptions correctly. This is no longer necessary. These tests are
+// retained to avoid regressions.
+
+async function getTransferredReason(originalReason) {
+  let resolvePromise;
+  const rv = new Promise(resolve => {
+    resolvePromise = resolve;
+  });
+  const rs = await createTransferredReadableStream({
+    cancel(reason) {
+      resolvePromise(reason);
+    }
+  });
+  await rs.cancel(originalReason);
+  return rv;
+}
+
+for (const value of ['hi', '\t\r\n', 7, 3.0, undefined, null, true, false,
+                    NaN, Infinity]) {
+  promise_test(async () => {
+    const reason = await getTransferredReason(value);
+    assert_equals(reason, value, 'reason should match');
+  }, `reason with a simple value of '${value}' should be preserved`);
+}
+
+for (const badType of [Symbol('hi'), _ => 'hi']) {
+  promise_test(async t => {
+    return promise_rejects_dom(t, 'DataCloneError',
+                               getTransferredReason(badType),
+                               'cancel() should reject');
+  }, `reason with a type of '${typeof badType}' should be rejected and ` +
+     `error the stream`);
+}
+
+promise_test(async () => {
+  const reasonAsJson =
+        `{"foo":[1,"col"],"bar":{"hoge":0.2,"baz":{},"shan":null}}`;
+  const reason = await getTransferredReason(JSON.parse(reasonAsJson));
+  assert_equals(JSON.stringify(reason), reasonAsJson,
+                'object should be preserved');
+}, 'objects that can be completely expressed in JSON should be preserved');
+
+promise_test(async () => {
+  const circularObject = {};
+  circularObject.self = circularObject;
+  const reason = await getTransferredReason(circularObject);
+  assert_true(reason instanceof Object, 'an Object should be output');
+  assert_equals(reason.self, reason,
+                'the object should have a circular reference');
+}, 'objects that cannot be expressed in JSON should also be preserved');
+
+promise_test(async () => {
+  const originalReason = new TypeError('hi');
+  const reason = await getTransferredReason(originalReason);
+  assert_true(reason instanceof TypeError,
+              'type should be preserved');
+  assert_equals(reason.message, originalReason.message,
+                'message should be preserved');
+}, 'the type and message of a TypeError should be preserved');
+
+promise_test(async () => {
+  const originalReason = new TypeError('hi');
+  originalReason.foo = 'bar';
+  const reason = await getTransferredReason(originalReason);
+  assert_false('foo' in reason,
+               'foo should not be preserved');
+}, 'other attributes of a TypeError should not be preserved');
+
+promise_test(async () => {
+  const originalReason = new TypeError();
+  originalReason.message = [1, 2, 3];
+  const reason = await getTransferredReason(originalReason);
+  assert_equals(reason.message, '1,2,3', 'message should be stringified');
+}, 'a TypeError message should be converted to a string');
+
+promise_test(async () => {
+  const originalReason = new TypeError();
+  Object.defineProperty(originalReason, 'message', {
+    get() { return 'words'; }
+  });
+  const reason = await getTransferredReason(originalReason);
+  assert_equals(reason.message, '', 'message should not be preserved');
+}, 'a TypeError message should not be preserved if it is a getter');
+
+promise_test(async () => {
+  const originalReason = new TypeError();
+  delete originalReason.message;
+  TypeError.prototype.message = 'inherited message';
+  const reason = await getTransferredReason(originalReason);
+  delete TypeError.prototype.message;
+  assert_equals(reason.message, '', 'message should not be preserved');
+}, 'a TypeError message should not be preserved if it is inherited');
+
+promise_test(async () => {
+  const originalReason = new DOMException('yes', 'AbortError');
+  const reason = await getTransferredReason(originalReason);
+  assert_true(reason instanceof DOMException,
+              'reason should be a DOMException');
+  assert_equals(reason.message, originalReason.message,
+                'the messages should match');
+  assert_equals(reason.name, originalReason.name,
+                'the names should match');
+}, 'DOMException errors should be preserved');
+
+for (const errorConstructor of [EvalError, RangeError,
+                                ReferenceError, SyntaxError, TypeError,
+                                URIError]) {
+  promise_test(async () => {
+    const originalReason = new errorConstructor('nope');
+    const reason = await getTransferredReason(originalReason);
+    assert_equals(typeof reason, 'object', 'reason should have type object');
+    assert_true(reason instanceof errorConstructor,
+                `reason should inherit ${errorConstructor.name}`);
+    assert_true(reason instanceof Error, 'reason should inherit Error');
+    assert_equals(reason.constructor, errorConstructor,
+                  'reason should have the right constructor');
+    assert_equals(reason.name, errorConstructor.name,
+                  `name should match constructor name`);
+    assert_equals(reason.message, 'nope', 'message should match');
+  }, `${errorConstructor.name} should be preserved`);
+}
+
+</script>

--- a/streams/transferable/resources/echo-iframe.html
+++ b/streams/transferable/resources/echo-iframe.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script>
+addEventListener('message', evt => {
+  evt.source.postMessage(evt.data, '*', [evt.data]);
+});
+</script>

--- a/streams/transferable/resources/echo-worker.js
+++ b/streams/transferable/resources/echo-worker.js
@@ -1,0 +1,2 @@
+// A worker that just transfers back any message that is sent to it.
+onmessage = evt => postMessage(evt.data, [evt.data]);

--- a/streams/transferable/resources/helpers.js
+++ b/streams/transferable/resources/helpers.js
@@ -1,0 +1,121 @@
+'use strict';
+
+// Create a ReadableStream that will pass the tests in
+// testTransferredReadableStream(), below.
+function createOriginalReadableStream() {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.close();
+    }
+  });
+}
+
+// Common tests to roughly determine that |rs| is a correctly transferred
+// version of a stream created by createOriginalReadableStream().
+function testTransferredReadableStream(rs) {
+  assert_equals(rs.constructor, ReadableStream,
+                'rs should be a ReadableStream in this realm');
+  assert_true(rs instanceof ReadableStream,
+              'instanceof check should pass');
+
+  // Perform a brand-check on |rs| in the process of calling getReader().
+  const reader = ReadableStream.prototype.getReader.call(rs);
+
+  return reader.read().then(({value, done}) => {
+    assert_false(done, 'done should be false');
+    assert_equals(value, 'a', 'value should be "a"');
+    return reader.read();
+  }).then(({done}) => {
+    assert_true(done, 'done should be true');
+  });
+}
+
+function testMessage(msg) {
+  assert_array_equals(msg.ports, [], 'there should be no ports in the event');
+  return testTransferredReadableStream(msg.data);
+}
+
+function testMessageEvent(target) {
+  return new Promise((resolve, reject) => {
+    target.addEventListener('message', ev => {
+      try {
+        resolve(testMessage(ev));
+      } catch (e) {
+        reject(e);
+      }
+    }, {once: true});
+  });
+}
+
+function testMessageEventOrErrorMessage(target) {
+  return new Promise((resolve, reject) => {
+    target.addEventListener('message', ev => {
+      if (typeof ev.data === 'string') {
+        // Assume it's an error message and reject with it.
+        reject(ev.data);
+        return;
+      }
+
+      try {
+        resolve(testMessage(ev));
+      } catch (e) {
+        reject(e);
+      }
+    }, {once: true});
+  });
+}
+
+function checkTestResults(target) {
+  return new Promise((resolve, reject) => {
+    target.onmessage = msg => {
+      // testharness.js sends us objects which we need to ignore.
+      if (typeof msg.data !== 'string')
+        return;
+
+      if (msg.data === 'OK') {
+        resolve();
+      } else {
+        reject(msg.data);
+      }
+    };
+  });
+}
+
+// These tests assume that a transferred ReadableStream will behave the same
+// regardless of how it was transferred. This enables us to simply transfer the
+// stream to ourselves.
+function createTransferredReadableStream(underlyingSource) {
+  const original = new ReadableStream(underlyingSource);
+  const promise = new Promise((resolve, reject) => {
+    addEventListener('message', msg => {
+      const rs = msg.data;
+      if (rs instanceof ReadableStream) {
+        resolve(rs);
+      } else {
+        reject(new Error(`what is this thing: "${rs}"?`));
+      }
+    }, {once: true});
+  });
+  postMessage(original, '*', [original]);
+  return promise;
+}
+
+function recordingTransferredReadableStream(underlyingSource, strategy) {
+  const original = recordingReadableStream(underlyingSource, strategy);
+  const promise = new Promise((resolve, reject) => {
+    addEventListener('message', msg => {
+      const rs = msg.data;
+      if (rs instanceof ReadableStream) {
+        rs.events = original.events;
+        rs.eventsWithoutPulls = original.eventsWithoutPulls;
+        rs.controller = original.controller;
+        resolve(rs);
+      } else {
+        reject(new Error(`what is this thing: "${rs}"?`));
+      }
+    }, {once: true});
+  });
+  postMessage(original, '*', [original]);
+  return promise;
+}

--- a/streams/transferable/resources/receiving-shared-worker.js
+++ b/streams/transferable/resources/receiving-shared-worker.js
@@ -1,0 +1,11 @@
+'use strict';
+importScripts('/resources/testharness.js', 'helpers.js');
+
+onconnect = evt => {
+  const port = evt.source;
+  const promise = testMessageEvent(port);
+  port.start();
+  promise
+      .then(() => port.postMessage('OK'))
+      .catch(err => port.postMessage(`BAD: ${err}`));
+};

--- a/streams/transferable/resources/receiving-worker.js
+++ b/streams/transferable/resources/receiving-worker.js
@@ -1,0 +1,7 @@
+'use strict';
+importScripts('/resources/testharness.js', 'helpers.js');
+
+const promise = testMessageEvent(self);
+promise
+    .then(() => postMessage('OK'))
+    .catch(err => postMessage(`BAD: ${err}`));

--- a/streams/transferable/resources/sending-shared-worker.js
+++ b/streams/transferable/resources/sending-shared-worker.js
@@ -1,0 +1,12 @@
+'use strict';
+importScripts('helpers.js');
+
+onconnect = msg => {
+  const port = msg.source;
+  const orig = createOriginalReadableStream();
+  try {
+    port.postMessage(orig, [orig]);
+  } catch (e) {
+    port.postMessage(e.message);
+  }
+};

--- a/streams/transferable/resources/sending-worker.js
+++ b/streams/transferable/resources/sending-worker.js
@@ -1,0 +1,5 @@
+'use strict';
+importScripts('helpers.js');
+
+const orig = createOriginalReadableStream();
+postMessage(orig, [orig]);

--- a/streams/transferable/resources/service-worker-iframe.html
+++ b/streams/transferable/resources/service-worker-iframe.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="helpers.js"></script>
+<script>
+'use strict';
+
+setup({
+  explicit_done: true
+});
+
+function startTests() {
+  promise_test(() => {
+    const orig = createOriginalReadableStream();
+    const promise = checkTestResults(navigator.serviceWorker);
+    navigator.serviceWorker.controller.postMessage(orig, [orig]);
+    assert_true(orig.locked, 'the original stream should be locked');
+    return promise;
+  }, 'serviceWorker.controller.postMessage should be able to transfer a ' +
+               'ReadableStream');
+
+  promise_test(() => {
+    const promise = testMessageEventOrErrorMessage(navigator.serviceWorker);
+    navigator.serviceWorker.controller.postMessage('SEND');
+    return promise;
+  }, 'postMessage in a service worker should be able to transfer ReadableStream');
+
+  done();
+}
+
+// Delay running the tests until we get a message from the page telling us to.
+// This is to work around an issue where testharness.js doesn't detect
+// completion of the tests if they fail too early.
+onmessage = msg => {
+  if (msg.data === 'explicit trigger')
+    startTests();
+};
+
+</script>

--- a/streams/transferable/resources/service-worker.js
+++ b/streams/transferable/resources/service-worker.js
@@ -1,0 +1,30 @@
+'use strict';
+importScripts('/resources/testharness.js', 'helpers.js');
+
+onmessage = msg => {
+  const client = msg.source;
+  if (msg.data === 'SEND') {
+    sendingTest(client);
+  } else {
+    receivingTest(msg, client);
+  }
+};
+
+function sendingTest(client) {
+  const orig = createOriginalReadableStream();
+  try {
+    client.postMessage(orig, [orig]);
+  } catch (e) {
+    client.postMessage(e.message);
+  }
+}
+
+function receivingTest(msg, client) {
+  try {
+    msg.waitUntil(testMessage(msg)
+                  .then(() => client.postMessage('OK'))
+                  .catch(e => client.postMessage(`BAD: ${e}`)));
+  } catch (e) {
+    client.postMessage(`BAD: ${e}`);
+  }
+}

--- a/streams/transferable/service-worker.https.html
+++ b/streams/transferable/service-worker.https.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+<script>
+'use strict';
+
+const kServiceWorkerUrl = 'resources/service-worker.js';
+const kIframeUrl = 'resources/service-worker-iframe.html';
+
+// A dummy test so that we can use the test-helpers.sub.js functions
+const test = async_test('service-worker');
+
+async function registerAndStart() {
+  const reg = await service_worker_unregister_and_register(
+    test, kServiceWorkerUrl, kIframeUrl);
+  await wait_for_state(test, reg.installing, 'activated');
+  const iframe = await with_iframe(kIframeUrl);
+  fetch_tests_from_window(iframe.contentWindow);
+  add_completion_callback(() => iframe.remove());
+  iframe.contentWindow.postMessage('explicit trigger', '*');
+  return service_worker_unregister_and_done(test, kIframeUrl);
+}
+
+onload = registerAndStart;
+
+</script>

--- a/streams/transferable/shared-worker.html
+++ b/streams/transferable/shared-worker.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  const orig = createOriginalReadableStream();
+  const w = new SharedWorker('resources/receiving-shared-worker.js');
+  const promise = checkTestResults(w.port);
+  w.port.postMessage(orig, [orig]);
+  assert_true(orig.locked, 'the original stream should be locked');
+  return promise;
+}, 'worker.postMessage should be able to transfer a ReadableStream');
+
+promise_test(t => {
+  const w = new SharedWorker('resources/sending-shared-worker.js');
+  const promise = testMessageEventOrErrorMessage(w.port);
+  w.port.start();
+  return promise;
+}, 'postMessage in a worker should be able to transfer a ReadableStream');
+
+</script>

--- a/streams/transferable/transform-stream.html
+++ b/streams/transferable/transform-stream.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/test-utils.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  const orig = new TransformStream();
+  const promise = new Promise(resolve => {
+    addEventListener('message', t.step_func(evt => {
+      const transferred = evt.data;
+      assert_equals(transferred.constructor, TransformStream,
+                    'transferred should be a TransformStream in this realm');
+      assert_true(transferred instanceof TransformStream,
+                  'instanceof check should pass');
+
+      // Perform a brand-check on |transferred|.
+      const readableGetter = Object.getOwnPropertyDescriptor(
+        TransformStream.prototype, 'readable').get;
+      assert_true(readableGetter.call(transferred) instanceof ReadableStream,
+                 'brand check should pass and readable stream should result');
+      const writableGetter = Object.getOwnPropertyDescriptor(
+        TransformStream.prototype, 'writable').get;
+      assert_true(writableGetter.call(transferred) instanceof WritableStream,
+                 'brand check should pass and writable stream should result');
+      resolve();
+    }), {once: true});
+  });
+  postMessage(orig, '*', [orig]);
+  assert_true(orig.readable.locked, 'the readable side should be locked');
+  assert_true(orig.writable.locked, 'the writable side should be locked');
+  return promise;
+}, 'window.postMessage should be able to transfer a TransformStream');
+
+test(() => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
+                    'postMessage should throw');
+}, 'a TransformStream with a locked writable should not be transferable');
+
+test(() => {
+  const ts = new TransformStream();
+  const reader = ts.readable.getReader();
+  assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
+                    'postMessage should throw');
+}, 'a TransformStream with a locked readable should not be transferable');
+
+test(() => {
+  const ts = new TransformStream();
+  const reader = ts.readable.getReader();
+  const writer = ts.writable.getWriter();
+  assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
+                    'postMessage should throw');
+}, 'a TransformStream with both sides locked should not be transferable');
+
+promise_test(t => {
+  const source = new ReadableStream({
+    start(controller) {
+      controller.enqueue('hello ');
+      controller.enqueue('there ');
+      controller.close();
+    }
+  });
+  let result = '';
+  const sink = new WritableStream({
+    write(chunk) {
+      result += chunk;
+    }
+  });
+  const transform1 = new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk.toUpperCase());
+    }
+  });
+  const transform2 = new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk + chunk);
+    }
+  });
+  const promise = new Promise(resolve => {
+    addEventListener('message', t.step_func(evt => {
+      const data = evt.data;
+      resolve(data.source
+                .pipeThrough(data.transform1)
+                .pipeThrough(data.transform2)
+                .pipeTo(data.sink));
+    }));
+  });
+  postMessage({source, sink, transform1, transform2}, '*',
+              [source, transform1, sink, transform2]);
+  return promise
+    .then(() => delay(0))
+    .then(() => {
+      assert_equals(result, 'HELLO HELLO THERE THERE ',
+                    'transforms should have been applied');
+    });
+}, 'piping through transferred transforms should work');
+
+</script>

--- a/streams/transferable/transform-stream.html
+++ b/streams/transferable/transform-stream.html
@@ -39,8 +39,7 @@ test(() => {
   const writer = ts.writable.getWriter();
   assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
                     'postMessage should throw');
-  // Readable side should not be locked.
-  const reader = ts.readable.getReader();
+  assert_false(ts.readable.locked, 'readable side should not get locked');
 }, 'a TransformStream with a locked writable should not be transferable');
 
 test(() => {
@@ -48,8 +47,7 @@ test(() => {
   const reader = ts.readable.getReader();
   assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
                     'postMessage should throw');
-  // Writable side should not be locked.
-  const writer = ts.writable.getWriter();
+  assert_false(ts.writable.locked, 'writable side should not get locked');
 }, 'a TransformStream with a locked readable should not be transferable');
 
 test(() => {

--- a/streams/transferable/transform-stream.html
+++ b/streams/transferable/transform-stream.html
@@ -39,6 +39,8 @@ test(() => {
   const writer = ts.writable.getWriter();
   assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
                     'postMessage should throw');
+  // Readable side should not be locked.
+  const reader = ts.readable.getReader();
 }, 'a TransformStream with a locked writable should not be transferable');
 
 test(() => {
@@ -46,6 +48,8 @@ test(() => {
   const reader = ts.readable.getReader();
   assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
                     'postMessage should throw');
+  // Writable side should not be locked.
+  const writer = ts.writable.getWriter();
 }, 'a TransformStream with a locked readable should not be transferable');
 
 test(() => {

--- a/streams/transferable/window.html
+++ b/streams/transferable/window.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  const orig = createOriginalReadableStream();
+  const promise = testMessageEvent(window);
+  postMessage(orig, '*', [orig]);
+  assert_true(orig.locked, 'the original stream should be locked');
+  return promise;
+}, 'window.postMessage should be able to transfer a ReadableStream');
+
+promise_test(t => {
+  const orig = createOriginalReadableStream();
+  const promise = new Promise(resolve => {
+    window.addEventListener('message', msg => {
+      const port = msg.data;
+      resolve(testMessageEvent(port));
+      port.start();
+    }, {once: true});
+  });
+  const mc = new MessageChannel();
+  postMessage(mc.port1, '*', [mc.port1]);
+  mc.port2.postMessage(orig, [orig]);
+  mc.port2.close();
+  assert_true(orig.locked, 'the original stream should be locked');
+  return promise;
+}, 'port.postMessage should be able to transfer a ReadableStream');
+
+promise_test(t => {
+  const orig = createOriginalReadableStream();
+  const promise = new Promise(resolve => {
+    addEventListener('message', t.step_func(evt => {
+      const [rs1, rs2] = evt.data;
+      assert_equals(rs1, rs2, 'both ReadableStreams should be the same object');
+      resolve();
+    }), {once: true});
+  });
+  postMessage([orig, orig], '*', [orig]);
+  return promise;
+}, 'the same ReadableStream posted multiple times should arrive together');
+
+const onloadPromise = new Promise(resolve => onload = resolve);
+
+promise_test(() => {
+  const orig = createOriginalReadableStream();
+  const promise = testMessageEvent(window);
+  return onloadPromise.then(() => {
+    const echoIframe = document.querySelector('#echo');
+    echoIframe.contentWindow.postMessage(orig, '*', [orig]);
+    return promise;
+  });
+}, 'transfer to and from an iframe should work');
+</script>
+
+<iframe id=echo src="resources/echo-iframe.html" style="display:none"></iframe>

--- a/streams/transferable/worker.html
+++ b/streams/transferable/worker.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+<script src="../resources/test-utils.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  const orig = createOriginalReadableStream();
+  const w = new Worker('resources/receiving-worker.js');
+  t.add_cleanup(() => {
+    w.terminate();
+  });
+  const promise = new Promise((resolve, reject) => {
+    checkTestResults(w).then(resolve, reject);
+    w.onerror = () => reject('error in worker');
+  });
+  w.postMessage(orig, [orig]);
+  assert_true(orig.locked, 'the original stream should be locked');
+  return promise;
+}, 'worker.postMessage should be able to transfer a ReadableStream');
+
+promise_test(t => {
+  const w = new Worker('resources/sending-worker.js');
+  t.add_cleanup(() => {
+    w.terminate();
+  });
+  return new Promise((resolve, reject) => {
+    testMessageEvent(w).then(resolve, reject);
+    w.onerror = () => reject('error in worker');
+  });
+}, 'postMessage in a worker should be able to transfer a ReadableStream');
+
+promise_test(async t => {
+  const w = new Worker('resources/echo-worker.js');
+  let controller;
+  const orig = new ReadableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const targetStream = await new Promise((resolve, reject) => {
+    w.onmessage = evt => resolve(evt.data);
+    w.onerror = () => reject('error in worker');
+    w.postMessage(orig, [orig]);
+  });
+  const reader = targetStream.getReader();
+  const reads = [];
+  // Place a lot of chunks "in transit". This should increase the likelihood
+  // that they is a chunk at each relevant step when the worker is terminated.
+  for (let i = 0; i < 50; ++i) {
+    await delay(0);
+    controller.enqueue(i);
+    const expected = i;
+    reads.push(reader.read().then(({value, done}) => {
+      assert_false(done, 'we should not be done');
+      assert_equals(value, expected, 'value should match expectation');
+    }));
+  }
+  w.terminate();
+  for (let i = 50; i < 60; ++i) {
+    controller.enqueue(i);
+    reads.push(
+      reader.read().then(t.unreached_func('read() should not resolve')));
+    await delay(0);
+  }
+  // We don't expect every read() to complete, but we want to give them a chance
+  // to reject if they're going to.
+  return Promise.race([
+    Promise.all(reads),
+    flushAsyncEvents()
+  ]);
+}, 'terminating a worker should not error the stream');
+</script>

--- a/streams/transferable/writable-stream.html
+++ b/streams/transferable/writable-stream.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+<script src="../resources/test-utils.js"></script>
+<script src="../resources/recording-streams.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  const orig = new WritableStream();
+  const promise = new Promise(resolve => {
+    addEventListener('message', t.step_func(evt => {
+      const transferred = evt.data;
+      assert_equals(transferred.constructor, WritableStream,
+                    'transferred should be a WritableStream in this realm');
+      assert_true(transferred instanceof WritableStream,
+                  'instanceof check should pass');
+
+      // Perform a brand-check on |transferred|.
+      const writer = WritableStream.prototype.getWriter.call(transferred);
+      resolve();
+    }), {once: true});
+  });
+  postMessage(orig, '*', [orig]);
+  assert_true(orig.locked, 'the original stream should be locked');
+  return promise;
+}, 'window.postMessage should be able to transfer a WritableStream');
+
+test(() => {
+  const ws = new WritableStream();
+  const writer = ws.getWriter();
+  assert_throws_dom('DataCloneError', () => postMessage(ws, '*', [ws]),
+                    'postMessage should throw');
+}, 'a locked WritableStream should not be transferable');
+
+promise_test(t => {
+  const {writable, readable} = new TransformStream();
+  const promise = new Promise(resolve => {
+    addEventListener('message', t.step_func(async evt => {
+      const {writable, readable} = evt.data;
+      const reader = readable.getReader();
+      const writer = writable.getWriter();
+      const writerPromises = Promise.all([
+        writer.write('hi'),
+        writer.close(),
+      ]);
+      const {value, done} = await reader.read();
+      assert_false(done, 'we should not be done');
+      assert_equals(value, 'hi', 'chunk should have been delivered');
+      const readResult = await reader.read();
+      assert_true(readResult.done, 'readable should be closed');
+      await writerPromises;
+      resolve();
+    }), {once: true});
+  });
+  postMessage({writable, readable}, '*', [writable, readable]);
+  return promise;
+}, 'window.postMessage should be able to transfer a {readable, writable} pair');
+
+function transfer(stream) {
+  return new Promise(resolve => {
+    addEventListener('message', evt => resolve(evt.data), { once: true });
+    postMessage(stream, '*', [stream]);
+  });
+}
+
+promise_test(async () => {
+  const orig = new WritableStream(
+    {}, new ByteLengthQueuingStrategy({ highWaterMark: 65536 }));
+  const transferred = await transfer(orig);
+  const writer = transferred.getWriter();
+  assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+}, 'desiredSize for a newly-transferred stream should be 1');
+
+promise_test(async () => {
+  const orig = new WritableStream({
+    write() {
+      return new Promise(() => {});
+    }
+  });
+  const transferred = await transfer(orig);
+  const writer = transferred.getWriter();
+  await writer.write('a');
+  assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+}, 'effective queue size of a transferred writable should be 2');
+
+promise_test(async () => {
+  let resolveWrite;
+  const orig = new WritableStream({
+    write() {
+      return new Promise(resolve => {
+        resolveWrite = resolve;
+      });
+    }
+  });
+  const transferred = await transfer(orig);
+  const writer = transferred.getWriter();
+  await writer.write('a');
+  let writeDone = false;
+  writer.write('b').then(() => {
+    writeDone = true;
+  });
+  await flushAsyncEvents();
+  assert_false(writeDone, 'second write should not have resolved yet');
+  resolveWrite();
+  await delay(0);
+  assert_true(writeDone, 'second write should have resolved');
+}, 'second write should wait for first underlying write to complete');
+
+promise_test(async t => {
+  const orig = recordingWritableStream();
+  const transferred = await transfer(orig);
+  transferred.abort('p');
+  await delay(0);
+  assert_array_equals(orig.events, ['abort', 'p'],
+                      'abort() should have been called');
+}, 'abort() should work');
+
+promise_test(async t => {
+  const orig = recordingWritableStream();
+  const transferred = await transfer(orig);
+  const writer = transferred.getWriter();
+  // A WritableStream object cannot be cloned.
+  await promise_rejects_dom(t, 'DataCloneError', writer.write(new WritableStream()),
+                            'the write should reject');
+  await promise_rejects_dom(t, 'DataCloneError', writer.closed,
+                            'the stream should be errored');
+  await delay(0);
+  assert_equals(orig.events.length, 2, 'abort should have been called');
+  assert_equals(orig.events[0], 'abort', 'first event should be abort');
+  assert_equals(orig.events[1].name, 'DataCloneError',
+                'reason should be a DataCloneError');
+}, 'writing a unclonable object should error the stream');
+</script>


### PR DESCRIPTION
The Streams Standard change https://github.com/whatwg/streams/pull/1053
adds the ability to transfer streams to a different realm using
postMessage(). Add tests for this feature.