### PR TITLE
Fix tests that return values to async_test in webrtc/

### DIFF
--- a/webrtc/RTCPeerConnection-getStats.https.html
+++ b/webrtc/RTCPeerConnection-getStats.https.html
@@ -247,7 +247,7 @@
 
     const dataChannel = pc1.createDataChannel('test-channel');
 
-    return getNoiseStream({
+    getNoiseStream({
       audio: true,
       video: true
     })

--- a/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html
@@ -13,7 +13,7 @@
   async_test(t => {
     const caller = new RTCPeerConnection();
     t.add_cleanup(() => caller.close());
-    return getUserMediaTracksAndStreams(2)
+    getUserMediaTracksAndStreams(2)
     .then(t.step_func(([tracks, streams]) => {
       const sender = caller.addTrack(tracks[0], streams[0]);
       return sender.replaceTrack(tracks[1])
@@ -30,7 +30,7 @@
   async_test(t => {
     const caller = new RTCPeerConnection();
     t.add_cleanup(() => caller.close());
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       const sender = caller.addTrack(tracks[0], streams[0]);
       return sender.replaceTrack(null)
@@ -47,7 +47,7 @@
   async_test(t => {
     const caller = new RTCPeerConnection();
     t.add_cleanup(() => caller.close());
-    return getUserMediaTracksAndStreams(2)
+    getUserMediaTracksAndStreams(2)
     .then(t.step_func(([tracks, streams]) => {
       const sender = caller.addTrack(tracks[0], streams[0]);
       assert_equals(sender.track, tracks[0]);
@@ -66,7 +66,7 @@
     const expectedException = 'InvalidStateError';
     const caller = new RTCPeerConnection();
     t.add_cleanup(() => caller.close());
-    return getUserMediaTracksAndStreams(2)
+    getUserMediaTracksAndStreams(2)
     .then(t.step_func(([tracks, streams]) => {
       const sender = caller.addTrack(tracks[0], streams[0]);
       caller.close();

--- a/webrtc/RTCPeerConnection-track-stats.https.html
+++ b/webrtc/RTCPeerConnection-track-stats.https.html
@@ -23,7 +23,7 @@
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
     let track;
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       track = tracks[0];
@@ -49,7 +49,7 @@
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
     let stream;
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       let track = tracks[0];
@@ -72,7 +72,7 @@
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
     let track;
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       track = tracks[0];
@@ -100,7 +100,7 @@
     const pc = new RTCPeerConnection();
     t.add_cleanup(() => pc.close());
     let stream;
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       let track = tracks[0];
@@ -130,7 +130,7 @@
     t.add_cleanup(() => pc.close());
     let track;
     let stream;
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       track = tracks[0];
@@ -165,7 +165,7 @@
     t.add_cleanup(() => pc.close());
     let track;
     let stream;
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       track = tracks[0];
@@ -203,7 +203,7 @@
     const callee = new RTCPeerConnection();
     t.add_cleanup(() => callee.close());
     let sendingTrack;
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       sendingTrack = tracks[0];
@@ -238,7 +238,7 @@
       assert_equals(receivingTrack, undefined, 'ontrack has not fired before');
       receivingTrack = trackEvent.track;
     };
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       caller.addTrack(tracks[0], streams[0]);
@@ -271,7 +271,7 @@
     let sendingTrack1;
     let sendingTrack2;
     let sender;
-    return getUserMediaTracksAndStreams(2)
+    getUserMediaTracksAndStreams(2)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       sendingTrack1 = tracks[0];
@@ -301,7 +301,7 @@
     let sendingTrack1;
     let sendingTrack2;
     let sender;
-    return getUserMediaTracksAndStreams(2)
+    getUserMediaTracksAndStreams(2)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       sendingTrack1 = tracks[0];
@@ -339,7 +339,7 @@
     let sendingTrack1;
     let sendingTrack2;
     let sender;
-    return getUserMediaTracksAndStreams(2)
+    getUserMediaTracksAndStreams(2)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       sendingTrack1 = tracks[0];
@@ -376,7 +376,7 @@
     let sendingTrack1;
     let sendingTrack2;
     let sender;
-    return getUserMediaTracksAndStreams(2)
+    getUserMediaTracksAndStreams(2)
     .then(t.step_func(([tracks, streams]) => {
       t.add_cleanup(() => tracks.forEach(track => track.stop()));
       sendingTrack1 = tracks[0];

--- a/webrtc/legacy/RTCPeerConnection-addStream.https.html
+++ b/webrtc/legacy/RTCPeerConnection-addStream.https.html
@@ -27,7 +27,7 @@
     t.add_cleanup(() => pc.close());
     let track;
     let stream;
-    return getUserMediaTracksAndStreams(1)
+    getUserMediaTracksAndStreams(1)
     .then(t.step_func(([tracks, streams]) => {
       track = tracks[0];
       stream = streams[0];


### PR DESCRIPTION
These tests are written correctly, they just need to not return the
promises they use as part of the flow.

They could be rewritten to use promise_tests if desired, but that would
have performance implications (as it changes them from concurrent to
sequential) so leaving that for now.

See https://github.com/web-platform-tests/wpt/issues/21435