### PR TITLE
Remove hanging script tag in font-parse-numeric-stretch-style-weight.html

### DIFF
--- a/css/css-fonts/variations/font-parse-numeric-stretch-style-weight.html
+++ b/css/css-fonts/variations/font-parse-numeric-stretch-style-weight.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <script src="/resources/testharness.js"></script>
-        <script src="/resources/testharnessreport.js"></script>
-
-</script>
+<head>
+    <meta charset="utf-8">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>


### PR DESCRIPTION
The hanging `</script>` tag breaks syntax highlighting for the JavaScript in this file in some IDEs, so remove it.