### PR TITLE
Adding a blur() method to selection-contenteditable-011.html

### DIFF
--- a/css/css-pseudo/selection-contenteditable-011.html
+++ b/css/css-pseudo/selection-contenteditable-011.html
@@ -35,6 +35,15 @@
   /* Then we set the range boundaries to the children of div#test */
   window.getSelection().addRange(targetRange);
   /* Finally, we now select such range of content */
+  document.getElementById("test").blur();
+  /*
+  Some browsers, like Chromium 80+, will
+  transfer focus to a selected element
+  like a contenteditable div and
+  therefore style the border of
+  such element. We remove such
+  focus with the blur() method.
+  */
   }
   </script>
 


### PR DESCRIPTION
/css/css-pseudo/selection-contenteditable-011.html

Right now, both Chrome 87 and Safari Preview 113 appear to be styling the border of focused `<div contenteditable="true">` in the selection-contenteditable-011.html . This focusing creates an additional (and unwanted) cause of failure in both browsers. The addition of the blur() in the code of this selection-contenteditable-011.html test is trying to neutralize such focusing style. [If this works for selection-contenteditable-011.html , then I will be able to add the same blur() code into selection-textarea-011.html later.]

On my website,

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/selection-contenteditable-011-new.html

[Addendum: now that I am thinking more about it, maybe it was better to add focus() to the `<div contenteditable="true">` in the reference file instead of adding blur() to the `<div contenteditable="true">` of the test.]