### PR TITLE
[wptrunner] Skip h2 tests if h2 is not enabled

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -208,6 +208,7 @@ class TestLoader(object):
                  total_chunks=1,
                  chunk_number=1,
                  include_https=True,
+                 include_h2=True,
                  include_quic=False,
                  skip_timeout=False,
                  skip_implementation_status=None,
@@ -222,6 +223,7 @@ class TestLoader(object):
         self.tests = None
         self.disabled_tests = None
         self.include_https = include_https
+        self.include_h2 = include_h2
         self.include_quic = include_quic
         self.skip_timeout = skip_timeout
         self.skip_implementation_status = skip_implementation_status
@@ -308,6 +310,8 @@ class TestLoader(object):
         for test_path, test_type, test in self.iter_tests():
             enabled = not test.disabled()
             if not self.include_https and test.environment["protocol"] == "https":
+                enabled = False
+            if not self.include_h2 and test.environment["protocol"] == "h2":
                 enabled = False
             if not self.include_quic and test.environment["quic"]:
                 enabled = False

--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -30,19 +30,11 @@ def test_loader_h2_tests():
                 "a": {
                     "foo.html": [
                         "abcdef123456",
-                        # TODO: This isn't what MANIFEST.json looks like. It
-                        # has 'null' here rather than the full HTML. But if
-                        # this manifest is loaded by load_json, it ultimately
-                        # ends up in the URLManifestItem __init__ with a url
-                        # value of the string 'null'. This then gets saved in
-                        # _url, and in the url @property we end up with rel_url
-                        # == 'null', return '/null' (rather than fall back to
-                        # the path).
-                        ["a/foo.html", {}],
+                        None,
                     ],
                     "bar.h2.html": [
                         "uvwxyz987654",
-                        ["a/bar.h2.html", {}],
+                        None,
                     ],
                 }
             }

--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -30,11 +30,11 @@ def test_loader_h2_tests():
                 "a": {
                     "foo.html": [
                         "abcdef123456",
-                        None,
+                        [None, {}],
                     ],
                     "bar.h2.html": [
                         "uvwxyz987654",
-                        None,
+                        [None, {}],
                     ],
                 }
             }

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -5,6 +5,7 @@ import os
 import sys
 from six import iteritems, itervalues
 
+import wptserve
 from wptserve import sslutils
 
 from . import environment as env
@@ -75,6 +76,7 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, chunker_kw
                                                       explicit=kwargs["default_exclude"]))
 
     ssl_enabled = sslutils.get_cls(kwargs["ssl_type"]).ssl_enabled
+    h2_enabled = wptserve.utils.http2_compatible()
     test_loader = testloader.TestLoader(test_manifests,
                                         kwargs["test_types"],
                                         run_info,
@@ -83,6 +85,7 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, chunker_kw
                                         total_chunks=kwargs["total_chunks"],
                                         chunk_number=kwargs["this_chunk"],
                                         include_https=ssl_enabled,
+                                        include_h2=h2_enabled,
                                         include_quic=kwargs["enable_quic"],
                                         skip_timeout=kwargs["skip_timeout"],
                                         skip_implementation_status=kwargs["skip_implementation_status"],


### PR DESCRIPTION
Previously we would try to run h2 tests even if the h2 server was not
enabled. This would lead to marionette crashing when it tried to load a
URL that wouldn't respond.

Fixes https://github.com/web-platform-tests/wpt/issues/25012