### PR TITLE
testharness.js: Use the right function name in step_wait_func's assert() call

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2069,7 +2069,7 @@ policies and contribution forms [3].
                 func();
             } else {
                 if(remaining === 0) {
-                    assert(false, "wait_for", description,
+                    assert(false, "step_wait_func", description,
                            "Timed out waiting on condition");
                 }
                 remaining--;


### PR DESCRIPTION
Using "wait_for" in the call to `assert()` can lead users into thinking the
error is coming from `EventWatcher.wait_for()` rather than a call to
`t.step_*()` functions.