### PR TITLE
Updating sanitizer-api.tentative.idl

### DIFF
--- a/interfaces/sanitizer-api.tentative.idl
+++ b/interfaces/sanitizer-api.tentative.idl
@@ -5,7 +5,6 @@ typedef (DOMString or DocumentFragment or Document) SanitizerInput;
 [Exposed=Window, SecureContext]
  interface Sanitizer {
   [RaisesException] constructor();
-  DOMString sanitize(SanitizerInput input);
+  DocumentFragment sanitize(SanitizerInput input);
   DOMString sanitizeToString(SanitizerInput input);
-  
 };

--- a/interfaces/sanitizer-api.tentative.idl
+++ b/interfaces/sanitizer-api.tentative.idl
@@ -1,8 +1,11 @@
 // https://wicg.github.io/sanitizer-api/
 
-[
-  Exposed=Window
-] interface Sanitizer {
+typedef (DOMString or DocumentFragment or Document) SanitizerInput;
+
+[Exposed=Window, SecureContext]
+ interface Sanitizer {
   [RaisesException] constructor();
-  DOMString sanitizeToString(DOMString input);
+  DOMString sanitize(SanitizerInput input);
+  DOMString sanitizeToString(SanitizerInput input);
+  
 };


### PR DESCRIPTION
See also recent discussions in https://github.com/WICG/sanitizer-api/issues/22.

- We only want to expose the interface to Secure Contexts (like Trusted Types, for example)
- `sanitize` method was missing
- input types should be more allowing

CCing @otherdaniel 