### PR TITLE
[tools] Pin mock to v3.*

### DIFF
--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -7,7 +7,8 @@ skip_missing_interpreters = False
 deps =
   pytest
   pytest-cov
-  mock
+  # mock no longer supports Python 2 since v4
+  mock==3.*
   hypothesis
   requests
   taskcluster

--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -8,7 +8,8 @@ deps =
   pytest
   pytest-cov
   hypothesis
-  mock
+  # mock no longer supports Python 2 since v4
+  mock==3.*
   -r{toxinidir}/../wptrunner/requirements.txt
   -r{toxinidir}/../wptrunner/requirements_chrome.txt
   -r{toxinidir}/../wptrunner/requirements_firefox.txt

--- a/tools/wptrunner/tox.ini
+++ b/tools/wptrunner/tox.ini
@@ -10,7 +10,8 @@ deps =
      pytest>=2.9
      pytest-cov
      pytest-xdist
-     mock
+     # mock no longer supports Python 2 since v4
+     mock==3.*
      -r{toxinidir}/requirements.txt
      chrome: -r{toxinidir}/requirements_chrome.txt
      edge: -r{toxinidir}/requirements_edge.txt


### PR DESCRIPTION
mock stops supporting Python 2 since v4.0.0:
https://pypi.org/project/mock/4.0.0/