### PR TITLE
Include testharness in lazy loading reftest-wait tests

### DIFF
--- a/html/semantics/embedded-content/the-img-element/image-loading-lazy-slow-aspect-ratio.html
+++ b/html/semantics/embedded-content/the-img-element/image-loading-lazy-slow-aspect-ratio.html
@@ -3,6 +3,8 @@
   <link rel="match" href="image-loading-lazy-slow-aspect-ratio-ref.html">
   <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
   <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-img-element">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
   <script src="/common/reftest-wait.js"></script>
   <img id=target loading="lazy"
       width="200" height="100" style="width: 100px; height: auto; border: 1px solid black">

--- a/html/semantics/embedded-content/the-img-element/image-loading-lazy-slow.html
+++ b/html/semantics/embedded-content/the-img-element/image-loading-lazy-slow.html
@@ -3,7 +3,8 @@
   <link rel="match" href="image-loading-lazy-slow-ref.html">
   <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
   <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-img-element">
-
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
   <script src="/common/reftest-wait.js"></script>
   <img id=target loading="lazy"
        width="330" height="254" style="border: 1px solid black">

--- a/html/semantics/embedded-content/the-img-element/image-loading-subpixel-clip.html
+++ b/html/semantics/embedded-content/the-img-element/image-loading-subpixel-clip.html
@@ -10,6 +10,8 @@
     <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
     <link rel="help" href="https://html.spec.whatwg.org/#lazy-loading-attributes">
     <link rel="match" href="image-loading-subpixel-clip-ref.html">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
   </head>
   <div style="height: 44.5px"></div>
   <div style="overflow: hidden">


### PR DESCRIPTION
Include testharness in lazy loading reftest-wait tests since WebKit
uses testharness to enable lazy image loading.