### PR TITLE
Add Chrome nightly (Chromium trunk) to wpt

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -536,10 +536,13 @@ class Chrome(Browser):
     requirements = "requirements_chrome.txt"
 
     def download(self, dest=None, channel=None, rename=None):
-        raise NotImplementedError
+        if channel != "nightly":
+            raise NotImplementedError("We can only download Chrome Nightly (Chromium ToT) for you.")
+        url_base = self.latest_chromium_snapshot_url()
 
     def install(self, dest=None, channel=None):
-        raise NotImplementedError
+        if channel != "nightly":
+            raise NotImplementedError("We can only install Chrome Nightly (Chromium ToT) for you.")
 
     def platform_string(self):
         platform = {
@@ -574,6 +577,12 @@ class Chrome(Browser):
             platform += "_x64"
 
         return platform
+
+    def latest_chromium_snapshot_url(self):
+        arch = self.chromium_platform_string()
+        revision_url = "https://storage.googleapis.com/chromium-browser-snapshots/%s/LAST_CHANGE" % arch
+        revision = get(revision_url).text.strip()
+        return "https://storage.googleapis.com/chromium-browser-snapshots/%s/%s/" % arch, revision
 
     def find_binary(self, venv_path=None, channel=None):
         if uname[0] == "Linux":
@@ -626,11 +635,7 @@ class Chrome(Browser):
             get(url)
         except requests.RequestException:
             # Fall back to the tip-of-tree Chromium build.
-            revision_url = "https://storage.googleapis.com/chromium-browser-snapshots/%s/LAST_CHANGE" % (
-                self.chromium_platform_string())
-            revision = get(revision_url).text.strip()
-            url = "https://storage.googleapis.com/chromium-browser-snapshots/%s/%s/chromedriver_%s.zip" % (
-                self.chromium_platform_string(), revision, self.platform_string())
+            url = "%s/chromedriver_%s.zip" % self.latest_chromium_snapshot_url(), self.platform_string()
         return url
 
     def _latest_chromedriver_url(self, chrome_version):

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -12,7 +12,7 @@ from distutils.spawn import find_executable
 from six.moves.urllib.parse import urlsplit
 import requests
 
-from .utils import call, get, untar, unzip, rmtree
+from .utils import call, get, rmtree, untar, unzip
 
 uname = platform.uname()
 
@@ -592,11 +592,11 @@ class Chrome(Browser):
 
     def _latest_chromium_snapshot_url(self):
         # Make sure we use the same revision in an invocation.
+        architecture = self._chromium_platform_string()
         if self._last_change is None:
-            arch = self._chromium_platform_string()
-            revision_url = "https://storage.googleapis.com/chromium-browser-snapshots/%s/LAST_CHANGE" % arch
+            revision_url = "https://storage.googleapis.com/chromium-browser-snapshots/%s/LAST_CHANGE" % architecture
             self._last_change = get(revision_url).text.strip()
-        return "https://storage.googleapis.com/chromium-browser-snapshots/%s/%s/" % (arch, self._last_change)
+        return "https://storage.googleapis.com/chromium-browser-snapshots/%s/%s/" % (architecture, self._last_change)
 
     def find_nightly_binary(self, dest, channel):
         binary = "Chromium" if uname[0] == "Darwin" else "chrome"

--- a/tools/wpt/install.py
+++ b/tools/wpt/install.py
@@ -3,7 +3,7 @@ from . import browser
 
 latest_channels = {
     'firefox': 'nightly',
-    'chrome': 'dev',
+    'chrome': 'nightly',
     'chrome_android': 'dev',
     'edgechromium': 'dev',
     'safari': 'preview',
@@ -14,11 +14,11 @@ channel_by_name = {
     'stable': 'stable',
     'release': 'stable',
     'beta': 'beta',
+    'dev': 'dev',
+    'canary': 'canary',
     'nightly': latest_channels,
-    'dev': latest_channels,
     'preview': latest_channels,
     'experimental': latest_channels,
-    'canary': 'canary',
 }
 
 channel_args = argparse.ArgumentParser(add_help=False)

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -343,8 +343,8 @@ class Chrome(BrowserSetup):
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
                 raise WptrunError("Unable to locate or install chromedriver binary")
-        if browser_channel in ("dev", "canary"):
-            logger.info("Automatically turning on experimental features for Chrome Dev/Canary")
+        if browser_channel in ("dev", "canary", "nightly"):
+            logger.info("Automatically turning on experimental features for Chrome Dev/Canary or Chromium trunk")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
             # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448
             kwargs["webdriver_args"].append("--disable-build-check")

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -16,7 +16,7 @@ except ImportError:
 
 import pytest
 
-from tools.wpt import wpt
+from tools.wpt import wpt, utils
 
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -61,7 +61,7 @@ def manifest_dir():
                         os.path.join(path, "MANIFEST.json"))
         yield path
     finally:
-        shutil.rmtree(path)
+        utils.rmtree(path)
 
 
 @pytest.fixture
@@ -86,7 +86,7 @@ def temp_test():
 
     yield make_test
 
-    shutil.rmtree("../../.tools-tests")
+    utils.rmtree("../../.tools-tests")
 
 
 def test_missing():
@@ -185,6 +185,7 @@ def test_run_zero_tests():
                        "chrome", "/non-existent-dir/non-existent-file.html"])
     assert excinfo.value.code != 0
 
+
 @pytest.mark.slow
 @pytest.mark.remote_network
 def test_run_failing_test():
@@ -240,6 +241,25 @@ def test_run_verify_unstable(temp_test):
 
 @pytest.mark.slow
 @pytest.mark.remote_network
+def test_install_chromium():
+    if sys.platform == "win32":
+        chromium_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", "nightly", "chrome-win")
+    elif sys.platform == "darwin":
+        chromium_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", "nightly", "chrome-mac")
+    else:
+        chromium_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", "nightly", "chrome-linux")
+
+    if os.path.exists(chromium_path):
+        utils.rmtree(chromium_path)
+    with pytest.raises(SystemExit) as excinfo:
+        wpt.main(argv=["install", "chrome", "browser", "--channel=nightly"])
+    assert excinfo.value.code == 0
+    assert os.path.exists(chromium_path)
+    utils.rmtree(chromium_path)
+
+
+@pytest.mark.slow
+@pytest.mark.remote_network
 def test_install_chromedriver():
     if sys.platform == "win32":
         chromedriver_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "Scripts", "chromedriver.exe")
@@ -251,7 +271,13 @@ def test_install_chromedriver():
         wpt.main(argv=["install", "chrome", "webdriver"])
     assert excinfo.value.code == 0
     assert os.path.exists(chromedriver_path)
-    os.unlink(chromedriver_path)
+    # FIXME: On Windows, this may sometimes fail (access denied), possibly
+    # because the file handler is not released immediately.
+    try:
+        os.unlink(chromedriver_path)
+    except OSError:
+        if sys.platform != "win32":
+            raise
 
 
 @pytest.mark.slow
@@ -264,12 +290,12 @@ def test_install_firefox():
     else:
         fx_path = os.path.join(wpt.localpaths.repo_root, wpt.venv_dir(), "browsers", "nightly", "firefox")
     if os.path.exists(fx_path):
-        shutil.rmtree(fx_path)
+        utils.rmtree(fx_path)
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["install", "firefox", "browser", "--channel=nightly"])
     assert excinfo.value.code == 0
     assert os.path.exists(fx_path)
-    shutil.rmtree(fx_path)
+    utils.rmtree(fx_path)
 
 
 def test_files_changed(capsys):

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -16,7 +16,7 @@ except ImportError:
 
 import pytest
 
-from tools.wpt import wpt, utils
+from tools.wpt import utils, wpt
 
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/tools/wpt/utils.py
+++ b/tools/wpt/utils.py
@@ -1,5 +1,8 @@
+import errno
 import logging
 import os
+import shutil
+import stat
 import subprocess
 import tarfile
 import zipfile
@@ -95,3 +98,19 @@ def get(url):
     resp = requests.get(url, stream=True)
     resp.raise_for_status()
     return resp
+
+
+def rmtree(path):
+    # This works around two issues:
+    # 1. Cannot delete read-only files owned by us (e.g. files extracted from tarballs)
+    # 2. On Windows, we sometimes just need to retry in case the file handler
+    #    hasn't been fully released (a common issue).
+    def handle_remove_readonly(func, path, exc):
+        excvalue = exc[1]
+        if func in (os.rmdir, os.remove) and excvalue.errno == errno.EACCES:
+            os.chmod(path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # 0777
+            func(path)
+        else:
+            raise
+
+    return shutil.rmtree(path, onerror=handle_remove_readonly)


### PR DESCRIPTION
Chrome does not really have an official "nightly" channel. We are using it to refer to the Chromium trunk (tip of the tree) build (available via https://download-chromium.appspot.com/).

This PR enables us to
* `wpt install [--download-only] [--channel nightly] chrome browser` and `wpt install [--channel nightly] chrome webdriver`
* `wpt run --install-browser --channel nightly chrome` (experimental web platform features will be enabled, same as dev or canary)

Note that this changes the default / latest channel for Chrome to nightly when no channel is supplied, which won't break the CI because we always specify the channel.

It might be easier to review the commits individually.