### PR TITLE
Make table-model-fixup-2 wait for load

### DIFF
--- a/css/css-tables/table-model-fixup-2.html
+++ b/css/css-tables/table-model-fixup-2.html
@@ -19,39 +19,28 @@
     div input { width: 100px; }
 </style>
 <script>
-    function assertEqualOffsetWidths(a,b) {
-        var desc = document.querySelector('main > hr:last-of-type + p + p') || document.querySelectorAll('main > hr + p + p')[document.querySelectorAll('main > hr + p + p').length-1];
-        var root = document.querySelector('main > div:last-of-type') || document.querySelectorAll('main > div')[document.querySelectorAll('main > div').length-1];
-        generate_tests(assert_equals, [
-            [
-                desc.textContent,
-                root.querySelector("[target="+a+"]").offsetWidth,
-                root.querySelector("[target="+b+"]").offsetWidth
-            ]
-        ]);
-    }
-    function assertEqualOffsetTops(a,b) {
-        var desc = document.querySelector('main > hr:last-of-type + p + p') || document.querySelectorAll('main > hr + p + p')[document.querySelectorAll('main > hr + p + p').length-1];
-        var root = document.querySelector('main > div:last-of-type') || document.querySelectorAll('main > div')[document.querySelectorAll('main > div').length-1];
-        generate_tests(assert_equals, [
-            [
-                desc.textContent,
-                root.querySelector("[target="+a+"]").getBoundingClientRect().top|0,
-                root.querySelector("[target="+b+"]").getBoundingClientRect().top|0
-            ]
-        ]);
-    }
-    function assertUnequalOffsetTops(a,b) {
-        var desc = document.querySelector('main > hr:last-of-type + p + p') || document.querySelectorAll('main > hr + p + p')[document.querySelectorAll('main > hr + p + p').length-1];
-        var root = document.querySelector('main > div:last-of-type') || document.querySelectorAll('main > div')[document.querySelectorAll('main > div').length-1];
-        generate_tests(assert_not_equals, [
-            [
-                desc.textContent,
-                root.querySelector("[target="+a+"]").getBoundingClientRect().top|0,
-                root.querySelector("[target="+b+"]").getBoundingClientRect().top|0
-            ]
-        ]);
-    }
+    window.addEventListener("DOMContentLoaded", function(){
+        var tests = document.getElementsByTagName("hr");
+        for (var i = 0; i < tests.length; i++) {
+            (function(){
+                var desc = tests[i].nextElementSibling.nextElementSibling;
+                var root = desc.nextElementSibling;
+                var t = async_test(desc.textContent);
+                window.addEventListener("load", t.step_func_done(function() {
+                    var a = root.querySelector("[target=a]");
+                    var b = root.querySelector("[target=b]");
+                    var offset = root.getAttribute("offset");
+                    var a_offset = a.getBoundingClientRect()[offset];
+                    var b_offset = b.getBoundingClientRect()[offset];
+                    if (root.hasAttribute("unequal")) {
+                        assert_not_equals(b_offset, a_offset);
+                    } else {
+                        assert_equals(b_offset, a_offset);
+                    }
+                }));
+            })();
+        }
+    });
 </script>
 
 <main>
@@ -62,403 +51,253 @@
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both input fields should look identical, on their own line:</p>
     <p>Replaced elements inside a table cannot be <mark>table-row</mark> and are considered <mark>block</mark> -- input elements</p>
-    <div>
+    <div offset=width>
         <x-table style="width: 400px">
             <x-tr><x-td><input block target=a /></x-tr>
             <input table-row target=b />
         </x-table>
     </div>
-    <script>
-
-        assertEqualOffsetWidths('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both images should look identical, on their own line:</p>
     <p>Replaced elements inside a table cannot be <mark>table-row</mark> and are considered <mark>block</mark> -- img elements</p>
-    <div>
+    <div offset=width>
         <x-table style="width: 400px">
             <x-tr><x-td><img block src="../support/blue32x32.ico" target=a /></x-tr>
             <img src="../support/blue32x32.ico" table-row target=b />
         </x-table>
     </div>
-    <script>
-
-        assertEqualOffsetWidths('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both input fields should look identical, on their own line:</p>
     <p>Replaced elements inside a table cannot be <mark>table-column</mark> and are considered <mark>inline</mark> -- input elements</p>
-    <div>
+    <div offset=width>
         <x-table style="width: 400px">
             <x-tr><x-td><input inline target=a /></x-tr>
             <input table-column target=b />
         </x-table>
     </div>
-    <script>
-
-        assertEqualOffsetWidths('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both images should look identical, on their own line:</p>
     <p>Replaced elements inside a table cannot be <mark>table-column</mark> and are considered <mark>inline</mark> -- img elements</p>
-    <div>
+    <div offset=width>
         <x-table style="width: 400px">
             <x-tr><x-td><img inline src="../support/blue32x32.ico" target=a /></x-tr>
             <img src="../support/blue32x32.ico" table-column target=b />
         </x-table>
     </div>
-    <script>
-
-        assertEqualOffsetWidths('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both input fields should look identical, on their own line:</p>
     <p>Replaced elements inside a table cannot be <mark>table-cell</mark> and are considered <mark>inline</mark> -- input elements</p>
-    <div>
+    <div offset=width>
         <x-table style="width: 400px">
             <x-tr><x-td><input inline target=a /></x-tr>
             <x-tr><input table-cell target=b /></x-tr>
         </x-table>
     </div>
-    <script>
-
-        assertEqualOffsetWidths('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both images should look identical, on their own line:</p>
     <p>Replaced elements inside a table cannot be <mark>table-cell</mark> and are considered <mark>inline</mark> -- img elements</p>
-    <div>
+    <div offset=width>
         <x-table style="width: 400px">
             <x-tr><x-td><img inline src="../support/blue32x32.ico" target=a /></x-tr>
             <x-tr><img src="../support/blue32x32.ico" table-cell target=b /></x-tr>
         </x-table>
     </div>
-    <script>
-
-        assertEqualOffsetWidths('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both text inputs should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>inline-table</mark> and are <mark>considered</mark> inline -- input=text elements</p>
-    <div>
+    <div offset=top>
         <input inline-table target=a />
         <input inline-table target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both button inputs should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>inline-table</mark> and are considered <mark>inline</mark> -- input=button elements</p>
-    <div>
+    <div offset=top>
         <input type=button inline-table target=a />
         <input type=button inline-table target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both file inputs should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>inline-table</mark> and are considered <mark>inline</mark> -- input=file elements</p>
-    <div>
+    <div offset=top>
         <input type=file inline-table target=a />
         <input type=file inline-table target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both images should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>inline-table</mark> and are considered <mark>inline</mark> -- img elements</p>
-    <div>
+    <div offset=top>
         <img src="../support/blue32x32.ico" inline-table target=a />
         <img src="../support/blue32x32.ico" inline-table target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both text inputs should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table</mark> and are considered <mark>block</mark> -- input=text elements</p>
-    <div>
+    <div offset=top unequal>
         <input type=text table target=a />
         <input type=text table target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both button inputs should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table</mark> and are considered <mark>block</mark> -- input=button elements</p>
-    <div>
+    <div offset=top unequal>
         <input type=button table target=a />
         <input type=button table target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both file inputs should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table</mark> and are considered <mark>block</mark> -- input=file elements</p>
-    <div>
+    <div offset=top unequal>
         <input type=file table target=a />
         <input type=file table target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both images should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table</mark> and are considered <mark>block</mark> -- img elements</p>
-    <div>
+    <div offset=top unequal>
         <img src="../support/blue32x32.ico" table target=a />
         <img src="../support/blue32x32.ico" table target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both text inputs should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-row</mark> and are considered <mark>block</mark> -- input=text elements</p>
-    <div>
+    <div offset=top unequal>
         <input type=text table-row target=a />
         <input type=text table-row target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both button inputs should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-row</mark> and are considered <mark>block</mark> -- input=button elements</p>
-    <div>
+    <div offset=top unequal>
         <input type=button table-row target=a />
         <input type=button table-row target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both file inputs should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-row</mark> and are considered <mark>block</mark> -- input=file elements</p>
-    <div>
+    <div offset=top unequal>
         <input type=file table-row target=a />
         <input type=file table-row target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both images should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-row</mark> and are considered <mark>block</mark> -- img elements</p>
-    <div>
+    <div offset=top unequal>
         <img src="../support/blue32x32.ico" table-row target=a />
         <img src="../support/blue32x32.ico" table-row target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both text inputs should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-row-group</mark> and are considered <mark>block</mark> -- input=text elements</p>
-    <div>
+    <div offset=top unequal>
         <input type=text table-row-group target=a />
         <input type=text table-row-group target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both button inputs should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-row-group</mark> and are considered <mark>block</mark> -- input=button elements</p>
-    <div>
+    <div offset=top unequal>
         <input type=button table-row-group target=a />
         <input type=button table-row-group target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both file inputs should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-row-group</mark> and are considered <mark>block</mark> -- input=file elements</p>
-    <div>
+    <div offset=top unequal>
         <input type=file table-row-group target=a />
         <input type=file table-row-group target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both images should stand on their own line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-row-group</mark> and are considered <mark>block</mark> -- img elements</p>
-    <div>
+    <div offset=top unequal>
         <img src="../support/blue32x32.ico" table-row-group target=a />
         <img src="../support/blue32x32.ico" table-row-group target=b />
     </div>
-    <script>
-
-        assertUnequalOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both text inputs should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-column</mark> and are <mark>considered</mark> inline -- input=text elements</p>
-    <div>
+    <div offset=top>
         <input table-column target=a />
         <input table-column target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both button inputs should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-column</mark> and are considered <mark>inline</mark> -- input=button elements</p>
-    <div>
+    <div offset=top>
         <input type=button table-column target=a />
         <input type=button table-column target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both file inputs should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-column</mark> and are considered <mark>inline</mark> -- input=file elements</p>
-    <div>
+    <div offset=top>
         <input type=file table-column target=a />
         <input type=file table-column target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both images should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-column</mark> and are considered <mark>inline</mark> -- img elements</p>
-    <div>
+    <div offset=top>
         <img src="../support/blue32x32.ico" table-column target=a />
         <img src="../support/blue32x32.ico" table-column target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both text inputs should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-cell</mark> and are <mark>considered</mark> inline -- input=text elements</p>
-    <div>
+    <div offset=top>
         <input table-cell target=a />
         <input table-cell target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both button inputs should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-cell</mark> and are considered <mark>inline</mark> -- input=button elements</p>
-    <div>
+    <div offset=top>
         <input type=button table-cell target=a />
         <input type=button table-cell target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both file inputs should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-cell</mark> and are considered <mark>inline</mark> -- input=file elements</p>
-    <div>
+    <div offset=top>
         <input type=file table-cell target=a />
         <input type=file table-cell target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
     <hr/><!------------------------------------------------------------------------------------------------------------>
     <p>Both images should share the same line:</p>
     <p>Replaced elements outside a table cannot be <mark>table-cell</mark> and are considered <mark>inline</mark> -- img elements</p>
-    <div>
+    <div offset=top>
         <img src="../support/blue32x32.ico" table-cell target=a />
         <img src="../support/blue32x32.ico" table-cell target=b />
     </div>
-    <script>
-
-        assertEqualOffsetTops('a','b');
-
-    </script>
 
 </main>


### PR DESCRIPTION
This was previously flaky, especially in Safari. This flakiness came from the race between the images loading and the tests running.