### PR TITLE
[Azure Pipelines] upgrade to macOS Catalina (10.15)

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
   displayName: 'affected tests: Safari Technology Preview'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -54,7 +54,7 @@ jobs:
   displayName: 'affected tests without changes: Safari Technology Preview'
   condition: eq(variables['Build.Reason'], 'PullRequest')
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -91,7 +91,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_infrastructure']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -120,7 +120,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   variables:
     HYPOTHESIS_PROFILE: ci
   steps:
@@ -138,7 +138,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -154,7 +154,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.tools_unittest']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -170,7 +170,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   variables:
     HYPOTHESIS_PROFILE: ci
   steps:
@@ -188,7 +188,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -204,7 +204,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wptrunner_unittest']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -220,7 +220,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   variables:
     HYPOTHESIS_PROFILE: ci
   steps:
@@ -242,7 +242,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   # full checkout required
   - task: UsePythonVersion@0
@@ -262,7 +262,7 @@ jobs:
   dependsOn: decision
   condition: dependencies.decision.outputs['test_jobs.wpt_integration']
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   # full checkout required
   - task: UsePythonVersion@0
@@ -595,7 +595,7 @@ jobs:
     parallel: 5 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -633,7 +633,7 @@ jobs:
     parallel: 5 # chosen to make runtime ~2h
   timeoutInMinutes: 180
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/tools/ci/azure/com.apple.SafariTechnologyPreview.plist
+++ b/tools/ci/azure/com.apple.SafariTechnologyPreview.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AllowRemoteAutomation</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/ci/azure/install_safari.yml
+++ b/tools/ci/azure/install_safari.yml
@@ -9,7 +9,10 @@ steps:
 - ${{ if eq(parameters.channel, 'preview') }}:
   - script: |
       HOMEBREW_NO_AUTO_UPDATE=1 brew cask install tools/ci/azure/safari-technology-preview.rb
-      sudo "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable
+      # Workaround for `sudo safardriver --enable` not working on Catalina:
+      # https://github.com/web-platform-tests/wpt/issues/21751
+      mkdir -p ~/Library/WebDriver/
+      cp tools/ci/azure/com.apple.SafariTechnologyPreview.plist ~/Library/WebDriver/
       defaults write com.apple.SafariTechnologyPreview WebKitJavaScriptCanOpenWindowsAutomatically 1
       defaults write com.apple.SafariTechnologyPreview ExperimentalServerTimingEnabled 1
     displayName: 'Install Safari Technology Preview'

--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask 'safari-technology-preview' do
-  if MacOS.version <= :mojave
-    version '108,001-15210-20200610-d35e22e0-d9fa-4503-9988-cf7b2b554e15'
-    sha256 '0299fd2f2836b170a8b633b00d289bcc6913716042e82251af4fa1d5394b87d5'
+  if MacOS.version <= :catalina
+    version '111,001-32177-20200728-f459b529-99a7-4707-a85c-e693ddb56eee'
+    sha256 'f95f72e8cf6a3160fad71411168c8f0eeb805ca1e7a7eec06b6e92d2a0ab6e85'
   else
-    version '108,001-16091-20200610-09f04256-ae36-4930-b7c4-b1333f8d8e5f'
-    sha256 '22a4d9ca7fb39227cbf4a83be13ad05973171cf88eb6bcc2fac4556a36017357'
+    version '111,001-32479-20200728-12c458d1-e348-4ec5-9d55-9e9bad9c805e'
+    sha256 '6b199cca77be7407f40a62bc1ec576a8751b24da15613dfc0a951ac3d996f45f'
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
@@ -13,7 +13,7 @@ cask 'safari-technology-preview' do
   homepage 'https://developer.apple.com/safari/download/'
 
   auto_updates true
-  depends_on macos: '>= :mojave'
+  depends_on macos: '>= :catalina'
 
   pkg 'Safari Technology Preview.pkg'
 

--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask 'safari-technology-preview' do
-  if MacOS.version <= :catalina
-    version '111,001-32177-20200728-f459b529-99a7-4707-a85c-e693ddb56eee'
-    sha256 'f95f72e8cf6a3160fad71411168c8f0eeb805ca1e7a7eec06b6e92d2a0ab6e85'
+  if MacOS.version <= :mojave
+    version '108,001-15210-20200610-d35e22e0-d9fa-4503-9988-cf7b2b554e15'
+    sha256 '0299fd2f2836b170a8b633b00d289bcc6913716042e82251af4fa1d5394b87d5'
   else
-    version '111,001-32479-20200728-12c458d1-e348-4ec5-9d55-9e9bad9c805e'
-    sha256 '6b199cca77be7407f40a62bc1ec576a8751b24da15613dfc0a951ac3d996f45f'
+    version '108,001-16091-20200610-09f04256-ae36-4930-b7c4-b1333f8d8e5f'
+    sha256 '22a4d9ca7fb39227cbf4a83be13ad05973171cf88eb6bcc2fac4556a36017357'
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
@@ -13,7 +13,7 @@ cask 'safari-technology-preview' do
   homepage 'https://developer.apple.com/safari/download/'
 
   auto_updates true
-  depends_on macos: '>= :catalina'
+  depends_on macos: '>= :mojave'
 
   pkg 'Safari Technology Preview.pkg'
 


### PR DESCRIPTION
This updates the Azure Pipelines configuration to macOS Catalina
(10.15). Due to safardriver --enable not working on CI systems on
Catalina (https://github.com/web-platform-tests/wpt/issues/21751),
we sadly re-introduce the 'known good plist file' hack.