### PR TITLE
TC: don't run print tests for WebKitGTK and Servo

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -139,8 +139,6 @@ tasks:
         - vars:
             suite: reftest
         - vars:
-            suite: print-reftest
-        - vars:
             suite: wdspec
         - vars:
             suite: crashtest
@@ -198,6 +196,63 @@ tasks:
             - vars:
                 browser: servo
                 channel: nightly
+              use:
+                - trigger-daily
+                - trigger-push
+          do:
+            - ${vars.browser}-${vars.channel}-${vars.suite}:
+                use:
+                  - wpt-base
+                  - run-options
+                  - wpt-run
+                  - browser-${vars.browser}
+                  - wpt-${vars.suite}
+                description: >-
+                  A subset of WPT's "${vars.suite}" tests (chunk number ${chunks.id}
+                  of ${chunks.total}), run in the ${vars.channel} release of
+                  ${vars.browser}.
+
+  # print-reftest are currently only supported by Chrome and Firefox.
+  - $map:
+      for:
+        - vars:
+            suite: print-reftest
+      do:
+        $map:
+          for:
+            - vars:
+                browser: firefox
+                channel: nightly
+              use:
+                - trigger-master
+                - trigger-push
+            - vars:
+                browser: firefox
+                channel: beta
+              use:
+                - trigger-weekly
+                - trigger-push
+            - vars:
+                browser: firefox
+                channel: stable
+              use:
+                - trigger-daily
+                - trigger-push
+            - vars:
+                browser: chrome
+                channel: dev
+              use:
+                - trigger-master
+                - trigger-push
+            - vars:
+                browser: chrome
+                channel: beta
+              use:
+                - trigger-weekly
+                - trigger-push
+            - vars:
+                browser: chrome
+                channel: stable
               use:
                 - trigger-daily
                 - trigger-push

--- a/tools/ci/tc/tests/test_valid.py
+++ b/tools/ci/tc/tests/test_valid.py
@@ -123,14 +123,14 @@ def test_verify_payload():
       'wpt-chrome-dev-reftest-3',
       'wpt-chrome-dev-reftest-4',
       'wpt-chrome-dev-reftest-5',
-      'wpt-firefox-nightly-print-reftest-1',
-      'wpt-chrome-dev-print-reftest-1',
       'wpt-firefox-nightly-wdspec-1',
       'wpt-firefox-nightly-wdspec-2',
       'wpt-chrome-dev-wdspec-1',
       'wpt-chrome-dev-wdspec-2',
       'wpt-firefox-nightly-crashtest-1',
       'wpt-chrome-dev-crashtest-1',
+      'wpt-firefox-nightly-print-reftest-1',
+      'wpt-chrome-dev-print-reftest-1',
       'lint']),
     ("pr_event.json", True, {".taskcluster.yml",".travis.yml","tools/ci/start.sh"},
      ['lint',
@@ -243,10 +243,6 @@ def test_verify_payload():
       'wpt-servo-nightly-reftest-3',
       'wpt-servo-nightly-reftest-4',
       'wpt-servo-nightly-reftest-5',
-      'wpt-firefox-stable-print-reftest-1',
-      'wpt-chrome-stable-print-reftest-1',
-      'wpt-webkitgtk_minibrowser-nightly-print-reftest-1',
-      'wpt-servo-nightly-print-reftest-1',
       'wpt-firefox-stable-wdspec-1',
       'wpt-firefox-stable-wdspec-2',
       'wpt-chrome-stable-wdspec-1',
@@ -258,7 +254,9 @@ def test_verify_payload():
       'wpt-firefox-stable-crashtest-1',
       'wpt-chrome-stable-crashtest-1',
       'wpt-webkitgtk_minibrowser-nightly-crashtest-1',
-      'wpt-servo-nightly-crashtest-1'])
+      'wpt-servo-nightly-crashtest-1',
+      'wpt-firefox-stable-print-reftest-1',
+      'wpt-chrome-stable-print-reftest-1',])
 ])
 def test_schedule_tasks(event_path, is_pr, files_changed, expected):
     with mock.patch("tools.ci.tc.decision.get_fetch_rev", return_value=(None, None, None)):


### PR DESCRIPTION
* print-reftests are currently not supported for this two browsers.
So we need to avoid triggering those runs on taskcluster for them to
avoid failing the whole run. This fixes: #24360 and #24257.
* This patch removes the print-reftest suite from the general block
and adds a new block for it and for the browsers that support this
tests on taskcluster (chrome and firefox).