### PR TITLE
Remove annotationsArtifactName override from test.yml

### DIFF
--- a/tools/ci/tc/tasks/test.yml
+++ b/tools/ci/tc/tasks/test.yml
@@ -13,10 +13,7 @@ components:
     extra:
       github:
         customCheckRun:
-          # We set both textArtifactName and annotationsArtifactName due
-          # to https://github.com/taskcluster/taskcluster/issues/3191
           textArtifactName: public/results/checkrun.md
-          annotationsArtifactName: public/results/checkrun.md
 
   wpt-testharness:
     chunks: 16


### PR DESCRIPTION
https://github.com/taskcluster/taskcluster/issues/3191 appears to have
reached community-tc, so we should no longer set annotationsArtifactName
to be our text output file (its now correctly handled by
textArtifactName).