### PR TITLE
[Azure Pipelines] Use Python 3.8.x for Edge test-suite runs

### DIFF
--- a/tools/ci/azure/checkout.yml
+++ b/tools/ci/azure/checkout.yml
@@ -2,3 +2,4 @@ steps:
 - checkout: self
   fetchDepth: 50
   submodules: false
+  clean: true

--- a/tools/ci/azure/checkout.yml
+++ b/tools/ci/azure/checkout.yml
@@ -2,4 +2,3 @@ steps:
 - checkout: self
   fetchDepth: 50
   submodules: false
-  clean: true

--- a/tools/ci/azure/install_python.yml
+++ b/tools/ci/azure/install_python.yml
@@ -1,15 +1,30 @@
 steps:
 - powershell: |
-    Start-BitsTransfer -Source https://www.python.org/ftp/python/2.7.15/python-2.7.15.amd64.msi -Destination python.msi
-    $hash = (Get-FileHash python.msi).Hash.ToLower()
-    $expectedHash = "5e85f3c4c209de98480acbf2ba2e71a907fd5567a838ad4b6748c76deb286ad7"
+    Write-Host "logging pwd"
+    Get-Location
+    Write-Host "Dump path BEFORE install"
+    Get-ChildItem Env:Path
+    Write-Host "downloading python installer exe"
+    Start-BitsTransfer -Source https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe  -Destination python_installer.exe
+    $hash = (Get-FileHash python_installer.exe).Hash.ToLower()
+    $expectedHash = "cd427c7b17337d7c13761ca20877d2d8be661bd30415ddc17072a31a65a91b64"
     if ($hash.Equals($expectedHash)) {
-      Write-Host "python.msi hash verified"
+      Write-Host "python_installer.exe hash verified"
     } else {
-      Throw "python.msi hash mismatch, got $hash, expected $expectedHash"
+      Throw "python_installer.exe hash mismatch, got $hash, expected $expectedHash"
     }
-    msiexec /i python.msi TARGETDIR=C:\Python27 /q
-    Write-Host "##vso[task.prependpath]C:\Python27"
-    Write-Host "##vso[task.prependpath]C:\Python27\Scripts"
+    Write-Host "Running python_installer.exe"
+    & .\python_installer.exe /passive TargetDir=C:\Python38
+    Write-Host "Dumping C: dir"
+    Get-ChildItem "C:\"
+    Write-Host "Dumping C:\Python38 dir"
+    Get-ChildItem "C:\Python38"
+    Write-Host "Dumping C:\Python38\Scripts dir"
+    Get-ChildItem "C:\Python38\Scripts"
+    Write-Host "Adding to path"
+    Write-Host "##vso[task.prependpath]C:\Python38"
+    Write-Host "##vso[task.prependpath]C:\Python38\Scripts"
+    Write-Host "Dump path AFTER install"
+    Get-ChildItem Env:Path
   displayName: 'Install Python (Windows)'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/tools/ci/azure/install_python.yml
+++ b/tools/ci/azure/install_python.yml
@@ -33,7 +33,7 @@ steps:
     Get-ChildItem -File "."
     Write-Host "Logging cwd:"
     Get-Location
-    Write-Host "Running $downloadPath"
+    Write-Host "Running $downloadPath with args $installArgs"
     $p = Start-Process -FilePath $downloadPath -Verb RunAs -ArgumentList $installArgs -PassThru -Wait
     Write-Host "$downloadPath finished. Exit code was: $($p.ExitCode)"
     Write-Host "After install, listing current dir"

--- a/tools/ci/azure/install_python.yml
+++ b/tools/ci/azure/install_python.yml
@@ -1,33 +1,41 @@
 steps:
 - powershell: |
-    if (Test-Path -LiteralPath "C:\Python27") {
-      Write-Host "Deleting C:\Python27"
-      Remove-Item -Force -Recurse "C:\Python27"
+    $pythonPath = 'C:\Python27'
+    if (Test-Path -LiteralPath $pythonPath) {
+        Write-Host "Deleting $pythonPath"
+        Remove-Item -Force -Recurse $pythonPath
     }
-    if (Test-Path -LiteralPath "C:\Python38") {
-      Write-Host "Deleting C:\Python38"
-      Remove-Item -Force -Recurse "C:\Python38"
+    $pythonPath = 'C:\Python38'
+    $pythonInstallerLogPath = 'python_installer.log'
+    $installArgs = "/passive /log $pythonInstallerLogPath TargetDir=$pythonPath"
+    if (Test-Path -LiteralPath $pythonPath) {
+        Write-Host "Deleting $pythonPath"
+        Remove-Item -Force -Recurse $pythonPath
+        Write-Host "$pythonPath already exists, repair it"
+        $installArgs = $installArgs + " /repair"
     }
     Write-Host "Downloading python installer exe"
-    Start-BitsTransfer -Source https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe  -Destination python_installer.exe
-    $hash = (Get-FileHash python_installer.exe).Hash.ToLower()
+    $downloadPath = 'python_installer.exe'
+    Start-BitsTransfer -Source https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe  -Destination $downloadPath
+    $hash = (Get-FileHash $downloadPath).Hash.ToLower()
     $expectedHash = "cd427c7b17337d7c13761ca20877d2d8be661bd30415ddc17072a31a65a91b64"
     if ($hash.Equals($expectedHash)) {
-      Write-Host "python_installer.exe hash verified"
+      Write-Host "$downloadPath hash verified"
     } else {
-      Throw "python_installer.exe hash mismatch, got $hash, expected $expectedHash"
+      Throw "$downloadPath hash mismatch, got $hash, expected $expectedHash"
     }
     Write-Host "Before install, looking at disk space"
-    Get-WmiObject -Class Win32_logicaldisk
+    $driveData = Get-WmiObject -Class win32_LogicalDisk -Filter "DeviceID = '$env:SystemDrive'"
+    Write-Host "Disk space on $env:SystemDrive: ($($driveData.FreeSpace / 1GB) GB)"
     Write-Host "Before install, listing directories in C:\"
     Get-ChildItem -Directory "C:\"
     Write-Host "Before install, listing current dir"
     Get-ChildItem -File "."
     Write-Host "Logging cwd:"
     Get-Location
-    Write-Host "Running python_installer.exe"
-    Start-Process -FilePath "python_installer.exe" -Verb RunAs -ArgumentList "/passive /log `"log.txt`" InstallAllUsers=1 TargetDir=`"C:\Python38`""
-    Write-Host "python_installer.exe finished. Exit code was: $LastExitCode"
+    Write-Host "Running $downloadPath"
+    $p = Start-Process -FilePath $downloadPath -Verb RunAs -ArgumentList -PassThru -Wait
+    Write-Host "$downloadPath finished. Exit code was: $($p.ExitCode)"
     Write-Host "After install, listing current dir"
     Get-ChildItem -File "."
   displayName: 'Install Python (Windows)'

--- a/tools/ci/azure/install_python.yml
+++ b/tools/ci/azure/install_python.yml
@@ -34,7 +34,7 @@ steps:
     Write-Host "Logging cwd:"
     Get-Location
     Write-Host "Running $downloadPath"
-    $p = Start-Process -FilePath $downloadPath -Verb RunAs -ArgumentList -PassThru -Wait
+    $p = Start-Process -FilePath $downloadPath -Verb RunAs -ArgumentList $installArgs -PassThru -Wait
     Write-Host "$downloadPath finished. Exit code was: $($p.ExitCode)"
     Write-Host "After install, listing current dir"
     Get-ChildItem -File "."

--- a/tools/ci/azure/install_python.yml
+++ b/tools/ci/azure/install_python.yml
@@ -1,10 +1,14 @@
 steps:
 - powershell: |
-    Write-Host "logging pwd"
-    Get-Location
-    Write-Host "Dump path BEFORE install"
-    Get-ChildItem Env:Path
-    Write-Host "downloading python installer exe"
+    if (Test-Path -LiteralPath "C:\Python27") {
+      Write-Host "Deleting C:\Python27"
+      Remove-Item -Force -Recurse "C:\Python27"
+    }
+    if (Test-Path -LiteralPath "C:\Python38") {
+      Write-Host "Deleting C:\Python38"
+      Remove-Item -Force -Recurse "C:\Python38"
+    }
+    Write-Host "Downloading python installer exe"
     Start-BitsTransfer -Source https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe  -Destination python_installer.exe
     $hash = (Get-FileHash python_installer.exe).Hash.ToLower()
     $expectedHash = "cd427c7b17337d7c13761ca20877d2d8be661bd30415ddc17072a31a65a91b64"
@@ -13,18 +17,40 @@ steps:
     } else {
       Throw "python_installer.exe hash mismatch, got $hash, expected $expectedHash"
     }
+    Write-Host "Before install, looking at disk space"
+    Get-WmiObject -Class Win32_logicaldisk
+    Write-Host "Before install, listing directories in C:\"
+    Get-ChildItem -Directory "C:\"
+    Write-Host "Before install, listing current dir"
+    Get-ChildItem -File "."
+    Write-Host "Logging cwd:"
+    Get-Location
     Write-Host "Running python_installer.exe"
-    & .\python_installer.exe /passive TargetDir=C:\Python38
+    Start-Process -FilePath "python_installer.exe" -Verb RunAs -ArgumentList "/passive /log `"log.txt`" InstallAllUsers=1 TargetDir=`"C:\Python38`""
+    Write-Host "python_installer.exe finished. Exit code was: $LastExitCode"
+    Write-Host "After install, listing current dir"
+    Get-ChildItem -File "."
+  displayName: 'Install Python (Windows)'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+- task: CopyFiles@2
+  inputs:
+    contents: 'log*'
+    targetFolder: $(Build.ArtifactStagingDirectory)
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: $(Build.ArtifactStagingDirectory)
+    artifactName: PythonInstallLogs
+- powershell: |
+    Write-Host "Dumping log file"
+    Get-Content -Path "log.txt"
     Write-Host "Dumping C: dir"
-    Get-ChildItem "C:\"
+    Get-ChildItem -Directory "C:\"
     Write-Host "Dumping C:\Python38 dir"
     Get-ChildItem "C:\Python38"
     Write-Host "Dumping C:\Python38\Scripts dir"
     Get-ChildItem "C:\Python38\Scripts"
-    Write-Host "Adding to path"
+    Write-Host "Adding Python dirs to path"
     Write-Host "##vso[task.prependpath]C:\Python38"
     Write-Host "##vso[task.prependpath]C:\Python38\Scripts"
-    Write-Host "Dump path AFTER install"
-    Get-ChildItem Env:Path
-  displayName: 'Install Python (Windows)'
+  displayName: 'Post-Install Python (Windows)'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/tools/ci/azure/install_python.yml
+++ b/tools/ci/azure/install_python.yml
@@ -42,7 +42,7 @@ steps:
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 - task: CopyFiles@2
   inputs:
-    contents: 'log*'
+    contents: 'python_installer.log'
     targetFolder: $(Build.ArtifactStagingDirectory)
 - task: PublishBuildArtifacts@1
   inputs:
@@ -50,7 +50,7 @@ steps:
     artifactName: PythonInstallLogs
 - powershell: |
     Write-Host "Dumping log file"
-    Get-Content -Path "log.txt"
+    Get-Content -Path "python_installer.log"
     Write-Host "Dumping C: dir"
     Get-ChildItem -Directory "C:\"
     Write-Host "Dumping C:\Python38 dir"

--- a/tools/ci/azure/install_python.yml
+++ b/tools/ci/azure/install_python.yml
@@ -8,12 +8,7 @@ steps:
     $pythonPath = 'C:\Python38'
     $pythonInstallerLogPath = 'python_installer.log'
     $installArgs = "/passive /log $pythonInstallerLogPath TargetDir=$pythonPath"
-    if (Test-Path -LiteralPath $pythonPath) {
-        Write-Host "Deleting $pythonPath"
-        Remove-Item -Force -Recurse $pythonPath
-        Write-Host "$pythonPath already exists, repair it"
-        $installArgs = $installArgs + " /repair"
-    }
+
     Write-Host "Downloading python installer exe"
     $downloadPath = 'python_installer.exe'
     Start-BitsTransfer -Source https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe  -Destination $downloadPath
@@ -24,6 +19,14 @@ steps:
     } else {
       Throw "$downloadPath hash mismatch, got $hash, expected $expectedHash"
     }
+
+    if (Test-Path -LiteralPath $pythonPath) {
+        Write-Host "$pythonPath already exists, uninstall it"
+        $uninstallArgs = $installArgs + " /uninstall /quiet"
+        $p = Start-Process -FilePath $downloadPath -Verb RunAs -ArgumentList $uninstallArgs -PassThru -Wait
+        Write-Host "Uninstall finished. Exit code was: $($p.ExitCode)"
+    }
+
     Write-Host "Before install, looking at disk space"
     $driveData = Get-WmiObject -Class win32_LogicalDisk -Filter "DeviceID = '$env:SystemDrive'"
     Write-Host "Disk space on $env:SystemDrive: ($($driveData.FreeSpace / 1GB) GB)"

--- a/tools/ci/azure/install_python.yml
+++ b/tools/ci/azure/install_python.yml
@@ -1,10 +1,5 @@
 steps:
 - powershell: |
-    $pythonPath = 'C:\Python27'
-    if (Test-Path -LiteralPath $pythonPath) {
-        Write-Host "Deleting $pythonPath"
-        Remove-Item -Force -Recurse $pythonPath
-    }
     $pythonPath = 'C:\Python38'
     $pythonInstallerLogPath = 'python_installer.log'
     $installArgs = "/passive /log $pythonInstallerLogPath TargetDir=$pythonPath"

--- a/tools/ci/azure/install_python.yml
+++ b/tools/ci/azure/install_python.yml
@@ -22,41 +22,15 @@ steps:
         Write-Host "Uninstall finished. Exit code was: $($p.ExitCode)"
     }
 
-    Write-Host "Before install, looking at disk space"
-    $driveData = Get-WmiObject -Class win32_LogicalDisk -Filter "DeviceID = '$env:SystemDrive'"
-    Write-Host "Disk space on $env:SystemDrive: ($($driveData.FreeSpace / 1GB) GB)"
-    Write-Host "Before install, listing directories in C:\"
-    Get-ChildItem -Directory "C:\"
-    Write-Host "Before install, listing current dir"
-    Get-ChildItem -File "."
-    Write-Host "Logging cwd:"
-    Get-Location
     Write-Host "Running $downloadPath with args $installArgs"
     $p = Start-Process -FilePath $downloadPath -Verb RunAs -ArgumentList $installArgs -PassThru -Wait
     Write-Host "$downloadPath finished. Exit code was: $($p.ExitCode)"
-    Write-Host "After install, listing current dir"
-    Get-ChildItem -File "."
-  displayName: 'Install Python (Windows)'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
-- task: CopyFiles@2
-  inputs:
-    contents: 'python_installer.log'
-    targetFolder: $(Build.ArtifactStagingDirectory)
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: $(Build.ArtifactStagingDirectory)
-    artifactName: PythonInstallLogs
-- powershell: |
-    Write-Host "Dumping log file"
-    Get-Content -Path "python_installer.log"
-    Write-Host "Dumping C: dir"
-    Get-ChildItem -Directory "C:\"
-    Write-Host "Dumping C:\Python38 dir"
-    Get-ChildItem "C:\Python38"
-    Write-Host "Dumping C:\Python38\Scripts dir"
-    Get-ChildItem "C:\Python38\Scripts"
+
     Write-Host "Adding Python dirs to path"
     Write-Host "##vso[task.prependpath]C:\Python38"
     Write-Host "##vso[task.prependpath]C:\Python38\Scripts"
-  displayName: 'Post-Install Python (Windows)'
+
+    Write-Host "Dumping install log file:"
+    Get-Content -Path "python_installer.log"
+  displayName: 'Install Python (Windows)'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))


### PR DESCRIPTION
See the RFC: https://github.com/web-platform-tests/rfcs/pull/65

This also affects `infrastructure/ tests: Windows 10`, but that job is currently only manually triggered and is basically unused.