### PR TITLE
Clean up venv configs in commands.json

### DIFF
--- a/tools/serve/commands.json
+++ b/tools/serve/commands.json
@@ -12,7 +12,6 @@
     "parser": "get_parser",
     "help": "Run wptserve server for WAVE",
     "virtualenv": true,
-    "install": ["ua-parser"],
     "requirements": ["../wave/requirements.txt"]
   }
 }

--- a/tools/wpt/commands.json
+++ b/tools/wpt/commands.json
@@ -5,6 +5,9 @@
     "parser": "create_parser",
     "help": "Run tests in a browser",
     "virtualenv": true,
+    "install": [
+      "zstandard"
+    ],
     "requirements": [
       "../wptrunner/requirements.txt"
     ]

--- a/tools/wpt/commands.json
+++ b/tools/wpt/commands.json
@@ -5,10 +5,6 @@
     "parser": "create_parser",
     "help": "Run tests in a browser",
     "virtualenv": true,
-    "install": [
-      "requests",
-      "zstandard"
-    ],
     "requirements": [
       "../wptrunner/requirements.txt"
     ]
@@ -25,9 +21,6 @@
     "parser": "create_parser_update",
     "help": "Update expectations files from raw logs.",
     "virtualenv": true,
-    "install": [
-      "requests"
-    ],
     "requirements": [
       "../wptrunner/requirements.txt"
     ]
@@ -51,6 +44,7 @@
     "script": "run",
     "parser": "get_parser",
     "help": "Install browser components",
+    "virtualenv": true,
     "install": [
       "mozinstall"
     ]

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -26,6 +26,10 @@ def load_commands():
             for command, props in iteritems(data):
                 assert "path" in props
                 assert "script" in props
+                if "install" in props and "requirements" in props:
+                    logging.warn("Command %s has both install and "
+                                 "requirements in %s; please merge them.",
+                                 command, abs_path)
                 rv[command] = {
                     "path": os.path.join(base_dir, props["path"]),
                     "script": props["script"],
@@ -38,6 +42,8 @@ def load_commands():
                     "requirements": [os.path.join(base_dir, item)
                                      for item in props.get("requirements", [])]
                 }
+                if rv[command]["install"] or rv[command]["requirements"]:
+                    assert rv[command]["virtualenv"]
     return rv
 
 

--- a/tools/wpt/wpt.py
+++ b/tools/wpt/wpt.py
@@ -26,10 +26,6 @@ def load_commands():
             for command, props in iteritems(data):
                 assert "path" in props
                 assert "script" in props
-                if "install" in props and "requirements" in props:
-                    logging.warn("Command %s has both install and "
-                                 "requirements in %s; please merge them.",
-                                 command, abs_path)
                 rv[command] = {
                     "path": os.path.join(base_dir, props["path"]),
                     "script": props["script"],

--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -7,4 +7,3 @@ pillow==6.2.2  # pyup: <7.0
 urllib3[secure]==1.25.10
 requests==2.24.0
 six==1.15.0
-zstandard==0.14.0

--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -7,3 +7,4 @@ pillow==6.2.2  # pyup: <7.0
 urllib3[secure]==1.25.10
 requests==2.24.0
 six==1.15.0
+zstandard==0.14.0


### PR DESCRIPTION
1. Fold most dependencies in "install" into existing requirements.txt
2. Fail when a command has either "install" or "requirements" but
   disables "virtualenv".