### PR TITLE
[wpt] Support MojoJS in Chrome Dev

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -560,8 +560,15 @@ class Chrome(Browser):
         os.remove(installer_path)
         return self.find_nightly_binary(dest)
 
-    def install_mojojs(self, dest):
-        url = self._latest_chromium_snapshot_url() + "mojojs.zip"
+    def install_mojojs(self, dest, channel, browser_binary):
+        if channel == "nightly":
+            url = self._latest_chromium_snapshot_url() + "mojojs.zip"
+        else:
+            chrome_version = self.version(binary=browser_binary)
+            assert chrome_version, "Cannot determine the version of Chrome"
+            # Remove channel suffixes (e.g. " dev").
+            chrome_version = chrome_version.split(' ')[0]
+            url = "https://storage.googleapis.com/chrome-wpt-mojom/%s/linux64/mojojs.zip" % chrome_version
         self.logger.info("Downloading Mojo bindings from %s" % url)
         unzip(get(url).raw, dest)
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -569,8 +569,20 @@ class Chrome(Browser):
             # Remove channel suffixes (e.g. " dev").
             chrome_version = chrome_version.split(' ')[0]
             url = "https://storage.googleapis.com/chrome-wpt-mojom/%s/linux64/mojojs.zip" % chrome_version
+
+        last_url_file = os.path.join(dest, "mojojs", "gen", "DOWNLOADED_FROM")
+        if os.path.exists(last_url_file):
+            with open(last_url_file, "rt") as f:
+                last_url = f.read().strip()
+            if last_url == url:
+                self.logger.info("Mojo bindings already up to date")
+                return
+            rmtree(os.path.join(dest, "mojojs", "gen"))
+
         self.logger.info("Downloading Mojo bindings from %s" % url)
         unzip(get(url).raw, dest)
+        with open(last_url_file, "wt") as f:
+            f.write(url)
 
     def _chromedriver_platform_string(self):
         platform = self.platforms.get(uname[0])

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -312,6 +312,7 @@ class FirefoxAndroid(BrowserSetup):
 class Chrome(BrowserSetup):
     name = "chrome"
     browser_cls = browser.Chrome
+    experimental_channels = ("dev", "canary", "nightly")
 
     def setup_kwargs(self, kwargs):
         browser_channel = kwargs["browser_channel"]
@@ -321,9 +322,14 @@ class Chrome(BrowserSetup):
                 kwargs["binary"] = binary
             else:
                 raise WptrunError("Unable to locate Chrome binary")
-        if browser_channel == "nightly":
+        # TODO(Hexcles): Enable this everywhere when Chrome 86 becomes stable.
+        if browser_channel in self.experimental_channels:
             try:
-                self.browser.install_mojojs(self.venv.path)
+                self.browser.install_mojojs(
+                    dest=self.venv.path,
+                    channel=browser_channel,
+                    browser_binary=kwargs["binary"],
+                )
                 kwargs["enable_mojojs"] = True
                 logger.info("MojoJS enabled")
             except Exception as e:
@@ -350,7 +356,7 @@ class Chrome(BrowserSetup):
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
                 raise WptrunError("Unable to locate or install chromedriver binary")
-        if browser_channel in ("dev", "canary", "nightly"):
+        if browser_channel in self.experimental_channels:
             logger.info("Automatically turning on experimental features for Chrome Dev/Canary or Chromium trunk")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")
             # HACK(Hexcles): work around https://github.com/web-platform-tests/wpt/issues/16448


### PR DESCRIPTION
Automatically download mojojs.zip and turn on relevant flags for Chrome
Dev. Follow-up to #24739.

Test: `./wpt run --channel dev --log-mach - chrome webxr`