### PR TITLE
Update docker image for Servo dependencies.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,7 +57,7 @@ tasks:
             owner: ${owner}
             source: ${event.repository.clone_url}
           payload:
-            image: webplatformtests/wpt:0.42
+            image: webplatformtests/wpt:0.46
             maxRunTime: 7200
             artifacts:
               public/results:

--- a/tools/ci/tc/decision.py
+++ b/tools/ci/tc/decision.py
@@ -199,7 +199,6 @@ def build_full_command(event, task):
 ~/start.sh \
   %(repo_url)s \
   %(fetch_ref)s;
-sudo add-apt-repository ppa:deadsnakes/ppa
 %(install_str)s
 cd web-platform-tests;
 ./tools/ci/run_tc.py %(options_str)s -- %(task_cmd)s;

--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -4,7 +4,7 @@ components:
     workerType: ci
     schedulerId: taskcluster-github
     deadline: "24 hours"
-    image: webplatformtests/wpt:0.42
+    image: webplatformtests/wpt:0.46
     maxRunTime: 7200
     artifacts:
       public/results:
@@ -392,6 +392,9 @@ tasks:
         - trigger-pr
         - tox-python3
       command: ./tools/ci/ci_tools_unittest.sh
+      install:
+        - python3.6
+        - python3.6-dev
       env:
         HYPOTHESIS_PROFILE: ci
       schedule-if:
@@ -444,6 +447,8 @@ tasks:
       command: ./tools/ci/ci_tools_integration_test.sh
       install:
         - libnss3-tools
+        - python3.6
+        - python3.6-dev
       options:
         oom-killer: true
         browser:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # No interactive frontend during docker build
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -10,12 +10,14 @@ RUN apt-get -qqy update \
     bridge-utils \
     bzip2 \
     ca-certificates \
+    curl \
     dbus-x11 \
     earlyoom \
     fluxbox \
     gdebi \
     git \
     gstreamer1.0-plugins-bad \
+    gstreamer1.0-gl \
     libosmesa6-dev \
     libvirt-daemon-system \
     libvirt-clients \
@@ -24,16 +26,28 @@ RUN apt-get -qqy update \
     locales \
     openjdk-8-jre-headless \
     pulseaudio \
-    python \
-    python-pip \
+    python2 \
+    python2-dev \
     python3 \
+    python3-dev \
     python3-pip \
+    software-properties-common \
     qemu-kvm \
     tzdata \
     sudo \
     unzip \
     wget \
     xvfb
+
+# python3.6 is not available by default in new versions of Ubuntu.
+RUN apt-add-repository -y ppa:deadsnakes/ppa
+
+# Ensure that scripts referencing `/usr/bin/env python` work.
+RUN apt install python-is-python2
+
+# The python-pip package no longer exists in new versions of Ubuntu.
+RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
+RUN python2 get-pip.py
 
 # Installing just the deps of firefox and chrome is moderately tricky, so
 # just install the default versions of them, and some extra deps we happen


### PR DESCRIPTION
Servo nightly builds are built from a Ubuntu 19.10 image so they require glibc 2.29. 18.04 only makes 2.27 available, so I'm hoping that updating the image to 19.10 to match is acceptable. Fixes #24607.