### PR TITLE
Change writing-mode in vertical underline thickness test

### DIFF
--- a/css/css-text-decor/text-decoration-thickness-vertical-002.html
+++ b/css/css-text-decor/text-decoration-thickness-vertical-002.html
@@ -28,12 +28,13 @@
          */
         #text{
             color: transparent;
-            writing-mode: sideways-lr;
+            writing-mode: vertical-lr;
             position: relative;
-            right: 1em;
+            right: 1.1em;
             text-decoration: green underline;
             text-decoration-skip-ink: none;
             text-decoration-thickness: 1.2em;
+            text-underline-position: from-font right;
         }
     </style>
 </head>


### PR DESCRIPTION
Replace sideways-lr writing mode with more widely supported vertical-lr
in text-decoration-thickness-vertical-002.html and update
text-underline-position: from-font. This makes this underline test
compatible with Chromium while preserving the logic of the test.