### PR TITLE
Update math-level depth to match the new syntax

### DIFF
--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-001.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-001.tentative.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>math-depth</title>
+    <meta charset="utf-8">
+    <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-math-script-level-property">
+    <meta name="assert" content="Check the computed value of math-depth">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+      function mathDepth(id) {
+          return window.getComputedStyle(document.getElementById(id)).
+              getPropertyValue("math-depth");
+      }
+      setup({ explicit_done: true });
+      window.addEventListener("load", function() {
+          test(function() {
+              assert_equals(mathDepth("initial"), "0");
+              assert_equals(mathDepth("initialFrom11"), "0");
+          }, "Initial value of math-depth");
+          test(function() {
+              assert_equals(mathDepth("inherited11"), "11");
+              assert_equals(mathDepth("inherited-7"), "-7");
+          }, "Inherited values of math-depth");
+          test(function() {
+              assert_equals(mathDepth("inherited9specifiedAutoInline"), "10");
+              assert_equals(mathDepth("inherited9specifiedAutoDisplay"), "9");
+          }, "Specified math-depth: auto-add");
+          test(function() {
+              assert_equals(mathDepth("specified11"), "11");
+              assert_equals(mathDepth("specified-7"), "-7");
+          }, "Specified math-depth: <integer>");
+          test(function() {
+              assert_equals(mathDepth("specifiedAdd10From5"), "15");
+              assert_equals(mathDepth("specifiedAdd-15From5"), "-10");
+          }, "Specified math-depth: add(<integer>)");
+          done();
+      });
+    </script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="initial"></div>
+    <div id="specified11" style="math-depth: 11">
+      <div id="initialFrom11" style="math-depth: initial"></div>
+      <div id="inherited11"></div>
+    </div>
+    <div id="specified-7" style="math-depth: -7">
+      <div id="inherited-7"></div>
+    </div>
+    <div style="math-depth: 9">
+      <div style="math-style: compact">
+        <div id="inherited9specifiedAutoInline" style="math-depth: auto-add" ></div>
+      </div>
+      <div style="math-style: normal">
+        <div id="inherited9specifiedAutoDisplay" style="math-depth: auto-add" ></div>
+      </div>
+    </div>
+    <div style="math-depth: 5">
+      <div id="specifiedAdd10From5" style="math-depth: add(10)"></div>
+      <div id="specifiedAdd-15From5" style="math-depth: add(-15)"></div>
+    </div>
+  </body>
+</html>

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-002.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-002.tentative.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/3746">
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-math-script-level-property">
     <link rel="help" href="https://www.w3.org/TR/cssom-1/#serialize-a-css-component-value">
-    <meta name="assert" content="Verify effect of font-size: scriptlevel(auto) | scriptlevel(add(<integer>)) | scriptlevel(<integer>), starting from different values of math-script-level.">
+    <meta name="assert" content="Verify effect of math-depth: auto-add | add(<integer) | (<integer>, starting from different values of math-depth.">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
@@ -81,111 +81,111 @@
       <div class="container">
         <div>
           <div style="font-size: 200px; math-style: normal">
-            <div id="autoDisplay" style="font-size: scriptlevel(auto)"></div>
+            <div id="autoDisplay" style="font-size: math; math-depth: auto-add"></div>
           </div>
           <div style="font-size: 500px; math-style: compact">
-            <div id="autoInline" style="font-size: scriptlevel(auto)"></div>
+            <div id="autoInline" style="font-size: math; math-depth: auto-add"></div>
           </div>
         </div>
         <div style="font-size: 2000px;">
-          <div style="math-style: normal; font-size: scriptlevel(7)">
-            <div id="autoDisplayFrom7" style="font-size: scriptlevel(auto)"></div>
+          <div style="math-style: normal; font-size: math; math-depth: 7">
+            <div id="autoDisplayFrom7" style="font-size: math; math-depth: auto-add"></div>
           </div>
-          <div style="math-style: compact; font-size: scriptlevel(7)">
-            <div id="autoInlineFrom7" style="font-size: scriptlevel(auto)"></div>
+          <div style="math-style: compact; font-size: math; math-depth: 7">
+            <div id="autoInlineFrom7" style="font-size: math; math-depth: auto-add"></div>
           </div>
         </div>
         <div>
           <div style="font-size: 200px">
-            <div id="add0" style="font-size: scriptlevel(add(0))"></div>
+            <div id="add0" style="font-size: math; math-depth: add(0)"></div>
           </div>
           <div style="font-size: 71px">
-            <div id="add-1" style="font-size: scriptlevel(add(-1))"></div>
+            <div id="add-1" style="font-size: math; math-depth: add(-1)"></div>
           </div>
           <div style="font-size: 500px">
-            <div id="add1" style="font-size: scriptlevel(add(1))"></div>
+            <div id="add1" style="font-size: math; math-depth: add(1)"></div>
           </div>
           <div style="font-size: 200px">
-            <div id="add-2" style="font-size: scriptlevel(add(-2))"></div>
+            <div id="add-2" style="font-size: math; math-depth: add(-2)"></div>
           </div>
           <div style="font-size: 1000px">
-            <div id="add2" style="font-size: scriptlevel(add(2))"></div>
+            <div id="add2" style="font-size: math; math-depth: add(2)"></div>
           </div>
           <div style="font-size: 30px">
-            <div id="add-9" style="font-size: scriptlevel(add(-9))"></div>
+            <div id="add-9" style="font-size: math; math-depth: add(-9)"></div>
           </div>
           <div style="font-size: 2000px">
-            <div id="add9" style="font-size: scriptlevel(add(9))"></div>
+            <div id="add9" style="font-size: math; math-depth: add(9)"></div>
           </div>
         </div>
-        <div style="font-size: scriptlevel(3);">
+        <div style="math-depth: 3;">
           <div style="font-size: 200px;">
-            <div id="add0from3" style="font-size: scriptlevel(add(0))"></div>
+            <div id="add0from3" style="font-size: math; math-depth: add(0)"></div>
           </div>
           <div style="font-size: 71px;">
-            <div id="add-1from3" style="font-size: scriptlevel(add(-1))"></div>
+            <div id="add-1from3" style="font-size: math; math-depth: add(-1)"></div>
           </div>
           <div style="font-size: 500px;">
-            <div id="add1from3" style="font-size: scriptlevel(add(1))"></div>
+            <div id="add1from3" style="font-size: math; math-depth: add(1)"></div>
           </div>
           <div style="font-size: 200px;">
-            <div id="add-2from3" style="font-size: scriptlevel(add(-2))"></div>
+            <div id="add-2from3" style="font-size: math; math-depth: add(-2)"></div>
           </div>
           <div style="font-size: 1000px;">
-            <div id="add2from3" style="font-size: scriptlevel(add(2))"></div>
+            <div id="add2from3" style="font-size: math; math-depth: add(2)"></div>
           </div>
           <div style="font-size: 30px;">
-            <div id="add-9from3" style="font-size: scriptlevel(add(-9))"></div>
+            <div id="add-9from3" style="font-size: math; math-depth: add(-9)"></div>
           </div>
           <div style="font-size: 2000px;">
-            <div id="add9from3" style="font-size: scriptlevel(add(9))"></div>
+            <div id="add9from3" style="font-size: math; math-depth: add(9)"></div>
           </div>
         </div>
         <div>
           <div style="font-size: 200px">
-            <div id="set0" style="font-size: scriptlevel(0)"></div>
+            <div id="set0" style="font-size: math; math-depth: 0"></div>
           </div>
           <div style="font-size: 71px">
-            <div id="set-1" style="font-size: scriptlevel(-1)"></div>
+            <div id="set-1" style="font-size: math; math-depth: -1"></div>
           </div>
           <div style="font-size: 500px">
-            <div id="set1" style="font-size: scriptlevel(1)"></div>
+            <div id="set1" style="font-size: math; math-depth: 1"></div>
           </div>
           <div style="font-size: 200px">
-            <div id="set-2" style="font-size: scriptlevel(-2)"></div>
+            <div id="set-2" style="font-size: math; math-depth: -2"></div>
           </div>
           <div style="font-size: 1000px">
-            <div id="set2" style="font-size: scriptlevel(2)"></div>
+            <div id="set2" style="font-size: math; math-depth: 2"></div>
           </div>
           <div style="font-size: 30px">
-            <div id="set-9" style="font-size: scriptlevel(-9)"></div>
+            <div id="set-9" style="font-size: math; math-depth: -9"></div>
           </div>
           <div style="font-size: 2000px">
-            <div id="set9" style="font-size: scriptlevel(9)"></div>
+            <div id="set9" style="font-size: math; math-depth: 9"></div>
           </div>
         </div>
       </div>
-        <div style="font-size: scriptlevel(50)">
+        <div style="math-depth: 50">
           <div style="font-size: 200px;">
-            <div id="set50" style="font-size: scriptlevel(50)"></div>
+            <div id="set50" style="font-size: math; math-depth: 50"></div>
           </div>
           <div style="font-size: 71px;">
-            <div id="set49" style="font-size: scriptlevel(49)"></div>
+            <div id="set49" style="font-size: math; math-depth: 49"></div>
           </div>
           <div style="font-size: 500px;">
-            <div id="set51" style="font-size: scriptlevel(51)"></div>
+            <div id="set51" style="font-size: math; math-depth: 51"></div>
           </div>
           <div style="font-size: 200px;">
-            <div id="set48" style="font-size: scriptlevel(48)"></div>
+            <div id="set48" style="font-size: math; math-depth: 48"></div>
           </div>
           <div style="font-size: 1000px;">
-            <div id="set52" style="font-size: scriptlevel(52)"></div>
+            <div id="set52" style="font-size: math; math-depth: 52"></div>
           </div>
           <div style="font-size: 30px;">
-            <div id="set41" style="font-size: scriptlevel(41)"></div>
+            <div id="set41" style="font-size: math; math-depth: 41"></div>
           </div>
           <div style="font-size: 2000px;">
-            <div id="set59" style="font-size: scriptlevel(59)"></div>
+            <div id="set59" style="font-size: math; math-depth: 59"></div>
           </div>
         </div>
       </div>

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-003.tentative-ref.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-003.tentative-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>math-depth</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <style>
+      .container {
+          /* Ahem font does not have a MATH table so the font-size scale factor
+             is always 0.71^{computed - inherited math script level} */
+          font: 100px/1 Ahem;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Test passes if you see two squares of side 100px.</p>
+    <div class="container">
+      <div>X</div>
+    </div>
+    <br/>
+    <div class="container">
+      <div>X</div>
+    </div>
+  </body>
+</html>

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-003.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-003.tentative.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>math-depth</title>
+    <meta charset="utf-8">
+    <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/3746">
+    <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-math-script-level-property">
+    <meta name="assert" content="If specified font-size is not 'math' then math-depth does not affect the computed value of font-size.">
+    <link rel="match" href="math-script-level-003.tentative-ref.html">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <style>
+      .container {
+          /* Ahem font does not have a MATH table so the font-size scale factor
+             is always 0.71^{computed - inherited math script level} */
+          font: 100px/1 Ahem;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Test passes if you see two squares of side 100px.</p>
+    <div class="container" style="math-script-level: 3;">
+      <div style="math-level: 9; font-size: 100px;">X</div>
+    </div>
+    <br/>
+    <div class="container" style="math-script-level: 3;">
+      <div style="math-level: 9;">X</div>
+    </div>
+  </body>
+</html>

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-004.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-004.tentative.html
@@ -37,13 +37,13 @@
       }
       .big { font-size: 3000px; }
       .small { font-size: 150px; }
-      .level-3 { font-size: scriptlevel(-3); }
-      .level-1 { font-size: scriptlevel(-1); }
-      .level0 { font-size: scriptlevel(0); }
-      .level1 { font-size: scriptlevel(1); }
-      .level2 { font-size: scriptlevel(2); }
-      .level3 { font-size: scriptlevel(3); }
-      .level5 { font-size: scriptlevel(5); }
+      .level-3 { font-size: math; math-depth: -3; }
+      .level-1 { font-size: math; math-depth: -1; }
+      .level0 { font-size: math; math-depth: 0; }
+      .level1 { font-size: math; math-depth: 1; }
+      .level2 { font-size: math; math-depth: 2; }
+      .level3 { font-size: math; math-depth: 3; }
+      .level5 { font-size: math; math-depth: 5; }
     </style>
     <script>
       const big = 3000;

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-001.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-001.tentative.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/3746">
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-math-script-level-property">
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-math-style-property">
-    <meta name="assert" content="If font-size is scriptlevel('auto') and the inherited value of math-style is 'display' then the internal scriptlevel is the one of its parent.">
+    <meta name="assert" content="If specified font-size is math and specified math-depth is 'auto-add' and the inherited value of math-style is 'normal' then the computed math-depth is the one of its parent.">
     <link rel="match" href="math-script-level-auto-and-math-style-001.tentative-ref.html">
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
@@ -20,7 +20,7 @@
   <body>
     <p>Test passes if you see a square of side 100 × 0.71^(0 − 0) = 100px.</p>
     <div class="container" style="math-style: normal;">
-      <div style="font-size: scriptlevel(auto)">X</div>
+      <div style="font-size: math; math-depth: auto-add">X</div>
     </div>
   </body>
 </html>

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-002.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-002.tentative.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/3746">
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-math-script-level-property">
     <link rel="help" href="https://mathml-refresh.github.io/mathml-core/#the-math-style-property">
-    <meta name="assert" content="If font-size is scriptlevel('auto') and the inherited value of math-style is 'inline' then the internal scriptlevel is the one of its parent.">
+    <meta name="assert" content="If the specified font-size is 'math' and specified math-depth is 'auto-add' and the inherited value of math-style is 'compact' then the computed math-depth is the one of its parent.">
     <link rel="match" href="math-script-level-auto-and-math-style-002.tentative-ref.html">
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style>
@@ -20,7 +20,7 @@
   <body>
     <p>Test passes if you see a square of side 500 × 0.71^(1 − 0) = 355px.</p>
     <div class="container" style="math-style: compact;">
-      <div style="font-size: scriptlevel(auto)">X</div>
+      <div style="font-size: math; math-depth: auto-add">X</div>
     </div>
   </body>
 </html>

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-003.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-003.tentative.html
@@ -20,7 +20,7 @@
   <body>
     <p>Test passes if you see a square of side 500px.</p>
     <div class="container">
-      <div style="font-size: scriptlevel(auto)">X</div>
+      <div style="font-size: math; math-depth: auto-add">X</div>
     </div>
   </body>
 </html>

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-004.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-004.tentative.html
@@ -22,7 +22,7 @@
     <div class="container">
       <div style="math-style: compact">
         <div style="math-style: initial">
-          <div style="font-size: scriptlevel(auto)">X</div>
+          <div style="font-size: math; math-depth: auto-add">X</div>
         </div>
       </div>
     </div>

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-005.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-005.tentative.html
@@ -23,7 +23,7 @@
       <div style="math-style: normal;">
         <div>
           <div>
-            <div style="font-size: scriptlevel(auto)">X</div>
+            <div style="font-size: math; math-depth: auto-add">X</div>
           </div>
         </div>
       </div>

--- a/css/css-fonts/math-script-level-and-math-style/math-script-level-font-size-clamping-001.tentative.html
+++ b/css/css-fonts/math-script-level-and-math-style/math-script-level-font-size-clamping-001.tentative.html
@@ -19,8 +19,8 @@
   <body>
     <p>Test passes if you see a square of side 12px.</p>
     <div class="container"><!-- Initial size is 12px. -->
-      <div style="font-size: scriptlevel(add(8));"><!-- Size is 12*.71^8 = 0.7749042374949131 < 1px. -->
-        <div style="font-size: scriptlevel(add(-8));">X</div><!-- back to 12px. -->
+      <div style="font-size: math; math-depth: add(8);"><!-- Size is 12*.71^8 = 0.7749042374949131 < 1px. -->
+        <div style="font-size: math; math-depth: add(-8);">X</div><!-- back to 12px. -->
       </div>
     </div>
   </body>

--- a/mathml/relations/css-styling/attribute-mapping-002.html
+++ b/mathml/relations/css-styling/attribute-mapping-002.html
@@ -43,30 +43,26 @@
           }, `mathvariant on the ${tag} element is mapped to CSS text-transform`)
 
           test(function() {
-              var epsilon = .1
-              var fontSizeAtScriptLevelZero = fontSize(window.getComputedStyle(container));
-              var inheritedSize = fontSize(window.getComputedStyle(element.parentNode));
-
               // none and mprescripts appear as scripts
-              assert_approx_equals(fontSize(style), tag === "none" || tag === "mprescripts" ? inheritedSize * .71 : inheritedSize, epsilon, "no attribute");
+              assert_equals(style.getPropertyValue("math-depth"), tag === "none" || tag === "mprescripts" ? 1 : 0, "no attribute");
 
               var absoluteScriptlevel = 2;
               element.setAttribute("scriptlevel", absoluteScriptlevel);
-              assert_approx_equals(fontSize(style), fontSizeAtScriptLevelZero * Math.pow(.71, absoluteScriptlevel), epsilon, "attribute specified (<U>)");
+              assert_equals(style.getPropertyValue("math-depth"), absoluteScriptlevel, "attribute specified (<U>)");
 
               var positiveScriptlevelDelta = 1;
               element.setAttribute("scriptlevel", `+${positiveScriptlevelDelta}`);
-              assert_approx_equals(fontSize(style), inheritedSize * Math.pow(.71, positiveScriptlevelDelta), epsilon, "attribute specified (+<U>)");
+              assert_equals(style.getPropertyValue("math-depth"), positiveScriptlevelDelta, epsilon, "attribute specified (+<U>)");
 
               var negativeScriptlevelDelta = -3;
       element.setAttribute("scriptlevel", negativeScriptlevelDelta);
-              assert_approx_equals(fontSize(style), inheritedSize * Math.pow(.71, negativeScriptlevelDelta), epsilon, "attribute specified (-<U>)");
+              assert_approx_equals(style.getPropertyValue("math-depth"), negativeScriptlevelDelta, "attribute specified (-<U>)");
 
               element.setAttribute("scriptlevel", absoluteScriptlevel);
               element.setAttribute("mathsize", "42px");
               assert_approx_equals(fontSize(style), 42, epsilon, "mathsize wins over scriptlevel");
 
-          }, `scriptlevel on the ${tag} element is mapped to font-size: scriptlevel(...)`);
+          }, `scriptlevel on the ${tag} element is mapped to math-depth(...)`);
 
           test(function() {
               assert_equals(style.getPropertyValue("math-style"), "compact", "no attribute");

--- a/mathml/relations/css-styling/presentational-hints-001-ref.html
+++ b/mathml/relations/css-styling/presentational-hints-001-ref.html
@@ -55,7 +55,7 @@
   </p>
   <p>scriptlevel:
     <math>
-      <mtext style="font-size: scriptlevel(0);">X</mtext>
+      <mtext style="math-depth: 0;">X</mtext>
     </math>
   </p>
 </body>

--- a/mathml/relations/css-styling/presentational-hints-001.html
+++ b/mathml/relations/css-styling/presentational-hints-001.html
@@ -65,7 +65,7 @@
   </p>
   <p>scriptlevel:
     <math>
-      <mtext scriptlevel="1" style="font-size: scriptlevel(0);">X</mtext>
+      <mtext scriptlevel="1" style="math-depth: 0;">X</mtext>
     </math>
   </p>
 </body>


### PR DESCRIPTION
Discussed with the CSSWG at [1]. Syntax changes are
- Split scriptlevel(...) into math-depth: ... and font-size: math.
- Rename auto to auto-add

The old tests math-script-level-001 and math-script-level-003
are restored and adjusted to check the computed math-level in
various situations and that the math-level does not have any
effect when the specified font-size is not 'math'.

[1] https://github.com/w3c/csswg-drafts/issues/5389