### PR TITLE
Corrected active-selection-031.html

### DIFF
--- a/css/css-pseudo/active-selection-031.html
+++ b/css/css-pseudo/active-selection-031.html
@@ -67,20 +67,20 @@
 
   <body onload="startTest();">
 
-  <p>Test passes if each glyph of the 6 "Selected Text" is green and if there is <strong>no red</strong>.
+  <p>Test passes if each glyph of the 6 "Selected" is green and if there is <strong>no red</strong>.
 
   <div id="test">
 
-    <div class="vrl mixed">Selected Text</div>
+    <div class="vrl mixed">Selected</div>
 
-    <div class="vrl sideways">Selected Text</div>
+    <div class="vrl sideways">Selected</div>
 
-    <div class="vrl upright">Selected Text</div>
+    <div class="vrl upright">Selected</div>
 
-    <div class="vlr mixed">Selected Text</div>
+    <div class="vlr mixed">Selected</div>
 
-    <div class="vlr sideways">Selected Text</div>
+    <div class="vlr sideways">Selected</div>
 
-    <div class="vlr upright">Selected Text</div>
+    <div class="vlr upright">Selected</div>
 
   </div>

--- a/css/css-pseudo/active-selection-031.html
+++ b/css/css-pseudo/active-selection-031.html
@@ -15,7 +15,7 @@
     {
       color: red;
       float: left;
-      font-size: 48px;
+      font-size: 32px;
       margin-left: 16px;
     }
 
@@ -67,20 +67,20 @@
 
   <body onload="startTest();">
 
-  <p>Test passes if each glyph of the 6 "Selected" is green and if there is <strong>no red</strong>.
+  <p>Test passes if each glyph of the 6 "Selected Text" is green and if there is <strong>no red</strong>.
 
   <div id="test">
 
-    <div class="vrl mixed">Selected</div>
+    <div class="vrl mixed">Selected Text</div>
 
-    <div class="vrl sideways">Selected</div>
+    <div class="vrl sideways">Selected Text</div>
 
-    <div class="vrl upright">Selected</div>
+    <div class="vrl upright">Selected Text</div>
 
-    <div class="vlr mixed">Selected</div>
+    <div class="vlr mixed">Selected Text</div>
 
-    <div class="vlr sideways">Selected</div>
+    <div class="vlr sideways">Selected Text</div>
 
-    <div class="vlr upright">Selected</div>
+    <div class="vlr upright">Selected Text</div>
 
   </div>

--- a/css/css-pseudo/reference/active-selection-031-ref.html
+++ b/css/css-pseudo/reference/active-selection-031-ref.html
@@ -12,7 +12,7 @@
       background-color: yellow;
       color: green;
       float: left;
-      font-size: 48px;
+      font-size: 32px;
       margin-left: 16px;
     }
 
@@ -42,16 +42,16 @@
     }
   </style>
 
-  <p>Test passes if each glyph of the 6 "Selected" is green and if there is <strong>no red</strong>.
+  <p>Test passes if each glyph of the 6 "Selected Text" is green and if there is <strong>no red</strong>.
 
-  <div class="vrl mixed">Selected</div>
+  <div class="vrl mixed">Selected Text</div>
 
-  <div class="vrl sideways">Selected</div>
+  <div class="vrl sideways">Selected Text</div>
 
-  <div class="vrl upright">Selected</div>
+  <div class="vrl upright">Selected Text</div>
 
-  <div class="vlr mixed">Selected</div>
+  <div class="vlr mixed">Selected Text</div>
 
-  <div class="vlr sideways">Selected</div>
+  <div class="vlr sideways">Selected Text</div>
 
-  <div class="vlr upright">Selected</div>
+  <div class="vlr upright">Selected Text</div>

--- a/css/css-pseudo/reference/active-selection-031-ref.html
+++ b/css/css-pseudo/reference/active-selection-031-ref.html
@@ -42,16 +42,16 @@
     }
   </style>
 
-  <p>Test passes if each glyph of the 6 "Selected Text" is green and if there is <strong>no red</strong>.
+  <p>Test passes if each glyph of the 6 "Selected" is green and if there is <strong>no red</strong>.
 
-  <div class="vrl mixed">Selected Text</div>
+  <div class="vrl mixed">Selected</div>
 
-  <div class="vrl sideways">Selected Text</div>
+  <div class="vrl sideways">Selected</div>
 
-  <div class="vrl upright">Selected Text</div>
+  <div class="vrl upright">Selected</div>
 
-  <div class="vlr mixed">Selected Text</div>
+  <div class="vlr mixed">Selected</div>
 
-  <div class="vlr sideways">Selected Text</div>
+  <div class="vlr sideways">Selected</div>
 
-  <div class="vlr upright">Selected Text</div>
+  <div class="vlr upright">Selected</div>


### PR DESCRIPTION
This is a followup to 
https://github.com/web-platform-tests/wpt/issues/24809
and - implicitly - a correction of
https://github.com/web-platform-tests/wpt/pull/24715

active-selection-031.html

reference/active-selection-031-ref.html

The test now uses smaller text content ("Selected Text" replaced with "Selected") and the reference file is correct and reliable. 

It must be noted that **Chromium 86 currently fails this new version of active-selection-031**. 