### PR TITLE
Fix some simple cases of async_test(async ...)

### DIFF
--- a/content-security-policy/frame-src/frame-src-same-document-meta.sub.html
+++ b/content-security-policy/frame-src/frame-src-same-document-meta.sub.html
@@ -3,7 +3,7 @@
 <html>
 <body></body>
 <script>
-    async_test(async test => {
+    promise_test(async test => {
       // 1. Load an iframe (not blocked).
       let iframe = document.createElement("iframe");
       {
@@ -47,8 +47,6 @@
       // 5. Regression test for https://crbug.com/1018385. The browser should
       // not crash while displaying the error page.
       await new Promise(resolve => window.setTimeout(resolve, 1000));
-
-      test.done();
     }, "Same-document navigations in an iframe blocked by CSP frame-src dynamically using the <meta> tag");
 </script>
 </html>

--- a/content-security-policy/frame-src/frame-src-same-document.sub.html
+++ b/content-security-policy/frame-src/frame-src-same-document.sub.html
@@ -6,8 +6,7 @@
     let crossOriginUrl =
       "http://www1.{{host}}:{{ports[http][0]}}/content-security-policy/support/frame.html";
 
-    async_test(async test => {
-      test.done();
+    promise_test(async test => {
       let iframe = document.createElement("iframe");
       document.body.appendChild(iframe);
 
@@ -18,8 +17,6 @@
         iframe.src = crossOriginUrl + hash;
         await violation;
       }
-
-      test.done();
     }, "Same-document navigation in an iframe blocked by CSP frame-src");
 </script>
 </html>

--- a/content-security-policy/frame-src/frame-src-same-document.sub.html
+++ b/content-security-policy/frame-src/frame-src-same-document.sub.html
@@ -4,7 +4,7 @@
 <body></body>
 <script>
     let crossOriginUrl =
-      "http://www1.{{host}}:{{ports[http][0]}}/content-security-policy/support/frame.html";
+      "http://www1.{{host}}:{{ports[http][0]}}/content-security-policy/frame-src/support/frame.html";
 
     promise_test(async test => {
       let iframe = document.createElement("iframe");

--- a/css/selectors/focus-visible-007.html
+++ b/css/selectors/focus-visible-007.html
@@ -57,7 +57,7 @@
       document.body.dataset.hadmousedown = "";
     }, true);
 
-    async_test(async function(t) {
+    async_test(function(t) {
       let tested_modality_change = false;
       let tested_modality_unchanged_by_mouse_click = false;
       let tested_mouse_focus_after_modality_change = false;

--- a/css/selectors/focus-visible-011.html
+++ b/css/selectors/focus-visible-011.html
@@ -41,7 +41,7 @@
       next.focus();
     });
 
-    async_test(async function(t) {
+    async_test(function(t) {
       next.addEventListener("focus", t.step_func(() => {
         assert_equals(getComputedStyle(next).outlineColor, "rgb(0, 100, 0)");
         t.done()

--- a/navigation-timing/nav2_test_navigate_iframe.html
+++ b/navigation-timing/nav2_test_navigate_iframe.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <script>
-async_test(async function (t) {
+promise_test(async function (t) {
   var ifr = document.createElement("iframe");
   document.body.appendChild(ifr);
 
@@ -34,8 +34,6 @@ async_test(async function (t) {
       resolve();
     }
   });
-
-  t.done();
 }, "navigation.name updated when iframe URL changes");
     </script>
   </body>

--- a/navigation-timing/test_document_onload.html
+++ b/navigation-timing/test_document_onload.html
@@ -17,7 +17,7 @@
         <div id="log"></div>
 
         <script>
-            async_test(async function (t) {
+            async_test(function (t) {
                 document.addEventListener("DOMContentLoaded", t.step_func_done(() => {
                     let entry = window.performance.getEntriesByType("navigation")[0];
                     assert_greater_than(entry.transferSize, 1000, "descr");
@@ -26,13 +26,13 @@
                 }));
             }, "Test that the attributes have a proper value during DOMContentLoaded");
 
-            async_test(async function (t) {
+            async_test(function (t) {
                 window.addEventListener("load", t.step_func_done(() => {
                     let entry = window.performance.getEntriesByType("navigation")[0];
                     assert_greater_than(entry.transferSize, 1000, "descr");
                     assert_greater_than(entry.encodedBodySize, 1000, "descr");
                     assert_greater_than(entry.decodedBodySize, 1000, "descr");
-                    async_test(async function (t) {
+                    async_test(function (t) {
                         setTimeout(t.step_func_done(() => {
                           let entry = window.performance.getEntriesByType("navigation")[0];
                           assert_greater_than(entry.transferSize, 1000, "descr");

--- a/resource-timing/resource_nested_dedicated_worker.worker.js
+++ b/resource-timing/resource_nested_dedicated_worker.worker.js
@@ -1,6 +1,6 @@
 importScripts("/resources/testharness.js");
 
-async_test(async function() {
+async_test(function() {
   const worker = new Worker('resources/worker_with_images.js');
   worker.onmessage = this.step_func_done((event) => {
     const childNumEntries = event.data;


### PR DESCRIPTION
These cases can all either be trivially converted to promise tests, or
never needed an async function in the first place.

See https://github.com/web-platform-tests/wpt/issues/21435