### PR TITLE
[wptrunner] Drop --ignore-certificate-errors for Chrome

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -69,7 +69,6 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     # browsing context, whereas the CLI flag works for workers, too.
     chrome_options["args"] = []
 
-    chrome_options["args"].append("--ignore-certificate-errors")
     chrome_options["args"].append("--ignore-certificate-errors-spki-list=%s" %
                                   ','.join(chrome_spki_certs.IGNORE_CERTIFICATE_ERRORS_SPKI_LIST))
 


### PR DESCRIPTION
As per crbug.com/1125272, --ignore-certificate-errors is deprecated for
Chrome. The replacement is to use `--ignore-certificate-errors-spki-list`,
listing all certificates you care about. We already do the latter for
`tools/certs/web-platform.test.pem` (and the SXG certificate), so remove
the unnecessary flag.