### PR TITLE
Update Safari Technology Preview to 112

### DIFF
--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,33 +1,33 @@
-cask 'safari-technology-preview' do
+cask "safari-technology-preview" do
   if MacOS.version <= :catalina
-    version '111,001-32177-20200728-f459b529-99a7-4707-a85c-e693ddb56eee'
-    sha256 'f95f72e8cf6a3160fad71411168c8f0eeb805ca1e7a7eec06b6e92d2a0ab6e85'
+    version "112,001-36858-20200817-24aabed5-4c89-4ed0-a1d9-2a50a6b99771"
+    sha256 "bcf47d0671913cc4e2122a6b54618b620e8c5751c71873e94d2516da065b769e"
   else
-    version '111,001-32479-20200728-12c458d1-e348-4ec5-9d55-9e9bad9c805e'
-    sha256 '6b199cca77be7407f40a62bc1ec576a8751b24da15613dfc0a951ac3d996f45f'
+    version "112,001-37237-20200817-e8f512a3-4939-46ec-9404-6e673db90ab0"
+    sha256 "7729e983a498f45b00bf2e0938085e8b97732b05fb98041960c7ced14082562e"
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-  appcast 'https://developer.apple.com/safari/download/'
-  name 'Safari Technology Preview'
-  homepage 'https://developer.apple.com/safari/download/'
+  appcast "https://developer.apple.com/safari/download/"
+  name "Safari Technology Preview"
+  homepage "https://developer.apple.com/safari/download/"
 
   auto_updates true
-  depends_on macos: '>= :catalina'
+  depends_on macos: ">= :catalina"
 
-  pkg 'Safari Technology Preview.pkg'
+  pkg "Safari Technology Preview.pkg"
 
-  uninstall delete: '/Applications/Safari Technology Preview.app'
+  uninstall delete: "/Applications/Safari Technology Preview.app"
 
   zap trash: [
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.apple.safaritechnologypreview.sfl*',
-               '~/Library/Caches/com.apple.SafariTechnologyPreview',
-               '~/Library/Preferences/com.apple.SafariTechnologyPreview.plist',
-               '~/Library/SafariTechnologyPreview',
-               '~/Library/Saved Application State/com.apple.SafariTechnologyPreview.savedState',
-               '~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview-com.apple.Safari.UserRequests.plist',
-               '~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview-com.apple.Safari.WebFeedSubscriptions.plist',
-               '~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview.plist',
-               '~/Library/WebKit/com.apple.SafariTechnologyPreview',
-             ]
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.apple.safaritechnologypreview.sfl*",
+    "~/Library/Caches/com.apple.SafariTechnologyPreview",
+    "~/Library/Preferences/com.apple.SafariTechnologyPreview.plist",
+    "~/Library/SafariTechnologyPreview",
+    "~/Library/Saved Application State/com.apple.SafariTechnologyPreview.savedState",
+    "~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview-com.apple.Safari.UserRequests.plist",
+    "~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview-com.apple.Safari.WebFeedSubscriptions.plist",
+    "~/Library/SyncedPreferences/com.apple.SafariTechnologyPreview.plist",
+    "~/Library/WebKit/com.apple.SafariTechnologyPreview",
+  ]
 end


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 112, 15610.1.25.5.1)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=2078&view=logs