### PR TITLE
cookie-store: Simplify usage of promise_rejects_js()

### DIFF
--- a/cookie-store/cookieStore_delete_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_delete_arguments.tentative.https.any.js
@@ -22,17 +22,17 @@ promise_test(async testCase => {
   assert_equals(cookie, null);
 }, 'cookieStore.delete with name in options');
 
-promise_test(async testCase => {
+promise_test(testCase => {
   const currentUrl = new URL(self.location.href);
   const currentDomain = currentUrl.hostname;
 
-  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+  return promise_rejects_js(testCase, TypeError, cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value',
         domain: `.${currentDomain}` }));
 }, 'cookieStore.delete domain starts with "."');
 
-promise_test(async testCase => {
-  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+promise_test(testCase => {
+  return promise_rejects_js(testCase, TypeError, cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', domain: 'example.com' }));
 }, 'cookieStore.delete with domain that is not equal current host');
 
@@ -50,23 +50,23 @@ promise_test(async testCase => {
   assert_equals(cookie, null);
 }, 'cookieStore.delete with domain set to the current hostname');
 
-promise_test(async testCase => {
+promise_test(testCase => {
   const currentUrl = new URL(self.location.href);
   const currentDomain = currentUrl.hostname;
   const subDomain = `sub.${currentDomain}`;
 
-  await promise_rejects_js(testCase, TypeError, cookieStore.delete(
+  return promise_rejects_js(testCase, TypeError, cookieStore.delete(
       { name: 'cookie-name', domain: subDomain }));
 }, 'cookieStore.delete with domain set to a subdomain of the current hostname');
 
-promise_test(async testCase => {
+promise_test(testCase => {
   const currentUrl = new URL(self.location.href);
   const currentDomain = currentUrl.hostname;
   assert_not_equals(currentDomain[0] === '.',
       'this test assumes that the current hostname does not start with .');
   const domainSuffix = currentDomain.substr(1);
 
-  await promise_rejects_js(testCase, TypeError, cookieStore.delete(
+  return promise_rejects_js(testCase, TypeError, cookieStore.delete(
       { name: 'cookie-name', domain: domainSuffix }));
 }, 'cookieStore.delete with domain set to a non-domain-matching suffix of ' +
    'the current hostname');
@@ -122,14 +122,14 @@ promise_test(async testCase => {
   assert_equals(cookie, null);
 }, 'cookieStore.delete with missing / at the end of path');
 
-promise_test(async testCase => {
+promise_test(testCase => {
   const currentUrl = new URL(self.location.href);
   const currentPath = currentUrl.pathname;
   const currentDirectory =
       currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
   const invalidPath = currentDirectory.substr(1);
 
-  await promise_rejects_js(testCase, TypeError, cookieStore.delete(
+  return promise_rejects_js(testCase, TypeError, cookieStore.delete(
       { name: 'cookie-name', path: invalidPath }));
 }, 'cookieStore.delete with path that does not start with /');
 

--- a/cookie-store/cookieStore_getAll_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_getAll_arguments.tentative.https.any.js
@@ -132,7 +132,7 @@ promise_test(async testCase => {
 
   const invalid_url =
       `${self.location.protocol}//${self.location.host}/different/path`;
-  await promise_rejects_js(testCase, TypeError, cookieStore.getAll(
+  return promise_rejects_js(testCase, TypeError, cookieStore.getAll(
       { url: invalid_url }));
 }, 'cookieStore.getAll with invalid url path in options');
 
@@ -144,6 +144,6 @@ promise_test(async testCase => {
 
   const invalid_url =
       `${self.location.protocol}//www.example.com${self.location.pathname}`;
-  await promise_rejects_js(testCase, TypeError, cookieStore.getAll(
+  return promise_rejects_js(testCase, TypeError, cookieStore.getAll(
       { url: invalid_url }));
 }, 'cookieStore.getAll with invalid url host in options');

--- a/cookie-store/cookieStore_get_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_get_arguments.tentative.https.any.js
@@ -9,7 +9,7 @@ promise_test(async testCase => {
     await cookieStore.delete('cookie-name');
   });
 
-  await promise_rejects_js(testCase, TypeError, cookieStore.get());
+  return promise_rejects_js(testCase, TypeError, cookieStore.get());
 }, 'cookieStore.get with no arguments returns TypeError');
 
 promise_test(async testCase => {
@@ -18,7 +18,7 @@ promise_test(async testCase => {
     await cookieStore.delete('cookie-name');
   });
 
-  await promise_rejects_js(testCase, TypeError, cookieStore.get({}));
+  return promise_rejects_js(testCase, TypeError, cookieStore.get({}));
 },'cookieStore.get with empty options returns TypeError');
 
 promise_test(async testCase => {
@@ -87,16 +87,16 @@ promise_test(async testCase => {
   assert_equals(cookie.value, 'cookie-value');
 }, 'cookieStore.get with relative url in options');
 
-promise_test(async testCase => {
+promise_test(testCase => {
   const invalid_url =
       `${self.location.protocol}//${self.location.host}/different/path`;
-  await promise_rejects_js(testCase, TypeError, cookieStore.get(
+  return promise_rejects_js(testCase, TypeError, cookieStore.get(
       { url: invalid_url }));
 }, 'cookieStore.get with invalid url path in options');
 
-promise_test(async testCase => {
+promise_test(testCase => {
   const invalid_url =
       `${self.location.protocol}//www.example.com${self.location.pathname}`;
-  await promise_rejects_js(testCase, TypeError, cookieStore.get(
+  return promise_rejects_js(testCase, TypeError, cookieStore.get(
       { url: invalid_url }));
 }, 'cookieStore.get with invalid url host in options');

--- a/cookie-store/cookieStore_set_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_set_arguments.tentative.https.any.js
@@ -28,8 +28,8 @@ promise_test(async testCase => {
   assert_equals(cookie.value, 'cookie-value');
 }, 'cookieStore.set with name and value in options');
 
-promise_test(async testCase => {
-  await promise_rejects_js(testCase, TypeError,
+promise_test(testCase => {
+  return promise_rejects_js(testCase, TypeError,
       cookieStore.set('', 'suspicious-value=resembles-name-and-value'));
 }, "cookieStore.set with empty name and an '=' in value");
 
@@ -106,18 +106,18 @@ promise_test(async testCase => {
   assert_equals(cookie, null);
 }, 'cookieStore.set with expires set to a past timestamp');
 
-promise_test(async testCase => {
+promise_test(testCase => {
   const currentUrl = new URL(self.location.href);
   const currentDomain = currentUrl.hostname;
 
-  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+  return promise_rejects_js(testCase, TypeError, cookieStore.set(
       { name: 'cookie-name',
         value: 'cookie-value',
         domain: `.${currentDomain}` }));
 }, 'cookieStore.set domain starts with "."');
 
-promise_test(async testCase => {
-  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+promise_test(testCase => {
+  return promise_rejects_js(testCase, TypeError, cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', domain: 'example.com' }));
 }, 'cookieStore.set with domain that is not equal current host');
 
@@ -258,14 +258,14 @@ promise_test(async testCase => {
   assert_equals(cookie.path, currentDirectory + '/');
 }, 'cookieStore.set adds / to path that does not end with /');
 
-promise_test(async testCase => {
+promise_test(testCase => {
   const currentUrl = new URL(self.location.href);
   const currentPath = currentUrl.pathname;
   const currentDirectory =
       currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
   const invalidPath = currentDirectory.substr(1);
 
-  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+  return promise_rejects_js(testCase, TypeError, cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', path: invalidPath }));
 }, 'cookieStore.set with path that does not start with /');
 

--- a/cookie-store/cookieStore_special_names.tentative.https.any.js
+++ b/cookie-store/cookieStore_special_names.tentative.https.any.js
@@ -32,10 +32,10 @@
   }, `cookieStore.delete with ${prefix} name on secure origin`);
 });
 
-promise_test(async testCase => {
+promise_test(testCase => {
   const currentUrl = new URL(self.location.href);
   const currentDomain = currentUrl.hostname;
-  await promise_rejects_js(testCase, TypeError,
+  return promise_rejects_js(testCase, TypeError,
       cookieStore.set({ name: '__Host-cookie-name', value: 'cookie-value',
                         domain: currentDomain }));
 }, 'cookieStore.set with __Host- prefix and a domain option');
@@ -47,7 +47,7 @@ promise_test(async testCase => {
   assert_equals(
       (await cookieStore.get(`__Host-cookie-name`)).value, "cookie-value");
 
-  await promise_rejects_js(testCase, TypeError,
+  return promise_rejects_js(testCase, TypeError,
       cookieStore.set( { name: '__Host-cookie-name', value: 'cookie-value',
                          path: "/path" }));
 }, 'cookieStore.set with __Host- prefix a path option');

--- a/cookie-store/cookieStore_subscribe_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_subscribe_arguments.tentative.https.any.js
@@ -57,7 +57,7 @@ promise_test(async testCase => {
     });
   }
 
-  await promise_rejects_js(testCase, TypeError,
+  return promise_rejects_js(testCase, TypeError,
       registration.cookies.subscribe(
           { name: 'cookie-name', url: '/wrong/path' }));
 }, 'cookieStore.subscribe with invalid url path in option');


### PR DESCRIPTION
There is no need to `await` on `promise_rejects_js()` when it is the last
call in a test: just returning it achieves the same result and looks more
idiomatic. Subsequently drop `async` from functions that no longer use
`await`.