### PR TITLE
screen-wake-lock: Add tests for WakeLockSentinel's "released" attribute.

### DIFF
--- a/screen-wake-lock/wakelock-document-hidden-manual.https.html
+++ b/screen-wake-lock/wakelock-document-hidden-manual.https.html
@@ -9,6 +9,7 @@
 
 promise_test(async t => {
   const screenWakeLock = await navigator.wakeLock.request('screen');
+  assert_false(screenWakeLock.released, "The released attribute is initially false")
   const screenWakeLockReleased =
       new EventWatcher(t, screenWakeLock, "release").wait_for("release");
 
@@ -16,6 +17,7 @@ promise_test(async t => {
   await eventWatcher.wait_for("visibilitychange");
   assert_true(document.hidden, "document is hidden after the visibilitychange event");
   await screenWakeLockReleased;
+  assert_true(screenWakeLock.released, "The released attribute is true after the lock is released");
   await promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request('screen'),
       "new screen locks are not allowed when the page is not visible");
 

--- a/screen-wake-lock/wakelock-released.https.html
+++ b/screen-wake-lock/wakelock-released.https.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<link rel="help" href="https://w3c.github.io/screen-wake-lock/#dom-wakelocksentinel-released">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+promise_test(async t => {
+  await test_driver.set_permission({name: 'screen-wake-lock'}, 'granted', false);
+
+  const lock = await navigator.wakeLock.request("screen");
+  assert_false(lock.released, "lock.release must be false on creation");
+
+  const watcher = new EventWatcher(t, lock, "release");
+
+  lock.release();
+  assert_false(lock.released, "WakeLockSentinel.release does not become true immediately");
+
+  await watcher.wait_for("release");
+  assert_true(lock.released, "lock.release must be true after calling release()");
+}, "Basic WakeLockSentinel.released functionality");
+
+promise_test(async t => {
+  await test_driver.set_permission({ name: 'screen-wake-lock' }, 'granted', false);
+
+  const lock = await navigator.wakeLock.request("screen");
+  assert_false(lock.released, "lock.release must be false on creation");
+
+  return new Promise(resolve => {
+    lock.onrelease = t.step_func(ev => {
+      assert_true(lock.released, "WakeLockSentinel.release is true in an onrelease event handler");
+      resolve();
+    });
+    lock.release();
+    assert_false(lock.released, "WakeLockSentinel.release does not become true immediately")
+  })
+}, "The release attribute inside an event handler");
+</script>


### PR DESCRIPTION
The new attribute was added to the spec in w3c/screen-wake-lock#279.