### PR TITLE
Add `break-inside: avoid` to the content in the second column

### DIFF
--- a/css/css-multicol/multicol-overflow-clip-auto-sized-ref.html
+++ b/css/css-multicol/multicol-overflow-clip-auto-sized-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <div style="columns: 2">
   <div>Column1</div>
-  <div style="padding: 2px">Column2<br>Column2 line2</div>
+  <div style="break-inside: avoid; padding: 2px">Column2<br>Column2 line2</div>
 </div>

--- a/css/css-multicol/multicol-overflow-clip-auto-sized.html
+++ b/css/css-multicol/multicol-overflow-clip-auto-sized.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>CSS Multi-column Layout Test: multicol with overflow-clipped content</title>
 <link rel="help" href="https://www.w3.org/TR/css-multicol-1/">
+<link rel="help" href="https://drafts.csswg.org/css-break/#possible-breaks">
 <link rel="match" href="multicol-overflow-clip-auto-sized-ref.html">
 <meta name="assert" content="Overflow clip sized to content should not clip even under multicol.">
 <div style="columns: 2">


### PR DESCRIPTION
Per https://drafts.csswg.org/css-break/#possible-breaks, UAs may
consider any elements with `overflow: hidden` monolithic.

Firefox can break between `Column2` and `Column2 line2` in the
reference. Add `break-inside: avoid` to prevent that to match the test
behavior.