### PR TITLE
Turn on MojoJS in Chrome nightly (Chromium trunk)

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -560,6 +560,11 @@ class Chrome(Browser):
         os.remove(installer_path)
         return self.find_nightly_binary(dest, channel)
 
+    def install_mojojs(self, dest):
+        url = self._latest_chromium_snapshot_url() + "mojojs.zip"
+        self.logger.info("Downloading Mojo bindings from %s" % url)
+        unzip(get(url).raw, dest)
+
     def _chromedriver_platform_string(self):
         platform = self.platforms.get(uname[0])
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -321,6 +321,13 @@ class Chrome(BrowserSetup):
                 kwargs["binary"] = binary
             else:
                 raise WptrunError("Unable to locate Chrome binary")
+        if browser_channel == "nightly":
+            try:
+                self.browser.install_mojojs(self.venv.path)
+                kwargs["enable_mojojs"] = True
+                logger.info("MojoJS enabled")
+            except Exception as e:
+                logger.error("Cannot enable MojoJS: %s" % e)
         if kwargs["webdriver_binary"] is None:
             webdriver_binary = None
             if not kwargs["install_webdriver"]:

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -78,6 +78,9 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     # Point all .test domains to localhost for Chrome
     chrome_options["args"].append("--host-resolver-rules=MAP nonexistent.*.test ~NOTFOUND, MAP *.test 127.0.0.1")
 
+    if kwargs["enable_mojojs"]:
+        chrome_options["args"].append("--enable-blink-features=MojoJS,MojoJSTest")
+
     # Copy over any other flags that were passed in via --binary_args
     if kwargs["binary_args"] is not None:
         chrome_options["args"].extend(kwargs["binary_args"])

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -55,7 +55,7 @@ class TestEnvironment(object):
     websockets servers"""
     def __init__(self, test_paths, testharness_timeout_multipler,
                  pause_after_test, debug_info, options, ssl_config, env_extras,
-                 enable_quic=False):
+                 enable_quic=False, serve_mojojs=False):
         self.test_paths = test_paths
         self.server = None
         self.config_ctx = None
@@ -72,6 +72,7 @@ class TestEnvironment(object):
         self.env_extras_cms = None
         self.ssl_config = ssl_config
         self.enable_quic = enable_quic
+        self.serve_mojojs = serve_mojojs
 
     def __enter__(self):
         self.config_ctx = self.build_config()
@@ -162,7 +163,7 @@ class TestEnvironment(object):
     def setup_server_logging(self):
         server_logger = get_default_logger(component="wptserve")
         assert server_logger is not None
-        log_filter = handlers.LogLevelFilter(lambda x:x, "info")
+        log_filter = handlers.LogLevelFilter(lambda x: x, "info")
         # Downgrade errors to warnings for the server
         log_filter = LogLevelRewriter(log_filter, ["error"], "warning")
         server_logger.component_filter = log_filter
@@ -170,7 +171,7 @@ class TestEnvironment(object):
         server_logger = proxy.QueuedProxyLogger(server_logger)
 
         try:
-            #Set as the default logger for wptserve
+            # Set as the default logger for wptserve
             serve.set_logger(server_logger)
             serve.logger = server_logger
         except Exception:
@@ -215,6 +216,10 @@ class TestEnvironment(object):
 
         if "/" not in self.test_paths:
             del route_builder.mountpoint_routes["/"]
+
+        if self.serve_mojojs:
+            # TODO(Hexcles): Properly pass venv.path in.
+            route_builder.add_mount_point("/gen/", "_venv2/mojojs/gen")
 
         return route_builder.get_routes()
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -240,7 +240,6 @@ scheme host and port.""")
                             default=None,
                             help="Build is a release (overrides any mozinfo file)")
 
-
     chunking_group = parser.add_argument_group("Test Chunking")
     chunking_group.add_argument("--total-chunks", action="store", type=int, default=1,
                                 help="Total number of chunks to use")
@@ -251,20 +250,20 @@ scheme host and port.""")
 
     ssl_group = parser.add_argument_group("SSL/TLS")
     ssl_group.add_argument("--ssl-type", action="store", default=None,
-                        choices=["openssl", "pregenerated", "none"],
-                        help="Type of ssl support to enable (running without ssl may lead to spurious errors)")
+                           choices=["openssl", "pregenerated", "none"],
+                           help="Type of ssl support to enable (running without ssl may lead to spurious errors)")
 
     ssl_group.add_argument("--openssl-binary", action="store",
-                        help="Path to openssl binary", default="openssl")
+                           help="Path to openssl binary", default="openssl")
     ssl_group.add_argument("--certutil-binary", action="store",
-                        help="Path to certutil binary for use with Firefox + ssl")
+                           help="Path to certutil binary for use with Firefox + ssl")
 
     ssl_group.add_argument("--ca-cert-path", action="store", type=abs_path,
-                        help="Path to ca certificate when using pregenerated ssl certificates")
+                           help="Path to ca certificate when using pregenerated ssl certificates")
     ssl_group.add_argument("--host-key-path", action="store", type=abs_path,
-                        help="Path to host private key when using pregenerated ssl certificates")
+                           help="Path to host private key when using pregenerated ssl certificates")
     ssl_group.add_argument("--host-cert-path", action="store", type=abs_path,
-                        help="Path to host certificate when using pregenerated ssl certificates")
+                           help="Path to host certificate when using pregenerated ssl certificates")
 
     gecko_group = parser.add_argument_group("Gecko-specific")
     gecko_group.add_argument("--prefs-root", dest="prefs_root", action="store", type=abs_path,
@@ -313,6 +312,11 @@ scheme host and port.""")
                              default=[], action="append", dest="user_stylesheets",
                              help="Inject a user CSS stylesheet into every test.")
 
+    servo_group = parser.add_argument_group("Chrome-specific")
+    servo_group.add_argument("--enable-mojojs", action="store_true", default=False,
+                             help="Enable MojoJS for testing. Mojo bindings need to be available in "
+                             "_venv2/mojojs.")
+
     sauce_group = parser.add_argument_group("Sauce Labs-specific")
     sauce_group.add_argument("--sauce-browser", dest="sauce_browser",
                              help="Sauce Labs browser name")
@@ -346,7 +350,7 @@ scheme host and port.""")
 
     webkit_group = parser.add_argument_group("WebKit-specific")
     webkit_group.add_argument("--webkit-port", dest="webkit_port",
-                             help="WebKit port")
+                              help="WebKit port")
 
     parser.add_argument("test_list", nargs="*",
                         help="List of URLs for tests to run, or paths including tests to run. "

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -218,7 +218,8 @@ def run_tests(config, test_paths, product, **kwargs):
                                  product.env_options,
                                  ssl_config,
                                  env_extras,
-                                 kwargs["enable_quic"]) as test_environment:
+                                 kwargs["enable_quic"],
+                                 kwargs["enable_mojojs"]) as test_environment:
             recording.set(["startup", "ensure_environment"])
             try:
                 test_environment.ensure_started()


### PR DESCRIPTION
* install_mojo is added to wpt.browser.Chrome and used automatically
  when running the nightly channel (only nightly is supported for now).
* A new flag, --enable-mojojs, is added to wptrunner, which will map
  downloaded Mojo bindings to /gen/, and add necessary flags to Chrome.
* In `wpt run`, if mojojs.zip is downloaded successfully,
  --enable-mojojs flag is added automatically when starting wptrunner.

(A bunch of drive-by auto style fixes are included, too.)

Test: `./wpt run --install-browser --channel=nightly chrome webxr/xrDevice_requestSession_immersive.https.html` now passes!