### PR TITLE
Python 3: Drop use of flush on ResponseWriter in a couple of files

### DIFF
--- a/fetch/range/resources/long-wav.py
+++ b/fetch/range/resources/long-wav.py
@@ -118,7 +118,7 @@ def main(request, response):
     bytes_remaining_to_send -= len(initial_write)
 
     while bytes_remaining_to_send > 0:
-        if not response.writer.flush():
+        if not response.writer.write(b"."):
             break
 
         to_send = b'\x00' * min(bytes_remaining_to_send, sample_rate)

--- a/fetch/range/resources/long-wav.py
+++ b/fetch/range/resources/long-wav.py
@@ -118,12 +118,11 @@ def main(request, response):
     bytes_remaining_to_send -= len(initial_write)
 
     while bytes_remaining_to_send > 0:
-        if not response.writer.write(b"."):
-            break
-
         to_send = b'\x00' * min(bytes_remaining_to_send, sample_rate)
         bytes_remaining_to_send -= len(to_send)
 
-        response.writer.write(to_send)
+        if not response.writer.write(to_send):
+            break
+
         # Throttle the stream
         time.sleep(0.5)

--- a/html/semantics/embedded-content/the-iframe-element/support/download_stash.py
+++ b/html/semantics/embedded-content/the-iframe-element/support/download_stash.py
@@ -22,7 +22,6 @@ def main(request, response):
     single_delay = finish_delay / count
     for i in range(count): # pylint: disable=unused-variable
         time.sleep(single_delay)
-        response.writer.write_content(u"\n")
-        if not response.writer.write(b"."):
+        if not response.writer.write_content(b"\n"):
           return
     request.server.stash.put(token, True)

--- a/html/semantics/embedded-content/the-iframe-element/support/download_stash.py
+++ b/html/semantics/embedded-content/the-iframe-element/support/download_stash.py
@@ -23,6 +23,6 @@ def main(request, response):
     for i in range(count): # pylint: disable=unused-variable
         time.sleep(single_delay)
         response.writer.write_content(u"\n")
-        if not response.writer.flush():
+        if not response.writer.write(b"."):
           return
     request.server.stash.put(token, True)


### PR DESCRIPTION
This patch only drops the use of response.write.flush() in a couple of
files as they directly affect test results in Python 3.

Detailed discussions on dropping use of flush on ResponseWriter can be
found at https://github.com/web-platform-tests/wpt/pull/24617
(Also see #24719 )