### PR TITLE
Corrected active-selection-018.html and its reference

### DIFF
--- a/css/css-pseudo/active-selection-018.html
+++ b/css/css-pseudo/active-selection-018.html
@@ -7,7 +7,7 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-selectors">
   <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-styling">
-  <link rel="match" href="reference/active-selection-011-ref.html">
+  <link rel="match" href="reference/active-selection-018-ref.html">
 
   <meta content="" name="flags">
 
@@ -55,6 +55,6 @@
 
   <body onload="startTest();">
 
-  <p>Test passes if each glyph of "Selected Text" is green and if there is <strong>no red</strong>.
+  <p>Test passes if each glyph of "Selected Text" is green, if background color of each glyph of "Selected Text" is white and if there is <strong>no red</strong>.
 
   <div id="parent">Selected Text <span>FAIL</span></div>

--- a/css/css-pseudo/reference/active-selection-018-ref.html
+++ b/css/css-pseudo/reference/active-selection-018-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      color: green;
+      font-size: 300%;
+    }
+  </style>
+
+   <p>Test passes if each glyph of "Selected Text" is green, if background color of each glyph of "Selected Text" is white and if there is <strong>no red</strong>.
+
+  <div>Selected Text</div>


### PR DESCRIPTION
This spun from 
https://github.com/web-platform-tests/wpt/issues/24803

active-selection-018.html 

reference/active-selection-018-ref.html

Credits should go to @xiaochengh Xiaocheng Hu for finding and reporting the mismatch of pass-fail-conditions sentence between test and reference.