### PR TITLE
Coop header parsing null byte

### DIFF
--- a/html/cross-origin-opener-policy/header-parsing.https.html
+++ b/html/cross-origin-opener-policy/header-parsing.https.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<meta charset=utf-8>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/common.js"></script>
+
+<div id=log></div>
+<script>
+
+let tests = [
+  // popup Origin, popup COOP, expect opener
+
+  // None of the following should be recognized as "same-origin" (hence the
+  // "expected opener" value of `true`).
+  [SAME_ORIGIN, "same\u2014origin;", true], // non-ASCII character (em dash)
+  [SAME_ORIGIN, "same-origin;", true],
+  [SAME_ORIGIN, "same-origin\0", true],
+  [SAME_ORIGIN, "\u000bsame-origin\u000b", true], // vertical tab
+  [SAME_ORIGIN, "\u000csame-origin\u000c", true], // form feed
+  [SAME_ORIGIN, "\u000dsame-origin\u000d", true], // carriage return
+  [SAME_ORIGIN, "Same-origin", true],
+  [SAME_ORIGIN, "same-origin; foo=bar", true],
+  [SAME_ORIGIN, "\"same-origin\"", true], // HTTP structured header "string" item
+  [SAME_ORIGIN, "*c2FtZS1vcmlnaW4=*", true], // HTTP structured header "byte sequence" item
+  [SAME_ORIGIN, "same-origin same-origin", true],
+  [SAME_ORIGIN, "same-origin,same-origin", true],
+  [SAME_ORIGIN, "same-origin;same-origin", true],
+
+  // All of the following should be recognized as "same-origin" (hence the
+  // "expected opener" value of `false`).
+  [SAME_ORIGIN, " \tsame-origin", false],
+  [SAME_ORIGIN, "same-origin\t ", false],
+];
+
+run_coop_tests("unspecified", tests);
+
+async_test((t) => {
+  const channelName = `none_to_${SAME_ORIGIN.name}_duplicated-header`;
+  const url = `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-same-origin-repeated.asis?channel=${channelName}`;
+
+  url_test(t, url, channelName, true);
+}, `unspecified document opening popup to ${SAME_ORIGIN.origin} with repeated COOP header`);
+</script>

--- a/html/cross-origin-opener-policy/header-parsing.https.html
+++ b/html/cross-origin-opener-policy/header-parsing.https.html
@@ -29,14 +29,14 @@ let tests = [
   [SAME_ORIGIN, "$same-origin", true], // the item type is unrecognized
   [SAME_ORIGIN, "same-origin same-origin", true],
   [SAME_ORIGIN, "same-origin,same-origin", true],
-  [SAME_ORIGIN, "\tsame-origin", true],
-  [SAME_ORIGIN, "same-origin\t", true],
   [SAME_ORIGIN, "*same-origin ", true],
 
   // All of the following should be recognized as "same-origin" (hence the
   // "expected opener" value of `false`).
   [SAME_ORIGIN, " same-origin", false],
   [SAME_ORIGIN, "same-origin ", false],
+  [SAME_ORIGIN, "\tsame-origin", true],
+  [SAME_ORIGIN, "same-origin\t", true],
   [SAME_ORIGIN, "same-origin;same-origin", false],
   [SAME_ORIGIN, "same-origin; foo=bar", false],
 ];

--- a/html/cross-origin-opener-policy/header-parsing.https.html
+++ b/html/cross-origin-opener-policy/header-parsing.https.html
@@ -19,6 +19,7 @@ let tests = [
   [SAME_ORIGIN, "\u000csame-origin\u000c", true], // form feed
   [SAME_ORIGIN, "\u000dsame-origin\u000d", true], // carriage return
   [SAME_ORIGIN, "Same-origin", true],
+  [SAME_ORIGIN, "same-origin\0", true],
   [SAME_ORIGIN, "same-origin;\tfoo=bar", true],
   [SAME_ORIGIN, "same-origin ;foo=bar", true],
   [SAME_ORIGIN, "same-origin; foo=bar;", true],

--- a/html/cross-origin-opener-policy/header-parsing.https.html
+++ b/html/cross-origin-opener-policy/header-parsing.https.html
@@ -35,8 +35,8 @@ let tests = [
   // "expected opener" value of `false`).
   [SAME_ORIGIN, " same-origin", false],
   [SAME_ORIGIN, "same-origin ", false],
-  [SAME_ORIGIN, "\tsame-origin", true],
-  [SAME_ORIGIN, "same-origin\t", true],
+  [SAME_ORIGIN, "\tsame-origin", false],
+  [SAME_ORIGIN, "same-origin\t", false],
   [SAME_ORIGIN, "same-origin;same-origin", false],
   [SAME_ORIGIN, "same-origin; foo=bar", false],
 ];

--- a/html/cross-origin-opener-policy/header-parsing.https.html
+++ b/html/cross-origin-opener-policy/header-parsing.https.html
@@ -13,24 +13,32 @@ let tests = [
 
   // None of the following should be recognized as "same-origin" (hence the
   // "expected opener" value of `true`).
-  [SAME_ORIGIN, "same\u2014origin;", true], // non-ASCII character (em dash)
+  [SAME_ORIGIN, "same\u2014origin", true], // non-ASCII character (em dash)
   [SAME_ORIGIN, "same-origin;", true],
-  [SAME_ORIGIN, "same-origin\0", true],
   [SAME_ORIGIN, "\u000bsame-origin\u000b", true], // vertical tab
   [SAME_ORIGIN, "\u000csame-origin\u000c", true], // form feed
   [SAME_ORIGIN, "\u000dsame-origin\u000d", true], // carriage return
   [SAME_ORIGIN, "Same-origin", true],
-  [SAME_ORIGIN, "same-origin; foo=bar", true],
-  [SAME_ORIGIN, "\"same-origin\"", true], // HTTP structured header "string" item
-  [SAME_ORIGIN, "*c2FtZS1vcmlnaW4=*", true], // HTTP structured header "byte sequence" item
+  [SAME_ORIGIN, "same-origin;\tfoo=bar", true],
+  [SAME_ORIGIN, "same-origin ;foo=bar", true],
+  [SAME_ORIGIN, "same-origin; foo=bar;", true],
+  [SAME_ORIGIN, "\"same-origin\"", true], // HTTP structured fields "string" item
+  [SAME_ORIGIN, ":c2FtZS1vcmlnaW4=:", true], // HTTP structured fields "byte sequence" item
+  [SAME_ORIGIN, "?1", true], // HTTP structured fields "boolean" item
+  [SAME_ORIGIN, "1", true], // HTTP structured fields "integer or decimal" item
+  [SAME_ORIGIN, "$same-origin", true], // the item type is unrecognized
   [SAME_ORIGIN, "same-origin same-origin", true],
   [SAME_ORIGIN, "same-origin,same-origin", true],
-  [SAME_ORIGIN, "same-origin;same-origin", true],
+  [SAME_ORIGIN, "\tsame-origin", true],
+  [SAME_ORIGIN, "same-origin\t", true],
+  [SAME_ORIGIN, "*same-origin ", true],
 
   // All of the following should be recognized as "same-origin" (hence the
   // "expected opener" value of `false`).
-  [SAME_ORIGIN, " \tsame-origin", false],
-  [SAME_ORIGIN, "same-origin\t ", false],
+  [SAME_ORIGIN, " same-origin", false],
+  [SAME_ORIGIN, "same-origin ", false],
+  [SAME_ORIGIN, "same-origin;same-origin", false],
+  [SAME_ORIGIN, "same-origin; foo=bar", false],
 ];
 
 run_coop_tests("unspecified", tests);

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -63,7 +63,7 @@ function run_coop_tests(documentCOOPValueTitle, testArray) {
       coop_test(t, test[0], test[1],
                 `${documentCOOPValueTitle}_to_${test[0].name}_${test[1].replace(/ /g,"-")}`,
                 test[2], () => { t.done(); });
-    }, `${documentCOOPValueTitle} document opening popup to ${test[0].origin} with COOP: "${test[1]}"`);
+    }, `${documentCOOPValueTitle} document opening popup to ${test[0].origin} with COOP: ${format_value(test[1])}`);
   }
 }
 
@@ -91,5 +91,5 @@ function run_coop_test_iframe (documentTitle, iframe_origin, popup_origin, popup
               assert_equals(payload.name, expects_name? name:"", 'name');
       });
       document.body.append(frame);
-  }, `${documentTitle} with ${iframe_origin.name} iframe opening popup a ${popup_origin.name} with COOP: ${popup_coop}`);
+  }, `${documentTitle} with ${iframe_origin.name} iframe opening popup a ${popup_origin.name} with COOP: ${format_value(popup_coop)}`);
 }

--- a/html/cross-origin-opener-policy/resources/common.js
+++ b/html/cross-origin-opener-policy/resources/common.js
@@ -50,7 +50,7 @@ function url_test(t, url, channelName, hasOpener, openerDOMAccess, callback) {
 }
 
 function coop_coep_test(t, host, coop, coep, channelName, hasOpener, openerDOMAccess, callback) {
-  url_test(t, `${host.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${encodeURIComponent(coop)}&coep=${coep}&channel=${channelName}`, channelName, hasOpener, openerDOMAccess, callback);
+  url_test(t, `${host.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${encodeURIComponent(coop)}&coep=${coep}&channel=${encodeURIComponent(channelName)}`, channelName, hasOpener, openerDOMAccess, callback);
 }
 
 function coop_test(t, host, coop, channelName, hasOpener, callback) {

--- a/html/cross-origin-opener-policy/resources/coop-coep.py
+++ b/html/cross-origin-opener-policy/resources/coop-coep.py
@@ -70,7 +70,7 @@ def main(request, response):
       iframe.contentWindow.postMessage(payload, "*");
     };
     const channelName = new URL(location).searchParams.get("channel");
-    iframe.src = `${get_host_info().HTTPS_ORIGIN}/html/cross-origin-opener-policy/resources/postback.html?channel=${channelName}`;
+    iframe.src = `${get_host_info().HTTPS_ORIGIN}/html/cross-origin-opener-policy/resources/postback.html?channel=${encodeURIComponent(channelName)}`;
     document.body.appendChild(iframe);
   }
 </script>

--- a/html/cross-origin-opener-policy/resources/coop-same-origin-repeated.asis
+++ b/html/cross-origin-opener-policy/resources/coop-same-origin-repeated.asis
@@ -1,0 +1,24 @@
+HTTP/1.1 200 OK
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Opener-Policy: same-origin
+Server: BaseHTTP/0.3 Python/2.7.15+
+Date: Wed, 18 Dec 2019 00:47:08 GMT
+
+<!doctype html>
+<meta charset=utf-8>
+<script src="/common/get-host-info.sub.js"></script>
+<iframe></iframe>
+<script>
+  const navigate = new URL(location).searchParams.get("navigate");
+  if (navigate !== null) {
+    self.location = navigate;
+  } else {
+    const iframe = document.querySelector("iframe");
+    iframe.onload = () => {
+      const payload = { name: self.name, opener: !!self.opener };
+      iframe.contentWindow.postMessage(payload, "*");
+    };
+    const channelName = new URL(location).searchParams.get("channel");
+    iframe.src = `${get_host_info().HTTPS_ORIGIN}/html/cross-origin-opener-policy/resources/postback.html?channel=${channelName}`;
+  }
+</script>


### PR DESCRIPTION
@Hexcles as per https://github.com/web-platform-tests/wpt/pull/20873#issuecomment-678260581 (which this PR is on top of, only the last commit here is new).

When looking at this again, it seems the connection rejection may be happening in Chromium, since this test is working in Firefox. That is, wptserve handles this fine.

The interesting URL is https://web-platform.test:8443/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin%00&coep=&channel=unspecified_to_SAME_ORIGIN_same-origin%00 (or whatever port you get with `wpt run` or `wpt serve`)

In Chrome, I get an error page:
```
This page isn’t working
web-platform.test sent an invalid response.
ERR_INVALID_HTTP_RESPONSE
```