### PR TITLE
[webdriver] Close old windows at the end of each test as well as beginning

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -446,6 +446,11 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
             done, rv = handler(result)
             if done:
                 break
+
+        # TESTING: attempt to detect problems during the test that caused them,
+        # not at the start of the next test.
+        protocol.testharness.close_old_windows()
+
         return rv
 
     def wait_for_load(self, protocol):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -409,7 +409,10 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
     def do_testharness(self, protocol, url, timeout):
         format_map = {"url": strip_server(url)}
 
+        # In theory the previous test should have closed any leftover windows,
+        # but to avoid relying on that we also attempt cleanup here.
         parent_window = protocol.testharness.close_old_windows()
+
         # Now start the test harness
         protocol.base.execute_script("window.open('about:blank', '%s', 'noopener')" % self.window_id)
         test_window = protocol.testharness.get_test_window(self.window_id,
@@ -447,8 +450,8 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
             if done:
                 break
 
-        # TESTING: attempt to detect problems during the test that caused them,
-        # not at the start of the next test.
+        # Attempt to cleanup any leftover windows. This should create a clean
+        # state for future tests, and expose any unexpectedly-open prompts.
         protocol.testharness.close_old_windows()
 
         return rv


### PR DESCRIPTION
Previously, we closed old windows at the start of each test. This was nice in terms
of defensiveness (don't assume the last run left the world in a good state), but made
it hard to find problematic tests that left dialogs open (since they wouldn't throw until
the next test).

Instead, this patch does both - close both at the start and end of a test. This should
improve the blaming situation, whilst still being defensive.

There are potential performance implications to this patch, however test runs are
inconclusive. Full runs of Chrome and Safari show +- 2%, which is possibly within
margin of error. Running locally, some directories showed a ~2% slowdown, whilst
others had little or no difference.