### PR TITLE
Fix tools/ unit tests

### DIFF
--- a/tools/.coveragerc
+++ b/tools/.coveragerc
@@ -13,6 +13,7 @@ omit =
   wpt/*
   wptrunner/*
   */tests/*
+  quic/*
 
 [paths]
 html5lib =

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 from io import open
 
 import jsone
@@ -8,6 +9,7 @@ import pytest
 import requests
 import yaml
 from jsonschema import validate
+from six import PY3
 
 from tools.ci.tc import decision
 
@@ -19,6 +21,8 @@ def data_path(filename):
     return os.path.join(here, "..", "testdata", filename)
 
 
+@pytest.mark.xfail(sys.platform == "win32" and PY3,
+                   reason="https://github.com/web-platform-tests/wpt/issues/24561")
 def test_verify_taskcluster_yml():
     """Verify that the json-e in the .taskcluster.yml is valid"""
     with open(os.path.join(root, ".taskcluster.yml"), encoding="utf8") as f:

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -50,11 +50,7 @@ def test_verify_payload():
     r.raise_for_status()
     create_task_schema = r.json()
 
-    # TODO(Hexcles): Change it to https://community-tc.services.mozilla.com/references/schemas/docker-worker/v1/payload.json
-    # after the next Community-TC release (see https://bugzilla.mozilla.org/show_bug.cgi?id=1639732)..
-    r = requests.get(
-        "https://raw.githubusercontent.com/taskcluster/taskcluster/"
-        "3ed511ef9119da54fc093e976b7b5955874c9b54/workers/docker-worker/schemas/v1/payload.json")
+    r = requests.get("https://community-tc.services.mozilla.com/references/schemas/docker-worker/v1/payload.json")
     r.raise_for_status()
     payload_schema = r.json()
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -900,7 +900,7 @@ def main(**kwargs_str):
 
 
 def lint(repo_root, paths, output_format, ignore_glob=None):
-    # type: (Text, List[Text], Text, Optional[List]) -> int
+    # type: (Text, List[Text], Text, Optional[List[Text]]) -> int
     error_count = defaultdict(int)  # type: Dict[Text, int]
     last = None
 

--- a/tools/pytest.ini
+++ b/tools/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-norecursedirs = .* {arch} *.egg html5lib third_party pywebsocket six wave wpt wptrunner
+# Directories with their own tox.ini: wave, wpt, wptrunner
+# Python 3 only: quic (it should have its own tox.ini eventually)
+norecursedirs = .* {arch} *.egg third_party wave wpt wptrunner quic
 xfail_strict = true
 addopts = --strict-markers
 markers =


### PR DESCRIPTION
1. Fix an incorrect type annotation in `lint.py` introduced in #24520 accidentally.
2. Disable coverage collection in `quic/` to silence some warnings.
3. Temporarily disable a mysterious error on Windows+py3 regarding `datetime.strptime` (#24561).

Drive-by: change docker-worker schema URL