### PR TITLE
Reland "[webdriver] Close old windows at the end of each test as well as beginning"

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -37,6 +37,12 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
         executor_kwargs["webdriver_binary"] = kwargs.get("webdriver_binary")
         executor_kwargs["webdriver_args"] = kwargs.get("webdriver_args")
 
+    # By default the executor may try to cleanup windows after a test (to best
+    # associate any problems with the test causing them). If the user might
+    # want to view the results, however, the executor has to skip that cleanup.
+    if kwargs["pause_after_test"] or kwargs["pause_on_unexpected"]:
+        executor_kwargs["cleanup_after_test"] = False
+
     return executor_kwargs
 
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -409,7 +409,10 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
     def do_testharness(self, protocol, url, timeout):
         format_map = {"url": strip_server(url)}
 
+        # In theory the previous test should have closed any leftover windows,
+        # but to avoid relying on that we also attempt cleanup here.
         parent_window = protocol.testharness.close_old_windows()
+
         # Now start the test harness
         protocol.base.execute_script("window.open('about:blank', '%s', 'noopener')" % self.window_id)
         test_window = protocol.testharness.get_test_window(self.window_id,
@@ -446,6 +449,11 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
             done, rv = handler(result)
             if done:
                 break
+
+        # Attempt to cleanup any leftover windows. This should create a clean
+        # state for future tests, and expose any unexpectedly-open prompts.
+        protocol.testharness.close_old_windows()
+
         return rv
 
     def wait_for_load(self, protocol):

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -369,7 +369,8 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
                  close_after_done=True, capabilities=None, debug_info=None,
-                 supports_eager_pageload=True, **kwargs):
+                 supports_eager_pageload=True, may_pause_after_test=False,
+                 **kwargs):
         """WebDriver-based executor for testharness.js tests"""
         TestharnessExecutor.__init__(self, logger, browser, server_config,
                                      timeout_multiplier=timeout_multiplier,
@@ -383,6 +384,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
         self.close_after_done = close_after_done
         self.window_id = str(uuid.uuid4())
         self.supports_eager_pageload = supports_eager_pageload
+        self.may_pause_after_test = may_pause_after_test
 
     def is_alive(self):
         return self.protocol.is_alive()
@@ -409,9 +411,9 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
     def do_testharness(self, protocol, url, timeout):
         format_map = {"url": strip_server(url)}
 
-        # It is possible that the previous test did not close its old windows,
-        # either if something went wrong or if close_after_done was specified,
-        # so clean them up here.
+        # The previous test may not have closed its old windows (if something
+        # went wrong or if may_pause_after_test was specified), so clean them
+        # up here.
         parent_window = protocol.testharness.close_old_windows()
 
         # Now start the test harness
@@ -453,9 +455,9 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
 
         # Attempt to cleanup any leftover windows, if allowed. This is
         # preferable as it will blame the correct test if something goes wrong
-        # closing windows, but we cannot always do so (e.g. if the user wants
-        # to pause after the test has run then we can't close the window yet.)
-        if self.close_after_done:
+        # closing windows, but if the user wants to see the test results we
+        # have to leave the window(s) open.
+        if self.may_pause_after_test:
             protocol.testharness.close_old_windows()
 
         return rv

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -369,7 +369,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
 
     def __init__(self, logger, browser, server_config, timeout_multiplier=1,
                  close_after_done=True, capabilities=None, debug_info=None,
-                 supports_eager_pageload=True, may_pause_after_test=False,
+                 supports_eager_pageload=True, cleanup_after_test=True,
                  **kwargs):
         """WebDriver-based executor for testharness.js tests"""
         TestharnessExecutor.__init__(self, logger, browser, server_config,
@@ -384,7 +384,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
         self.close_after_done = close_after_done
         self.window_id = str(uuid.uuid4())
         self.supports_eager_pageload = supports_eager_pageload
-        self.may_pause_after_test = may_pause_after_test
+        self.cleanup_after_test = cleanup_after_test
 
     def is_alive(self):
         return self.protocol.is_alive()
@@ -412,8 +412,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
         format_map = {"url": strip_server(url)}
 
         # The previous test may not have closed its old windows (if something
-        # went wrong or if may_pause_after_test was specified), so clean them
-        # up here.
+        # went wrong or if cleanup_after_test was False), so clean up here.
         parent_window = protocol.testharness.close_old_windows()
 
         # Now start the test harness
@@ -457,7 +456,7 @@ class WebDriverTestharnessExecutor(TestharnessExecutor):
         # preferable as it will blame the correct test if something goes wrong
         # closing windows, but if the user wants to see the test results we
         # have to leave the window(s) open.
-        if self.may_pause_after_test:
+        if self.cleanup_after_test:
             protocol.testharness.close_old_windows()
 
         return rv

--- a/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_webkitgtk.py
@@ -39,6 +39,8 @@ def test_webkitgtk_certificate_domain_list(product):
     kwargs["webkit_port"] = "gtk"
     kwargs["binary"] = None
     kwargs["webdriver_binary"] = None
+    kwargs["pause_after_test"] = False
+    kwargs["pause_on_unexpected"] = False
     with ConfigBuilder(browser_host="example.net",
                        alternate_hosts={"alt": "example.org"},
                        subdomains={"a", "b"},

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -285,6 +285,10 @@ def run_tests(config, test_paths, product, **kwargs):
                                                                   run_info,
                                                                   **kwargs)
 
+                    # TODO(before submitting): Find a better place to set this.
+                    if kwargs["pause_after_test"] or kwargs["pause_on_unexpected"]:
+                        executor_kwargs["close_after_done"] = False
+
                     if executor_cls is None:
                         logger.error("Unsupported test type %s for product %s" %
                                      (test_type, product.name))

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -287,7 +287,7 @@ def run_tests(config, test_paths, product, **kwargs):
 
                     # TODO(before submitting): Find a better place to set this.
                     if kwargs["pause_after_test"] or kwargs["pause_on_unexpected"]:
-                        executor_kwargs["close_after_done"] = False
+                        executor_kwargs["may_pause_after_test"] = False
 
                     if executor_cls is None:
                         logger.error("Unsupported test type %s for product %s" %

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -285,10 +285,6 @@ def run_tests(config, test_paths, product, **kwargs):
                                                                   run_info,
                                                                   **kwargs)
 
-                    # TODO(before submitting): Find a better place to set this.
-                    if kwargs["pause_after_test"] or kwargs["pause_on_unexpected"]:
-                        executor_kwargs["may_pause_after_test"] = False
-
                     if executor_cls is None:
                         logger.error("Unsupported test type %s for product %s" %
                                      (test_type, product.name))


### PR DESCRIPTION
This is a reland of #24879 (which was reverted in #25544). It updates the code
to only close the windows if the user hasn't asked us to pause after a test has run.

From the original PR:

----

Previously, we closed old windows at the start of each test. This was nice in terms
of defensiveness (don't assume the last run left the world in a good state), but made
it hard to find problematic tests that left dialogs open (since they wouldn't throw until
the next test).

Instead, this patch does both - close both at the start and end of a test. This should
improve the blaming situation, whilst still being defensive.

There are potential performance implications to this patch, however test runs are
inconclusive. Full runs of Chrome and Safari show +- 2%, which is possibly within
margin of error. Running locally, some directories showed a ~2% slowdown, whilst
others had little or no difference.