### PR TITLE
update python version in build for html/canvas

### DIFF
--- a/html/canvas/tools/build.sh
+++ b/html/canvas/tools/build.sh
@@ -2,6 +2,6 @@
 set -ex
 
 cd "${0%/*}"
-virtualenv -p python2 .virtualenv
+virtualenv -p python .virtualenv
 .virtualenv/bin/pip install pyyaml cairocffi
 .virtualenv/bin/python gentest.py


### PR DESCRIPTION
It's currently building with virtualenv -p python2 .virtualenv, which requires python2 specifically. Updated to use python, so it's compatible with both python2 and python3.