### PR TITLE
[wptrunner] Two small fixes for python3 compatibility

### DIFF
--- a/tools/wptrunner/wptrunner/vcs.py
+++ b/tools/wptrunner/wptrunner/vcs.py
@@ -57,4 +57,4 @@ def is_git_root(path, log_error=True):
         rv = git("rev-parse", "--show-cdup", repo=path, log_error=log_error)
     except subprocess.CalledProcessError:
         return False
-    return rv == "\n"
+    return rv == b"\n"

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -101,7 +101,7 @@ class RunInfo(dict):
         except (OSError, subprocess.CalledProcessError):
             rev = None
         if rev:
-            self["revision"] = rev
+            self["revision"] = rev.decode("utf-8")
 
         self["python_version"] = sys.version_info.major
         self["product"] = product


### PR DESCRIPTION
These were discovered in https://github.com/web-platform-tests/wpt/pull/24952,
but apply equally to other platforms. There are two fixes here:

1. For `is_git_root` in vcs.py, compare bytes against bytes, rather than against string
1. Make sure the revision recorded in WPTTest is a string, not bytes

The first of these would cause us to always return None for the revision in Python 3, because `is_git_root` would always be false. After that was fixed, the latter was discovered where we would write bytes into the WPTTest information, which we would later try to dump as JSON - which fails for byte data.