### PR TITLE
Corrected active selection tests involving pseudo-elements

### DIFF
--- a/css/css-pseudo/active-selection-025.html
+++ b/css/css-pseudo/active-selection-025.html
@@ -6,27 +6,38 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-selectors">
-  <link rel="match" href="reference/active-selection-024-ref.html">
+  <link rel="match" href="reference/active-selection-025-ref.html">
 
   <meta content="" name="flags">
-  <meta name="assert" content="In this test, the ::selection pseudo-element must paint over the ::first-letter pseudo-element since the first letter is being selected.">
+  <meta name="assert" content="In this test, the div::selection selector has no 'color' declaration. The div::selection selector should use the 'color' declaration from the div rule and, for the first letter only, it should use the 'color' declaration from the ::first-letter pseudo-element. Therefore the first letter 'S' should be purple and the rest of the words should be green.">
+
+  <!--
+
+  More info:
+  [css-pseudo-4] Original color of highlight pseudo inside
+  ::first-letter/::first-line
+  https://github.com/w3c/csswg-drafts/issues/4625
+
+  RESOLVED: Whatever highlight being applied uses colors from before
+  even if came from pseudo element like ::first-letter/::first-line
+
+  -->
 
   <style>
   div
     {
-      color: black;
+      color: green;
       font-size: 300%;
     }
 
   div::first-letter
     {
-      color: red;
+      color: purple;
     }
 
   div::selection
     {
       background-color: yellow;
-      color: green;
     }
   </style>
 
@@ -44,6 +55,6 @@
 
   <body onload="startTest();">
 
-  <p>Test passes if background color of "Selected Text" is yellow and if each glyph of "Selected Text" is green.
+  <p>Test passes if background color of "Selected Text" is yellow, if the "S" glyph is purple and if the other glyphs are green.
 
   <div id="test">Selected Text</div>

--- a/css/css-pseudo/active-selection-027.html
+++ b/css/css-pseudo/active-selection-027.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Pseudo-Elements Test: active selection and first-line pseudo-element</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-pseudo-4/#highlight-selectors">
+  <link rel="match" href="reference/active-selection-027-ref.html">
+
+  <meta content="" name="flags">
+  <meta name="assert" content="In this test, the div::selection selector has no 'color' declaration. The div::selection selector should use the 'color' declaration from the div rule and, for the first line only, it should use the 'color' declaration from the ::first-line pseudo-element. Therefore the '1st selected text' should be purple and the '2nd selected text' should be green.">
+
+  <!--
+
+  More info:
+  [css-pseudo-4] Original color of highlight pseudo inside
+  ::first-letter/::first-line
+  https://github.com/w3c/csswg-drafts/issues/4625
+
+  RESOLVED: Whatever highlight being applied uses colors from before
+  even if came from pseudo element like ::first-letter/::first-line
+
+  -->
+
+  <style>
+  div
+    {
+      color: green;
+      font-size: 300%;
+    }
+
+  div::first-line
+    {
+      color: purple;
+    }
+
+  div::selection
+    {
+      background-color: yellow;
+    }
+  </style>
+
+  <script>
+  function startTest()
+  {
+  var targetRange = document.createRange();
+  /* We first create an empty range */
+  targetRange.selectNodeContents(document.getElementById("test"));
+  /* Then we set the range boundaries to the children of div#test */
+  window.getSelection().addRange(targetRange);
+  /* Finally, we now select such range of content */
+  }
+  </script>
+
+  <body onload="startTest();">
+
+  <p>Test passes if both "selected text" have a yellow background, if the glyphs of "1st selected text" are purple and if the glyphs of "2nd selected text" are green.
+
+  <div id="test">1st selected text<br>2nd selected text</div>

--- a/css/css-pseudo/reference/active-selection-025-ref.html
+++ b/css/css-pseudo/reference/active-selection-025-ref.html
@@ -14,8 +14,13 @@
       display: inline;
       font-size: 300%;
     }
+
+  span
+    {
+      color: purple;
+    }
   </style>
 
-  <p>Test passes if background color of "Selected Text" is yellow and if each glyph of "Selected Text" is green.
+  <p>Test passes if background color of "Selected Text" is yellow, if the "S" glyph is purple and if the other glyphs are green.
 
-  <div>Selected Text</div>
+  <div><span>S</span>elected Text</div>

--- a/css/css-pseudo/reference/active-selection-027-ref.html
+++ b/css/css-pseudo/reference/active-selection-027-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reftest Reference</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      font-size: 300%;
+    }
+
+  span
+    {
+      background-color: yellow;
+    }
+
+  span#first
+    {
+      color: purple;
+    }
+
+  span#second
+    {
+      color: green;
+    }
+  </style>
+
+  <p>Test passes if both "selected text" have a yellow background, if the glyphs of "1st selected text" are purple and if the glyphs of "2nd selected text" are green.
+
+  <div><span id="first">1st selected text</span></div>
+
+  <div><span id="second">2nd selected text</span></div>


### PR DESCRIPTION
This PR25803 is the logical continuation of the recently resolved issue https://github.com/w3c/csswg-drafts/issues/4625

New files:
css/css-pseudo/active-selection-025.html
css/css-pseudo/active-selection-027.html
css/css-pseudo/reference/active-selection-025-ref.html
css/css-pseudo/reference/active-selection-027-ref.html

Removed files:
css/css-pseudo/active-selection-024.html
css/css-pseudo/reference/active-selection-024-ref.html

On my website:

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/active-selection-025-new.html
http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/reference/active-selection-025-ref-new.html

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/active-selection-027-new.html
http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/reference/active-selection-027-ref-new.html
