### PR TITLE
Streams: clean up patched globals after test

### DIFF
--- a/streams/piping/then-interception.any.js
+++ b/streams/piping/then-interception.any.js
@@ -21,7 +21,7 @@ function interceptThen() {
   return intercepted;
 }
 
-promise_test(async () => {
+promise_test(async t => {
   const rs = new ReadableStream({
     start(controller) {
       controller.enqueue('a');
@@ -31,6 +31,9 @@ promise_test(async () => {
   const ws = recordingWritableStream();
 
   const intercepted = interceptThen();
+  t.add_cleanup(() => {
+    delete Object.prototype.then;
+  });
 
   await rs.pipeTo(ws);
   delete Object.prototype.then;
@@ -40,7 +43,7 @@ promise_test(async () => {
   assert_array_equals(ws.events, ['write', 'a', 'close'], 'written chunk should be "a"');
 }, 'piping should not be observable');
 
-promise_test(async () => {
+promise_test(async t => {
   const rs = new ReadableStream({
     start(controller) {
       controller.enqueue('a');
@@ -52,6 +55,9 @@ promise_test(async () => {
   const [ branch1, branch2 ] = rs.tee();
 
   const intercepted = interceptThen();
+  t.add_cleanup(() => {
+    delete Object.prototype.then;
+  });
 
   await branch1.pipeTo(ws);
   delete Object.prototype.then;

--- a/streams/transform-streams/patched-global.any.js
+++ b/streams/transform-streams/patched-global.any.js
@@ -1,19 +1,25 @@
 // META: global=window,worker,jsshell
 'use strict';
 
-// Tests which patch the global environment are kept separate to avoid interfering with other tests.
+// Tests which patch the global environment are kept separate to avoid
+// interfering with other tests.
 
-// eslint-disable-next-line no-extend-native, accessor-pairs
-Object.defineProperty(Object.prototype, 'highWaterMark', {
-  set() { throw new Error('highWaterMark setter called'); }
-});
+test(t => {
+  // eslint-disable-next-line no-extend-native, accessor-pairs
+  Object.defineProperty(Object.prototype, 'highWaterMark', {
+    set() { throw new Error('highWaterMark setter called'); }
+  });
 
-// eslint-disable-next-line no-extend-native, accessor-pairs
-Object.defineProperty(Object.prototype, 'size', {
-  set() { throw new Error('size setter called'); }
-});
+  // eslint-disable-next-line no-extend-native, accessor-pairs
+  Object.defineProperty(Object.prototype, 'size', {
+    set() { throw new Error('size setter called'); }
+  });
 
-test(() => {
+  t.add_cleanup(() => {
+    delete Object.prototype.highWaterMark;
+    delete Object.prototype.size;
+  });
+
   assert_not_equals(new TransformStream(), null, 'constructor should work');
 }, 'TransformStream constructor should not call setters for highWaterMark or size');
 


### PR DESCRIPTION
All the "patched globals" tests use `t.add_cleanup` to clean up after themselves, except for the _"TransformStream constructor should not call setters for highWaterMark or size"_ test and the "then interception" tests. This fixes that.

It doesn't matter _that_ much in practice. Implementations should run each test in isolation, so they cannot affect each other. That said, I think it's still a good practice to do some clean up ourselves. 😄