### PR TITLE
Added 2 selection-overlay-* tests with their respective references

### DIFF
--- a/css/css-pseudo/reference/selection-overlay-and-grammar-001-ref.html
+++ b/css/css-pseudo/reference/selection-overlay-and-grammar-001-ref.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+
+ <html lang="en">
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      background-color: rgba(0%, 50%, 100%, 0.5);
+      /*
+      a very lite blue color
+      according to
+      https://www.colorhexa.com/7fbfff
+      */
+      color: yellow;
+      float: left;
+      font-size: 300%;
+    }
+
+  span
+    {
+      background-color: #7FBF80; /* lime-green-ish */
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  document.getElementById("reference").blur();
+  /*
+  Some browsers, like Chromium 80+, will
+  transfer focus to a selected element
+  like a contenteditable div and
+  therefore style the border of
+  such element. We remove such
+  focus with the blur() method.
+  */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+
+  <p>PREREQUISITE: User agent needs to have an enabled and capable grammar error module. If it does not, then this test does not apply to such user agent.
+
+  <p>Test passes
+
+  <ul>
+    <li>if each glyph of the sentence is yellow
+    <li>if "thing" has a desaturated lime green background
+    <li>if the other words have a very lite blue background and
+    <li>if there is no red.
+  </ul>
+
+  <div contenteditable="true" id="reference">Many <span>thing</span> can happen.</div>

--- a/css/css-pseudo/reference/selection-overlay-and-grammar-001-ref.html
+++ b/css/css-pseudo/reference/selection-overlay-and-grammar-001-ref.html
@@ -11,6 +11,12 @@
   <style>
   div
     {
+      float: left;
+      font-size: 300%;
+    }
+
+  span#outer
+    {
       background-color: rgba(0%, 50%, 100%, 0.5);
       /*
       a very lite blue color
@@ -18,11 +24,9 @@
       https://www.colorhexa.com/7fbfff
       */
       color: yellow;
-      float: left;
-      font-size: 300%;
     }
 
-  span
+  span#inner
     {
       background-color: #7FBF80; /* lime-green-ish */
     }
@@ -45,7 +49,6 @@
 
   <body onload="startTest();">
 
-
   <p>PREREQUISITE: User agent needs to have an enabled and capable grammar error module. If it does not, then this test does not apply to such user agent.
 
   <p>Test passes
@@ -57,4 +60,4 @@
     <li>if there is no red.
   </ul>
 
-  <div contenteditable="true" id="reference">Many <span>thing</span> can happen.</div>
+  <div contenteditable="true" id="reference"><span id="outer">Many <span id="inner">thing</span> can happen.</span></div>

--- a/css/css-pseudo/reference/selection-overlay-and-grammar-001-ref.html
+++ b/css/css-pseudo/reference/selection-overlay-and-grammar-001-ref.html
@@ -11,11 +11,22 @@
   <style>
   div
     {
-      float: left;
-      font-size: 300%;
+      font-size: 60px;
+      line-height: 90px;
     }
 
-  span#outer
+  div#overlapped-line
+    {
+      color: transparent;
+      margin-bottom: -90px;
+    }
+
+  span#single-word
+    {
+      background-color: yellow;
+    }
+
+  span#overlapping-line
     {
       background-color: rgba(0%, 50%, 100%, 0.5);
       /*
@@ -24,11 +35,6 @@
       https://www.colorhexa.com/7fbfff
       */
       color: yellow;
-    }
-
-  span#inner
-    {
-      background-color: #7FBF80; /* lime-green-ish */
     }
   </style>
 
@@ -60,4 +66,6 @@
     <li>if there is no red.
   </ul>
 
-  <div contenteditable="true" id="reference"><span id="outer">Many <span id="inner">thing</span> can happen.</span></div>
+  <div id="overlapped-line">Many <span id="single-word">thing</span> can happen.</div>
+
+  <div contenteditable="true"><span id="overlapping-line">Many thing can happen.</span></div>

--- a/css/css-pseudo/reference/selection-overlay-and-spelling-001-ref.html
+++ b/css/css-pseudo/reference/selection-overlay-and-spelling-001-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+ <html lang="en">
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      background-color: rgba(0%, 50%, 100%, 0.5);
+      /*
+      a very lite blue color
+      according to
+      https://www.colorhexa.com/7fbfff
+      */
+      color: yellow;
+      float: left;
+      font-size: 300%;
+    }
+
+  span
+    {
+      background-color: #7FBF80; /* lime-green-ish */
+    }
+  </style>
+
+  <p>PREREQUISITE: User agent needs to have an enabled and capable spelling error module. If it does not, then this test does not apply to such user agent.
+
+  <p>Test passes
+
+  <ul>
+    <li>if each glyph of "Txet sample" is yellow
+    <li>if "Txet" has a desaturated lime green background
+    <li>if " sample" has a very lite blue background and
+    <li>if there is no red.
+  </ul>
+
+  <!--
+  The bad spelling of Txet is intentional and part of this test
+  -->
+
+  <div><span>Txet</span> sample</div>

--- a/css/css-pseudo/reference/selection-overlay-and-spelling-001-ref.html
+++ b/css/css-pseudo/reference/selection-overlay-and-spelling-001-ref.html
@@ -11,11 +11,26 @@
   <style>
   div
     {
-      float: left;
-      font-size: 300%;
+      font-size: 60px;
+      line-height: 90px;
     }
 
   span#outer
+    {
+      color: transparent;
+    }
+
+  span#inner
+    {
+      background-color: yellow;
+    }
+
+  div#overlapping-line
+    {
+      margin-top: -90px; /* -1lh unfortunately is not implemented */
+    }
+
+  div#overlapping-line > span
     {
       background-color: rgba(0%, 50%, 100%, 0.5);
       /*
@@ -24,11 +39,6 @@
       https://www.colorhexa.com/7fbfff
       */
       color: yellow;
-    }
-
-  span#inner
-    {
-      background-color: #7FBF80; /* lime-green-ish */
     }
   </style>
 
@@ -47,4 +57,6 @@
   The bad spelling of Txet is intentional and part of this test
   -->
 
-  <div><span id="outer"><span id="inner">Txet</span> sample</span></div>
+  <div id="overlapped-line"><span id="outer"><span id="inner">Txet</span> sample</span></div>
+
+  <div id="overlapping-line"><span>Txet sample</span></div>

--- a/css/css-pseudo/reference/selection-overlay-and-spelling-001-ref.html
+++ b/css/css-pseudo/reference/selection-overlay-and-spelling-001-ref.html
@@ -12,7 +12,7 @@
   div
     {
       font-size: 60px;
-      line-height: 90px;
+      line-height: 1;
     }
 
   span#outer
@@ -27,7 +27,7 @@
 
   div#overlapping-line
     {
-      margin-top: -90px; /* -1lh unfortunately is not implemented */
+      margin-top: -60px; /* -1lh unfortunately is not implemented */
     }
 
   div#overlapping-line > span

--- a/css/css-pseudo/reference/selection-overlay-and-spelling-001-ref.html
+++ b/css/css-pseudo/reference/selection-overlay-and-spelling-001-ref.html
@@ -11,6 +11,12 @@
   <style>
   div
     {
+      float: left;
+      font-size: 300%;
+    }
+
+  span#outer
+    {
       background-color: rgba(0%, 50%, 100%, 0.5);
       /*
       a very lite blue color
@@ -18,11 +24,9 @@
       https://www.colorhexa.com/7fbfff
       */
       color: yellow;
-      float: left;
-      font-size: 300%;
     }
 
-  span
+  span#inner
     {
       background-color: #7FBF80; /* lime-green-ish */
     }
@@ -43,4 +47,4 @@
   The bad spelling of Txet is intentional and part of this test
   -->
 
-  <div><span>Txet</span> sample</div>
+  <div><span id="outer"><span id="inner">Txet</span> sample</span></div>

--- a/css/css-pseudo/selection-overlay-and-grammar-001.html
+++ b/css/css-pseudo/selection-overlay-and-grammar-001.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+
+ <html lang="en">
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: ::selection overlay drawn over the ::grammar-error overlay</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-painting">
+  <link rel="match" href="reference/selection-overlay-and-grammar-001-ref.html">
+
+  <meta content="" name="flags">
+  <meta name="assert" content="In this test, the div::selection pseudo-element must be drawn over the div::grammar-error overlay. The test predicts that, since div::selection uses a semi-transparent very lite blue background layer, the resulting background color for div::grammar-error will be lime-green-ish (#7FBF80: slightly desaturated lime green).">
+
+  <!--
+
+  "#7fbf80 color description : Slightly desaturated lime green"
+  https://www.colorhexa.com/7fbf80
+
+  -->
+
+  <style>
+  div
+    {
+      float: left;
+      font-size: 300%;
+    }
+
+  div::selection
+    {
+      background-color: rgba(0%, 50%, 100%, 0.5);
+      /*
+      a very lite blue color
+      according to
+      https://www.colorhexa.com/7fbfff
+      */
+      color: yellow;
+    }
+
+  div::grammar-error
+    {
+      background-color: yellow;
+      color: red;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  document.getElementById("test").blur();
+  /*
+  Some browsers, like Chromium 80+, will
+  transfer focus to a selected element
+  like a contenteditable div and
+  therefore style the border of
+  such element. We remove such
+  focus with the blur() method.
+  */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>PREREQUISITE: User agent needs to have an enabled and capable grammar error module. If it does not, then this test does not apply to such user agent.
+
+  <p>Test passes
+
+  <ul>
+    <li>if each glyph of the sentence is yellow
+    <li>if "thing" has a desaturated lime green background
+    <li>if the other words have a very lite blue background and
+    <li>if there is no red.
+  </ul>
+
+  <div contenteditable="true" id="test">Many thing can happen.</div>

--- a/css/css-pseudo/selection-overlay-and-grammar-001.html
+++ b/css/css-pseudo/selection-overlay-and-grammar-001.html
@@ -11,20 +11,28 @@
   <link rel="match" href="reference/selection-overlay-and-grammar-001-ref.html">
 
   <meta content="" name="flags">
-  <meta name="assert" content="In this test, the div::selection pseudo-element must be drawn over the div::grammar-error overlay. The test predicts that, since div::selection uses a semi-transparent very lite blue background layer, the resulting background color for div::grammar-error will be lime-green-ish (#7FBF80: slightly desaturated lime green).">
+  <meta name="assert" content="In this test, the div::selection pseudo-element must be drawn over the div::grammar-error overlay.">
 
   <!--
 
+  The initial version of this test was relying on color
+  composition and was predicting a lime-green-ish (#7FBF80:
+  slightly desaturated lime green) background color for "thing".
+
   "#7fbf80 color description : Slightly desaturated lime green"
   https://www.colorhexa.com/7fbf80
+
+  This test does not rely on color composition but the
+  test nevertheless verifies the ::selection overlay drawn
+  over the ::grammar-error overlay.
 
   -->
 
   <style>
   div
     {
-      float: left;
-      font-size: 300%;
+      font-size: 60px;
+      line-height: 90px;
     }
 
   div::selection

--- a/css/css-pseudo/selection-overlay-and-spelling-001.html
+++ b/css/css-pseudo/selection-overlay-and-spelling-001.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+
+ <html lang="en">
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: ::selection overlay drawn over the ::spelling-error overlay</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-painting">
+  <link rel="match" href="reference/selection-overlay-and-spelling-001-ref.html">
+
+  <meta content="" name="flags">
+  <meta name="assert" content="In this test, the div::selection pseudo-element must be drawn over the div::spelling-error overlay. The test predicts that, since div::selection uses a semi-transparent very lite blue background layer, the resulting background color for div::spelling-error will be lime-green-ish (#7FBF80: slightly desaturated lime green).">
+
+  <!--
+
+  "#7fbf80 color description : Slightly desaturated lime green"
+  https://www.colorhexa.com/7fbf80
+
+  -->
+
+  <style>
+  div
+    {
+      font-size: 300%;
+    }
+
+  div::selection
+    {
+      background-color: rgba(0%, 50%, 100%, 0.5);
+      /*
+      a very lite blue color
+      according to
+      https://www.colorhexa.com/7fbfff
+      */
+      color: yellow;
+    }
+
+  div::spelling-error
+    {
+      background-color: yellow;
+      color: red;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>PREREQUISITE: User agent needs to have an enabled and capable spelling error module. If it does not, then this test does not apply to such user agent.
+
+  <p>Test passes
+
+  <ul>
+    <li>if each glyph of "Txet sample" is yellow
+    <li>if "Txet" has a desaturated lime green background
+    <li>if " sample" has a very lite blue background and
+    <li>if there is no red.
+  </ul>
+
+  <!--
+  The bad spelling of Txet is intentional and part of this test
+  -->
+
+  <div id="test">Txet sample</div>

--- a/css/css-pseudo/selection-overlay-and-spelling-001.html
+++ b/css/css-pseudo/selection-overlay-and-spelling-001.html
@@ -11,19 +11,36 @@
   <link rel="match" href="reference/selection-overlay-and-spelling-001-ref.html">
 
   <meta content="" name="flags">
-  <meta name="assert" content="In this test, the div::selection pseudo-element must be drawn over the div::spelling-error overlay. The test predicts that, since div::selection uses a semi-transparent very lite blue background layer, the resulting background color for div::spelling-error will be lime-green-ish (#7FBF80: slightly desaturated lime green).">
+  <meta name="assert" content="In this test, the div::selection pseudo-element must be drawn over the div::spelling-error overlay.">
 
   <!--
 
+  The initial version of this test was relying on color
+  composition and was predicting a lime-green-ish (#7FBF80:
+  slightly desaturated lime green) background color for "Txet".
+
   "#7fbf80 color description : Slightly desaturated lime green"
   https://www.colorhexa.com/7fbf80
+
+  This test does not rely on color composition but the
+  test nevertheless verifies the ::selection overlay drawn
+  over the ::grammar-error overlay.
+
+  Chromium 83+'s selection highlight will vertically
+  extend to line box top and bottom... which is
+  under an eventual discussion in
+  https://github.com/w3c/csswg-drafts/issues/5395
+  One easy way to work around this issue
+  would be to set 'line-height' to '1' instead of
+  '90px'.
 
   -->
 
   <style>
   div
     {
-      font-size: 300%;
+      font-size: 60px;
+      line-height: 90px;
     }
 
   div::selection

--- a/css/css-pseudo/selection-overlay-and-spelling-001.html
+++ b/css/css-pseudo/selection-overlay-and-spelling-001.html
@@ -40,7 +40,16 @@
   div
     {
       font-size: 60px;
-      line-height: 90px;
+      line-height: 1;
+      /*
+      We deliberately set line-height to 1 in order
+      to avoid/work around a possible difference
+      of rendering of highlight overlay among browsers.
+      In Chrome 80+, the selection highlight
+      overlay will extent vertically to include line
+      box top and line box bottom. This is not
+      the case in Firefox 68+.
+      */
     }
 
   div::selection


### PR DESCRIPTION
This is a followup to
https://github.com/web-platform-tests/wpt/pull/20032#issuecomment-623866546

selection-overlay-and-spelling-001.html
selection-overlay-and-grammar-001.html
reference/selection-overlay-and-spelling-001-ref.html
reference/selection-overlay-and-grammar-001-ref.html

Latest and most relevant review comments from @fantasai about those tests were:
{
"
if you at least have a solid background on ::spelling-error underneath the semi-transparent highlight, that will at least prove the background layering, and it will distinguish it from not supporting ::spelling-error.
"
}

Those tests and references are on my website (under slightly different filenames):

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/selection-overlay-and-spelling-001-newest.html

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/selection-overlay-and-grammar-001-newest.html

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/reference/selection-overlay-and-spelling-001-ref-newest.html

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/reference/selection-overlay-and-grammar-001-ref-newest.html

**There is a 1px difference between test and reference for Firefox81 ... and I just do not know or see how to neutralize it.** 