### PR TITLE
[taskcluster] Pass --use-gl=swiftshader-webgl for Chrome

### DIFF
--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -18,8 +18,13 @@ def get_browser_args(product, channel):
         return ["--install-browser", "--install-webdriver"]
     if product == "servo":
         return ["--install-browser", "--processes=12"]
-    if product == "chrome" and channel == "nightly":
-        return ["--install-browser", "--install-webdriver"]
+    if product == "chrome":
+        # Taskcluster machines do not have proper GPUs, so we need to use
+        # software rendering for webgl: https://crbug.com/1130585
+        args = ["--binary-arg=--use-gl=swiftshader-webgl"]
+        if channel == "nightly":
+            args.extend(["--install-browser", "--install-webdriver"])
+        return args
     if product == "webkitgtk_minibrowser":
         return ["--install-browser"]
     return []


### PR DESCRIPTION
The taskcluster machines do not have discrete GPUs, and Chrome does not
default advertise WebGL 2.0 if software rendering is being used (for
performance concerns). This breaks a few tests that test webgl2 content,
so set this flag to fix them.
    
Fixes https://crbug.com/1130585