### PR TITLE
[Resource timing] move some tests to not rely on sync entry addition

### DIFF
--- a/resource-timing/buffer-full-add-entries-during-callback-that-drop.html
+++ b/resource-timing/buffer-full-add-entries-during-callback-that-drop.html
@@ -22,7 +22,8 @@ let overflowTheBufferAndWaitForEvent = () => {
         var add_entry = () => {
             performance.setResourceTimingBufferSize(resource_timing_buffer_size + 1);
             // The sync entry is added to the secondary buffer, so will be the last one there and eventually dropped.
-            asyncXHR("resources/empty.js?xhr").then(resolve);
+            syncXHR("resources/empty.js?xhr");
+            resolve();
         }
         performance.addEventListener('resourcetimingbufferfull', add_entry);
         // This resource overflows the entry buffer, and goes into the secondary buffer.

--- a/resource-timing/buffer-full-add-entries-during-callback-that-drop.html
+++ b/resource-timing/buffer-full-add-entries-during-callback-that-drop.html
@@ -22,12 +22,11 @@ let overflowTheBufferAndWaitForEvent = () => {
         var add_entry = () => {
             performance.setResourceTimingBufferSize(resource_timing_buffer_size + 1);
             // The sync entry is added to the secondary buffer, so will be the last one there and eventually dropped.
-            xhrScript("resources/empty.js?xhr");
-            resolve();
+            asyncXHR("resources/empty.js?xhr").then(resolve);
         }
         performance.addEventListener('resourcetimingbufferfull', add_entry);
         // This resource overflows the entry buffer, and goes into the secondary buffer.
-        appendScript('resources/empty_script.js');
+        appendScript('resources/empty_script.js', resolve);
     });
 };
 

--- a/resource-timing/buffer-full-add-entries-during-callback.html
+++ b/resource-timing/buffer-full-add-entries-during-callback.html
@@ -19,14 +19,14 @@ setup(() => {
 
 let overflowTheBufferAndWaitForEvent = () => {
     return new Promise(resolve => {
-        var add_entry = () => {
+        const add_entry = () => {
             performance.setResourceTimingBufferSize(resource_timing_buffer_size + 2);
-            xhrScript("resources/empty.js?xhr");
+            syncXHR("resources/empty.js?xhr");
             resolve();
         }
         performance.addEventListener('resourcetimingbufferfull', add_entry);
         // This resource overflows the entry buffer, and goes into the secondary buffer.
-        appendScript('resources/empty_script.js');
+        appendScript('resources/empty_script.js', resolve);
     });
 };
 

--- a/resource-timing/buffer-full-add-then-clear.html
+++ b/resource-timing/buffer-full-add-then-clear.html
@@ -18,7 +18,7 @@ setup(() => {
     performance.addEventListener('resourcetimingbufferfull', () => { assert_unreached("resourcetimingbufferfull should not fire")});
 });
 
-const overflowTheBuffer = async () => {
+const overflowTheBuffer = () => {
     // These resources overflow the entry buffer, and go into the secondary buffer.
     syncXHR('resources/empty.js?xhr2');
     syncXHR('resources/empty.js?xhr3');

--- a/resource-timing/buffer-full-add-then-clear.html
+++ b/resource-timing/buffer-full-add-then-clear.html
@@ -18,13 +18,13 @@ setup(() => {
     performance.addEventListener('resourcetimingbufferfull', () => { assert_unreached("resourcetimingbufferfull should not fire")});
 });
 
-let overflowTheBuffer = () => {
+const overflowTheBuffer = async () => {
     // These resources overflow the entry buffer, and go into the secondary buffer.
-    xhrScript('resources/empty.js?xhr2');
-    xhrScript('resources/empty.js?xhr3');
+    syncXHR('resources/empty.js?xhr2');
+    syncXHR('resources/empty.js?xhr3');
     performance.clearResourceTimings();
     performance.setResourceTimingBufferSize(3);
-    xhrScript('resources/empty.js?xhr4');
+    syncXHR('resources/empty.js?xhr4');
     window.entriesAfterAddition = performance.getEntriesByType('resource');
 };
 

--- a/resource-timing/buffer-full-inspect-buffer-during-callback.html
+++ b/resource-timing/buffer-full-inspect-buffer-during-callback.html
@@ -15,7 +15,7 @@ let eventFired = false;
 
 setup(() => {
     clearBufferAndSetSize(resource_timing_buffer_size);
-  const resize = async () => {
+  const resize = () => {
         assert_equals(performance.getEntriesByType("resource").length, resource_timing_buffer_size, "resource timing buffer in resourcetimingbufferfull is the size of the limit");
         ++resource_timing_buffer_size;
         performance.setResourceTimingBufferSize(resource_timing_buffer_size);

--- a/resource-timing/buffer-full-inspect-buffer-during-callback.html
+++ b/resource-timing/buffer-full-inspect-buffer-during-callback.html
@@ -15,11 +15,11 @@ let eventFired = false;
 
 setup(() => {
     clearBufferAndSetSize(resource_timing_buffer_size);
-    var resize = function() {
+  const resize = async () => {
         assert_equals(performance.getEntriesByType("resource").length, resource_timing_buffer_size, "resource timing buffer in resourcetimingbufferfull is the size of the limit");
         ++resource_timing_buffer_size;
         performance.setResourceTimingBufferSize(resource_timing_buffer_size);
-        xhrScript("resources/empty.js?xhr");
+        syncXHR("resources/empty.js?xhr");
         assert_equals(performance.getEntriesByType("resource").length, resource_timing_buffer_size - 1, "A sync request was not added to the primary buffer just yet, because it is full");
         ++resource_timing_buffer_size;
         performance.setResourceTimingBufferSize(resource_timing_buffer_size);

--- a/resource-timing/buffer-full-then-increased.html
+++ b/resource-timing/buffer-full-then-increased.html
@@ -19,8 +19,8 @@ setup(() => {
 
 let overflowTheBuffer = () => {
     // These resources overflow the entry buffer, and go into the secondary buffer.
-    xhrScript('resources/empty.js?xhr2');
-    xhrScript('resources/empty.js?xhr3');
+    syncXHR('resources/empty.js?xhr2');
+    syncXHR('resources/empty.js?xhr3');
     performance.setResourceTimingBufferSize(3);
 };
 

--- a/resource-timing/buffer-full-when-populate-entries.html
+++ b/resource-timing/buffer-full-when-populate-entries.html
@@ -14,12 +14,13 @@
 const resource_timing_buffer_size = 2;
 let bufferFullCount = 0;
 let eventFired = false;
+let eventBubbles = true;
 setup(() => {
     clearBufferAndSetSize(resource_timing_buffer_size);
     performance.addEventListener('resourcetimingbufferfull', e => {
-        assert_equals(e.bubbles, false, "Event bubbles attribute is false");
         bufferFullCount++;
         eventFired = true;
+        eventBubbles = e.bubbles;
     });
 });
 
@@ -33,6 +34,7 @@ let overflowTheBuffer = () => {
 let testThatBufferContainsTheRightResources = () => {
     assert_equals(performance.getEntriesByType('resource').length, resource_timing_buffer_size, 'There should only be |bufferSize| resource entries.');
     assert_equals(bufferFullCount, 1, 'onresourcetimingbufferfull should have been invoked once.');
+    assert_false(eventBubbles, 'onresourcetimingbufferfull should not bubble.');
 };
 
 promise_test(async () => {

--- a/resource-timing/resources/buffer-full-utilities.js
+++ b/resource-timing/resources/buffer-full-utilities.js
@@ -1,13 +1,30 @@
 let appendScript = (src, resolve) => {
+    const po = new PerformanceObserver((list, observer) =>  { 
+      observer.disconnect();
+      resolve();
+    });
+    po.observe({entryTypes: ["resource"]});
     const script = document.createElement('script');
     script.type = 'text/javascript';
     script.src = src;
-    script.onload = resolve;
     document.body.appendChild(script);
 }
 
-let xhrScript = src => {
-    var xhr = new XMLHttpRequest();
+const asyncXHR = src => {
+    return new Promise(resolve => {
+      const po = new PerformanceObserver((list, observer) =>  { 
+        observer.disconnect();
+        resolve();
+      });
+      po.observe({entryTypes: ["resource"]});
+      const xhr = new XMLHttpRequest();
+      xhr.open("GET", src);
+      xhr.send(null);
+    });
+}
+
+const syncXHR = src => {
+    const xhr = new XMLHttpRequest();
     xhr.open("GET", src, false);
     xhr.send(null);
 }

--- a/resource-timing/resources/buffer-full-utilities.js
+++ b/resource-timing/resources/buffer-full-utilities.js
@@ -1,4 +1,7 @@
 let appendScript = (src, resolve) => {
+    // This PerformanceObserver ensures the Promise resolves once the script's
+    // entry was added to the observer, under the assumption that this implies
+    // it was also added to the PerformanceTimeline.
     const po = new PerformanceObserver((list, observer) =>  { 
       observer.disconnect();
       resolve();

--- a/resource-timing/resources/buffer-full-utilities.js
+++ b/resource-timing/resources/buffer-full-utilities.js
@@ -10,19 +10,6 @@ let appendScript = (src, resolve) => {
     document.body.appendChild(script);
 }
 
-const asyncXHR = src => {
-    return new Promise(resolve => {
-      const po = new PerformanceObserver((list, observer) =>  { 
-        observer.disconnect();
-        resolve();
-      });
-      po.observe({entryTypes: ["resource"]});
-      const xhr = new XMLHttpRequest();
-      xhr.open("GET", src);
-      xhr.send(null);
-    });
-}
-
 const syncXHR = src => {
     const xhr = new XMLHttpRequest();
     xhr.open("GET", src, false);


### PR DESCRIPTION
This PR does several things:
* Rename `xhrScript` to `syncXHR` to make the fact it's sync obvious
* Ensure `appendScript` no longer relies on its entries being added synchronously
* Avoid an assert outside of a test for `event.bubbles`
* Clean up

Partially addresses #25650