### PR TITLE
Test more display variants

### DIFF
--- a/css/css-display/display-math-on-non-mathml-elements.html
+++ b/css/css-display/display-math-on-non-mathml-elements.html
@@ -8,14 +8,18 @@
 <div id="container">
 
   <div data-expected="block" style="display: math;"></div>
-  <div data-expected="inline" style="display: inline-math;"></div>
+  <div data-expected="block" style="display: inline-math;"></div>
   <div data-expected="inline" style="display: inline math;"></div>
+  <div data-expected="inline" style="display: math inline;"></div>
   <div data-expected="block" style="display: block math;"></div>
+  <div data-expected="block" style="display: math block;"></div>
 
   <svg data-expected="block" style="display: math;"></svg>
-  <svg data-expected="inline" style="display: inline-math;"></svg>
+  <svg data-expected="block" style="display: inline-math;"></svg>
   <svg data-expected="inline" style="display: inline math;"></svg>
+  <svg data-expected="inline" style="display: math inline;"></svg>
   <svg data-expected="block" style="display: block math;"></svg>
+  <svg data-expected="block" style="display: math block;"></svg>
 
 </div>
 


### PR DESCRIPTION
In addition to the usual outside-inside format for display also
test inside-outside. The value inline-math is no longer accepted
so change the expectation since it now acts as if no display value
is stated, since it is now invalid.