### PR TITLE
Added navigation-timing/nav2_test_redirect_chain_xserver_final_original_origin

### DIFF
--- a/navigation-timing/nav2_test_redirect_chain_xserver_final_original_origin.html
+++ b/navigation-timing/nav2_test_redirect_chain_xserver_final_original_origin.html
@@ -11,13 +11,6 @@
         <script>
             setup({ single_test: true });
 
-            function verifyTimingEventOrder(eventOrder, timingEntry) {
-                for (let i = 0; i < eventOrder.length - 1; i++) {
-                    assert_true(timingEntry[eventOrder[i]] < timingEntry[eventOrder[i + 1]],
-                        "Expected " + eventOrder[i] + " to be no greater than " + eventOrder[i + 1] + ".");
-                }
-            }
-
             function onload_test()
             {
                 const frame_performance = document.getElementById("frameContext").contentWindow.performance;

--- a/navigation-timing/nav2_test_redirect_chain_xserver_final_original_origin.html
+++ b/navigation-timing/nav2_test_redirect_chain_xserver_final_original_origin.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Navigation Timing 2 WPT</title>
+        <link rel="author" title="Google" href="http://www.google.com/" />
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing-2/#sec-PerformanceNavigationTiming"/>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="/common/utils.js"></script>
+        <script>
+            setup({ single_test: true });
+
+            function verifyTimingEventOrder(eventOrder, timingEntry) {
+                for (let i = 0; i < eventOrder.length - 1; i++) {
+                    assert_true(timingEntry[eventOrder[i]] < timingEntry[eventOrder[i + 1]],
+                        "Expected " + eventOrder[i] + " to be no greater than " + eventOrder[i + 1] + ".");
+                }
+            }
+
+            function onload_test()
+            {
+                const frame_performance = document.getElementById("frameContext").contentWindow.performance;
+                assert_equals(frame_performance.getEntriesByType("navigation")[0].type,
+                    "navigate",
+                    "Expected navigation type to be navigate.");
+                assert_equals(frame_performance.getEntriesByType("navigation")[0].redirectCount, 0,
+                    "Expected redirectCount to be 0.");
+                assert_equals(frame_performance.getEntriesByType("navigation")[0].redirectStart, 0,
+                    "Expected redirectStart to be 0.");
+                assert_equals(frame_performance.getEntriesByType("navigation")[0].redirectEnd, 0,
+                    "Expected redirectEnd to be 0.");
+                done();
+            }
+        </script>
+
+    </head>
+    <body>
+        <h1>Description</h1>
+        <p>This test validates the values of the window.performance.getEntriesByType("navigation")[0].redirectCount and the
+           window.performance.getEntriesByType("navigation")[0].redirectStart/End times for a cross-origin server side redirect navigation when the final
+           document is the same as the original origin.</p>
+
+        <iframe id="frameContext" src="" style="width: 250px; height: 250px;"></iframe>
+        <script>
+            // combine the page origin and redirect origin into the IFRAME's src URL
+            const destUrl_first = make_absolute_url({subdomain: "www",
+                                             path: "/common/redirect-opt-in.py",
+                                             query: "location=" + make_absolute_url(
+                                                         {path: "/navigation-timing/resources/blank_page_green.html"})
+                                             });
+            const destUrl = make_absolute_url({
+                                             path: "/common/redirect.py",
+                                             query: "location=" + destUrl_first});
+            let frameContext = document.getElementById("frameContext");
+            frameContext.onload = onload_test;
+            frameContext.src = destUrl;
+        </script>
+    </body>
+</html>

--- a/navigation-timing/nav2_test_redirect_chain_xserver_partial_opt_in.html
+++ b/navigation-timing/nav2_test_redirect_chain_xserver_partial_opt_in.html
@@ -11,13 +11,6 @@
         <script>
             setup({ single_test: true });
 
-            function verifyTimingEventOrder(eventOrder, timingEntry) {
-                for (let i = 0; i < eventOrder.length - 1; i++) {
-                    assert_true(timingEntry[eventOrder[i]] < timingEntry[eventOrder[i + 1]],
-                        "Expected " + eventOrder[i] + " to be no greater than " + eventOrder[i + 1] + ".");
-                }
-            }
-
             function onload_test()
             {
                 const frame_performance = document.getElementById("frameContext").contentWindow.performance;


### PR DESCRIPTION
Adds a test that:

* starts from a page on `web-platform.test/...`
* iframe added for `www.web-platform.test/...` (cross origin)
* which redirects to `www.web-platform.test/...` (cross origin)
* which redirects to `web-platform.test/...` (same as original origin)

In this case, because of the cross-origin redirects, `redirectCount`, `redirectStart` and `redirectEnd` should all be `0`.

