### PR TITLE
[weakref] WeakRef/FinalizationRegistry, cleanupSome testing

### DIFF
--- a/js/builtins/weakrefs/cleanup-prevented-with-reference.optional.any.js
+++ b/js/builtins/weakrefs/cleanup-prevented-with-reference.optional.any.js
@@ -1,0 +1,50 @@
+// META: script=resources/maybe-garbage-collect.js
+// ├──> maybeGarbageCollectAndCleanupAsync
+// └──> resolveGarbageCollection
+/*---
+esid: sec-finalization-registry.prototype.cleanupSome
+info: |
+  FinalizationRegistry.prototype.cleanupSome ( [ callback ] )
+
+  1. Let finalizationRegistry be the this value.
+  2. If Type(finalizationRegistry) is not Object, throw a TypeError exception.
+  3. If finalizationRegistry does not have a [[Cells]] internal slot, throw a TypeError exception.
+  4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
+  5. Perform ? CleanupFinalizationRegistry(finalizationRegistry, callback).
+  6. Return undefined.
+---*/
+
+let holdingsList = [];
+function cb(holding) {
+  holdingsList.push(holding);
+};
+let finalizationRegistry = new FinalizationRegistry(function() {});
+
+let referenced = {};
+
+function emptyCells() {
+  let target = {};
+  finalizationRegistry.register(target, 'target!');
+  finalizationRegistry.register(referenced, 'referenced');
+
+  let prom = maybeGarbageCollectAndCleanupAsync(target);
+  target = null;
+
+  return prom;
+}
+
+promise_test(() => {
+  return (async () => {
+    assert_implements(
+      typeof FinalizationRegistry.prototype.cleanupSome === 'function',
+      'FinalizationRegistry.prototype.cleanupSome is not implemented.'
+    );
+
+    await emptyCells();
+    finalizationRegistry.cleanupSome(cb);
+
+    assert_equals(holdingsList.length, 1);
+    assert_equals(holdingsList[0], 'target!');
+    assert_equals(typeof referenced, 'object', 'referenced preserved');
+  })().catch(resolveGarbageCollection);
+}, 'cleanupCallback has only one optional chance to be called for a GC that cleans up a registered target.');

--- a/js/builtins/weakrefs/cleanup-prevented-with-unregister.optional.any.js
+++ b/js/builtins/weakrefs/cleanup-prevented-with-unregister.optional.any.js
@@ -1,0 +1,57 @@
+// META: script=resources/maybe-garbage-collect.js
+// ├──> maybeGarbageCollectAndCleanupAsync
+// └──> resolveGarbageCollection
+/*---
+esid: sec-finalization-registry.prototype.cleanupSome
+info: |
+  FinalizationRegistry.prototype.cleanupSome ( [ callback ] )
+
+  1. Let finalizationRegistry be the this value.
+  2. If Type(finalizationRegistry) is not Object, throw a TypeError exception.
+  3. If finalizationRegistry does not have a [[Cells]] internal slot, throw a TypeError exception.
+  4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
+  5. Perform ? CleanupFinalizationRegistry(finalizationRegistry, callback).
+  6. Return undefined.
+
+  FinalizationRegistry.prototype.unregister ( unregisterToken )
+
+  1. Let removed be false.
+  2. For each Record { [[Target]], [[Holdings]], [[UnregisterToken]] } cell that is an element of finalizationRegistry.[[Cells]], do
+    a. If SameValue(cell.[[UnregisterToken]], unregisterToken) is true, then
+      i. Remove cell from finalizationRegistry.[[Cells]].
+      ii. Set removed to true.
+  3. Return removed.
+---*/
+let token = {};
+let finalizationRegistry = new FinalizationRegistry(function() {});
+
+function emptyCells() {
+  let target = {};
+  finalizationRegistry.register(target, 'target!', token);
+
+  let prom = maybeGarbageCollectAndCleanupAsync(target);
+  target = null;
+
+  return prom;
+}
+
+promise_test(() => {
+  return (async () => {
+    assert_implements(
+      typeof FinalizationRegistry.prototype.cleanupSome === 'function',
+      'FinalizationRegistry.prototype.cleanupSome is not implemented.'
+    );
+
+    await emptyCells();
+    let called = 0;
+
+    let res = finalizationRegistry.unregister(token);
+    assert_equals(res, true, 'unregister target before iterating over it in cleanup');
+
+    finalizationRegistry.cleanupSome((holding) => {
+      called += 1;
+    });
+
+    assert_equals(called, 0, 'callback was not called');
+  })().catch(resolveGarbageCollection);
+}, 'Cleanup might be prevented with an unregister usage');

--- a/js/builtins/weakrefs/gc-has-one-chance-to-call-cleanupCallback.optional.any.js
+++ b/js/builtins/weakrefs/gc-has-one-chance-to-call-cleanupCallback.optional.any.js
@@ -1,0 +1,100 @@
+// META: script=resources/maybe-garbage-collect.js
+// ├──> maybeGarbageCollectAndCleanupAsync
+// ├──> maybeGarbageCollectAsync
+// └──> resolveGarbageCollection
+/*---
+esid: sec-finalization-registry-target
+info: |
+  FinalizationRegistry ( cleanupCallback )
+
+  FinalizationRegistry.prototype.cleanupSome ( [ callback ] )
+
+  ...
+  4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
+  5. Perform ? CleanupFinalizationRegistry(finalizationRegistry, callback).
+  6. Return undefined.
+
+  Execution
+
+  At any time, if an object obj is not live, an ECMAScript implementation may perform the following steps atomically:
+
+  1. For each WeakRef ref such that ref.[[Target]] is obj,
+    a. Set ref.[[Target]] to empty.
+  2. For each FinalizationRegistry finalizationRegistry such that finalizationRegistry.[[Cells]] contains cell, such that cell.[[Target]] is obj,
+    a. Set cell.[[Target]] to empty.
+    b. Optionally, perform ! HostCleanupFinalizationRegistry(finalizationRegistry).
+---*/
+
+
+let cleanupCallback = 0;
+let called = 0;
+function cb(holding) {
+  assert_equals(holding, 'a');
+  called += 1;
+}
+
+let finalizationRegistry = new FinalizationRegistry(function() {
+  cleanupCallback += 1;
+});
+
+function emptyCells() {
+  let target = {};
+  finalizationRegistry.register(target, 'a');
+
+  let prom = maybeGarbageCollectAndCleanupAsync(target);
+  target = null;
+
+  return prom;
+}
+
+promise_test(() => {
+  return (async () => {
+    assert_implements(
+      typeof FinalizationRegistry.prototype.cleanupSome === 'function',
+      'FinalizationRegistry.prototype.cleanupSome is not implemented.'
+    );
+
+    let ticks = 0;
+    await emptyCells();
+    await ticks++;
+
+    finalizationRegistry.cleanupSome(cb);
+
+    // cleanupSome will be invoked if there are empty cells left. If the
+    // cleanupCallback already ran, then cb won't be called.
+    let expectedCalled = cleanupCallback === 1 ? 0 : 1;
+    // This asserts the registered object was emptied in the previous GC.
+    assert_equals(called, expectedCalled, 'cleanupSome callback for the first time');
+
+    // At this point, we can't assert if cleanupCallback was called, because it's
+    // optional. Although, we can finally assert it's not gonna be called anymore
+    // for the other executions of the Garbage Collector.
+    // The chance of having it called only happens right after the
+    // cell.[[Target]] is set to empty.
+    assert_true(cleanupCallback >= 0, 'cleanupCallback might be 0');
+    assert_true(cleanupCallback <= 1, 'cleanupCallback might be 1');
+
+    // Restoring the cleanupCallback variable to 0 will help us asserting the
+    // finalizationRegistry callback is not called again.
+    cleanupCallback = 0;
+
+    await maybeGarbageCollectAsync();
+    await ticks++;
+
+    finalizationRegistry.cleanupSome(cb);
+
+    assert_equals(called, expectedCalled, 'cleanupSome callback is not called anymore, no empty cells');
+    assert_equals(cleanupCallback, 0, 'cleanupCallback is not called again #1');
+
+    await maybeGarbageCollectAsync();
+    await ticks++;
+
+    finalizationRegistry.cleanupSome(cb);
+
+    assert_equals(called, expectedCalled, 'cleanupSome callback is not called again #2');
+    assert_equals(cleanupCallback, 0, 'cleanupCallback is not called again #2');
+    await maybeGarbageCollectAsync();
+
+    assert_equals(ticks, 3, 'ticks is 3');
+  })().catch(resolveGarbageCollection);
+}, 'cleanupCallback has only one optional chance to be called for a GC that cleans up a registered target.');

--- a/js/builtins/weakrefs/holdings-multiple-values.optional.any.js
+++ b/js/builtins/weakrefs/holdings-multiple-values.optional.any.js
@@ -1,0 +1,65 @@
+// META: script=resources/maybe-garbage-collect.js
+// ├──> maybeGarbageCollectAndCleanupAsync
+// └──> resolveGarbageCollection
+/*---
+esid: sec-properties-of-the-finalization-registry-constructor
+info: |
+  FinalizationRegistry.prototype.cleanupSome ( [ callback ] )
+
+  1. Let finalizationRegistry be the this value.
+  ...
+  5. Perform ! CleanupFinalizationRegistry(finalizationRegistry, callback).
+  ...
+
+  CleanupFinalizationRegistry ( finalizationRegistry [ , callback ] )
+
+  ...
+  3. While finalizationRegistry.[[Cells]] contains a Record cell such that cell.[[WeakRefTarget]] is ~empty~, then an implementation may perform the following steps,
+    a. Choose any such cell.
+    b. Remove cell from finalizationRegistry.[[Cells]].
+    c. Perform ? Call(callback, undefined, << cell.[[HeldValue]] >>).
+
+---*/
+
+function check(value, expectedName) {
+  let holdings = [];
+  let called = 0;
+  let finalizationRegistry = new FinalizationRegistry(function() {});
+
+  function callback(holding) {
+    called += 1;
+    holdings.push(holding);
+  }
+
+  // This is internal to avoid conflicts
+  function emptyCells(value) {
+    let target = {};
+    finalizationRegistry.register(target, value);
+
+    let prom = maybeGarbageCollectAndCleanupAsync(target);
+    target = null;
+
+    return prom;
+  }
+
+  return emptyCells(value).then(function() {
+    finalizationRegistry.cleanupSome(callback);
+    assert_equals(called, 1, expectedName);
+    assert_equals(holdings.length, 1, expectedName);
+    assert_equals(holdings[0], value, expectedName);
+  });
+}
+
+test(() =>
+  assert_implements(
+  typeof FinalizationRegistry.prototype.cleanupSome === 'function',
+  'FinalizationRegistry.prototype.cleanupSome is not implemented.'
+), 'Requires FinalizationRegistry.prototype.cleanupSome');
+promise_test(() => check(undefined, 'undefined'), '`undefined` as registered holding value');
+promise_test(() => check(null, 'null'), '`null` as registered holding value');
+promise_test(() => check('', 'the empty string'), '`""` as registered holding value');
+promise_test(() => check({}, 'object'), '`{}` as registered holding value');
+promise_test(() => check(42, 'number'), '`42` as registered holding value');
+promise_test(() => check(true, 'true'), '`true` as registered holding value');
+promise_test(() => check(false, 'false'), '`false` as registered holding value');
+promise_test(() => check(Symbol(1), 'symbol'), '`Symbol(1)` as registered holding value');

--- a/js/builtins/weakrefs/reentrancy.optional.any.js
+++ b/js/builtins/weakrefs/reentrancy.optional.any.js
@@ -1,0 +1,50 @@
+// META: script=resources/maybe-garbage-collect.js
+// ├──> maybeGarbageCollectAndCleanupAsync
+// └──> resolveGarbageCollection
+/*---
+esid: sec-properties-of-the-finalization-registry-constructor
+---*/
+
+let called = 0;
+let endOfCall = 0;
+let finalizationRegistry = new FinalizationRegistry(function() {});
+
+function callback(holding) {
+  called += 1;
+
+  if (called === 1) {
+    // Atempt to re-enter the callback.
+    let nestedCallbackRan = false;
+    finalizationRegistry.cleanupSome(() => { nestedCallbackRan = true });
+    assert_equals(nestedCallbackRan, true);
+  }
+
+  endOfCall += 1;
+}
+
+function emptyCells() {
+  let o1 = {};
+  let o2 = {};
+  // Register more than one objects to test reentrancy.
+  finalizationRegistry.register(o1, 'holdings 1');
+  finalizationRegistry.register(o2, 'holdings 2');
+
+  let prom = maybeGarbageCollectAndCleanupAsync(o1);
+  o1 = null;
+
+  return prom;
+}
+
+promise_test(() => {
+  return (async () => {
+    assert_implements(
+      typeof FinalizationRegistry.prototype.cleanupSome === 'function',
+      'FinalizationRegistry.prototype.cleanupSome is not implemented.'
+    );
+    await emptyCells();
+    finalizationRegistry.cleanupSome(callback);
+
+    assert_equals(called, 1, 'callback was called');
+    assert_equals(endOfCall, 1, 'callback finished');
+  })().catch(resolveGarbageCollection);
+}, 'cleanupCallback has only one optional chance to be called for a GC that cleans up a registered target.');

--- a/js/builtins/weakrefs/resources/maybe-garbage-collect.js
+++ b/js/builtins/weakrefs/resources/maybe-garbage-collect.js
@@ -1,0 +1,96 @@
+/**
+ * maybeGarbageCollectAsync
+ *
+ * It might garbage collect, it might not. If it doesn't, that's ok.
+ *
+ * Based on "(default export)" in
+ * https://github.com/web-platform-tests/wpt/pull/22835/files#diff-fba53ea423a12f40917f41ba4ffadf1e, and "$262.gc()"
+ * defined in https://github.com/tc39/test262/blob/main/INTERPRETING.md
+ *
+ *
+ * @return {undefined}
+ */
+async function maybeGarbageCollectAsync() {
+  if (typeof TestUtils !== 'undefined' && TestUtils.gc) {
+    await TestUtils.gc();
+  } else if (self.gc) {
+    // Use --expose_gc for V8 (and Node.js)
+    // to pass this flag at chrome launch use: --js-flags="--expose-gc"
+    // Exposed in SpiderMonkey shell as well
+    await self.gc();
+  } else if (self.GCController) {
+    // Present in some WebKit development environments
+    await GCController.collect();
+  }
+  /* eslint-disable no-console */
+  console.warn('Tests are running without the ability to do manual ' +
+               'garbage collection. They will still work, but ' +
+               'coverage will be suboptimal.');
+  /* eslint-enable no-console */
+}
+
+/**
+ * maybeGarbageCollectKeptObjectsAsync
+ *
+ * Based on "asyncGCDeref" in https://github.com/tc39/test262/blob/master/harness/async-gc.js
+ *
+ * @return {Promise} Resolves to a trigger if ClearKeptObjects
+ *                   exists to provide one
+ */
+async function maybeGarbageCollectKeptObjectsAsync() {
+  let trigger;
+
+  if (typeof ClearKeptObjects === 'function') {
+    trigger = ClearKeptObjects();
+  }
+
+  await maybeGarbageCollectAsync();
+
+  return trigger;
+}
+
+/**
+ * maybeGarbageCollectAndCleanupAsync
+ *
+ * Based on "asyncGC" in https://github.com/tc39/test262/blob/master/harness/async-gc.js
+ *
+ * @return {undefined}
+ */
+async function maybeGarbageCollectAndCleanupAsync(...targets) {
+  let finalizationRegistry = new FinalizationRegistry(() => {});
+  let length = targets.length;
+
+  for (let target of targets) {
+    finalizationRegistry.register(target, 'target');
+    target = null;
+  }
+
+  targets = null;
+
+  await 'tick';
+  await maybeGarbageCollectKeptObjectsAsync();
+
+  let names = [];
+
+  finalizationRegistry.cleanupSome(name => names.push(name));
+
+  if (names.length !== length) {
+    throw maybeGarbageCollectAndCleanupAsync.NOT_COLLECTED;
+  }
+}
+
+maybeGarbageCollectAndCleanupAsync.NOT_COLLECTED = Symbol('Object was not collected');
+
+/**
+ * resolveGarbageCollection
+ *
+ * Based on "resolveAsyncGC" in https://github.com/tc39/test262/blob/master/harness/async-gc.js
+ *
+ * @param  {Error} error An error object.
+ * @return {undefined}
+ */
+function resolveGarbageCollection(error) {
+  if (error && error !== maybeGarbageCollectAndCleanupAsync.NOT_COLLECTED) {
+    throw error;
+  }
+}

--- a/js/builtins/weakrefs/return-undefined-with-gc.optional.any.js
+++ b/js/builtins/weakrefs/return-undefined-with-gc.optional.any.js
@@ -1,0 +1,78 @@
+// META: script=resources/maybe-garbage-collect.js
+// ├──> maybeGarbageCollectAndCleanupAsync
+// └──> resolveGarbageCollection
+/*---
+esid: sec-finalization-registry.prototype.cleanupSome
+info: |
+  FinalizationRegistry.prototype.cleanupSome ( [ callback ] )
+
+  1. Let finalizationRegistry be the this value.
+  2. If Type(finalizationRegistry) is not Object, throw a TypeError exception.
+  3. If finalizationRegistry does not have a [[Cells]] internal slot, throw a TypeError exception.
+  4. If callback is not undefined and IsCallable(callback) is false, throw a TypeError exception.
+  5. Perform ? CleanupFinalizationRegistry(finalizationRegistry, callback).
+  6. Return undefined.
+---*/
+
+let called;
+let fn = function() {
+  called += 1;
+  return 39;
+};
+let cb = function() {
+  called += 1;
+  return 42;
+};
+let finalizationRegistry = new FinalizationRegistry(fn);
+
+function emptyCells() {
+  let target = {};
+  finalizationRegistry.register(target);
+
+  let prom = maybeGarbageCollectAndCleanupAsync(target);
+  target = null;
+
+  return prom;
+}
+
+promise_test(() => {
+  return (async () => {
+    assert_implements(
+      typeof FinalizationRegistry.prototype.cleanupSome === 'function',
+      'FinalizationRegistry.prototype.cleanupSome is not implemented.'
+    );
+
+    await emptyCells();
+    called = 0;
+    assert_equals(finalizationRegistry.cleanupSome(cb), undefined, 'regular callback');
+    assert_equals(called, 1);
+
+    await emptyCells();
+    called = 0;
+    assert_equals(finalizationRegistry.cleanupSome(fn), undefined, 'regular callback, same FG cleanup function');
+    assert_equals(called, 1);
+
+    await emptyCells();
+    called = 0;
+    assert_equals(finalizationRegistry.cleanupSome(), undefined, 'undefined (implicit) callback, defer to FB callback');
+    assert_equals(called, 1);
+
+    await emptyCells();
+    called = 0;
+    assert_equals(finalizationRegistry.cleanupSome(undefined), undefined, 'undefined (explicit) callback, defer to FB callback');
+    assert_equals(called, 1);
+
+    await emptyCells();
+    assert_equals(finalizationRegistry.cleanupSome(() => 1), undefined, 'arrow function');
+
+    await emptyCells();
+    assert_equals(finalizationRegistry.cleanupSome(async function() {}), undefined, 'async function');
+
+    await emptyCells();
+    assert_equals(finalizationRegistry.cleanupSome(function *() {}), undefined, 'generator');
+
+    await emptyCells();
+    assert_equals(finalizationRegistry.cleanupSome(async function *() {}), undefined, 'async generator');
+
+  })().catch(resolveGarbageCollection);
+}, 'Return undefined regardless the result of CleanupFinalizationRegistry');

--- a/js/builtins/weakrefs/unregister-cleaned-up-cell.optional.any.js
+++ b/js/builtins/weakrefs/unregister-cleaned-up-cell.optional.any.js
@@ -1,0 +1,72 @@
+// META: script=resources/maybe-garbage-collect.js
+// ├──> maybeGarbageCollectAndCleanupAsync
+// └──> resolveGarbageCollection
+/*---
+esid: sec-finalization-registry.prototype.unregister
+info: |
+  FinalizationRegistry.prototype.cleanupSome ( [ callback ] )
+
+  1. Let finalizationRegistry be the this value.
+  ...
+  5. Perform ! CleanupFinalizationRegistry(finalizationRegistry, callback).
+  ...
+
+  CleanupFinalizationRegistry ( finalizationRegistry [ , callback ] )
+
+  ...
+  3. While finalizationRegistry.[[Cells]] contains a Record cell such that cell.[[WeakRefTarget]] is ~empty~, then an implementation may perform the following steps,
+    a. Choose any such cell.
+    b. Remove cell from finalizationRegistry.[[Cells]].
+    c. Perform ? Call(callback, undefined, << cell.[[HeldValue]] >>).
+  ...
+
+  FinalizationRegistry.prototype.unregister ( unregisterToken )
+
+  1. Let removed be false.
+  2. For each Record { [[Target]], [[Holdings]], [[UnregisterToken]] } cell that is an element of finalizationRegistry.[[Cells]], do
+    a. If SameValue(cell.[[UnregisterToken]], unregisterToken) is true, then
+      i. Remove cell from finalizationRegistry.[[Cells]].
+      ii. Set removed to true.
+  3. Return removed.
+
+---*/
+
+let value = 'target!';
+let token = {};
+let finalizationRegistry = new FinalizationRegistry(function() {});
+
+function emptyCells() {
+  let target = {};
+  finalizationRegistry.register(target, value, token);
+
+  let prom = maybeGarbageCollectAndCleanupAsync(target);
+  target = null;
+
+  return prom;
+}
+
+promise_test(() => {
+  return (async () => {
+    assert_implements(
+      typeof FinalizationRegistry.prototype.cleanupSome === 'function',
+      'FinalizationRegistry.prototype.cleanupSome is not implemented.'
+    );
+
+    await emptyCells();
+    let called = 0;
+    let holdings = [];
+    finalizationRegistry.cleanupSome((holding) => {
+      called += 1;
+      holdings.push(holding);
+    });
+
+    assert_equals(called, 1);
+    assert_equals(holdings.length, 1);
+    assert_equals(holdings[0], value);
+
+    let res = finalizationRegistry.unregister(token);
+    assert_equals(res, false, 'unregister after iterating over it in cleanup');
+
+  })().catch(resolveGarbageCollection);
+}, 'Cannot unregister a cell that has been cleaned up');
+

--- a/lint.ignore
+++ b/lint.ignore
@@ -106,6 +106,7 @@ PRINT STATEMENT: webdriver/tests/support/helpers.py
 
 # semi-legitimate use of console.*
 CONSOLE: console/*
+CONSOLE: js/builtins/weakrefs/resources/maybe-garbage-collect.js
 CONSOLE: resources/check-layout-th.js
 CONSOLE: resources/chromium/*
 CONSOLE: streams/resources/test-utils.js


### PR DESCRIPTION
@syg @leobalter This set of tests are built from the Test262 tests that allow for "maybe" garbage collection. Our harness utilities have been ported over, but with more obvious naming to make everything as clear as possible. 

Once these are approved and merged, I will move on to writing additional tests that cover interactions across various async web APIs ("things that micro task").