### PR TITLE
[service-workers] Correct multipart response

### DIFF
--- a/service-workers/service-worker/resources/multipart-image.py
+++ b/service-workers/service-worker/resources/multipart-image.py
@@ -8,7 +8,7 @@ BOUNDARY = b'cutHere'
 
 def create_part(path):
     with open(path, u'rb') as f:
-        return b'Content-Type: image/png\r\n\r\n' + f.read() + b'--%s' % BOUNDARY
+        return b'Content-Type: image/png\r\n\r\n' + f.read() + b'\r\n--%s\r\n' % BOUNDARY
 
 
 def main(request, response):
@@ -18,6 +18,7 @@ def main(request, response):
         headers.append((b'Access-Control-Allow-Origin', b'*'))
 
     image_path = os.path.join(request.doc_root, u'images')
-    body = create_part(os.path.join(image_path, u'red.png'))
+    body = b'--%s\r\n' % BOUNDARY
+    body = body + create_part(os.path.join(image_path, u'red.png'))
     body = body + create_part(os.path.join(image_path, u'red-16x16.png'))
     return headers, body


### PR DESCRIPTION
RFC2046 [1] specifies:

> implementations must ignore anything that appears before the first
> boundary delimiter line or after the last one.

The modified resource was ostensibly designed to include two body parts.
Insert an initial boundary delimiter so that each image is interpreted
as a distinct body part.

Insert the requisite CRLF sequences around the boundaries.

https://tools.ietf.org/html/rfc2046