### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=216266

### DIFF
--- a/xhr/xhr-timeout-longtask.any.js
+++ b/xhr/xhr-timeout-longtask.any.js
@@ -1,0 +1,14 @@
+async_test(function() {
+  var client = new XMLHttpRequest();
+  client.open("GET", "resources/delay.py?ms=100", true);
+
+  client.timeout = 150;
+  client.ontimeout = this.step_func(assert_unreached);
+  client.onloadend = () => this.done();
+
+  client.send();
+
+  const start = performance.now();
+  while (performance.now() - start < 200) { }
+}, "Long tasks should not trigger load timeout")
+


### PR DESCRIPTION
WebKit export from bug: [XHR.timeout is affected by long tasks](https://bugs.webkit.org/show_bug.cgi?id=216266)