### PR TITLE
Fix path in subresource.py

### DIFF
--- a/common/security-features/subresource/subresource.py
+++ b/common/security-features/subresource/subresource.py
@@ -121,7 +121,8 @@ def preprocess_stash_action(request, response):
 
     key = request.GET[b"key"]
     stash = request.server.stash
-    path = request.GET.get(b"path", isomorphic_encode(request.url.split(u'?')[0]))
+    path = request.GET[b"path"] if b"path" in request.GET \
+           else isomorphic_encode(request.url.split(u'?')[0])
 
     if action == b"put":
         value = isomorphic_decode(request.GET[b"value"])


### PR DESCRIPTION
The change was introduced in #24481, which assumed request.GET.get would
return a single value (though not documented explicitly, it's a very
reasonable assumption), but unfortunately it actually returns a list.
This caused widespread timeout in many referrer-policy tests, which were
not caught as affected tests.

This change fixes the immediate issue. #24614 will fix MultiDict to match
the intuition.