### PR TITLE
Fix running reftests in Firefox stable.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -143,6 +143,7 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
         executor_kwargs["capabilities"] = capabilities
     executor_kwargs["debug"] = run_info_data["debug"]
     executor_kwargs["ccov"] = run_info_data.get("ccov", False)
+    executor_kwargs["browser_version"] = run_info_data["browser_version"]
     return executor_kwargs
 
 

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -860,7 +860,8 @@ class MarionetteRefTestExecutor(RefTestExecutor):
                  screenshot_cache=None, close_after_done=True,
                  debug_info=None, reftest_internal=False,
                  reftest_screenshot="unexpected", ccov=False,
-                 group_metadata=None, capabilities=None, debug=False, **kwargs):
+                 group_metadata=None, capabilities=None, debug=False,
+                 browser_version=None, **kwargs):
         """Marionette-based executor for reftests"""
         RefTestExecutor.__init__(self,
                                  logger,
@@ -873,9 +874,11 @@ class MarionetteRefTestExecutor(RefTestExecutor):
                                            timeout_multiplier, kwargs["e10s"],
                                            ccov)
         self.implementation = self.get_implementation(reftest_internal)
-        self.implementation_kwargs = ({"screenshot": reftest_screenshot} if
-                                      reftest_internal else {})
-
+        self.implementation_kwargs = {}
+        if reftest_internal:
+            self.implementation_kwargs["screenshot"] = reftest_screenshot
+            self.implementation_kwargs["chrome_scope"] = (browser_version is not None and
+                                                          int(browser_version.split(".")[0]) < 82)
         self.close_after_done = close_after_done
         self.has_window = False
         self.original_pref_values = {}
@@ -980,18 +983,23 @@ class InternalRefTestImplementation(RefTestImplementation):
     def __init__(self, executor):
         self.timeout_multiplier = executor.timeout_multiplier
         self.executor = executor
+        self.chrome_scope = False
 
     @property
     def logger(self):
         return self.executor.logger
 
-    def setup(self, screenshot="unexpected"):
+    def setup(self, screenshot="unexpected", chrome_scope=False):
         data = {"screenshot": screenshot, "isPrint": self.executor.is_print}
         if self.executor.group_metadata is not None:
             data["urlCount"] = {urljoin(self.executor.server_url(key[0]), key[1]):value
                                 for key, value in iteritems(
                                     self.executor.group_metadata.get("url_count", {}))
                                 if value > 1}
+        self.chrome_scope = chrome_scope
+        if chrome_scope:
+            self.logger.debug("Using marionette Chrome scope for reftests")
+            self.executor.protocol.marionette.set_context(self.executor.protocol.marionette.CONTEXT_CHROME)
         self.executor.protocol.marionette._send_message("reftest:setup", data)
 
     def reset(self, screenshot=None):
@@ -1023,6 +1031,9 @@ class InternalRefTestImplementation(RefTestImplementation):
         try:
             if self.executor.protocol.marionette and self.executor.protocol.marionette.session_id:
                 self.executor.protocol.marionette._send_message("reftest:teardown", {})
+                if self.chrome_scope:
+                    self.executor.protocol.marionette.set_context(
+                        self.executor.protocol.marionette.CONTEXT_CONTENT)
                 # the reftest runner opens/closes a window with focus, so as
                 # with after closing a window we need to give a new window
                 # focus


### PR DESCRIPTION
The change from gecko bug 1661332 stopped using reftests in Chrome
scope in Firefox. Unfortunately that won't work on released versions
until the patch has ridden the trains in ~2 months. So in the meantime
switch to Chrome scope only in older versions.