### PR TITLE
Python 3: Use byte type for content

### DIFF
--- a/xhr/resources/invalid-utf8-html.py
+++ b/xhr/resources/invalid-utf8-html.py
@@ -1,5 +1,7 @@
+from six import  int2byte
+
 def main(request, response):
     headers = [(b"Content-type", b"text/html;charset=utf-8")]
-    content = chr(0xff)
+    content = int2byte(0xff)
 
     return headers, content

--- a/xhr/resources/invalid-utf8-html.py
+++ b/xhr/resources/invalid-utf8-html.py
@@ -1,4 +1,4 @@
-from six import  int2byte
+from six import int2byte
 
 def main(request, response):
     headers = [(b"Content-type", b"text/html;charset=utf-8")]

--- a/xhr/resources/shift-jis-html.py
+++ b/xhr/resources/shift-jis-html.py
@@ -1,6 +1,8 @@
+from six import  int2byte
+
 def main(request, response):
     headers = [(b"Content-type", b"text/html;charset=shift-jis")]
     # Shift-JIS bytes for katakana TE SU TO ('test')
-    content = chr(0x83) + chr(0x65) + chr(0x83) + chr(0x58) + chr(0x83) + chr(0x67)
+    content = int2byte(0x83) + int2byte(0x65) + int2byte(0x83) + int2byte(0x58) + int2byte(0x83) + int2byte(0x67)
 
     return headers, content

--- a/xhr/resources/shift-jis-html.py
+++ b/xhr/resources/shift-jis-html.py
@@ -1,4 +1,4 @@
-from six import  int2byte
+from six import int2byte
 
 def main(request, response):
     headers = [(b"Content-type", b"text/html;charset=shift-jis")]

--- a/xhr/resources/win-1252-xml.py
+++ b/xhr/resources/win-1252-xml.py
@@ -1,5 +1,7 @@
+from six import  int2byte
+
 def main(request, response):
     headers = [(b"Content-type", b"application/xml;charset=windows-1252")]
-    content = '<' + chr(0xff) + '/>'
+    content = b'<' + int2byte(0xff) + b'/>'
 
     return headers, content

--- a/xhr/resources/win-1252-xml.py
+++ b/xhr/resources/win-1252-xml.py
@@ -1,4 +1,4 @@
-from six import  int2byte
+from six import int2byte
 
 def main(request, response):
     headers = [(b"Content-type", b"application/xml;charset=windows-1252")]


### PR DESCRIPTION
in Python 3, strings are unicode. For non-ASCII characters it prepends
0xc2 for range[0x80, 0xbf] and 0xc3 for range[0xc0, 0xff]. This fix
is to use byte type for content to support both Python2 and Python 3.