### PR TITLE
Test that BroadcastChannel settings object is current, not incumbent

### DIFF
--- a/webmessaging/multi-globals/broadcastchannel-current.sub.html
+++ b/webmessaging/multi-globals/broadcastchannel-current.sub.html
@@ -28,7 +28,16 @@ window.onload = () => {
 
     createdCrossOrigin.postMessage("the message");
 
-    await new Promise(resolve => t.step_timeout(resolve, 3000));
+    // BroadcastChannel messages are guaranteed to be ordered within an event loop, as they all use
+    // the DOM manipulation task source. So, any messages from the "current" channel, if they are
+    // going to be erroneously delivered, would have to be delivered before those from this
+    // channel. I.e., if we recieve a message from this channel without first recieving one from
+    // the "current" channel, then the test passes.
+    const testEnder = new BroadcastChannel("current / test-ender");
+    const testEnder2 = new BroadcastChannel("current / test-ender");
+
+    testEnder.postMessage("end test");
+    await new Promise(resolve => testEnder2.onmessage = resolve);
   });
 
   done();

--- a/webmessaging/multi-globals/broadcastchannel-current.sub.html
+++ b/webmessaging/multi-globals/broadcastchannel-current.sub.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The current page being cross-origin must prevent the BroadcastChannel message from being seen</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- This is the entry global -->
+
+<iframe src="support/incumbent-document-domain.sub.html" id="incumbent"></iframe>
+<iframe src="http://{{hosts[][www]}}:{{ports[http][0]}}/webmessaging/multi-globals/support/current-document-domain.sub.html" id="current"></iframe>
+
+<script>
+"use strict";
+document.domain = "{{hosts[][]}}";
+
+setup({ explicit_done: true });
+
+const incumbentIframe = document.querySelector("#incumbent");
+const currentIframe = document.querySelector("#current");
+
+window.onload = () => {
+  promise_test(async t => {
+    const createdCrossOrigin = frames[0].createBroadcastChannel("current");
+    const createdSameOrigin = new BroadcastChannel("current");
+
+    createdSameOrigin.onmessage = t.unreached_func("message event fired");
+    createdSameOrigin.onmessageerror = t.unreached_func("messageerror event fired");
+
+    createdCrossOrigin.postMessage("the message");
+
+    await new Promise(resolve => t.step_timeout(resolve, 3000));
+  });
+
+  done();
+};
+</script>

--- a/webmessaging/multi-globals/broadcastchannel-incumbent.sub.html
+++ b/webmessaging/multi-globals/broadcastchannel-incumbent.sub.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The incumbent page being cross-origin must not prevent the BroadcastChannel message from being seen</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- This is the entry global -->
+
+<iframe src="http://{{hosts[][www]}}:{{ports[http][0]}}/webmessaging/multi-globals/support/incumbent-document-domain.sub.html" id="incumbent"></iframe>
+<iframe src="support/current-document-domain.sub.html" id="current"></iframe>
+
+<script>
+"use strict";
+document.domain = "{{hosts[][]}}";
+
+setup({ explicit_done: true });
+
+const incumbentIframe = document.querySelector("#incumbent");
+const currentIframe = document.querySelector("#current");
+
+window.onload = () => {
+  async_test(t => {
+    const createdThroughCrossOrigin = frames[0].createBroadcastChannel("incumbent");
+    const createdSameOrigin = new BroadcastChannel("incumbent");
+
+    createdSameOrigin.onmessage = () => t.done();
+    createdSameOrigin.onmessageerror = t.unreached_func("messageerror event fired");
+
+    createdThroughCrossOrigin.postMessage("the message");
+  });
+
+  done();
+};
+</script>

--- a/webmessaging/multi-globals/support/current-document-domain.sub.html
+++ b/webmessaging/multi-globals/support/current-document-domain.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Current page used as a test helper</title>
+
+<h1>Current</h1>
+
+<script>
+"use strict";
+document.domain = "{{hosts[][]}}";
+</script>

--- a/webmessaging/multi-globals/support/incumbent-document-domain.sub.html
+++ b/webmessaging/multi-globals/support/incumbent-document-domain.sub.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Incumbent page used as a test helper</title>
+
+<h1>Incumbent</h1>
+
+<script>
+"use strict";
+document.domain = "{{hosts[][]}}";
+
+window.createBroadcastChannel = (...args) => {
+  return new parent.frames[1].BroadcastChannel(...args);
+};
+</script>


### PR DESCRIPTION
Similar to https://github.com/web-platform-tests/wpt/pull/24566, but tests what origin is used for message-delivery filtering, which is the most important aspect of the BroadcastChannel settings object.

This tests my desired state, where the BroadcastChannel settings object can be eliminated and we use the relevant settings object instead. (Similar to what https://github.com/whatwg/html/pull/5728 does for MessagePort.)

It appears that unlike MessagePort, where browsers all behave the same (but disagreed with the current spec), here Chrome has the simpler, desirable behavior while Firefox has the per-spec, complicated behavior. <del>Let's see what Safari does when the CI results come in!</del><ins>Safari doesn't support BroadcastChannel</ins>