### PR TITLE
Attempt to fix escaping in CSP tests

### DIFF
--- a/content-security-policy/frame-ancestors/support/frame-in-frame.sub.html
+++ b/content-security-policy/frame-ancestors/support/frame-in-frame.sub.html
@@ -4,9 +4,13 @@
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
     <script src='/content-security-policy/frame-ancestors/support/frame-ancestors-test.sub.js'></script>
+
+    <span id="escape">{{GET[policy]}}</span>
+
     <script>
         test = async_test("Testing a {{GET[child]}}-origin child with a policy of {{GET[policy]}} nested in a {{GET[parent]}}-origin parent");
-        originFrameShouldBe("{{GET[child]}}", "{{GET[expectation]}}", "{{GET[policy]]}}");
+        const policy = document.getElementById("escape").textContent;
+        originFrameShouldBe("{{GET[child]}}", "{{GET[expectation]}}", policy);
     </script>
 </body>
 </html>

--- a/content-security-policy/navigation/support/test_csp_self_window.sub.html
+++ b/content-security-policy/navigation/support/test_csp_self_window.sub.html
@@ -2,7 +2,9 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
+<span id="escape">{{GET[window_url]}}</span>
+
 <script>
-  var window_url = decodeURIComponent("{{GET[window_url]}}").replace('&lt;', '<').replace('&gt;', '>');
+  var window_url = document.getElementById("escape").textContent;
   window.open(window_url, "_self");
 </script>


### PR DESCRIPTION
{{GET}} is automatically HTML-escaped (*not* URL-encoded) when used in
`.sub.html`. There is some insufficient workaround in this test suite
for things like < >. This PR attempts to properly decode HTML entities.

Note: this is most likely not complete (only covers the case in #25141 ).
There are so many uses of `{{GET}}` in `.sub.html` in this suite that might
need similar treatment, so we might want to do this in e.g.
`originFrameShouldBe` instead.