### PR TITLE
Update customElements.whenDefined().then to resolve with class

### DIFF
--- a/custom-elements/CustomElementRegistry.html
+++ b/custom-elements/CustomElementRegistry.html
@@ -716,7 +716,7 @@ promise_test(function () {
         assert_false('resolved' in promise, 'The promise returned by "whenDefined" must not be resolved until the end of the next microtask');
         assert_false('rejected' in promise, 'The promise returned by "whenDefined" must not be rejected until the end of the next microtask');
 
-        promiseAfterDefine = customElements.whenDefined('element-defined-after-whendefined', ElementDefinedAfterWhenDefined);
+        promiseAfterDefine = customElements.whenDefined('element-defined-after-whendefined');
         promiseAfterDefine.then(function (value) { promiseAfterDefine.resolved = value; }, function (value) { promiseAfterDefine.rejected = value; });
         assert_not_equals(promiseAfterDefine, promise, '"whenDefined" must return a resolved promise once the custom element is defined');
         assert_false('resolved' in promiseAfterDefine, 'The promise returned by "whenDefined" must not be resolved until the end of the next microtask');

--- a/custom-elements/CustomElementRegistry.html
+++ b/custom-elements/CustomElementRegistry.html
@@ -655,7 +655,8 @@ promise_test(function () {
 }, 'customElements.whenDefined must return a rejected promise when the given name is not a valid custom element name');
 
 promise_test(function () {
-    customElements.define('preexisting-custom-element', class extends HTMLElement { });
+    class PreexistingCustomElement extends HTMLElement { };
+    customElements.define('preexisting-custom-element', PreexistingCustomElement);
 
     var promise = customElements.whenDefined('preexisting-custom-element');
     promise.then(function (value) { promise.resolved = value; }, function (value) { promise.rejected = value; });
@@ -665,8 +666,8 @@ promise_test(function () {
 
     return Promise.resolve().then(function () {
         assert_true('resolved' in promise, 'The promise returned by "whenDefined" must be resolved when a custom element is defined');
-        assert_equals(promise.resolved, undefined,
-            'The promise returned by "whenDefined" must be resolved with "undefined" when a custom element is defined');
+        assert_equals(promise.resolved, PreexistingCustomElement,
+            'The promise returned by "whenDefined" must be resolved with the constructor of the element when a custom element is defined');
         assert_false('rejected' in promise, 'The promise returned by "whenDefined" must not be rejected when a custom element is defined');
     });
 }, 'customElements.whenDefined must return a resolved promise when the registry contains the entry with the given name');
@@ -688,16 +689,17 @@ promise_test(function () {
 
     return Promise.resolve().then(function () {
         assert_true('resolved' in promise1, 'The promise returned by "whenDefined" must be resolved when a custom element is defined');
-        assert_equals(promise1.resolved, undefined, 'The promise returned by "whenDefined" must be resolved with "undefined" when a custom element is defined');
+        assert_equals(promise1.resolved, AnotherExistingCustomElement, 'The promise returned by "whenDefined" must be resolved with the constructor of the element when a custom element is defined');
         assert_false('rejected' in promise1, 'The promise returned by "whenDefined" must not be rejected when a custom element is defined');
 
         assert_true('resolved' in promise2, 'The promise returned by "whenDefined" must be resolved when a custom element is defined');
-        assert_equals(promise2.resolved, undefined, 'The promise returned by "whenDefined" must be resolved with "undefined" when a custom element is defined');
+        assert_equals(promise2.resolved, AnotherExistingCustomElement, 'The promise returned by "whenDefined" must be resolved with the constructor of the element when a custom element is defined');
         assert_false('rejected' in promise2, 'The promise returned by "whenDefined" must not be rejected when a custom element is defined');
     });
 }, 'customElements.whenDefined must return a new resolved promise each time invoked when the registry contains the entry with the given name');
 
 promise_test(function () {
+    class ElementDefinedAfterWhenDefined extends HTMLElement { };
     var promise = customElements.whenDefined('element-defined-after-whendefined');
     promise.then(function (value) { promise.resolved = value; }, function (value) { promise.rejected = value; });
 
@@ -710,24 +712,24 @@ promise_test(function () {
         assert_false('rejected' in promise, 'The promise returned by "whenDefined" must not be rejected until the element is defined');
         assert_equals(customElements.whenDefined('element-defined-after-whendefined'), promise,
             '"whenDefined" must return the same unresolved promise before the custom element is defined');
-        customElements.define('element-defined-after-whendefined', class extends HTMLElement { });
+        customElements.define('element-defined-after-whendefined', ElementDefinedAfterWhenDefined);
         assert_false('resolved' in promise, 'The promise returned by "whenDefined" must not be resolved until the end of the next microtask');
         assert_false('rejected' in promise, 'The promise returned by "whenDefined" must not be rejected until the end of the next microtask');
 
-        promiseAfterDefine = customElements.whenDefined('element-defined-after-whendefined');
+        promiseAfterDefine = customElements.whenDefined('element-defined-after-whendefined', ElementDefinedAfterWhenDefined);
         promiseAfterDefine.then(function (value) { promiseAfterDefine.resolved = value; }, function (value) { promiseAfterDefine.rejected = value; });
         assert_not_equals(promiseAfterDefine, promise, '"whenDefined" must return a resolved promise once the custom element is defined');
         assert_false('resolved' in promiseAfterDefine, 'The promise returned by "whenDefined" must not be resolved until the end of the next microtask');
         assert_false('rejected' in promiseAfterDefine, 'The promise returned by "whenDefined" must not be rejected until the end of the next microtask');
     }).then(function () {
         assert_true('resolved' in promise, 'The promise returned by "whenDefined" must be resolved when a custom element is defined');
-        assert_equals(promise.resolved, undefined,
-            'The promise returned by "whenDefined" must be resolved with "undefined" when a custom element is defined');
+        assert_equals(promise.resolved, ElementDefinedAfterWhenDefined,
+            'The promise returned by "whenDefined" must be resolved with the constructor of the element when a custom element is defined');
         assert_false('rejected' in promise, 'The promise returned by "whenDefined" must not be rejected when a custom element is defined');
 
         assert_true('resolved' in promiseAfterDefine, 'The promise returned by "whenDefined" must be resolved when a custom element is defined');
-        assert_equals(promiseAfterDefine.resolved, undefined,
-            'The promise returned by "whenDefined" must be resolved with "undefined" when a custom element is defined');
+        assert_equals(promiseAfterDefine.resolved, ElementDefinedAfterWhenDefined,
+            'The promise returned by "whenDefined" must be resolved with the constructor of the element when a custom element is defined');
         assert_false('rejected' in promiseAfterDefine, 'The promise returned by "whenDefined" must not be rejected when a custom element is defined');
     });
 }, 'A promise returned by customElements.whenDefined must be resolved by "define"');


### PR DESCRIPTION
As per discussion on whatwg/html#5552, the currently specified behavior is to resolve with undefined, which requires an extra
step if the user want to extend the custom element by calling customElements.get() to get the element constructor first.

These updated tests will go along with a PR to whatwg/html to update the specification from "resolved with undefined"
to "resolved with such entry"

Adding a few links as @WebReflection was able to push his changes today:

* whatwg/html#5833 covers the HTML spec changes
* This PR and #25033 are similar and should probably merge somehow - this one updates existing test while the other introduce a new dedicated one