### PR TITLE
[tools] Fix some deprecation warnings

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -704,10 +704,10 @@ def check_script_metadata(repo_root, path, f):
     return errors
 
 
-ahem_font_re = re.compile(b"font.*:.*ahem", flags=re.IGNORECASE)
+ahem_font_re = re.compile(br"font.*:.*ahem", flags=re.IGNORECASE)
 # Ahem can appear either in the global location or in the support
 # directory for legacy Mozilla imports
-ahem_stylesheet_re = re.compile(b"\/fonts\/ahem\.css|support\/ahem.css",
+ahem_stylesheet_re = re.compile(br"\/fonts\/ahem\.css|support\/ahem.css",
                                 flags=re.IGNORECASE)
 
 

--- a/tools/manifest/typedata.py
+++ b/tools/manifest/typedata.py
@@ -1,6 +1,5 @@
-from collections import MutableMapping
-
 from six import itervalues, iteritems
+from six.moves.collections_abc import MutableMapping
 
 
 MYPY = False

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -3,9 +3,9 @@ import json
 import os
 import stat
 from collections import deque
-from collections import MutableMapping
 
 from six import with_metaclass, PY2
+from six.moves.collections_abc import MutableMapping
 
 from .utils import git
 

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -1,8 +1,9 @@
 import copy
 import logging
 import os
+from collections import defaultdict
 
-from collections import defaultdict, Mapping
+from six.moves.collections_abc import Mapping
 from six import integer_types, iteritems, itervalues, string_types
 
 from . import sslutils


### PR DESCRIPTION
Mostly from forgetting to use raw string literals and the
collections.abc move in Python 3