### PR TITLE
[wpt] Ignore testdriver* in changed files

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -744,12 +744,8 @@ def setup_wptrunner(venv, **kwargs):
 
     affected_revish = kwargs.get("affected")
     if affected_revish is not None:
-        # TODO: Consolidate with `./wpt tests-affected --ignore-rules`:
-        # https://github.com/web-platform-tests/wpt/issues/14560
         files_changed, _ = testfiles.files_changed(
-            affected_revish,
-            ignore_rules=["resources/testharness*"],
-            include_uncommitted=True, include_new=True)
+            affected_revish, include_uncommitted=True, include_new=True)
         # TODO: Perhaps use wptrunner.testloader.ManifestLoader here
         # and remove the manifest-related code from testfiles.
         # https://github.com/web-platform-tests/wpt/issues/14421

--- a/tools/wpt/tests/test_testfiles.py
+++ b/tools/wpt/tests/test_testfiles.py
@@ -44,3 +44,26 @@ def test_affected_testfiles():
             testfiles.wpt_root, "a", "b", "c", "foo-crash.html")
         tests_changed, _ = testfiles.affected_testfiles([full_test_path])
         assert tests_changed == set([full_test_path])
+
+
+def test_exclude_ignored():
+    default_ignored = [
+        "resources/testharness.js",
+        "resources/testharnessreport.js",
+        "resources/testdriver.js",
+        "resources/testdriver-vendor.js",
+    ]
+    default_ignored_abs = sorted(os.path.join(testfiles.wpt_root, x) for x in default_ignored)
+    default_changed = [
+        "foo/bar.html"
+    ]
+    default_changed_abs = sorted(os.path.join(testfiles.wpt_root, x) for x in default_changed)
+    files = default_ignored + default_changed
+
+    changed, ignored = testfiles.exclude_ignored(files, None)
+    assert sorted(changed) == default_changed_abs
+    assert sorted(ignored) == default_ignored_abs
+
+    changed, ignored = testfiles.exclude_ignored(files, [])
+    assert sorted(changed) == sorted(default_changed_abs + default_ignored_abs)
+    assert sorted(ignored) == []


### PR DESCRIPTION
when detecting affected tests.

Fixes #14560; fixes #15485.

FWIW, there seems to be no use of the `--ignore-rules` flag in our configurations, so it should be safe to change it to `--ignore-rule`. The main motivation for this change is that `nargs="*"` effectively swallows *all* remaining arguments, making the CLI difficult to use.