### PR TITLE
Fix expected initial AudioContext state in audiocontext-suspend-resum…

### DIFF
--- a/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-suspend-resume.html
+++ b/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-suspend-resume.html
@@ -129,7 +129,7 @@
             should(() => context = new AudioContext(), 'Create online context')
                 .notThrow();
 
-            should(context.state, 'context.state').beEqualTo('running');
+            should(context.state, 'context.state').beEqualTo('suspended');
             should(context.resume(), 'context.resume')
                 .beResolved()
                 .then(() => {


### PR DESCRIPTION
…e.html

As per specification, the initial state of an AudioContext right after constructing it should be
'suspended', not running. The state should only be set to 'running' asynchronously, if the user
agent allowed it.