### PR TITLE
Test that UTF8 BOM is honored over explicit HTTP charset info in CSS stylesheets

### DIFF
--- a/css/css-syntax/charset/page-windows-1252-http-windows-1251-css-utf8-bom.html
+++ b/css/css-syntax/charset/page-windows-1252-http-windows-1251-css-utf8-bom.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>CSS charset: page windows-1252, CSS-HTTP windows-1251, CSS UTF-8 BOM</title>
+<link rel=help href="https://drafts.csswg.org/css-syntax-3/#determine-the-fallback-encoding">
+<meta charset=windows-1252>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel=stylesheet href="support/utf8-bom-http-windows-1251.css">
+<div id=log></div>
+<div id=&#xfffd;></div>
+<script>
+var elm = document.getElementById('\ufffd');
+var t = async_test();
+onload = t.step_func(function(){
+  assert_equals(getComputedStyle(elm, '').visibility, 'hidden');
+  this.done();
+});
+</script>

--- a/css/css-syntax/charset/support/utf8-bom-http-windows-1251.css
+++ b/css/css-syntax/charset/support/utf8-bom-http-windows-1251.css
@@ -1,0 +1,1 @@
+ï»¿#È { visibility:hidden }

--- a/css/css-syntax/charset/support/utf8-bom-http-windows-1251.css.headers
+++ b/css/css-syntax/charset/support/utf8-bom-http-windows-1251.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css; charset=windows-1251


### PR DESCRIPTION
Fills in a missing test scenario for <https://github.com/w3c/csswg-drafts/issues/4126>; current tests only verify that the BOM is honored over the environment encoding.