### PR TITLE
Fix #23969: Use inexact test type for DUPLICATE-BASENAME-PATH

### DIFF
--- a/lint.ignore
+++ b/lint.ignore
@@ -781,3 +781,11 @@ TESTHARNESS-IN-OTHER-TYPE: svg/svg-in-svg/svg-in-svg-circular-filter-reference-c
 
 PRINT STATEMENT: webdriver/tests/print/printcmd.py
 PRINT STATEMENT: webdriver/tests/print/user_prompts.py
+
+DUPLICATE-BASENAME-PATH: acid/acid3/empty.html
+DUPLICATE-BASENAME-PATH: acid/acid3/empty.xml
+DUPLICATE-BASENAME-PATH: dom/nodes/Document-createElement-namespace-tests/*
+DUPLICATE-BASENAME-PATH: dom/nodes/ParentNode-querySelector-All-content.html
+DUPLICATE-BASENAME-PATH: dom/nodes/ParentNode-querySelector-All-content.xht
+DUPLICATE-BASENAME-PATH: svg/struct/reftests/reference/green-100x100.html
+DUPLICATE-BASENAME-PATH: svg/struct/reftests/reference/green-100x100.svg

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -367,7 +367,7 @@ def check_unique_testharness_basenames(repo_root, paths):
     file_dict = defaultdict(list)
     for path in paths:
         source_file = SourceFile(repo_root, path, "/")
-        if source_file.type != "testharness":
+        if "testharness" not in source_file.possible_types:
             continue
         file_name, file_extension = os.path.splitext(path)
         file_dict[file_name].append(file_extension)

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -865,6 +865,10 @@ class SourceFile(object):
     @property
     def type(self):
         # type: () -> Text
+        possible_types = self.possible_types
+        if len(possible_types) == 1:
+            return possible_types.pop()
+
         rv, _ = self.manifest_items()
         return rv
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -868,6 +868,61 @@ class SourceFile(object):
         rv, _ = self.manifest_items()
         return rv
 
+    @property
+    def possible_types(self):
+        # type: () -> Set[Text]
+        """Determines the set of possible types without reading the file"""
+
+        if self.items_cache:
+            return {self.items_cache[0]}
+
+        if self.name_is_non_test:
+            return {SupportFile.item_type}
+
+        if self.name_is_manual:
+            return {ManualTest.item_type}
+
+        if self.name_is_conformance:
+            return {ConformanceCheckerTest.item_type}
+
+        if self.name_is_conformance_support:
+            return {SupportFile.item_type}
+
+        if self.name_is_webdriver:
+            return {WebDriverSpecTest.item_type}
+
+        if self.name_is_visual:
+            return {VisualTest.item_type}
+
+        if self.name_is_crashtest:
+            return {CrashTest.item_type}
+
+        if self.name_is_print_reftest:
+            return {PrintRefTest.item_type}
+
+        if self.name_is_multi_global:
+            return {TestharnessTest.item_type}
+
+        if self.name_is_worker:
+            return {TestharnessTest.item_type}
+
+        if self.name_is_window:
+            return {TestharnessTest.item_type}
+
+        if self.markup_type is None:
+            return {SupportFile.item_type}
+
+        if not self.name_is_reference:
+            return {ManualTest.item_type,
+                    TestharnessTest.item_type,
+                    RefTest.item_type,
+                    VisualTest.item_type,
+                    SupportFile.item_type}
+
+        return {TestharnessTest.item_type,
+                RefTest.item_type,
+                SupportFile.item_type}
+
     def manifest_items(self):
         # type: () -> Tuple[Text, List[ManifestItem]]
         """List of manifest items corresponding to the file. There is typically one
@@ -1070,6 +1125,7 @@ class SourceFile(object):
                     self.rel_path
                 )]
 
+        assert rv[0] in self.possible_types
         assert len(rv[1]) == len(set(rv[1]))
 
         self.items_cache = rv


### PR DESCRIPTION
The introduction of the DUPLICATE-BASENAME-PATH lint caused a significant performance regression which this now reverses. That is (and this fixes) #23969.

This introduces a function that determines possible test types without actually reading the file, based purely on the file name. This provides a significant increase in performance for the lint without a significant change in accuracy.

Benchmarks on Arch Linux, 4C/8T Intel Core i7 3770K:

Py2:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| master | 253.784 ± 1.122 | 252.485 | 255.992 | 6.04 ± 0.03 |
| this | 173.852 ± 0.826 | 172.657 | 175.148 | 4.14 ± 0.02 |
| #25746  | 109.080 ± 0.701 | 108.120 | 110.229 | 2.60 ± 0.02 |
| this + #25746 | 42.007 ± 0.142 | 41.756 | 42.153 | 1.00 |

Py3:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| master | 171.874 ± 1.540 | 169.579 | 174.381 | 5.95 ± 0.06 |
| this | 117.550 ± 1.014 | 116.462 | 120.105 | 4.07 ± 0.04 |
| #25746 | 74.602 ± 0.365 | 74.108 | 75.198 | 2.58 ± 0.02 |
| this + #25746 | 28.873 ± 0.105 | 28.734 | 29.052 | 1.00 |