### PR TITLE
[wptserve] Make Request.GET.get return a value

### DIFF
--- a/tools/wptserve/tests/test_request.py
+++ b/tools/wptserve/tests/test_request.py
@@ -1,7 +1,7 @@
 import mock
 from six import binary_type
 
-from wptserve.request import Request, RequestHeaders
+from wptserve.request import Request, RequestHeaders, MultiDict
 
 
 class MockHTTPMessage(dict):
@@ -76,3 +76,30 @@ def test_request_url_from_host_header():
     request = Request(request_handler)
     assert request.url == 'http://web-platform.test:8001/demo'
     assert isinstance(request.url, str)
+
+
+def test_multidict():
+    m = MultiDict()
+    m["foo"] = "bar"
+    m["bar"] = "baz"
+    m.add("foo", "baz")
+    m.add("baz", "qux")
+
+    assert m["foo"] == "bar"
+    assert m.get("foo") == "bar"
+    assert m["bar"] == "baz"
+    assert m.get("bar") == "baz"
+    assert m["baz"] == "qux"
+    assert m.get("baz") == "qux"
+
+    assert m.first("foo") == "bar"
+    assert m.last("foo") == "baz"
+    assert m.get_list("foo") == ["bar", "baz"]
+    assert m.get_list("non_existent") == []
+
+    assert m.get("non_existent") is None
+    try:
+        m["non_existent"]
+        assert False, "An exception should be raised"
+    except KeyError:
+        pass

--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -560,6 +560,17 @@ class MultiDict(dict):
             return default
         raise KeyError(key)
 
+    # We need to explicitly override dict.get; otherwise, it won't call
+    # __getitem__ and would return a list instead.
+    def get(self, key, default=None):
+        """Get the first value with a given key
+
+        :param key: The key to lookup
+        :param default: The default to return if key is
+                        not found (None by default)
+        """
+        return self.first(key, default)
+
     def get_list(self, key):
         """Get all values with a given key as a list
 


### PR DESCRIPTION
instead of a list of values from the built-in get method inherited from
dict