### PR TITLE
Increase maximum open files for each server process on Darwin (WebKit export)

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import platform
+import resource
 import signal
 import socket
 import subprocess
@@ -418,6 +419,18 @@ class ServerProc(object):
 
     def create_daemon(self, init_func, host, port, paths, routes, bind_address,
                       config, **kwargs):
+        if sys.platform == "darwin":
+            # on Darwin, NOFILE starts with a very low limit (256), so bump it up a little
+            # by way of comparison, Debian starts with a limit of 1024, Windows 512
+            maxfilesperproc = int(subprocess.check_output(
+                ["sysctl", "-n", "kern.maxfilesperproc"]
+            ).strip())
+            soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+            # 2048 is somewhat arbitrary, but gives us some headroom for wptrunner --parallel
+            # note that it's expected that 2048 will be the min here
+            new_soft = min(2048, maxfilesperproc, hard)
+            if soft < new_soft:
+                resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
         try:
             self.daemon = init_func(host, port, paths, routes, bind_address, config, **kwargs)
         except socket.error:

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 import platform
-import resource
 import signal
 import socket
 import subprocess
@@ -422,6 +421,7 @@ class ServerProc(object):
         if sys.platform == "darwin":
             # on Darwin, NOFILE starts with a very low limit (256), so bump it up a little
             # by way of comparison, Debian starts with a limit of 1024, Windows 512
+            import resource  # local, as it only exists on Unix-like systems
             maxfilesperproc = int(subprocess.check_output(
                 ["sysctl", "-n", "kern.maxfilesperproc"]
             ).strip())


### PR DESCRIPTION
Export of https://bugs.webkit.org/show_bug.cgi?id=215829 & its regression fix https://bugs.webkit.org/show_bug.cgi?id=216823.

Delayed export to verify that this stopped the failures from happening, and we've not seen any over the past three days so I'm assume this fixed it.