### PR TITLE
Fix test cases intended for special URLs

### DIFF
--- a/url/resources/setters_tests.json
+++ b/url/resources/setters_tests.json
@@ -119,11 +119,11 @@
             }
         },
         {
-            "href": "gopher://example.net:1234",
+            "href": "https://example.net:1234",
             "new_value": "file",
             "expected": {
-                "href": "gopher://example.net:1234",
-                "protocol": "gopher:"
+                "href": "https://example.net:1234/",
+                "protocol": "https:"
             }
         },
         {
@@ -145,7 +145,7 @@
         },
         {
             "href": "file:///test",
-            "new_value": "gopher",
+            "new_value": "https",
             "expected": {
                 "href": "file:///test",
                 "protocol": "file:"


### PR DESCRIPTION
Test cases in the setters_tests.json file below comment "Can’t switch
from URL containing username/password/port to file" are intended for
special URLs. But there are two test cases with "gopher" scheme, which
is not special anymore.

Fix these test cases by changing "gopher" to special scheme "https".

Note. Test cases for non-special URLs are below comments "Can’t switch
from special scheme to non-special" and "Can’t switch from non-special
scheme to special".

See: https://url.spec.whatwg.org/#scheme-state