### PR TITLE
Improve coverage for callback `this` value

### DIFF
--- a/css/css-paint-api/paint-function-this-value.https.html
+++ b/css/css-paint-api/paint-function-this-value.https.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>Paint callback is invoked with `this` value of `paintInstance`</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-paint-api-1/#invoke-a-paint-callback">
+<link rel="match" href="parse-input-arguments-ref.html">
+<style>
+.container {
+  width: 100px;
+  height: 100px;
+}
+
+#canvas-geometry {
+  background-image: paint(geometry);
+}
+</style>
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/worklet-reftest.js"></script>
+<body>
+<div id="canvas-geometry" class="container"></div>
+
+<script id="code" type="text/worklet">
+let paintInstance;
+
+registerPaint('geometry', class {
+    constructor() {
+        paintInstance = this;
+    }
+    paint(ctx, geom) {
+        if (this === paintInstance)
+            ctx.fillStyle = 'green';
+        else
+            ctx.fillStyle = 'red';
+        ctx.fillRect(0, 0, geom.width, geom.height);
+    }
+});
+</script>
+
+<script>
+    importWorkletAndTerminateTestAfterAsyncPaint(CSS.paintWorklet, document.getElementById('code').textContent);
+</script>
+</body>
+</html>

--- a/dom/nodes/MutationObserver-callback-arguments.html
+++ b/dom/nodes/MutationObserver-callback-arguments.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>MutationObserver: callback arguments</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#notify-mutation-observers">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="mo-target"></div>
+<div id="log"></div>
+<script>
+"use strict";
+
+async_test(t => {
+  const moTarget = document.querySelector("#mo-target");
+  const mo = new MutationObserver(function(records, observer) {
+    t.step(() => {
+      assert_equals(this, mo);
+      assert_equals(arguments.length, 2);
+      assert_true(Array.isArray(records));
+      assert_equals(records.length, 1);
+      assert_true(records[0] instanceof MutationRecord);
+      assert_equals(observer, mo);
+
+      mo.disconnect();
+      t.done();
+    });
+  });
+
+  mo.observe(moTarget, {attributes: true});
+  moTarget.className = "trigger-mutation";
+}, "Callback is invoked with |this| value of MutationObserver and two arguments");
+</script>

--- a/intersection-observer/observer-callback-arguments.html
+++ b/intersection-observer/observer-callback-arguments.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>IntersectionObserver: callback arguments</title>
+<link rel="help" href="https://w3c.github.io/IntersectionObserver/#notify-intersection-observers-algo">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+"use strict";
+
+async_test(t => {
+  const io = new IntersectionObserver(function(entries, observer) {
+    t.step(() => {
+      assert_equals(this, io);
+      assert_equals(arguments.length, 2);
+      assert_true(Array.isArray(entries));
+      assert_equals(entries.length, 1);
+      assert_true(entries[0] instanceof IntersectionObserverEntry);
+      assert_equals(observer, io);
+
+      io.disconnect();
+      t.done();
+    });
+  });
+
+  io.observe(document.body);
+}, "Callback is invoked with |this| value of IntersectionObserver and two arguments");
+</script>


### PR DESCRIPTION
There are similar tests for [`PerformanceObserver`](https://github.com/web-platform-tests/wpt/blob/e35de4d284f3272e3f914eb9deea6cf7d1924605/performance-timeline/po-observe.any.js#L28) and [`ResizeObserver`](https://github.com/web-platform-tests/wpt/blob/e35de4d284f3272e3f914eb9deea6cf7d1924605/resize-observer/observe.html#L207).