### PR TITLE
Revert "[webdriver] Close old windows at the end of each test as well…

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -409,10 +409,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
     def do_testharness(self, protocol, url, timeout):
         format_map = {"url": strip_server(url)}
 
-        # In theory the previous test should have closed any leftover windows,
-        # but to avoid relying on that we also attempt cleanup here.
         parent_window = protocol.testharness.close_old_windows()
-
         # Now start the test harness
         protocol.base.execute_script("window.open('about:blank', '%s', 'noopener')" % self.window_id)
         test_window = protocol.testharness.get_test_window(self.window_id,
@@ -449,11 +446,6 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
             done, rv = handler(result)
             if done:
                 break
-
-        # Attempt to cleanup any leftover windows. This should create a clean
-        # state for future tests, and expose any unexpectedly-open prompts.
-        protocol.testharness.close_old_windows()
-
         return rv
 
     def wait_for_load(self, protocol):


### PR DESCRIPTION
… as beginning (#24879)"

This reverts commit c35a4f0c7a5b7b3a7376bbe932faee6996d2dac6.

Unfortunately this broke the debugging flow of --pause-after-test; the
window is closed at the end of the test so the user can't see the
results or edit/refresh etc.