### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=215539

### DIFF
--- a/streams/writable-streams/bad-underlying-sinks.any.js
+++ b/streams/writable-streams/bad-underlying-sinks.any.js
@@ -159,6 +159,24 @@ promise_test(t => {
 
 test(() => {
   assert_throws_js(TypeError, () => new WritableStream({
+    start: 'test'
+  }), 'constructor should throw');
+}, 'start: non-function start method');
+
+test(() => {
+  assert_throws_js(TypeError, () => new WritableStream({
+    write: 'test'
+  }), 'constructor should throw');
+}, 'write: non-function write method');
+
+test(() => {
+  assert_throws_js(TypeError, () => new WritableStream({
+    close: 'test'
+  }), 'constructor should throw');
+}, 'close: non-function close method');
+
+test(() => {
+  assert_throws_js(TypeError, () => new WritableStream({
     abort: { apply() {} }
   }), 'constructor should throw');
 }, 'abort: non-function abort method with .apply');


### PR DESCRIPTION
WebKit export from bug: [Check WritableStream underlyingSink methods](https://bugs.webkit.org/show_bug.cgi?id=215539)