### PR TITLE
[wptserve] Allow more headers in Python 3

### DIFF
--- a/tools/wptserve/tests/functional/test_server.py
+++ b/tools/wptserve/tests/functional/test_server.py
@@ -49,7 +49,7 @@ class TestRequestHandler(TestUsingServer):
         def handler(request, response):
             # Additional headers are added by urllib.request.
             assert len(request.headers) > len(headers)
-            for k, v in headers:
+            for k, v in headers.items():
                 assert request.headers.get(k) == v
             return "OK"
 

--- a/tools/wptserve/tests/functional/test_server.py
+++ b/tools/wptserve/tests/functional/test_server.py
@@ -14,6 +14,7 @@ class TestFileHandler(TestUsingServer):
 
         self.assertEqual(cm.exception.code, 404)
 
+
 class TestRewriter(TestUsingServer):
     def test_rewrite(self):
         @wptserve.handlers.handler
@@ -26,6 +27,7 @@ class TestRewriter(TestUsingServer):
         resp = self.request("/test/original")
         self.assertEqual(200, resp.getcode())
         self.assertEqual(b"/test/rewritten", resp.read())
+
 
 class TestRequestHandler(TestUsingServer):
     def test_exception(self):
@@ -40,12 +42,27 @@ class TestRequestHandler(TestUsingServer):
 
         self.assertEqual(cm.exception.code, 500)
 
+    def test_many_headers(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            assert len(request.headers) == 260
+            return "OK"
+
+        route = ("GET", "/test/headers", handler)
+        self.server.router.register(*route)
+        headers = {"X-Val%d" % i: str(i) for i in range(256)}
+        resp = self.request("/test/headers", headers=headers)
+
+        self.assertEqual(resp.status, 200)
+
+
 class TestFileHandlerH2(TestUsingH2Server):
     def test_not_handled(self):
         self.conn.request("GET", "/not_existing")
         resp = self.conn.get_response()
 
         assert resp.status == 404
+
 
 class TestRewriterH2(TestUsingH2Server):
     def test_rewrite(self):
@@ -60,6 +77,7 @@ class TestRewriterH2(TestUsingH2Server):
         resp = self.conn.get_response()
         assert resp.status == 200
         assert resp.read() == b"/test/rewritten"
+
 
 class TestRequestHandlerH2(TestUsingH2Server):
     def test_exception(self):
@@ -85,6 +103,7 @@ class TestRequestHandlerH2(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 500
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/wptserve/tests/functional/test_server.py
+++ b/tools/wptserve/tests/functional/test_server.py
@@ -50,7 +50,8 @@ class TestRequestHandler(TestUsingServer):
             # Additional headers are added by urllib.request.
             assert len(request.headers) > len(headers)
             for k, v in headers.items():
-                assert request.headers.get(k) == v
+                assert request.headers.get(k) == \
+                    wptserve.utils.isomorphic_encode(v)
             return "OK"
 
         route = ("GET", "/test/headers", handler)

--- a/tools/wptserve/tests/functional/test_server.py
+++ b/tools/wptserve/tests/functional/test_server.py
@@ -43,17 +43,20 @@ class TestRequestHandler(TestUsingServer):
         self.assertEqual(cm.exception.code, 500)
 
     def test_many_headers(self):
+        headers = {"X-Val%d" % i: str(i) for i in range(256)}
+
         @wptserve.handlers.handler
         def handler(request, response):
-            assert len(request.headers) == 260
+            # Additional headers are added by urllib.request.
+            assert len(request.headers) > len(headers)
+            for k, v in headers:
+                assert request.headers.get(k) == v
             return "OK"
 
         route = ("GET", "/test/headers", handler)
         self.server.router.register(*route)
-        headers = {"X-Val%d" % i: str(i) for i in range(256)}
         resp = self.request("/test/headers", headers=headers)
-
-        self.assertEqual(resp.status, 200)
+        self.assertEqual(200, resp.getcode())
 
 
 class TestFileHandlerH2(TestUsingH2Server):

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -29,10 +29,10 @@ from .router import Router
 from .utils import HTTPException
 from .constants import h2_headers
 
-# We need to stress test browsers to send/receive lots of headers, but Python
-# stdlib has an arbitrary limit of 100 headers. Hitting the limit would produce
-# an exception which is silently caught in Python 2 but leads to HTTP 431 in
-# Python 3, so we have to moneky patch this limit.
+# We need to stress test that browsers are able to send/receive many headers
+# (there is no specified limit), but the Python stdlib has an arbitrary limit of 100
+# headers. Hitting the limit would produce an exception that is silently caught
+# in Python 2 but leads to HTTP 431 in Python 3, so we monkey patch it higher.
 # See also https://github.com/web-platform-tests/wpt/pull/24451 .
 from six.moves import http_client
 assert isinstance(getattr(http_client, '_MAXHEADERS'), int)

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -29,6 +29,15 @@ from .router import Router
 from .utils import HTTPException
 from .constants import h2_headers
 
+# We need to stress test browsers to send/receive lots of headers, but Python
+# stdlib has an arbitrary limit of 100 headers. Hitting the limit would produce
+# an exception which is silently caught in Python 2 but leads to HTTP 431 in
+# Python 3, so we have to moneky patch this limit.
+# See also https://github.com/web-platform-tests/wpt/pull/24451 .
+from six.moves import http_client
+assert isinstance(getattr(http_client, '_MAXHEADERS'), int)
+setattr(http_client, '_MAXHEADERS', 512)
+
 """
 HTTP server designed for testing purposes.
 

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -29,11 +29,12 @@ from .router import Router
 from .utils import HTTPException
 from .constants import h2_headers
 
-# We need to stress test that browsers are able to send/receive many headers
-# (there is no specified limit), but the Python stdlib has an arbitrary limit of 100
+# We need to stress test that browsers can send/receive many headers (there is
+# no specified limit), but the Python stdlib has an arbitrary limit of 100
 # headers. Hitting the limit would produce an exception that is silently caught
 # in Python 2 but leads to HTTP 431 in Python 3, so we monkey patch it higher.
-# See also https://github.com/web-platform-tests/wpt/pull/24451 .
+# https://bugs.python.org/issue26586
+# https://github.com/web-platform-tests/wpt/pull/24451
 from six.moves import http_client
 assert isinstance(getattr(http_client, '_MAXHEADERS'), int)
 setattr(http_client, '_MAXHEADERS', 512)


### PR DESCRIPTION
Monkey patch http.client to support more headers.