### PR TITLE
Use column-fill:balance for non-adjacent-spanners-001.html.

### DIFF
--- a/css/css-multicol/non-adjacent-spanners-001.html
+++ b/css/css-multicol/non-adjacent-spanners-001.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://www.w3.org/TR/css-multicol-1/#spanning-columns">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
-<div style="columns:2; column-fill:auto; column-gap:0; width:100px; background:red;">
+<div style="columns:2; column-gap:0; width:100px; background:red;">
   <div style="height:200px; background:green;">
     <div style="column-span:all;"></div>
   </div>


### PR DESCRIPTION
Blink seems to consume the 200px height in the column row before the
column-span, while gecko consumes the 200px height after the column-span and
fill the columns sequentially. Either way, use column-fill:balance to request
column balancing behavior explicitly.