### PR TITLE
Run the file content lint in parallel

### DIFF
--- a/lint.ignore
+++ b/lint.ignore
@@ -180,8 +180,6 @@ SET TIMEOUT: media-source/mediasource-util.js
 SET TIMEOUT: media-source/URL-createObjectURL-revoke.html
 SET TIMEOUT: mixed-content/generic/sanity-checker.js
 SET TIMEOUT: navigation-timing/*
-SET TIMEOUT: html/canvas/offscreen/the-offscreen-canvas/*
-SET TIMEOUT: html/canvas/offscreen/manual/the-offscreen-canvas/*
 SET TIMEOUT: old-tests/submission/Microsoft/history/history_000.htm
 SET TIMEOUT: paint-timing/resources/subframe-painting.html
 SET TIMEOUT: payment-request/allowpayment/setting-allowpaymentrequest-timing.https.sub.html
@@ -691,14 +689,9 @@ MISSING-LINK: css/filter-effects/*.any.js
 
 # Tests that use WebKit/Blink testing APIs
 LAYOUTTESTS APIS: import-maps/common/resources/common-test-helper.js
-LAYOUTTESTS APIS: resources/test-only-api.js
 LAYOUTTESTS APIS: resources/chromium/enable-hyperlink-auditing.js
 LAYOUTTESTS APIS: resources/chromium/generic_sensor_mocks.js
-LAYOUTTESTS APIS: resources/chromium/nfc-mock.js
 LAYOUTTESTS APIS: resources/chromium/webxr-test.js
-LAYOUTTESTS APIS: web-nfc/NDEFReader-document-hidden-manual.https.html
-LAYOUTTESTS APIS: web-nfc/NDEFReader_scan.https.html
-LAYOUTTESTS APIS: web-nfc/NDEFWriter_write.https.html
 LAYOUTTESTS APIS: webxr/resources/webxr_util.js
 
 # Signed Exchange files have hard-coded URLs in the certUrl field
@@ -744,7 +737,6 @@ TESTHARNESS-IN-OTHER-TYPE: html/canvas/element/manual/wide-gamut-canvas/imagedat
 TESTHARNESS-IN-OTHER-TYPE: css/CSS2/floats-clear/adjoining-float-new-fc-crash.html
 TESTHARNESS-IN-OTHER-TYPE: css/CSS2/floats/floats-saturated-position-crash.html
 TESTHARNESS-IN-OTHER-TYPE: css/CSS2/linebox/video-needs-layout-crash.html
-TESTHARNESS-IN-OTHER-TYPE: css/css-animations/keyframes-remove-documentElement-crash.html
 TESTHARNESS-IN-OTHER-TYPE: css/css-break/break-before-with-no-fragmentation-crash.html
 TESTHARNESS-IN-OTHER-TYPE: css/css-multicol/abspos-in-multicol-with-spanner-crash.html
 TESTHARNESS-IN-OTHER-TYPE: css/css-multicol/extremely-tall-multicol-with-extremely-tall-child-crash.html

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -1033,15 +1033,16 @@ def lint(repo_root, paths, output_format, ignore_glob=None, github_checks_output
         return (errors[-1][0], path)
 
     to_check_content = []
+    skip = set()
 
-    for path in paths[:]:
+    for path in paths:
         abs_path = os.path.join(repo_root, path)
         if not os.path.exists(abs_path):
-            paths.remove(path)
+            skip.add(path)
             continue
 
         if any(fnmatch.fnmatch(path, file_match) for file_match in skipped_files):
-            paths.remove(path)
+            skip.add(path)
             continue
 
         errors = check_path(repo_root, path)

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -6,6 +6,7 @@ import ast
 import io
 import json
 import logging
+import multiprocessing
 import os
 import re
 import subprocess
@@ -34,6 +35,7 @@ if MYPY:
     from typing import Callable
     from typing import Dict
     from typing import IO
+    from typing import Iterator
     from typing import Iterable
     from typing import List
     from typing import Optional
@@ -42,6 +44,7 @@ if MYPY:
     from typing import Text
     from typing import Tuple
     from typing import Type
+    from typing import TypeVar
 
     # The Ignorelist is a two level dictionary. The top level is indexed by
     # error names (e.g. 'TRAILING WHITESPACE'). Each of those then has a map of
@@ -50,10 +53,24 @@ if MYPY:
     # ignores the error.
     Ignorelist = Dict[Text, Dict[Text, Set[Optional[int]]]]
 
+    # Define an arbitrary typevar
+    T = TypeVar("T")
+
     try:
         from xml.etree import cElementTree as ElementTree
     except ImportError:
         from xml.etree import ElementTree as ElementTree  # type: ignore
+
+
+if sys.version_info >= (3, 7):
+    from contextlib import nullcontext
+else:
+    from contextlib import contextmanager
+
+    @contextmanager
+    def nullcontext(enter_result=None):
+        # type: (Optional[T]) -> Iterator[Optional[T]]
+        yield enter_result
 
 
 logger = None  # type: Optional[logging.Logger]
@@ -793,8 +810,8 @@ def check_all_paths(repo_root, paths):
     return errors
 
 
-def check_file_contents(repo_root, path, f):
-    # type: (Text, Text, IO[bytes]) -> List[rules.Error]
+def check_file_contents(repo_root, path, f=None):
+    # type: (Text, Text, Optional[IO[bytes]]) -> List[rules.Error]
     """
     Runs lints that check the file contents.
 
@@ -803,12 +820,18 @@ def check_file_contents(repo_root, path, f):
     :param f: a file-like object with the file contents
     :returns: a list of errors found in ``f``
     """
+    with io.open(os.path.join(repo_root, path), 'rb') if f is None else nullcontext(f) as real_f:
+        assert real_f is not None  # Py2: prod mypy -2 into accepting this isn't None
+        errors = []
+        for file_fn in file_lints:
+            errors.extend(file_fn(repo_root, path, real_f))
+            real_f.seek(0)
+        return errors
 
-    errors = []
-    for file_fn in file_lints:
-        errors.extend(file_fn(repo_root, path, f))
-        f.seek(0)
-    return errors
+
+def check_file_contents_apply(args):
+    # type: (Tuple[Text, Text]) -> List[rules.Error]
+    return check_file_contents(*args)
 
 
 def output_errors_text(log, errors):
@@ -964,6 +987,10 @@ def main(**kwargs_str):
     return lint(repo_root, paths, output_format, ignore_glob, github_checks_outputter)
 
 
+# best experimental guess at a decent cut-off for using the parallel path
+MIN_FILES_FOR_PARALLEL = 80
+
+
 def lint(repo_root, paths, output_format, ignore_glob=None, github_checks_outputter=None):
     # type: (Text, List[Text], Text, Optional[List[Text]], Optional[GitHubChecksOutputter]) -> int
     error_count = defaultdict(int)  # type: Dict[Text, int]
@@ -1005,6 +1032,8 @@ def lint(repo_root, paths, output_format, ignore_glob=None, github_checks_output
 
         return (errors[-1][0], path)
 
+    to_check_content = []
+
     for path in paths[:]:
         abs_path = os.path.join(repo_root, path)
         if not os.path.exists(abs_path):
@@ -1019,12 +1048,30 @@ def lint(repo_root, paths, output_format, ignore_glob=None, github_checks_output
         last = process_errors(errors) or last
 
         if not os.path.isdir(abs_path):
-            with io.open(abs_path, 'rb') as test_file:
-                errors = check_file_contents(repo_root, path, test_file)
-                last = process_errors(errors) or last
+            to_check_content.append((repo_root, path))
 
-    errors = check_all_paths(repo_root, paths)
-    last = process_errors(errors) or last
+    paths = [p for p in paths if p not in skip]
+
+    if len(to_check_content) >= MIN_FILES_FOR_PARALLEL:
+        pool = multiprocessing.Pool()
+        # submit this job first, as it's the longest running
+        all_paths_result = pool.apply_async(check_all_paths, (repo_root, paths))
+        # each item tends to be quick, so pass things in large chunks to avoid too much IPC overhead
+        errors_it = pool.imap_unordered(check_file_contents_apply, to_check_content, chunksize=40)
+        pool.close()
+        for errors in errors_it:
+            last = process_errors(errors) or last
+
+        errors = all_paths_result.get()
+        pool.join()
+        last = process_errors(errors) or last
+    else:
+        for item in to_check_content:
+            errors = check_file_contents(*item)
+            last = process_errors(errors) or last
+
+        errors = check_all_paths(repo_root, paths)
+        last = process_errors(errors) or last
 
     if output_format in ("normal", "markdown"):
         output_error_count(error_count)


### PR DESCRIPTION
And while we're at it, also run the all_paths_lints in parallel too given there's no need to serialize its execution. You really want #25683 in combination with this, as otherwise all_paths_lints still takes forever, but there technically isn't any dependency between them.

Benchmarks on Arch Linux, 4C/8T Intel Core i7 3770K:

Py2:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| master | 253.784 ± 1.122 | 252.485 | 255.992 | 6.04 ± 0.03 |
| #25683 | 173.852 ± 0.826 | 172.657 | 175.148 | 4.14 ± 0.02 |
| this | 109.080 ± 0.701 | 108.120 | 110.229 | 2.60 ± 0.02 |
| #25683 + this | 42.007 ± 0.142 | 41.756 | 42.153 | 1.00 |

Py3:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| master | 171.874 ± 1.540 | 169.579 | 174.381 | 5.95 ± 0.06 |
| #25683 | 117.550 ± 1.014 | 116.462 | 120.105 | 4.07 ± 0.04 |
| this | 74.602 ± 0.365 | 74.108 | 75.198 | 2.58 ± 0.02 |
| #25683 + this | 28.873 ± 0.105 | 28.734 | 29.052 | 1.00 |
