### PR TITLE
[css-animations] Fix expected var() resolution for getKeyframes subtest

### DIFF
--- a/css/css-animations/KeyframeEffect-getKeyframes.tentative.html
+++ b/css/css-animations/KeyframeEffect-getKeyframes.tentative.html
@@ -618,14 +618,14 @@ test(t => {
 
 test(t => {
   const div = addDiv(t);
-  div.style.animation = 'anim-custom-property-in-keyframe 100s';
+  div.style.animation = 'anim-custom-property-in-keyframe 100s steps(2, start)';
 
   const frames = getKeyframes(div);
 
   const expected = [
-    { offset: 0, computedOffset: 0, easing: "ease", composite: "auto",
+    { offset: 0, computedOffset: 0, easing: "steps(2, start)", composite: "auto",
       color: "rgb(0, 0, 0)" },
-    { offset: 1, computedOffset: 1, easing: "ease", composite: "auto",
+    { offset: 1, computedOffset: 1, easing: "steps(2, start)", composite: "auto",
       color: "rgb(0, 255, 0)" },
   ];
   assert_frame_lists_equal(frames, expected);


### PR DESCRIPTION
When computing the keyframe, a var() reference will substitute
whatever the computed value of the referenced custom property currently
is, not to the value locally defined by the same keyframe.

Hence, in order to make the test valid, set timing function to
steps(2, start). This causes the animation to start at 50%, at which
time the computed value of --end-color will be aligned with the
current expectation.