### PR TITLE
[lint] Disallow *.mojom.js in WPT

### DIFF
--- a/lint.ignore
+++ b/lint.ignore
@@ -726,6 +726,12 @@ MISSING DEPENDENCY: web-nfc/resources/nfc-helpers.js
 MISSING DEPENDENCY: webusb/resources/usb-helpers.js
 MISSING DEPENDENCY: webxr/resources/webxr_util.js
 
+# TODO(Hexcles): delete these files once we include them in mojojs.zip.
+MOJOM-JS: resources/chromium/image_capture.mojom.js
+MOJOM-JS: resources/chromium/sensor_provider.mojom.js
+MOJOM-JS: resources/chromium/mojo_web_test_helper_test.mojom.js
+MOJOM-JS: resources/chromium/sensor.mojom.js
+
 # Tests that are false positives for using Ahem as a system font
 AHEM SYSTEM FONT: acid/acid3/test.html
 AHEM SYSTEM FONT: resource-timing/resources/all_resource_types.htm

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -198,6 +198,13 @@ def check_gitignore_file(repo_root, path):
     return [rules.GitIgnoreFile.error(path)]
 
 
+def check_mojom_js(repo_root, path):
+    # type: (Text, Text) -> List[rules.Error]
+    if path.endswith(".mojom.js"):
+        return [rules.MojomJSFile.error(path)]
+    return []
+
+
 def check_ahem_copy(repo_root, path):
     # type: (Text, Text) -> List[rules.Error]
     lpath = path.lower()
@@ -997,8 +1004,9 @@ def lint(repo_root, paths, output_format, ignore_glob=None):
                 logger.info(line)
     return sum(itervalues(error_count))
 
+
 path_lints = [check_file_type, check_path_length, check_worker_collision, check_ahem_copy,
-              check_tentative_directories, check_gitignore_file]
+              check_mojom_js, check_tentative_directories, check_gitignore_file]
 all_paths_lints = [check_css_globally_unique, check_unique_testharness_basenames]
 file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_metadata,
               check_ahem_system_font]

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -87,7 +87,7 @@ class MojomJSFile(Rule):
     to_fix = """
         Check if the file is already included in mojojs.zip:
         https://source.chromium.org/chromium/chromium/src/+/master:chrome/tools/build/linux/FILES.cfg
-        If yes, use loadMojoResources from resources/test-only-api.js to load
+        If yes, use `loadMojoResources` from `resources/test-only-api.js` to load
         it; if not, contact ecosystem-infra@chromium.org for adding new files
         to mojojs.zip.
     """

--- a/tools/lint/rules.py
+++ b/tools/lint/rules.py
@@ -81,6 +81,18 @@ class GitIgnoreFile(Rule):
     description = ".gitignore found outside the root"
 
 
+class MojomJSFile(Rule):
+    name = "MOJOM-JS"
+    description = "Don't check *.mojom.js files into WPT"
+    to_fix = """
+        Check if the file is already included in mojojs.zip:
+        https://source.chromium.org/chromium/chromium/src/+/master:chrome/tools/build/linux/FILES.cfg
+        If yes, use loadMojoResources from resources/test-only-api.js to load
+        it; if not, contact ecosystem-infra@chromium.org for adding new files
+        to mojojs.zip.
+    """
+
+
 class AhemCopy(Rule):
     name = "AHEM COPY"
     description = "Don't add extra copies of Ahem, use /fonts/Ahem.ttf"

--- a/tools/lint/tests/test_path_lints.py
+++ b/tools/lint/tests/test_path_lints.py
@@ -7,6 +7,7 @@ from ..lint import check_path
 from .base import check_errors
 import pytest
 
+
 def test_allowed_path_length():
     basename = 29 * "test/"
 
@@ -28,6 +29,7 @@ def test_forbidden_path_length():
         errors = check_path("/foo/", filename)
         check_errors(errors)
         assert errors == [("PATH LENGTH", message, filename, None)]
+
 
 @pytest.mark.parametrize("path_ending,generated", [(".worker.html", ".worker.js"),
                                                    (".any.worker.html", ".any.js"),
@@ -70,6 +72,7 @@ def test_ahem_copy(path):
 
     assert errors == [expected_error]
 
+
 @pytest.mark.parametrize("path", ["ahem.woff",
                                   "ahem.ttff",
                                   "support/ahem.woff",
@@ -78,6 +81,16 @@ def test_ahem_copy_negative(path):
     errors = check_path("/foo/", path)
 
     assert errors == []
+
+
+def test_mojom_js_file():
+    path = "resources/fake_device.mojom.js"
+    errors = check_path("/foo/", path)
+    assert errors == [("MOJOM-JS",
+                       "Don't check *.mojom.js files into WPT",
+                       path,
+                       None)]
+
 
 @pytest.mark.parametrize("path", ["css/foo.tentative/bar.html",
                                   "css/.tentative/bar.html",
@@ -94,6 +107,7 @@ def test_tentative_directories(path):
 
     assert errors == [expected_error]
 
+
 @pytest.mark.parametrize("path", ["css/bar.html",
                                   "css/tentative/baz.html"])
 def test_tentative_directories_negative(path):
@@ -101,6 +115,7 @@ def test_tentative_directories_negative(path):
     errors = check_path("/foo/", path)
 
     assert errors == []
+
 
 @pytest.mark.parametrize("path", ["elsewhere/.gitignore",
                                   "else/where/.gitignore"
@@ -119,6 +134,7 @@ def test_gitignore_file(path):
     errors = check_path("/foo/", path)
 
     assert errors == [expected_error]
+
 
 @pytest.mark.parametrize("path", [".gitignore",
                                   "elsewhere/.gitignores",


### PR DESCRIPTION
We now have established a formal way to do this (more documentation will
be available in Chromium, as this is Chrome-only) and should no longer
accept these auto-generated files in WPT.

Related to #16455.