### PR TITLE
Fix tests that return values to async_test in encrypted-media/

### DIFF
--- a/encrypted-media/scripts/onencrypted.js
+++ b/encrypted-media/scripts/onencrypted.js
@@ -25,7 +25,7 @@ function runTest(config) {
             };
 
         waitForEventAndRunStep('encrypted', video, onEncrypted, test);
-        return testmediasource(config).then(function (source) {
+        testmediasource(config).then(function (source) {
             mediaSource = source;
             config.video.src = URL.createObjectURL(mediaSource);
             return source.done;

--- a/encrypted-media/scripts/reset-src-after-setmediakeys.js
+++ b/encrypted-media/scripts/reset-src-after-setmediakeys.js
@@ -39,7 +39,7 @@ function runTest(config)
         };
 
         // Create a MediaKeys object and assign it to video.
-        return navigator.requestMediaKeySystemAccess(keysystem, [configuration]).then(test.step_func(function (access) {
+        navigator.requestMediaKeySystemAccess(keysystem, [configuration]).then(test.step_func(function (access) {
             assert_equals(access.keySystem, keysystem);
             return access.createMediaKeys();
         })).then(test.step_func(function (result) {


### PR DESCRIPTION
In both cases here, the test just didn't need to return the promise
that they use as part of the test flow.

See https://github.com/web-platform-tests/wpt/issues/21435