### PR TITLE
[wpt] Check ChromeDriver version before accepting found binary

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -786,7 +786,7 @@ class Chrome(Browser):
         except subprocess.CalledProcessError:
             self.logger.warning("Failed to call %s" % webdriver_binary)
             return None
-        m = re.match(r"ChromeDriver ([0-9.]*)", version_string)
+        m = re.match(r"ChromeDriver ([0-9][0-9.]*)", version_string)
         if not m:
             self.logger.warning("Failed to extract version from: %s" % version_string)
             return None

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -661,9 +661,6 @@ class Chrome(Browser):
         if not chromedriver_binary:
             return chromedriver_binary
 
-        # Check that the chromedriver matches the installed Chrome. We accept
-        # up to one version behind, to allow for using a tip-of-tree Chromium
-        # build right after branch point.
         chromedriver_version = self.webdriver_version(chromedriver_binary)
         if not chromedriver_version:
             self.logger.warning(
@@ -679,16 +676,12 @@ class Chrome(Browser):
             # ChromeDriver is good.
             return chromedriver_binary
 
-        chromedriver_major = int(chromedriver_version.split('.')[0])
-        browser_major = int(browser_version.split('.')[0])
-        if (chromedriver_major + 1 < browser_major):
+        # Check that the ChromeDriver version matches the Chrome version.
+        chromedriver_major = chromedriver_version.split('.')[0]
+        browser_major = browser_version.split('.')[0]
+        if chromedriver_major != browser_major:
             self.logger.warning(
-                    "Found ChromeDriver %s; too old for Chrome/Chromium %s" %
-                    (chromedriver_version, browser_version))
-            return None
-        if (chromedriver_major > browser_major):
-            self.logger.warning(
-                    "Found ChromeDriver %s; too new for Chrome/Chromium %s" %
+                    "Found ChromeDriver %s; does not match Chrome/Chromium %s" %
                     (chromedriver_version, browser_version))
             return None
 

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -732,12 +732,12 @@ class Chrome(Browser):
         # There may be an existing chromedriver binary from a previous install.
         # To provide a clean install experience, remove the old binary - this
         # avoids tricky issues like unzipping over a read-only file.
-        expected_binary_path = os.path.join(dest, 'chromedriver')
-        if os.path.isfile(expected_binary_path):
+        existing_binary_path = find_executable("chromedriver", dest)
+        if existing_binary_path:
             self.logger.info("Removing existing ChromeDriver binary: %s" %
-                expected_binary_path)
-            os.chmod(expected_binary_path, stat.S_IWUSR)
-            os.remove(expected_binary_path)
+                existing_binary_path)
+            os.chmod(existing_binary_path, stat.S_IWUSR)
+            os.remove(existing_binary_path)
 
         url = self._latest_chromedriver_url(version) if version \
             else self._chromium_chromedriver_url(None)
@@ -756,7 +756,7 @@ class Chrome(Browser):
             rmtree(chromedriver_dir)
 
         binary_path = find_executable("chromedriver", dest)
-        assert binary_path == expected_binary_path
+        assert binary_path is not None
         return binary_path
 
     def install_webdriver(self, dest=None, channel=None, browser_binary=None):

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -664,8 +664,8 @@ class Chrome(Browser):
         chromedriver_version = self.webdriver_version(chromedriver_binary)
         if not chromedriver_version:
             self.logger.warning(
-                    "Unable to get version for ChromeDriver %s, rejecting it" %
-                    chromedriver_binary)
+                "Unable to get version for ChromeDriver %s, rejecting it" %
+                chromedriver_binary)
             return None
 
         if not browser_binary:
@@ -681,8 +681,8 @@ class Chrome(Browser):
         browser_major = browser_version.split('.')[0]
         if chromedriver_major != browser_major:
             self.logger.warning(
-                    "Found ChromeDriver %s; does not match Chrome/Chromium %s" %
-                    (chromedriver_version, browser_version))
+                "Found ChromeDriver %s; does not match Chrome/Chromium %s" %
+                (chromedriver_version, browser_version))
             return None
 
         return chromedriver_binary
@@ -777,14 +777,14 @@ class Chrome(Browser):
             return None
         return m.group(1)
 
-    def webdriver_version(self, wedriver_binary):
+    def webdriver_version(self, webdriver_binary):
         if uname[0] == "Windows":
             return _get_fileversion(webdriver_binary, self.logger)
 
         try:
-            version_string = call(wedriver_binary, "--version").strip()
+            version_string = call(webdriver_binary, "--version").strip()
         except subprocess.CalledProcessError:
-            self.logger.warning("Failed to call %s" % binary)
+            self.logger.warning("Failed to call %s" % webdriver_binary)
             return None
         m = re.match(r"ChromeDriver ([0-9.]*)", version_string)
         if not m:

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -686,6 +686,11 @@ class Chrome(Browser):
                     "Found ChromeDriver %s; too old for Chrome/Chromium %s" %
                     (chromedriver_version, browser_version))
             return None
+        if (chromedriver_major > browser_major):
+            self.logger.warning(
+                    "Found ChromeDriver %s; too new for Chrome/Chromium %s" %
+                    (chromedriver_version, browser_version))
+            return None
 
         return chromedriver_binary
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -339,8 +339,8 @@ class Chrome(BrowserSetup):
             webdriver_binary = None
             if not kwargs["install_webdriver"]:
                 webdriver_binary = self.browser.find_webdriver(
-                        channel=kwargs["browser_channel"],
-                        browser_binary=kwargs["binary"]
+                    channel=kwargs["browser_channel"],
+                    browser_binary=kwargs["binary"]
                 )
 
             if webdriver_binary is None:

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -334,16 +334,20 @@ class Chrome(BrowserSetup):
                 logger.info("MojoJS enabled")
             except Exception as e:
                 logger.error("Cannot enable MojoJS: %s" % e)
+
         if kwargs["webdriver_binary"] is None:
             webdriver_binary = None
             if not kwargs["install_webdriver"]:
-                webdriver_binary = self.browser.find_webdriver()
+                webdriver_binary = self.browser.find_webdriver(
+                        channel=kwargs["browser_channel"],
+                        browser_binary=kwargs["binary"]
+                )
 
             if webdriver_binary is None:
                 install = self.prompt_install("chromedriver")
 
                 if install:
-                    logger.info("Downloading chromedriver")
+                    logger.info("Downloading ChromeDriver")
                     webdriver_binary = self.browser.install_webdriver(
                         dest=self.venv.bin_path,
                         channel=browser_channel,
@@ -355,7 +359,7 @@ class Chrome(BrowserSetup):
             if webdriver_binary:
                 kwargs["webdriver_binary"] = webdriver_binary
             else:
-                raise WptrunError("Unable to locate or install chromedriver binary")
+                raise WptrunError("Unable to locate or install matching ChromeDriver binary")
         if browser_channel in self.experimental_channels:
             logger.info("Automatically turning on experimental features for Chrome Dev/Canary or Chromium trunk")
             kwargs["binary_args"].append("--enable-experimental-web-platform-features")

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -347,7 +347,6 @@ class Chrome(BrowserSetup):
                 install = self.prompt_install("chromedriver")
 
                 if install:
-                    logger.info("Downloading ChromeDriver")
                     webdriver_binary = self.browser.install_webdriver(
                         dest=self.venv.bin_path,
                         channel=browser_channel,

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -59,6 +59,30 @@ def test_chrome_find_webdriver(mocked_find_executable):
     assert chrome.find_webdriver(browser_binary='/usr/bin/chrome') is None
 
 
+@mock.patch('tools.wpt.browser.call')
+def test_chrome_webdriver_version(mocked_call):
+    chrome = browser.Chrome(logger)
+    webdriver_binary = '/usr/bin/chromedriver'
+
+    # Working cases.
+    mocked_call.return_value = 'ChromeDriver 84.0.4147.30'
+    assert chrome.webdriver_version(webdriver_binary) == '84.0.4147.30'
+    mocked_call.return_value = 'ChromeDriver 87.0.1 (abcd1234-refs/branch-heads/4147@{#310})'
+    assert chrome.webdriver_version(webdriver_binary) == '87.0.1'
+
+    # Various invalid version strings
+    mocked_call.return_value = 'Chrome 84.0.4147.30 (dev)'
+    assert chrome.webdriver_version(webdriver_binary) is None
+    mocked_call.return_value = 'ChromeDriver New 84.0.4147.30'
+    assert chrome.webdriver_version(webdriver_binary) is None
+    mocked_call.return_value = ''
+    assert chrome.webdriver_version(webdriver_binary) is None
+
+    # The underlying subprocess call throws.
+    mocked_call.side_effect = subprocess.CalledProcessError(5, 'cmd', output='Call failed')
+    assert chrome.webdriver_version(webdriver_binary) is None
+
+
 @mock.patch('subprocess.check_output')
 def test_safari_version(mocked_check_output):
     safari = browser.Safari(logger)

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -59,6 +59,9 @@ def test_chrome_find_webdriver(mocked_find_executable):
     assert chrome.find_webdriver(browser_binary='/usr/bin/chrome') is None
 
 
+# On Windows, webdriver_version directly calls _get_fileversion, so there is no
+# logic to test there.
+@pytest.mark.skipif(sys.platform.startswith('win'), reason='just uses _get_fileversion on Windows')
 @mock.patch('tools.wpt.browser.call')
 def test_chrome_webdriver_version(mocked_call):
     chrome = browser.Chrome(logger)


### PR DESCRIPTION
This fixes a long standing annoyance where we will blindly accept any
'chromedriver' binary, even if it isn't compatible with the Chrome
version under test. Instead, check that the versions of Chrome and
ChromeDriver mostly match. ChromeDriver is allowed to lag behind by a
release version, to allow for using a local build of Chromium.