### PR TITLE
[tools] Disable some multiprocessing tests

### DIFF
--- a/tools/serve/test_functional.py
+++ b/tools/serve/test_functional.py
@@ -9,6 +9,7 @@ try:
     import Queue as queue  # noqa: N813
 except ImportError:
     import queue
+import sys
 import tempfile
 import threading
 
@@ -45,6 +46,8 @@ def tempfile_name():
     os.remove(name)
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 8) and sys.platform == 'darwin',
+                    reason="multiprocessing test hangs in Python 3.8 on macOS (#24880)")
 def test_subprocess_exit(server_subprocesses, tempfile_name):
     timeout = 30
 

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -188,6 +188,8 @@ def test_run_zero_tests():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
+@pytest.mark.skipif(sys.version_info >= (3, 8) and sys.platform == 'darwin',
+                    reason="multiprocessing test hangs in Python 3.8 on macOS (#24880)")
 def test_run_failing_test():
     """Failing tests should be reported with a non-zero exit status unless the
     `--no-fail-on-unexpected` option has been specified."""
@@ -211,6 +213,8 @@ def test_run_failing_test():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
+@pytest.mark.skipif(sys.version_info >= (3, 8) and sys.platform == 'darwin',
+                    reason="multiprocessing test hangs in Python 3.8 on macOS (#24880)")
 def test_run_verify_unstable(temp_test):
     """Unstable tests should be reported with a non-zero exit status. Stable
     tests should be reported with a zero exit status."""

--- a/tools/wptserve/tests/functional/test_stash.py
+++ b/tools/wptserve/tests/functional/test_stash.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 import uuid
 
@@ -9,6 +10,8 @@ from wptserve.stash import StashServer
 from .base import TestUsingServer
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 8) and sys.platform == 'darwin',
+                    reason="multiprocessing test hangs in Python 3.8 on macOS (#24880)")
 class TestResponseSetCookie(TestUsingServer):
     def run(self, result=None):
         with StashServer(None, authkey=str(uuid.uuid4())):


### PR DESCRIPTION
on macOS + Python 3.8

https://github.com/web-platform-tests/wpt/issues/24880