### PR TITLE
Fix running geckodriver nightly for nightly Firefox

### DIFF
--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -7,7 +7,7 @@ cd $WPT_ROOT
 
 test_infrastructure() {
     PY3_FLAG="$2"
-    TERM=dumb ./wpt $PY3_FLAG run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts $1 $PRODUCT infrastructure/
+    TERM=dumb ./wpt $PY3_FLAG run --log-mach - --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts --install-webdriver $1 $PRODUCT infrastructure/
 }
 
 main() {

--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -12,13 +12,14 @@ browser_specific_args = {
     "servo": ["--install-browser", "--processes=12"]
 }
 
+
 def get_browser_args(product):
     if product == "firefox":
         local_binary = os.path.expanduser(os.path.join("~", "build", "firefox", "firefox"))
         if os.path.exists(local_binary):
             return ["--binary=%s" % local_binary]
         print("WARNING: Local firefox binary not found")
-        return ["--install-browser"]
+        return ["--install-browser", "--install-webdriver"]
     return browser_specific_args.get(product, [])
 
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -52,6 +52,9 @@ def create_parser():
     parser.add_argument("--install-browser", action="store_true",
                         help="Install the browser from the release channel specified by --channel "
                         "(or the nightly channel by default).")
+    parser.add_argument("--install-webdriver", action="store_true",
+                        help="Install WebDriver from the release channel specified by --channel "
+                        "(or the nightly channel by default).")
     parser._add_container_actions(wptcommandline.create_parser())
     return parser
 
@@ -217,7 +220,9 @@ Consider installing certutil via your OS package manager or directly.""")
             kwargs["certutil_binary"] = certutil
 
         if kwargs["webdriver_binary"] is None and "wdspec" in kwargs["test_types"]:
-            webdriver_binary = self.browser.find_webdriver()
+            webdriver_binary = None
+            if not kwargs["install_webdriver"]:
+                webdriver_binary = self.browser.find_webdriver()
 
             if webdriver_binary is None:
                 install = self.prompt_install("geckodriver")
@@ -314,7 +319,9 @@ class Chrome(BrowserSetup):
             else:
                 raise WptrunError("Unable to locate Chrome binary")
         if kwargs["webdriver_binary"] is None:
-            webdriver_binary = self.browser.find_webdriver()
+            webdriver_binary = None
+            if not kwargs["install_webdriver"]:
+                webdriver_binary = self.browser.find_webdriver()
 
             if webdriver_binary is None:
                 install = self.prompt_install("chromedriver")
@@ -355,7 +362,9 @@ class ChromeAndroid(BrowserSetup):
             kwargs["package_name"] = self.browser.find_binary(
                 channel=browser_channel)
         if kwargs["webdriver_binary"] is None:
-            webdriver_binary = self.browser.find_webdriver()
+            webdriver_binary = None
+            if not kwargs["install_webdriver"]:
+                webdriver_binary = self.browser.find_webdriver()
 
             if webdriver_binary is None:
                 install = self.prompt_install("chromedriver")
@@ -397,7 +406,9 @@ class AndroidWeblayer(BrowserSetup):
         if kwargs.get("device_serial"):
             self.browser.device_serial = kwargs["device_serial"]
         if kwargs["webdriver_binary"] is None:
-            webdriver_binary = self.browser.find_webdriver()
+            webdriver_binary = None
+            if not kwargs["install_webdriver"]:
+                webdriver_binary = self.browser.find_webdriver()
 
             if webdriver_binary is None:
                 install = self.prompt_install("chromedriver")
@@ -422,7 +433,9 @@ class AndroidWebview(BrowserSetup):
         if kwargs.get("device_serial"):
             self.browser.device_serial = kwargs["device_serial"]
         if kwargs["webdriver_binary"] is None:
-            webdriver_binary = self.browser.find_webdriver()
+            webdriver_binary = None
+            if not kwargs["install_webdriver"]:
+                webdriver_binary = self.browser.find_webdriver()
 
             if webdriver_binary is None:
                 install = self.prompt_install("chromedriver")
@@ -445,7 +458,9 @@ class Opera(BrowserSetup):
 
     def setup_kwargs(self, kwargs):
         if kwargs["webdriver_binary"] is None:
-            webdriver_binary = self.browser.find_webdriver()
+            webdriver_binary = None
+            if not kwargs["install_webdriver"]:
+                webdriver_binary = self.browser.find_webdriver()
 
             if webdriver_binary is None:
                 install = self.prompt_install("operadriver")
@@ -475,7 +490,9 @@ class EdgeChromium(BrowserSetup):
             else:
                 raise WptrunError("Unable to locate Edge binary")
         if kwargs["webdriver_binary"] is None:
-            webdriver_binary = self.browser.find_webdriver()
+            webdriver_binary = None
+            if not kwargs["install_webdriver"]:
+                webdriver_binary = self.browser.find_webdriver()
 
             # Install browser if none are found or if it's found in venv path
             if webdriver_binary is None or webdriver_binary in self.venv.bin_path:

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -229,7 +229,10 @@ Consider installing certutil via your OS package manager or directly.""")
 
                 if install:
                     logger.info("Downloading geckodriver")
-                    webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path)
+                    webdriver_binary = self.browser.install_webdriver(
+                        dest=self.venv.bin_path,
+                        channel=kwargs["browser_channel"],
+                        browser_binary=kwargs["binary"])
             else:
                 logger.info("Using webdriver binary %s" % webdriver_binary)
 
@@ -330,6 +333,7 @@ class Chrome(BrowserSetup):
                     logger.info("Downloading chromedriver")
                     webdriver_binary = self.browser.install_webdriver(
                         dest=self.venv.bin_path,
+                        channel=browser_channel,
                         browser_binary=kwargs["binary"],
                     )
             else:
@@ -373,6 +377,7 @@ class ChromeAndroid(BrowserSetup):
                     logger.info("Downloading chromedriver")
                     webdriver_binary = self.browser.install_webdriver(
                         dest=self.venv.bin_path,
+                        channel=browser_channel,
                         browser_binary=kwargs["package_name"],
                     )
             else:
@@ -415,7 +420,9 @@ class AndroidWeblayer(BrowserSetup):
 
                 if install:
                     logger.info("Downloading chromedriver")
-                    webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path)
+                    webdriver_binary = self.browser.install_webdriver(
+                        dest=self.venv.bin_path,
+                        channel=kwargs["browser_channel"])
             else:
                 logger.info("Using webdriver binary %s" % webdriver_binary)
 
@@ -442,7 +449,9 @@ class AndroidWebview(BrowserSetup):
 
                 if install:
                     logger.info("Downloading chromedriver")
-                    webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path)
+                    webdriver_binary = self.browser.install_webdriver(
+                        dest=self.venv.bin_path,
+                        channel=kwargs["browser_channel"])
             else:
                 logger.info("Using webdriver binary %s" % webdriver_binary)
 
@@ -467,7 +476,9 @@ class Opera(BrowserSetup):
 
                 if install:
                     logger.info("Downloading operadriver")
-                    webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path)
+                    webdriver_binary = self.browser.install_webdriver(
+                        dest=self.venv.bin_path,
+                        channel=kwargs["browser_channel"])
             else:
                 logger.info("Using webdriver binary %s" % webdriver_binary)
 
@@ -500,7 +511,9 @@ class EdgeChromium(BrowserSetup):
 
                 if install:
                     logger.info("Downloading msedgedriver")
-                    webdriver_binary = self.browser.install_webdriver(dest=self.venv.bin_path, channel=browser_channel)
+                    webdriver_binary = self.browser.install_webdriver(
+                        dest=self.venv.bin_path,
+                        channel=browser_channel)
             else:
                 logger.info("Using webdriver binary %s" % webdriver_binary)
 


### PR DESCRIPTION
Two changes here:
* Add a `--install-webdriver` flag that forces install of the WebDriver binary even if it's already on the path
* Actually pass the channel down to the relevant methods, so that nightly browsers can get nightly drivers again.

The second part was causing Firefox nightly runs to use released geckodriver, which invalidated some of the results.