### PR TITLE
[Taskcluster] Switch to repeat-only for stability checks

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -317,6 +317,8 @@ tasks:
               --channel=${vars.channel}
               --verify
               --verify-no-chaos-mode
+              --verify-repeat-loop=0
+              --verify-repeat-restart=10
               --github-checks-text-file="/home/test/artifacts/checkrun.md"
 
         - wpt-${vars.browser}-${vars.channel}-results:


### PR DESCRIPTION
We frequently hear from test authors that they find it frustrating when
the stability checks turn up failures that they cannot reproduce. One
common case comes from the fact that stability checks run the same test
repeatedly without restarting the browser (the AAABBBCCC behavior). This
is unlike any other way we run tests, and can cause some tests to
consistently appear flaky due to global state (e.g.  the
origin-isolation/ tests).

To fix this, switch the stability checks to only use 'repeat-restart'
flake detection (previously we used both 'repeat-loop' and
'repeat-restart'). This mode run the tests in entire sets, then restarts
the browser and runs them again, aka ABC[restart]ABC[restart]ABC. The
hope is that we will not lose too much flake coverage, but will reduce
the amount of non-addressable flake that is reported.

This also makes it more feasible to implement a timeout-avoiding
mechanism for the stability checks; see
https://docs.google.com/document/d/1dAlCSHUQldtgWDDTrGJR-ksm19FZZ3k8ppqc5-kSwIk/edit#