### PR TITLE
Replace os.path.split with .dirname or .basename where appropriate

### DIFF
--- a/annotation-protocol/tools/protocol-server.py
+++ b/annotation-protocol/tools/protocol-server.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 import os
 import sys
 
-here = os.path.abspath(os.path.split(__file__)[0])
+here = os.path.abspath(os.path.dirname(__file__))
 repo_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
 
 sys.path.insert(0, os.path.join(repo_root, "tools"))

--- a/css/tools/w3ctestlib/Utils.py
+++ b/css/tools/w3ctestlib/Utils.py
@@ -20,7 +20,7 @@ def assetName(path):
 def basepath(path):
   """ Returns the path part of os.path.split.
   """
-  return os.path.split(path)[0]
+  return os.path.dirname(path)
 
 def isPathInsideBase(path, base=''):
   path = os.path.normpath(path)

--- a/eventsource/resources/cors.py
+++ b/eventsource/resources/cors.py
@@ -31,6 +31,6 @@ def main(request, response):
         elif handler == b"redirect":
             return run_other(request, response, os.path.join(request.doc_root, u"common", u"redirect.py"))
         else:
-            return run_other(request, response, os.path.join(os.path.split(isomorphic_decode(__file__))[0], isomorphic_decode(handler) + u".py"))
+            return run_other(request, response, os.path.join(os.path.dirname(isomorphic_decode(__file__)), isomorphic_decode(handler) + u".py"))
     else:
         return

--- a/html/tools/update_html5lib_tests.py
+++ b/html/tools/update_html5lib_tests.py
@@ -37,7 +37,7 @@ When you are done, type "deactivate" to deactivate the virtual environment.
 TESTS_PATH = "html/syntax/parsing/"
 
 def get_paths():
-    script_path = os.path.split(os.path.abspath(__file__))[0]
+    script_path = os.path.dirname(os.path.abspath(__file__))
     repo_base = get_repo_base(script_path)
     tests_path = os.path.join(repo_base, TESTS_PATH)
     return script_path, tests_path
@@ -47,7 +47,7 @@ def get_repo_base(path):
         if os.path.exists(os.path.join(path, ".git")):
             return path
         else:
-            path = os.path.split(path)[0]
+            path = os.path.dirname(path)
 
 def get_expected(data):
     data = "#document\n" + data
@@ -100,7 +100,7 @@ def make_tests(script_dir, out_dir, input_file_name, test_data):
 
 def write_test_file(script_dir, out_dir, tests, file_name, template_file_name):
     file_name = os.path.join(out_dir, file_name + ".html")
-    short_name = os.path.split(file_name)[1]
+    short_name = os.path.basename(file_name)
 
     with open(os.path.join(script_dir, template_file_name), "r") as f:
         template = MarkupTemplate(f)
@@ -139,7 +139,7 @@ def main():
                         os.path.join("tree-construction", "scripted")))))
 
     for (scripted, test_file) in test_iterator:
-        input_file_name = os.path.splitext(os.path.split(test_file)[1])[0]
+        input_file_name = os.path.splitext(os.path.basename(test_file))[0]
         if scripted:
             input_file_name = "scripted_" + input_file_name
         test_data = support.TestData(test_file)

--- a/tools/localpaths.py
+++ b/tools/localpaths.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-here = os.path.abspath(os.path.split(__file__)[0])
+here = os.path.abspath(os.path.dirname(__file__))
 
 sys.path.insert(0, os.path.join(here))
 sys.path.insert(0, os.path.join(here, "wptserve"))

--- a/tools/wptrunner/setup.py
+++ b/tools/wptrunner/setup.py
@@ -11,7 +11,7 @@ import textwrap
 
 from setuptools import setup, find_packages
 
-here = os.path.split(__file__)[0]
+here = os.path.dirname(__file__)
 
 PACKAGE_NAME = 'wptrunner'
 PACKAGE_VERSION = '1.14'

--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -7,7 +7,7 @@ from six import iteritems
 
 from ..wptcommandline import require_arg  # noqa: F401
 
-here = os.path.split(__file__)[0]
+here = os.path.dirname(__file__)
 
 
 def inherit(super_module, child_globals, product_name):

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -30,7 +30,7 @@ from ..executors.executormarionette import (MarionetteTestharnessExecutor,  # no
 from ..process import cast_env
 
 
-here = os.path.join(os.path.split(__file__)[0])
+here = os.path.dirname(__file__)
 
 __wptrunner__ = {"product": "firefox",
                  "check_args": "check_args",

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -20,7 +20,7 @@ from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorselenium import (SeleniumTestharnessExecutor,  # noqa: F401
                                           SeleniumRefTestExecutor)  # noqa: F401
 
-here = os.path.split(__file__)[0]
+here = os.path.dirname(__file__)
 # Number of seconds to wait between polling operations when detecting status of
 # Sauce Connect sub-process.
 sc_poll_period = 1

--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -8,7 +8,7 @@ from ..executors.executorservo import (ServoCrashtestExecutor,  # noqa: F401
                                        ServoRefTestExecutor,  # noqa: F401
                                        ServoWdspecExecutor)  # noqa: F401
 
-here = os.path.join(os.path.split(__file__)[0])
+here = os.path.dirname(__file__)
 
 __wptrunner__ = {
     "product": "servo",

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -13,7 +13,7 @@ from ..executors.executorservodriver import (ServoWebDriverTestharnessExecutor, 
                                              ServoWebDriverRefTestExecutor)  # noqa: F401
 from ..process import cast_env
 
-here = os.path.join(os.path.split(__file__)[0])
+here = os.path.dirname(__file__)
 
 __wptrunner__ = {
     "product": "servodriver",

--- a/tools/wptrunner/wptrunner/config.py
+++ b/tools/wptrunner/wptrunner/config.py
@@ -3,7 +3,7 @@ import os
 import sys
 from collections import OrderedDict
 
-here = os.path.split(__file__)[0]
+here = os.path.dirname(__file__)
 
 class ConfigDict(dict):
     def __init__(self, base_path, *args, **kwargs):
@@ -19,7 +19,7 @@ class ConfigDict(dict):
 
 def read(config_path):
     config_path = os.path.abspath(config_path)
-    config_root = os.path.split(config_path)[0]
+    config_root = os.path.dirname(config_path)
     parser = SafeConfigParser()
     success = parser.read(config_path)
     assert config_path in success, success

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -11,7 +11,7 @@ from mozlog import get_default_logger, handlers, proxy
 
 from .wptlogging import LogLevelRewriter
 
-here = os.path.split(__file__)[0]
+here = os.path.dirname(__file__)
 repo_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir, os.pardir))
 
 sys.path.insert(0, repo_root)

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -16,7 +16,7 @@ from ..testrunner import Stop
 from .actions import actions
 from .protocol import Protocol, BaseProtocolPart
 
-here = os.path.split(__file__)[0]
+here = os.path.dirname(__file__)
 
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data,

--- a/tools/wptrunner/wptrunner/executors/executorchrome.py
+++ b/tools/wptrunner/wptrunner/executors/executorchrome.py
@@ -8,7 +8,7 @@ from .executorwebdriver import WebDriverProtocol, WebDriverRefTestExecutor, WebD
 from .protocol import PrintProtocolPart
 from ..webdriver_server import ChromeDriverServer
 
-here = os.path.join(os.path.split(__file__)[0])
+here = os.path.dirname(__file__)
 
 
 class ChromeDriverPrintProtocolPart(PrintProtocolPart):

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -12,7 +12,7 @@ errors = None
 marionette = None
 pytestrunner = None
 
-here = os.path.join(os.path.split(__file__)[0])
+here = os.path.dirname(__file__)
 
 from .base import (CallbackHandler,
                    CrashtestExecutor,

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -24,7 +24,7 @@ from .protocol import (BaseProtocolPart,
                        TestDriverProtocolPart)
 from ..testrunner import Stop
 
-here = os.path.join(os.path.split(__file__)[0])
+here = os.path.dirname(__file__)
 
 webdriver = None
 exceptions = None

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -16,7 +16,7 @@ from ..webdriver_server import wait_for_service
 webdriver = None
 ServoCommandExtensions = None
 
-here = os.path.join(os.path.split(__file__)[0])
+here = os.path.dirname(__file__)
 
 
 def do_delayed_imports():

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -31,7 +31,7 @@ from ..testrunner import Stop
 import webdriver as client
 from webdriver import error
 
-here = os.path.join(os.path.split(__file__)[0])
+here = os.path.dirname(__file__)
 
 
 class WebDriverCallbackHandler(CallbackHandler):

--- a/tools/wptrunner/wptrunner/font.py
+++ b/tools/wptrunner/wptrunner/font.py
@@ -6,7 +6,7 @@ import plistlib
 from shutil import copy2, rmtree
 from subprocess import call, check_output
 
-HERE = os.path.split(__file__)[0]
+HERE = os.path.dirname(__file__)
 SYSTEM = platform.system().lower()
 
 

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -320,7 +320,7 @@ def write_new_expected(metadata_path, expected):
         manifest_str = wptmanifest.serialize(expected.node,
                                              skip_empty_data=True)
         assert manifest_str != ""
-        dir = os.path.split(path)[0]
+        dir = os.path.dirname(path)
         if not os.path.exists(dir):
             os.makedirs(dir)
         tmp_path = path + ".tmp"

--- a/tools/wptrunner/wptrunner/tests/__init__.py
+++ b/tools/wptrunner/wptrunner/tests/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-here = os.path.abspath(os.path.split(__file__)[0])
+here = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(here, os.pardir, os.pardir, os.pardir))
 
 import localpaths as _localpaths  # noqa: F401

--- a/tools/wptrunner/wptrunner/update/state.py
+++ b/tools/wptrunner/wptrunner/update/state.py
@@ -1,7 +1,7 @@
 import os
 from six.moves import cPickle as pickle  # noqa: N813
 
-here = os.path.abspath(os.path.split(__file__)[0])
+here = os.path.abspath(os.path.dirname(__file__))
 
 class BaseState(object):
     def __new__(cls, logger):

--- a/tools/wptrunner/wptrunner/update/sync.py
+++ b/tools/wptrunner/wptrunner/update/sync.py
@@ -8,7 +8,7 @@ import uuid
 from .base import Step, StepRunner
 from .tree import Commit
 
-here = os.path.abspath(os.path.split(__file__)[0])
+here = os.path.abspath(os.path.dirname(__file__))
 
 
 def copy_wpt_tree(tree, dest, excludes=None, includes=None):
@@ -41,7 +41,7 @@ def copy_wpt_tree(tree, dest, excludes=None, includes=None):
         source_path = os.path.join(tree.root, tree_path)
         dest_path = os.path.join(dest, tree_path)
 
-        dest_dir = os.path.split(dest_path)[0]
+        dest_dir = os.path.dirname(dest_path)
         if not os.path.isdir(source_path):
             if not os.path.exists(dest_dir):
                 os.makedirs(dest_dir)
@@ -50,7 +50,7 @@ def copy_wpt_tree(tree, dest, excludes=None, includes=None):
     for source, destination in [("testharness_runner.html", ""),
                                 ("testdriver-vendor.js", "resources/")]:
         source_path = os.path.join(here, os.pardir, source)
-        dest_path = os.path.join(dest, destination, os.path.split(source)[1])
+        dest_path = os.path.join(dest, destination, os.path.basename(source))
         shutil.copy2(source_path, dest_path)
 
 

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -19,7 +19,7 @@ from .font import FontInstaller
 from .testrunner import ManagerGroup
 from .browsers.base import NullBrowser
 
-here = os.path.split(__file__)[0]
+here = os.path.dirname(__file__)
 
 logger = None
 

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -135,7 +135,7 @@ class RunInfo(dict):
             if path in dirs:
                 break
             dirs.add(str(path))
-            path = os.path.split(path)[0]
+            path = os.path.dirname(path)
 
         mozinfo.find_and_update_from_json(*dirs)
 

--- a/tools/wptserve/tests/functional/base.py
+++ b/tools/wptserve/tests/functional/base.py
@@ -21,7 +21,7 @@ logging.basicConfig()
 
 wptserve.logger.set_logger(logging.getLogger())
 
-here = os.path.split(__file__)[0]
+here = os.path.dirname(__file__)
 doc_root = os.path.join(here, "docroot")
 
 

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -197,7 +197,7 @@ class FileHandler(object):
             raise HTTPException(404)
 
     def get_headers(self, request, path):
-        rv = (self.load_headers(request, os.path.join(os.path.split(path)[0], "__dir__")) +
+        rv = (self.load_headers(request, os.path.join(os.path.dirname(path), "__dir__")) +
               self.load_headers(request, path))
 
         if not any(key.lower() == b"content-type" for (key, _) in rv):

--- a/xhr/resources/auth1/auth.py
+++ b/xhr/resources/auth1/auth.py
@@ -3,7 +3,7 @@ import os
 
 from wptserve.utils import isomorphic_decode
 
-here = os.path.split(os.path.abspath(isomorphic_decode(__file__)))[0]
+here = os.path.dirname(os.path.abspath(isomorphic_decode(__file__)))
 
 def main(request, response):
     auth = imp.load_source(u"", os.path.join(here,

--- a/xhr/resources/auth10/auth.py
+++ b/xhr/resources/auth10/auth.py
@@ -3,7 +3,7 @@ import os
 
 from wptserve.utils import isomorphic_decode
 
-here = os.path.split(os.path.abspath(isomorphic_decode(__file__)))[0]
+here = os.path.dirname(os.path.abspath(isomorphic_decode(__file__)))
 
 def main(request, response):
     auth = imp.load_source(u"", os.path.join(here,

--- a/xhr/resources/auth11/auth.py
+++ b/xhr/resources/auth11/auth.py
@@ -3,7 +3,7 @@ import os
 
 from wptserve.utils import isomorphic_decode
 
-here = os.path.split(os.path.abspath(isomorphic_decode(__file__)))[0]
+here = os.path.dirname(os.path.abspath(isomorphic_decode(__file__)))
 
 def main(request, response):
     auth = imp.load_source(u"", os.path.join(here,

--- a/xhr/resources/auth2/auth.py
+++ b/xhr/resources/auth2/auth.py
@@ -3,7 +3,7 @@ import os
 
 from wptserve.utils import isomorphic_decode
 
-here = os.path.split(os.path.abspath(isomorphic_decode(__file__)))[0]
+here = os.path.dirname(os.path.abspath(isomorphic_decode(__file__)))
 
 def main(request, response):
     auth = imp.load_source(u"", os.path.join(here,

--- a/xhr/resources/auth3/auth.py
+++ b/xhr/resources/auth3/auth.py
@@ -3,7 +3,7 @@ import os
 
 from wptserve.utils import isomorphic_decode
 
-here = os.path.split(os.path.abspath(isomorphic_decode(__file__)))[0]
+here = os.path.dirname(os.path.abspath(isomorphic_decode(__file__)))
 
 def main(request, response):
     auth = imp.load_source(u"", os.path.join(here,

--- a/xhr/resources/auth4/auth.py
+++ b/xhr/resources/auth4/auth.py
@@ -3,7 +3,7 @@ import os
 
 from wptserve.utils import isomorphic_decode
 
-here = os.path.split(os.path.abspath(isomorphic_decode(__file__)))[0]
+here = os.path.dirname(os.path.abspath(isomorphic_decode(__file__)))
 
 def main(request, response):
     auth = imp.load_source(u"", os.path.join(here,

--- a/xhr/resources/auth9/auth.py
+++ b/xhr/resources/auth9/auth.py
@@ -3,7 +3,7 @@ import os
 
 from wptserve.utils import isomorphic_decode
 
-here = os.path.split(os.path.abspath(isomorphic_decode(__file__)))[0]
+here = os.path.dirname(os.path.abspath(isomorphic_decode(__file__)))
 
 def main(request, response):
     auth = imp.load_source(u"", os.path.join(here,


### PR DESCRIPTION
Most of the changes made by:

> git grep -lF os.path.split | xargs sed -i '' 's/os\.path\.split(\(.*\))\[0\]/os.path.dirname(\1)/g'

That gets some things wrong, so all changes were vetted and some fixed
or simplified.