### PR TITLE
Python3: Read file as binary type to avoid any decoding attempt

### DIFF
--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -407,7 +407,7 @@ class AsIsHandler(object):
         path = filesystem_path(self.base_path, request, self.url_base)
 
         try:
-            with open(path) as f:
+            with open(path, 'rb') as f:
                 response.writer.write_raw_content(f.read())
             wrap_pipeline(path, request, response)
             response.close_connection = True


### PR DESCRIPTION
In python 3, it tries to convert a byte-array to a unicode string. In some cases, it encounters a byte sequence which is not allowed in utf-8-encoded strings. This CL is to specify reading file as binary type.