### PR TITLE
[docs] explicit_done is always true for single_test

### DIFF
--- a/docs/writing-tests/testharness-api.md
+++ b/docs/writing-tests/testharness-api.md
@@ -515,7 +515,7 @@ properties of the test harness (enumerated in the following section).
 Both setup functions recognize the following properties:
 
 `explicit_done` - Wait for an explicit call to done() before declaring all
-tests complete (see below; implicitly true for single page tests)
+tests complete (see below; always true for single page tests)
 
 `output_document` - The document to which results should be logged. By default
 this is the current document but could be an ancestor document in some cases


### PR DESCRIPTION
The current doc does not describe the implementation clearly. Setting
"single_test" not only implies "explicit_done", but in fact forces it to be
true (cannot be overridden).

Reference:
https://github.com/web-platform-tests/rfcs/blob/master/rfcs/single_test.md