### PR TITLE
Tweak math-global-event-handlers.tentative.html

### DIFF
--- a/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
+++ b/mathml/relations/html5-tree/math-global-event-handlers.tentative.html
@@ -8,6 +8,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 
+<div style="display: none" id="container"></div>
+
 <script>
   "use strict";
 
@@ -153,5 +155,3 @@
       done();
     });
 </script>
-
-<div style="display: none" id="container"></div>


### PR DESCRIPTION
This is a tentative to fix flakiness reported in [1].
The #container is moved before the <script> tag to ensure the test
relying on it is never executed before that element is in DOM.

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=1093840