### PR TITLE
Streams: fix interceptThen assigning to a const

### DIFF
--- a/streams/piping/then-interception.any.js
+++ b/streams/piping/then-interception.any.js
@@ -5,7 +5,7 @@
 
 function interceptThen() {
   const intercepted = [];
-  const callCount = 0;
+  let callCount = 0;
   Object.prototype.then = function(resolver) {
     if (!this.done) {
       intercepted.push(this.value);


### PR DESCRIPTION
We try to modify `callCount` on [line 14](https://github.com/web-platform-tests/wpt/blob/df8d7e773b7d0af2956391c958967d5e9d962466/streams/piping/then-interception.any.js#L14), so it cannot be a `const`.