### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=215806

### DIFF
--- a/mediacapture-streams/MediaStreamTrack-getSettings.https.html
+++ b/mediacapture-streams/MediaStreamTrack-getSettings.https.html
@@ -73,8 +73,7 @@
         : {video: device_id_constraint};
 
       const stream = await navigator.mediaDevices.getUserMedia(constraints);
-      assert_equals(stream.getTracks()[0].getSettings().groupId,
-                    device.groupId);
+      assert_true(stream.getTracks()[0].getSettings().groupId === device.groupId, "device groupId");
       assert_greater_than(device.groupId.length, 0);
     }
   }, 'groupId is correctly reported by getSettings() for all input devices');


### PR DESCRIPTION
WebKit export from bug: [enumerateDevices should expose audiooutput devices that are tied to an audio input device](https://bugs.webkit.org/show_bug.cgi?id=215806)