### PR TITLE
Wasm: use idl_test

### DIFF
--- a/wasm/jsapi/idlharness.any.js
+++ b/wasm/jsapi/idlharness.any.js
@@ -6,32 +6,17 @@
 
 // https://webassembly.github.io/spec/js-api/
 
-promise_test(async () => {
-  const srcs = ['wasm-js-api'];
-  const [wasm] = await Promise.all(
-    srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
-
-  const idl_array = new IdlArray();
-  idl_array.add_idls(wasm, {
-    // Note the prose requirements in the specification.
-    except: ['CompileError', 'LinkError', 'RuntimeError']
-  });
-
-  // Ignored errors are surfaced in idlharness.js's test_object below.
-  try {
-    self.memory = new WebAssembly.Memory({initial: 1024});
-  } catch (e) { }
-
-  try {
+idl_test(
+  ['wasm-js-api'],
+  [],
+  async idl_array => {
     self.mod = await createWasmModule();
     self.instance = new WebAssembly.Instance(self.mod);
-  } catch (e) { }
 
-  idl_array.add_objects({
-    Memory: ['memory'],
-    Module: ['mod'],
-    Instance: ['instance'],
-  });
-  idl_array.test();
-}, 'wasm-js-api interfaces.');
-
+    idl_array.add_objects({
+      Memory: [new WebAssembly.Memory({initial: 1024})],
+      Module: [self.mod],
+      Instance: [self.instance],
+    });
+  }
+);


### PR DESCRIPTION
Also remove try/catch as the harness catches and reports those. (And Chrome and Firefox do not throw anyway.)