### PR TITLE
First functional tests for scrollbar-gutter

### DIFF
--- a/scrollbar-gutter-001.html
+++ b/scrollbar-gutter-001.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Overflow: test scrollbar-gutter: auto with classic scrollbars</title>
+<link rel="author" title="Felipe Erias Morandeira" href="mailto:felipeerias@gmail.com"/>
+<link rel="help" href="https://www.w3.org/TR/css-overflow-4/#scollbar-gutter-property"/>
+<meta name="assert" content="Test scrollbar-gutter: auto with classic scrollbars">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    
+    .container {
+        scrollbar-gutter: auto;
+        height: 200px;
+        width: 200px;
+        margin: 0px;
+        padding: 0px;
+        border: none;
+        background: deepskyblue;
+    }
+    
+    .content {
+        height: 100%;
+        width: 100%;
+        background: lightsalmon;
+    }
+    
+    /* ensure that we are using classic scrollbars */
+    .classic {
+        scrollbar-width: 20px;
+    }
+    .classic::-webkit-scrollbar {
+        width: 20px;
+    }
+    
+    /* overflow values */
+    .auto    { overflow-y: auto;    }
+    .scroll  { overflow-y: scroll;  }
+    .visible { overflow-y: visible; }
+    .hidden  { overflow-y: hidden;  }
+    .clip    { overflow-y: clip;    }
+    
+</style>
+<script type="text/javascript">
+    
+    function performTest() {
+        test(function() {
+            let container = document.getElementById('container_auto');
+            let content = document.getElementById('content_auto');
+            assert_equals(container.clientWidth, content.clientWidth, "visible/auto clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "visible/auto offsetWidth");
+        }, "Unexpected layout with overflow: auto and scrollbar-gutter: auto");
+        
+        test(function() {
+            container = document.getElementById('container_scroll');
+            content = document.getElementById('content_scroll');
+            assert_equals(container.clientWidth, content.clientWidth, "scroll/auto clientWidth");
+            assert_not_equals(container.offsetWidth, content.offsetWidth, "scroll/auto offsetWidth");
+        }, "Unexpected layout with overflow: scroll and scrollbar-gutter: auto");
+        
+        test(function() {
+            container = document.getElementById('container_visible');
+            content = document.getElementById('content_visible');
+            assert_equals(container.clientWidth, content.clientWidth, "visible/auto clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "visible/auto offsetWidth");
+        }, "Unexpected layout with overflow: visible and scrollbar-gutter: auto");
+        
+        test(function() {
+            container = document.getElementById('container_hidden');
+            content = document.getElementById('content_hidden');
+            assert_equals(container.clientWidth, content.clientWidth, "hidden/auto clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "hidden/auto offsetWidth");
+        }, "Unexpected layout with overflow: hidden and scrollbar-gutter: auto");
+        
+        test(function() {
+            container = document.getElementById('container_clip');
+            content = document.getElementById('content_clip');
+            assert_equals(container.clientWidth, content.clientWidth, "clip/auto clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "clip/auto offsetWidth");
+        }, "Unexpected layout with overflow: clip and scrollbar-gutter: auto");
+    }
+    
+</script>
+<body onload="performTest()">
+    
+    Test scrollbar-gutter: auto
+    
+    <div class="container classic auto" id="container_auto">
+        <div class="content" id="content_auto">overflow-y: auto</div>
+    </div>
+    
+    <div class="container classic scroll" id="container_scroll">
+        <div class="content" id="content_scroll">overflow-y: scroll</div>
+    </div>
+    
+    <div class="container classic visible" id="container_visible">
+        <div class="content" id="content_visible">overflow-y: visible</div>
+    </div>
+    
+    <div class="container classic hidden" id="container_hidden">
+        <div class="content" id="content_hidden">overflow-y: hidden</div>
+    </div>
+    
+    <div class="container classic clip" id="container_clip">
+        <div class="content" id="content_clip">overflow-y: clip</div>
+    </div>
+    
+</body>

--- a/scrollbar-gutter-002.html
+++ b/scrollbar-gutter-002.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Overflow: test scrollbar-gutter: stable with classic scrollbars</title>
+<link rel="author" title="Felipe Erias Morandeira" href="mailto:felipeerias@gmail.com"/>
+<link rel="help" href="https://www.w3.org/TR/css-overflow-4/#scollbar-gutter-property"/>
+<meta name="assert" content="Test scrollbar-gutter: stable with classic scrollbars">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+
+    .container {
+        scrollbar-gutter: stable;
+        height: 200px;
+        width: 200px;
+        margin: 0px;
+        padding: 0px;
+        border: none;
+        background: deepskyblue;
+    }
+
+    .content {
+        height: 100%;
+        width: 100%;
+        background: lightsalmon;
+    }
+
+    /* ensure that we are using classic scrollbars */
+    .classic {
+        scrollbar-width: 20px;
+    }
+    .classic::-webkit-scrollbar {
+        width: 20px;
+    }
+
+    /* overflow values */
+    .auto    { overflow-y: auto;    }
+    .scroll  { overflow-y: scroll;  }
+    .visible { overflow-y: visible; }
+    .hidden  { overflow-y: hidden;  }
+    .clip    { overflow-y: clip;    }
+
+</style>
+<script type="text/javascript">
+
+    function performTest() {
+        test(function() {
+            let container = document.getElementById('container_auto');
+            let content = document.getElementById('content_auto');
+            assert_equals(container.clientWidth, content.clientWidth, "auto/stable clientWidth");
+            assert_not_equals(container.offsetWidth, content.offsetWidth, "auto/stable offsetWidth");
+        }, "Unexpected layout with overflow: auto and scrollbar-gutter: stable");
+
+        test(function() {
+            container = document.getElementById('container_scroll');
+            content = document.getElementById('content_scroll');
+            assert_equals(container.clientWidth, content.clientWidth, "scroll/stable clientWidth");
+            assert_not_equals(container.offsetWidth, content.offsetWidth, "scroll/stable offsetWidth");
+        }, "Unexpected layout with overflow: scroll and scrollbar-gutter: stable");
+
+        test(function() {
+            container = document.getElementById('container_visible');
+            content = document.getElementById('content_visible');
+            assert_equals(container.clientWidth, content.clientWidth, "visible/stable clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "visible/stable offsetWidth");
+        }, "Unexpected layout with overflow: visible and scrollbar-gutter: stable");
+
+        test(function() {
+            container = document.getElementById('container_hidden');
+            content = document.getElementById('content_hidden');
+            assert_equals(container.clientWidth, content.clientWidth, "hidden/stable clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "hidden/stable offsetWidth");
+        }, "Unexpected layout with overflow: hidden and scrollbar-gutter: stable");
+
+        test(function() {
+            container = document.getElementById('container_clip');
+            content = document.getElementById('content_clip');
+            assert_equals(container.clientWidth, content.clientWidth, "clip/stable clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "clip/stable offsetWidth");
+        }, "Unexpected layout with overflow: clip and scrollbar-gutter: stable");
+    }
+
+</script>
+<body onload="performTest()">
+
+    Test scrollbar-gutter: stable
+
+    <div class="container classic auto" id="container_auto">
+        <div class="content" id="content_auto">overflow-y: auto</div>
+    </div>
+
+    <div class="container classic scroll" id="container_scroll">
+        <div class="content" id="content_scroll">overflow-y: scroll</div>
+    </div>
+
+    <div class="container classic visible" id="container_visible">
+        <div class="content" id="content_visible">overflow-y: visible</div>
+    </div>
+
+    <div class="container classic hidden" id="container_hidden">
+        <div class="content" id="content_hidden">overflow-y: hidden</div>
+    </div>
+
+    <div class="container classic clip" id="container_clip">
+        <div class="content" id="content_clip">overflow-y: clip</div>
+    </div>
+
+</body>

--- a/scrollbar-gutter-003.html
+++ b/scrollbar-gutter-003.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Overflow: test scrollbar-gutter: always with classic scrollbars</title>
+<link rel="author" title="Felipe Erias Morandeira" href="mailto:felipeerias@gmail.com"/>
+<link rel="help" href="https://www.w3.org/TR/css-overflow-4/#scollbar-gutter-property"/>
+<meta name="assert" content="Test scrollbar-gutter: always with classic scrollbars">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+    
+    .container {
+        scrollbar-gutter: always;
+        height: 200px;
+        width: 200px;
+        margin: 0px;
+        padding: 0px;
+        border: none;
+        background: deepskyblue;
+    }
+    
+    .content {
+        height: 100%;
+        width: 100%;
+        background: lightsalmon;
+    }
+    
+    /* ensure that we are using classic scrollbars */
+    .classic {
+        scrollbar-width: 20px;
+    }
+    .classic::-webkit-scrollbar {
+        width: 20px;
+    }
+    
+    /* overflow values */
+    .auto    { overflow-y: auto;    }
+    .scroll  { overflow-y: scroll;  }
+    .visible { overflow-y: visible; }
+    .hidden  { overflow-y: hidden;  }
+    .clip    { overflow-y: clip;    }
+    
+</style>
+<script type="text/javascript">
+    
+    function performTest() {
+        test(function() {
+            let container = document.getElementById('container_auto');
+            let content = document.getElementById('content_auto');
+            assert_equals(container.clientWidth, content.clientWidth, "auto/always clientWidth");
+            assert_not_equals(container.offsetWidth, content.offsetWidth, "auto/always offsetWidth");
+        }, "Unexpected layout with overflow: auto and scrollbar-gutter: always");
+        
+        test(function() {
+            container = document.getElementById('container_scroll');
+            content = document.getElementById('content_scroll');
+            assert_equals(container.clientWidth, content.clientWidth, "scroll/always clientWidth");
+            assert_not_equals(container.offsetWidth, content.offsetWidth, "scroll/always offsetWidth");
+        }, "Unexpected layout with overflow: auto and scrollbar-gutter: always");
+        
+        test(function() {
+            container = document.getElementById('container_visible');
+            content = document.getElementById('content_visible');
+            assert_equals(container.clientWidth, content.clientWidth, "visible/always clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "visible/always offsetWidth");
+        }, "Unexpected layout with overflow: auto and scrollbar-gutter: always");
+        
+        test(function() {
+            container = document.getElementById('container_hidden');
+            content = document.getElementById('content_hidden');
+            assert_equals(container.clientWidth, content.clientWidth, "hidden/always clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "hidden/always offsetWidth");
+        }, "Unexpected layout with overflow: auto and scrollbar-gutter: always");
+        
+        test(function() {
+            container = document.getElementById('container_hidden');
+            content = document.getElementById('content_hidden');
+            assert_equals(container.clientWidth, content.clientWidth, "hidden/always clientWidth");
+            assert_equals(container.offsetWidth, content.offsetWidth, "hidden/always offsetWidth");
+        }, "Unexpected layout with overflow: auto and scrollbar-gutter: always");
+    }
+    
+</script>
+<body onload="performTest()">
+    
+    Test scrollbar-gutter: always
+    
+    <div class="container classic auto" id="container_auto">
+        <div class="content" id="content_auto">overflow-y: auto</div>
+    </div>
+    
+    <div class="container classic scroll" id="container_scroll">
+        <div class="content" id="content_scroll">overflow-y: scroll</div>
+    </div>
+    
+    <div class="container classic visible" id="container_visible">
+        <div class="content" id="content_visible">overflow-y: visible</div>
+    </div>
+    
+    <div class="container classic hidden" id="container_hidden">
+        <div class="content" id="content_hidden">overflow-y: hidden</div>
+    </div>
+    
+</body>


### PR DESCRIPTION
Tests for the values `auto`, `stable` and `always` of the `scrollbar-gutter` property, using classic scrollbars.

Spec: https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property

The basic test works by comparing the size of the container and contained elements, which should be the same unless a scrollbar gutter is being shown.

It uses `scrollbar-width`and `::-webkit-scrollbar` to ensure that the scrollbars are of the "classic" kind. Testing `scrollbar-gutter` with overlay scrollbars will probably require browser-specific tests, since there isn't a cross-platform way to ensure the presence of overlay scrollbars.