### PR TITLE
HTML: make sure the default opacity of ::placeholder is 1

### DIFF
--- a/html/rendering/non-replaced-elements/form-controls/placeholder-opacity-default.tentative.html
+++ b/html/rendering/non-replaced-elements/form-controls/placeholder-opacity-default.tentative.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Placeholder Test: opacity default value</title>
+    <link rel="author" title="Karl Dubost" href="mailto:kdubost@mozilla.com"
+    />
+    <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#placeholder-pseudo"
+    />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <input
+      id="opacity"
+      placeholder="::placeholder should have default opacity: 1"
+    />
+    <script>
+      test(function () {
+        var target = document.getElementById("opacity");
+        assert_equals(getComputedStyle(target, '::placeholder').opacity, "1");
+      }, "Default opacity value is '1'");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This test relates to the opacity difference in between Gecko, Blink and WebKit as mentioned by @fvsch

```css
/* Gecko style */
::placeholder {
  color: inherit;
  opacity: 0.54;
}

/* WebKit style */
::placeholder {
  color: #9a9a9a;
  opacity: 1;
}

/* Blink style */
::placeholder {
  color: #757575;
  opacity: 1;
}
```

See https://github.com/whatwg/html/issues/2561#issuecomment-569920124
and https://codepen.io/webcompat/pen/bWEEJv

