### PR TITLE
Change offscreen commit to be an async test

### DIFF
--- a/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.commit.html
+++ b/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.commit.html
@@ -14,20 +14,23 @@ function verifyPlaceholder(placeholder, expectedR, expectedG, expectedB, expecte
     _assertPixel(canvas, 5,5, expectedR, expectedG, expectedB, expectedA, "5,5", expectedClrStr);
 }
 
-test(function() {
-    var placeholder = document.createElement('canvas');
-    placeholder.width = placeholder.height = 10;
-    var offscreenCanvas = placeholder.transferControlToOffscreen();
-    var ctx = offscreenCanvas.getContext('2d');
-    ctx.fillStyle = "#0f0";
-    ctx.fillRect(0, 0, 10, 10);
-    // commit() propagation is taken care of by an async task, which means the
-    // place holder contents should still be transparent black at this moment.
-    verifyPlaceholder(placeholder, 0,0,0,0, "0,0,0,0");
-    // Set timeout acts as a sync barrier to allow commit to propagate
-    setTimeout(function() {
-        verifyPlaceholder(placeholder, 0,255,0,255, "0,255,0,255");
-    }, 0);
+async_test(function(t) {
+    t.step(function() {
+        var placeholder = document.createElement('canvas');
+        placeholder.width = placeholder.height = 10;
+        var offscreenCanvas = placeholder.transferControlToOffscreen();
+        var ctx = offscreenCanvas.getContext('2d');
+        ctx.fillStyle = "#0f0";
+        ctx.fillRect(0, 0, 10, 10);
+        // commit() propagation is taken care of by an async task, which means the
+        // place holder contents should still be transparent black at this moment.
+        verifyPlaceholder(placeholder, 0,0,0,0, "0,0,0,0");
+        // Set timeout acts as a sync barrier to allow commit to propagate
+        setTimeout(t.step_func(function() {
+            verifyPlaceholder(placeholder, 0,255,0,255, "0,255,0,255");
+            t.done();
+        }), 0);
+    });
 }, "Test that calling OffscreenCanvas's commit pushes its contents to its placeholder.");
 
 test(function() {

--- a/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.commit.html
+++ b/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.commit.html
@@ -15,22 +15,20 @@ function verifyPlaceholder(placeholder, expectedR, expectedG, expectedB, expecte
 }
 
 async_test(function(t) {
-    t.step(function() {
-        var placeholder = document.createElement('canvas');
-        placeholder.width = placeholder.height = 10;
-        var offscreenCanvas = placeholder.transferControlToOffscreen();
-        var ctx = offscreenCanvas.getContext('2d');
-        ctx.fillStyle = "#0f0";
-        ctx.fillRect(0, 0, 10, 10);
-        // commit() propagation is taken care of by an async task, which means the
-        // place holder contents should still be transparent black at this moment.
-        verifyPlaceholder(placeholder, 0,0,0,0, "0,0,0,0");
-        // Set timeout acts as a sync barrier to allow commit to propagate
-        setTimeout(t.step_func(function() {
-            verifyPlaceholder(placeholder, 0,255,0,255, "0,255,0,255");
-            t.done();
-        }), 0);
-    });
+    var placeholder = document.createElement('canvas');
+    placeholder.width = placeholder.height = 10;
+    var offscreenCanvas = placeholder.transferControlToOffscreen();
+    var ctx = offscreenCanvas.getContext('2d');
+    ctx.fillStyle = "#0f0";
+    ctx.fillRect(0, 0, 10, 10);
+    // commit() propagation is taken care of by an async task, which means the
+    // place holder contents should still be transparent black at this moment.
+    verifyPlaceholder(placeholder, 0,0,0,0, "0,0,0,0");
+    // Set timeout acts as a sync barrier to allow commit to propagate
+    t.step_timeout(function() {
+        verifyPlaceholder(placeholder, 0,255,0,255, "0,255,0,255");
+        t.done();
+    }, 0);
 }, "Test that calling OffscreenCanvas's commit pushes its contents to its placeholder.");
 
 test(function() {


### PR DESCRIPTION
The first test case uses setTimeout to release the event loop and does
some asserts inside its callback. This causes the test to register as
PASS despite actually failing and logging just a console message.

Webkit bug that detected this: https://bugs.webkit.org/show_bug.cgi?id=215462