### PR TITLE
File API: make manual IDL test work

### DIFF
--- a/FileAPI/idlharness-manual.html
+++ b/FileAPI/idlharness-manual.html
@@ -13,13 +13,8 @@
   <body>
     <h1>File API manual IDL tests</h1>
 
-    <div>
-      <p>Test steps:</p>
-      <ol>
-        <li>Download <a href="support/upload.txt">upload.txt</a> to local.</li>
-        <li>Select the local upload.txt file to run the test.</li>
-      </ol>
-    </div>
+    <p>Either download <a href="support/upload.txt">upload.txt</a> and select it below or select an
+    arbitrary local file.</p>
 
     <form name="uploadData">
       <input type="file" id="fileChooser">
@@ -45,7 +40,6 @@
         idl_array.add_dependency_idls(url);
         idl_array.add_dependency_idls(html);
         idl_array.add_dependency_idls(dom);
-        idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
 
         idl_array.add_objects({
           FileList: [fileInput.files],


### PR DESCRIPTION
Usage of add_untested_idls causes the test to error in Chrome and Firefox.