### PR TITLE
Added 4 box-shadow-overlapping-* tests

### DIFF
--- a/css/css-backgrounds/box-shadow-overlapping-001.html
+++ b/css/css-backgrounds/box-shadow-overlapping-001.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Background and Borders Test: box-shadow and overlapping of adjacent text</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#shadow-layers" >
+  <link rel="match" href="reference/box-shadow-overlapping-001-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="Box shadows do not affect layout. Box shadows take up no space. Box shadows do not affect or influence normal flow of boxes. Therefore, box shadows can 'collide' with other boxes and can overlap other boxes (inline box or line box) or be overlapped by other boxes. In this test, the text ('PED') is before a left outer box-shadow box and such left outer box-shadow box is wide and wide enough to overlap the text 'PED'." name="assert">
+
+  <style>
+  div
+    {
+      color: red;
+      float: left;
+      font-family: Ahem;
+      font-size: 100px;
+      line-height: 1;
+    }
+
+  span
+    {
+      color: green;
+      box-shadow: -3em 0em;
+    }
+
+    /*
+
+    omitted colors default to the value of the color property.
+
+    1st <length>
+    Specifies the horizontal offset of the shadow. A positive value
+    draws a shadow that is offset to the right of the box, a negative
+    length to the left.
+
+    2nd <length>
+    Specifies the vertical offset of the shadow. A positive value
+    offsets the shadow down, a negative one up.
+
+    */
+  </style>
+
+  <p>Test passes if there is a filled green rectangle and <strong>no red</strong>.
+
+  <div>PED<span>PNG</span></div>

--- a/css/css-backgrounds/box-shadow-overlapping-002.html
+++ b/css/css-backgrounds/box-shadow-overlapping-002.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Background and Borders Test: box-shadow and overlapping of adjacent text</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#shadow-layers" >
+  <link rel="match" href="reference/box-shadow-overlapping-001-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="Box shadows do not affect layout. Box shadows take up no space. Box shadows do not affect or influence normal flow of boxes. Therefore, box shadows can 'collide' with other boxes and can overlap other boxes (inline box or line box) or be overlapped by other boxes. In this test, the text ('PNG') follows a right outer box shadow and therefore overlaps such shadow." name="assert">
+
+  <style>
+  div
+    {
+      background-color: yellow;
+      color: green;
+      float: left;
+      font-family: Ahem;
+      font-size: 100px;
+      line-height: 1;
+    }
+
+  span
+    {
+      box-shadow: 3em 0em red;
+    }
+
+    /*
+
+    omitted colors default to the value of the color property.
+
+    1st <length>
+    Specifies the horizontal offset of the shadow. A positive value
+    draws a shadow that is offset to the right of the box, a negative
+    length to the left.
+
+    2nd <length>
+    Specifies the vertical offset of the shadow. A positive value
+    offsets the shadow down, a negative one up.
+
+    */
+  </style>
+
+  <p>Test passes if there is a filled green rectangle and <strong>no red</strong>.
+
+  <div><span>PED</span>PNG</div>

--- a/css/css-backgrounds/box-shadow-overlapping-003.html
+++ b/css/css-backgrounds/box-shadow-overlapping-003.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Background and Borders Test: box-shadow and overlapping of adjacent text</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#shadow-layers" >
+  <link rel="match" href="reference/box-shadow-overlapping-003-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="Box shadows do not affect layout. Box shadows take up no space. Box shadows do not affect or influence normal flow of boxes. Therefore, box shadows can 'collide' with other boxes and can overlap other boxes (inline box or line box) or be overlapped by other boxes. In this test, the text ('OVLPED') is from a previous line box and is overlapped by a top outer box shadow box that is tall enough to overlap it entirely." name="assert">
+
+  <style>
+  div
+    {
+      float: left;
+      font-family: Ahem;
+      font-size: 100px;
+      line-height: 1;
+    }
+
+  div#previous-line-box
+    {
+      color: red;
+    }
+
+  div#outer-box-shadow
+    {
+      box-shadow: 0em -1em;
+      clear: left;
+      color: green;
+    }
+
+    /*
+
+    omitted colors default to the value of the color property.
+
+    1st <length>
+    Specifies the horizontal offset of the shadow. A positive value
+    draws a shadow that is offset to the right of the box, a negative
+    length to the left.
+
+    2nd <length>
+    Specifies the vertical offset of the shadow. A positive value
+    offsets the shadow down, a negative one up.
+
+    */
+  </style>
+
+  <p>Test passes if there is a filled green rectangle and <strong>no red</strong>.
+
+  <div id="previous-line-box">OVLPED</div>
+
+  <div id="outer-box-shadow">OVLPNG</div>

--- a/css/css-backgrounds/box-shadow-overlapping-004.html
+++ b/css/css-backgrounds/box-shadow-overlapping-004.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Background and Borders Test: box-shadow and overlapping of adjacent text</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#shadow-layers" >
+  <link rel="match" href="reference/box-shadow-overlapping-003-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+  <meta content="" name="flags">
+  <meta content="Box shadows do not affect layout. Box shadows take up no space. Box shadows do not affect or influence normal flow of boxes. Therefore, box shadows can 'collide' with other boxes and can overlap other boxes (inline box or line box) or be overlapped by other boxes. This test checks that the background of the following line box overlaps the box-shadow of an inline non-replaced box whose box-shadow expands onto and over the following line box. In this test, the box shadow of div#outer-box-shadow is red and protudes out and below onto the following line box. But since the glyphs of div#following-line-box are green, then such green color will overlap the red box shadow of div#outer-box-shadow." name="assert">
+
+  <style>
+  div
+    {
+      color: green;
+      float: left;
+      font-family: Ahem;
+      font-size: 100px;
+      line-height: 1;
+    }
+
+  div#outer-box-shadow
+    {
+      box-shadow: 0em 1em red;
+    }
+
+    /*
+
+    1st <length>
+    Specifies the horizontal offset of the shadow. A positive value
+    draws a shadow that is offset to the right of the box, a negative
+    length to the left.
+
+    2nd <length>
+    Specifies the vertical offset of the shadow. A positive value
+    offsets the shadow down, a negative one up.
+
+    */
+
+  div#following-line-box
+    {
+      clear: left;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green rectangle and <strong>no red</strong>.
+
+  <div id="outer-box-shadow">OVLPED</div>
+
+  <div id="following-line-box">OVLPNG</div>

--- a/css/css-backgrounds/reference/box-shadow-overlapping-001-ref.html
+++ b/css/css-backgrounds/reference/box-shadow-overlapping-001-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      background-color: green;
+      height: 100px;
+      width: 600px;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green rectangle and <strong>no red</strong>.
+
+  <div></div>

--- a/css/css-backgrounds/reference/box-shadow-overlapping-003-ref.html
+++ b/css/css-backgrounds/reference/box-shadow-overlapping-003-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      background-color: green;
+      height: 200px;
+      width: 600px;
+    }
+  </style>
+
+  <p>Test passes if there is a filled green rectangle and <strong>no red</strong>.
+
+  <div></div>


### PR DESCRIPTION
This is a followup of 
https://github.com/web-platform-tests/wpt/pull/23660
and I created a new PR because of new "TC config" started on July 7th.

box-shadow-overlapping-001.html
box-shadow-overlapping-002.html
box-shadow-overlapping-003.html
box-shadow-overlapping-004.html
reference/box-shadow-overlapping-001-ref.html
reference/box-shadow-overlapping-003-ref.html

The only change made is the removal of "nevertheless overlaps the background color (yellow) of the block element" in the assert text of box-shadow-overlapping-002.html , as requested

{
Your test is not checking "nevertheless overlaps the background color (yellow) of the block element".

Correct. box-shadow-overlapping-002.html does not check the "nevertheless overlaps the background color (yellow) of the block element" statement in the assert text. (...) Here, in box-shadow-overlapping-002.html, I will just remove this "nevertheless overlaps the background color (yellow) of the block element".
}

These 4 tests and 2 references are on my website:

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/box-shadow-overlapping-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/box-shadow-overlapping-002.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/box-shadow-overlapping-003.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/box-shadow-overlapping-004.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/box-shadow-overlapping-001-ref.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Backgrounds/reference/box-shadow-overlapping-003-ref.html