### PR TITLE
Support testdriver in cross-origin windows/frames

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -13,9 +13,6 @@ tests.
 testdriver.js exposes its API through the `test_driver` variable in
 the global scope.
 
-NB: presently, testdriver.js only works in the top-level test browsing
-context (and not therefore in any frame or window opened from it).
-
 ### Actions
 Usage:
 ```
@@ -25,12 +22,17 @@ let actions = new test_driver.Actions()
 actions.send()
 ```
 
-Test authors are encouraged to use the builder API to generate the sequence of actions. The builder
-API can be accessed via the `new test_driver.Actions()` object, and actions are defined in [testdriver-actions.js](https://github.com/web-platform-tests/wpt/blob/master/resources/testdriver-actions.js)
+Test authors are encouraged to use the builder API to generate the
+sequence of actions. The builder API can be accessed via the `new
+test_driver.Actions()` object, and actions are defined in
+[testdriver-actions.js](https://github.com/web-platform-tests/wpt/blob/master/resources/testdriver-actions.js)
 
-The `actions.send()` function causes the sequence of actions to be sent to the browser. It is based on the [WebDriver API](https://w3c.github.io/webdriver/#actions).
-The action can be a keyboard action, a pointer action or a pause. It returns a promise that
-resolves after the actions have been sent, or rejects if an error was thrown.
+The `actions.send()` function causes the sequence of actions to be
+sent to the browser. It is based on the [WebDriver
+API](https://w3c.github.io/webdriver/#actions).  The action can be a
+keyboard action, a pointer action or a pause. It returns a promise
+that resolves after the actions have been sent, or rejects if an error
+was thrown.
 
 
 Example:
@@ -49,7 +51,13 @@ let actions = new test_driver.Actions()
 actions.send();
 ```
 
-Calling into `send()` is going to dispatch the action sequence (via `test_driver.action_sequence`) and also returns a promise which should be handled however is appropriate in the test. The other functions in the `Actions()` object are going to modify the state of the object by adding a new action in the sequence and returning the same object. So the functions can be easily chained, as shown in the example above. Here is a list of helper functions in the `Actions` class:
+Calling into `send()` is going to dispatch the action sequence (via
+`test_driver.action_sequence`) and also returns a promise which should
+be handled however is appropriate in the test. The other functions in
+the `Actions()` object are going to modify the state of the object by
+adding a new action in the sequence and returning the same object. So
+the functions can be easily chained, as shown in the example
+above. Here is a list of helper functions in the `Actions` class:
 
 ```
 pointerDown: Create a pointerDown event for the current default pointer source
@@ -143,7 +151,7 @@ For example, to send the tab key you would send "\uE004".
 
 ### set_permission
 
-Usage: `test_driver.set_permission(descriptor, state, one_realm)`
+Usage: `test_driver.set_permission(descriptor, state, one_realm, context=null)`
  * _descriptor_: a
    [PermissionDescriptor](https://w3c.github.io/permissions/#dictdef-permissiondescriptor)
    or derived object
@@ -152,6 +160,7 @@ Usage: `test_driver.set_permission(descriptor, state, one_realm)`
    value
  * _one_realm_: a boolean that indicates whether the permission settings
    apply to only one realm
+ * context: a WindowProxy for the browsing context in which to perform the call
 
 This function causes permission requests and queries for the status of a
 certain permission type (e.g. "push", or "background-fetch") to always
@@ -164,3 +173,63 @@ Example:
 await test_driver.set_permission({ name: "background-fetch" }, "denied");
 await test_driver.set_permission({ name: "push", userVisibleOnly: true }, "granted", true);
 ```
+
+## Using testdriver in Other Browsing Contexts
+
+Testdriver can be used in browsing contexts (i.e. windows or frames)
+from which it's possible to get a reference to the top-level test
+context. There are two basic approaches depending on whether the
+context in which testdriver is used is same-origin with the test
+context, or different origin.
+
+For same-origin contexts, the context can be passed directly into the
+testdriver API calls. For functions that take an element argument this
+is done implicitly using the owner document of the element. For
+functions that don't take an element, this is done via an explicit
+context argument, which takes a WindowProxy object.
+
+Example:
+```
+let win = window.open("example.html")
+win.onload = () => {
+  await test_driver.set_permission({ name: "background-fetch" }, "denied", win);
+}
+```
+
+For the actions API, the context can be set using the `setContext`
+method on the builder:
+
+```
+let actions = new test_driver.Actions()
+    .setContext(frames[0])
+    .keyDown("p")
+    .keyUp("p");
+actions.send();
+```
+
+Note that if an action uses an element reference, the context will be
+derived from that element, and must match any explictly set
+context. Using elements in multiple contexts in a single action chain
+is not supported.
+
+
+For cross-origin cases, passing in the context id doesn't work because
+of limitations in the WebDriver protocol used to implement testdriver
+in a cross-browser fashion. Instead one may include the testdriver
+scripts directly in the relevant document, and use the
+`set_test_context` API to specify the browsing context containing
+testharness.js. Commands are then sent via postMessage to the test
+context. For convenience there is also a `message_test` function that
+can be used to send arbitary messages to the test window. For example,
+in an auxillary browsing context:
+
+
+```
+testdriver.set_test_context(window.opener)
+await testdriver.click(document.getElementsByTagName("button")[0])
+testdriver.message_test("click complete")
+```
+
+The requirement to have a handle to the test window does mean it's
+currently not possible to write tests where such handles can't be
+obtained e.g. in the case of `rel=noopener`.

--- a/infrastructure/metadata/infrastructure/testdriver/actions/crossOrigin.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/crossOrigin.sub.html.ini
@@ -1,0 +1,4 @@
+[crossOrigin.sub.html]
+  [Actions in cross-origin iframe]
+    expected:
+      if product == "safari": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/penPointerEventProperties.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/penPointerEventProperties.html.ini
@@ -1,3 +1,6 @@
 [penPointerEventProperties.html]
   expected:
     if product == "firefox": ERROR
+  [TestDriver actions: pointerevent properties of pen type]
+    expected:
+      if product == "safari": FAIL

--- a/infrastructure/testdriver/actions/crossOrigin.sub.html
+++ b/infrastructure/testdriver/actions/crossOrigin.sub.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Actions in cross-origin iframe</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<iframe src="https://{{host}}:{{ports[https][1]}}/infrastructure/testdriver/actions/crossOriginChild.html"></iframe>
+
+<script>
+setup({single_test: true});
+addEventListener("message", (msg) => {
+    if (msg.data === "PASS") {
+        done();
+    } else if (msg.data === "FAIL") {
+        assert_unreached("actions failed")
+    }
+});
+</script>

--- a/infrastructure/testdriver/actions/crossOriginChild.html
+++ b/infrastructure/testdriver/actions/crossOriginChild.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+
+<input type=text>
+<script>
+let input = document.getElementsByTagName("input")[0];
+addEventListener("load", async () => {
+    test_driver.set_test_context(parent);
+    await new test_driver.Actions()
+     .pointerMove(0, 0, {origin: input})
+     .pointerDown()
+     .pointerUp()
+     .send();
+    await new test_driver.Actions()
+     .keyDown("P")
+     .keyUp("P")
+     .keyDown("A")
+     .keyUp("A")
+     .keyDown("S")
+     .keyUp("S")
+     .keyDown("S")
+     .keyUp("S")
+     .send();
+    if (input.value === "PASS") {
+      test_driver.message_test("PASS", "*")
+    } else {
+      test_driver.message_test("FAIL", "*")
+    }
+});
+</script>

--- a/infrastructure/testdriver/actions/iframe.html
+++ b/infrastructure/testdriver/actions/iframe.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver actions on a document in an iframe</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+
+<iframe src="iframeChild.html"></iframe>
+
+<script>
+setup({single_test: true});
+addEventListener("load", async () => {
+  let input = frames[0].document.getElementsByTagName("input")[0];
+  await new test_driver.Actions()
+   .pointerMove(0, 0, {origin: input})
+   .pointerDown()
+   .pointerUp()
+   .send();
+  await new test_driver.Actions()
+   .setContext(frames[0])
+   .keyDown("P")
+   .keyUp("P")
+   .keyDown("A")
+   .keyUp("A")
+   .keyDown("S")
+   .keyUp("S")
+   .keyDown("S")
+   .keyUp("S")
+   .send();
+  assert_equals(input.value, "PASS");
+  done();
+});
+</script>

--- a/infrastructure/testdriver/actions/iframeChild.html
+++ b/infrastructure/testdriver/actions/iframeChild.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<input type=text>

--- a/infrastructure/testdriver/bless.html
+++ b/infrastructure/testdriver/bless.html
@@ -43,7 +43,7 @@ promise_test(t => {
 promise_test(() => {
   return test_driver.bless('demonstrates return value without action')
     .then((value) => {
-      assert_equals(value, undefined);
+      assert_equals(value, null);
     });
 }, 'no action function provided');
 

--- a/infrastructure/testdriver/click_child_crossorigin.html
+++ b/infrastructure/testdriver/click_child_crossorigin.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<button id="button">Button</button>
+<div id="log">FAIL</div>
+<script>
+let button = document.getElementById("button");
+button.addEventListener("click", () =>
+    document.getElementById("log").textContent = "PASS");
+
+addEventListener("load", () => {
+    test_driver.set_test_context(parent.opener);
+    test_driver.click(button)
+        .then(() => test_driver.message_test("PASS", "*"))
+        .catch(() => test_driver.message_test("FAIL", "*"));
+});
+</script>

--- a/infrastructure/testdriver/click_child_testdriver.html
+++ b/infrastructure/testdriver/click_child_testdriver.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<button id="button">Button</button>
+<div id="log">FAIL</div>
+<script>
+let button = document.getElementById("button");
+button.addEventListener("click", () =>
+    document.getElementById("log").textContent = "PASS");
+
+addEventListener("load", () => {
+    test_driver.set_test_context(parent);
+    test_driver.click(button)
+        .then(() => test_driver.message_test("PASS", "*"))
+        .catch(() => test_driver.message_test("FAIL", "*"));
+});
+</script>

--- a/infrastructure/testdriver/click_iframe_crossorigin.sub.html
+++ b/infrastructure/testdriver/click_iframe_crossorigin.sub.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver click on a document in an iframe</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<iframe src="https://{{host}}:{{ports[https][1]}}/infrastructure/testdriver/click_child_testdriver.html"></iframe>
+
+<script>
+setup({single_test: true});
+addEventListener("message", (msg) => {
+    if (msg.data === "PASS") {
+        done();
+    } else if (msg.data === "FAIL") {
+        assert_unreached("click failed")
+    }
+});
+</script>

--- a/infrastructure/testdriver/click_nested_crossorigin.sub.html
+++ b/infrastructure/testdriver/click_nested_crossorigin.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver click method with multiple windows and nested iframe</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<iframe src="about:blank"></iframe>
+
+<script>
+setup({single_test: true});
+
+window.open("about:blank")
+var child = window.open("https://{{host}}:{{ports[https][0]}}/infrastructure/testdriver/click_outer_child.sub.html")
+window.open("about:blank")
+
+addEventListener("message", (msg) => {
+    if (msg.data === "PASS") {
+        done();
+    } else if (msg.data === "FAIL") {
+        assert_unreached("click failed")
+    }
+});
+</script>

--- a/infrastructure/testdriver/click_outer_child.sub.html
+++ b/infrastructure/testdriver/click_outer_child.sub.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<iframe src="about:blank"></iframe>
+<iframe src="about:blank"></iframe>
+<iframe src="https://{{host}}:{{ports[https][1]}}/infrastructure/testdriver/click_child_crossorigin.html"></iframe>

--- a/resources/testdriver-actions.js
+++ b/resources/testdriver-actions.js
@@ -74,7 +74,6 @@
      * Set the context for the actions
      *
      * @param {WindowProxy} context - Context in which to run the action sequence
-     *
      */
     setContext: function(context) {
       this.context = context;

--- a/resources/testdriver-actions.js
+++ b/resources/testdriver-actions.js
@@ -23,6 +23,7 @@
     this.createSource("none");
     this.tickIdx = 0;
     this.defaultTickDuration = defaultTickDuration;
+    this.context = null;
   }
 
   Actions.prototype = {
@@ -66,7 +67,18 @@
       } catch(e) {
         return Promise.reject(e);
       }
-      return test_driver.action_sequence(actions);
+      return test_driver.action_sequence(actions, this.context);
+    },
+
+    /**
+     * Set the context for the actions
+     *
+     * @param {WindowProxy} context - Context in which to run the action sequence
+     *
+     */
+    setContext: function(context) {
+      this.context = context;
+      return this;
     },
 
     /**

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -52,8 +52,7 @@
         /**
          * Set the context in which testharness.js is loaded
          *
-         * @param {Window} context - the window containing testharness.js
-         *
+         * @param {WindowProxy} context - the window containing testharness.js
          **/
         set_test_context: function(context) {
           if (window.test_driver_internal.set_test_context) {
@@ -66,7 +65,6 @@
          * postMessage to the context containing testharness.js
          *
          * @param {Object} msg - the data to POST
-         *
          **/
         message_test: function(msg) {
             let target = testharness_context;
@@ -85,6 +83,9 @@
          * @param {String} intent - a description of the action which much be
          *                          triggered by user interaction
          * @param {Function} action - code requiring escalated privileges
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          *
          * @returns {Promise} fulfilled following user interaction and
          *                    execution of the provided `action` function;
@@ -181,6 +182,10 @@
          * https://github.com/WICG/page-lifecycle/blob/master/README.md|Lifecycle API
          * for Web Pages}
          *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
          * @returns {Promise} fulfilled after the freeze request is sent, or rejected
          *                    in case the WebDriver command errors
          */
@@ -196,14 +201,18 @@
          * https://w3c.github.io/webdriver/#actions|WebDriver Actions Command}
          *
          * @param {Array} actions - an array of actions. The format is the same as the actions
-                                    property of the WebDriver command {@link
-                                    https://w3c.github.io/webdriver/#perform-actions|Perform
-                                    Actions} command. Each element is an object representing an
-                                    input source and each input source itself has an actions
-                                    property detailing the behaviour of that source at each timestep
-                                    (or tick). Authors are not expected to construct the actions
-                                    sequence by hand, but to use the builder api provided in
-                                    testdriver-actions.js
+         *                          property of the WebDriver command {@link
+         *                          https://w3c.github.io/webdriver/#perform-actions|Perform
+         *                          Actions} command. Each element is an object representing an
+         *                          input source and each input source itself has an actions
+         *                          property detailing the behaviour of that source at each timestep
+         *                          (or tick). Authors are not expected to construct the actions
+         *                          sequence by hand, but to use the builder api provided in
+         *                          testdriver-actions.js
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
          * @returns {Promise} fufiled after the actions are performed, or rejected in
          *                    the cases the WebDriver command errors
          */
@@ -217,6 +226,10 @@
          * The generate_test_report function generates a report (to be observed
          * by ReportingObserver) for testing purposes, as described in
          * {@link https://w3c.github.io/reporting/#generate-test-report-command}
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          *
          * @returns {Promise} fulfilled after the report is generated, or
          *                    rejected if the report generation fails
@@ -236,6 +249,9 @@
          *                              object
          * @param {String} state - the state of the permission
          * @param {boolean} one_realm - Optional. Whether the permission applies to only one realm
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          *
          * The above params are used to create a [PermissionSetParameters]{@link
          * https://w3c.github.io/permissions/#dictdef-permissionsetparameters} object
@@ -262,6 +278,10 @@
          * @param {Object} config - an [Authenticator Configuration]{@link
          *                          https://w3c.github.io/webauthn/#authenticator-configuration}
          *                          object
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
          * @returns {Promise} fulfilled after the authenticator is added, or
          *                    rejected in the cases the WebDriver command
          *                    errors. Returns the ID of the authenticator
@@ -279,6 +299,9 @@
          *
          * @param {String} authenticator_id - the ID of the authenticator to be
          *                                    removed.
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          *
          * @returns {Promise} fulfilled after the authenticator is removed, or
          *                    rejected in the cases the WebDriver command
@@ -297,6 +320,9 @@
          * @param {Object} credential - A [Credential Parameters]{@link
          *                              https://w3c.github.io/webauthn/#credential-parameters}
          *                              object
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          *
          * @returns {Promise} fulfilled after the credential is added, or
          *                    rejected in the cases the WebDriver command
@@ -315,6 +341,9 @@
          * https://w3c.github.io/webauthn/#sctn-automation-get-credentials
          *
          * @param {String} authenticator_id - the ID of the authenticator
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          *
          * @returns {Promise} fulfilled after the credentials are returned, or
          *                    rejected in the cases the WebDriver command
@@ -333,6 +362,9 @@
          *
          * @param {String} authenticator_id - the ID of the authenticator
          * @param {String} credential_id - the ID of the credential
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          *
          * @returns {Promise} fulfilled after the credential is removed, or
          *                    rejected in the cases the WebDriver command
@@ -348,6 +380,9 @@
          * https://w3c.github.io/webauthn/#sctn-automation-remove-all-credentials
          *
          * @param {String} authenticator_id - the ID of the authenticator
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          *
          * @returns {Promise} fulfilled after the credentials are removed, or
          *                    rejected in the cases the WebDriver command
@@ -366,6 +401,9 @@
          *
          * @param {String} authenticator_id - the ID of the authenticator
          * @param {boolean} uv - the User Verified flag
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          */
         set_user_verified: function(authenticator_id, uv, context=null) {
             return window.test_driver_internal.set_user_verified(authenticator_id, uv, context);
@@ -385,6 +423,9 @@
          *                                    May be "*" to indicate all origins.
          * @param {String} state - The storage access setting.
          *                         Must be either "allowed" or "blocked".
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
          *
          * @returns {Promise} Fulfilled after the storage access rule has been
          *                    set, or rejected if setting the rule fails.
@@ -407,13 +448,6 @@
          */
         in_automation: false,
 
-        /**
-         * Waits for a user-initiated click
-         *
-         * @param {Element} element - element to be clicked
-         * @param {{x: number, y: number} coords - viewport coordinates to click at
-         * @returns {Promise} fulfilled after click occurs
-         */
         click: function(element, coords) {
             if (this.in_automation) {
                 return Promise.reject(new Error('Not implemented'));
@@ -424,14 +458,6 @@
             });
         },
 
-        /**
-         * Waits for an element to receive a series of key presses
-         *
-         * @param {Element} element - element which should receve key presses
-         * @param {String} keys - keys to expect
-         * @returns {Promise} fulfilled after keys are received or rejected if
-         *                    an incorrect key sequence is received
-         */
         send_keys: function(element, keys) {
             if (this.in_automation) {
                 return Promise.reject(new Error('Not implemented'));
@@ -464,157 +490,51 @@
             });
         },
 
-        /**
-         * Freeze the current page
-         *
-         * @returns {Promise} fulfilled after freeze request is sent, otherwise
-         * it gets rejected
-         */
-        freeze: function() {
+        freeze: function(context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Send a sequence of pointer actions
-         *
-         * @returns {Promise} fufilled after actions are sent, rejected if any actions
-         *                    fail
-         */
         action_sequence: function(actions, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Generates a test report on the current page
-         *
-         * @param {String} message - the message to be contained in the report
-         * @returns {Promise} fulfilled after the report is generated, or
-         *                    rejected if the report generation fails
-         */
         generate_test_report: function(message, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
 
-        /**
-         * Sets the state of a permission
-         *
-         * This function simulates a user setting a permission into a particular state as described
-         * in {@link https://w3c.github.io/permissions/#set-permission-command}
-         *
-         * @param {Object} permission_params - a [PermissionSetParameters]{@lint
-         *                                     https://w3c.github.io/permissions/#dictdef-permissionsetparameters}
-         *                                     object
-         * @returns {Promise} fulfilled after the permission is set, or rejected if setting the
-         *                    permission fails
-         */
         set_permission: function(permission_params, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Creates a virtual authenticator
-         *
-         * @param {Object} config - the authenticator configuration
-         * @returns {Promise} fulfilled after the authenticator is added, or
-         *                    rejected in the cases the WebDriver command
-         *                    errors.
-         */
         add_virtual_authenticator: function(config, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Removes a virtual authenticator
-         *
-         * @param {String} authenticator_id - the ID of the authenticator to be
-         *                                    removed.
-         *
-         * @returns {Promise} fulfilled after the authenticator is removed, or
-         *                    rejected in the cases the WebDriver command
-         *                    errors
-         */
         remove_virtual_authenticator: function(authenticator_id, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Adds a credential to a virtual authenticator
-         *
-         * @param {String} authenticator_id - the ID of the authenticator
-         * @param {Object} credential - A [Credential Parameters]{@link
-         *                              https://w3c.github.io/webauthn/#credential-parameters}
-         *                              object
-         *
-         * @returns {Promise} fulfilled after the credential is added, or
-         *                    rejected in the cases the WebDriver command
-         *                    errors
-         *
-         */
         add_credential: function(authenticator_id, credential, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Gets all the credentials stored in an authenticator
-         *
-         * @param {String} authenticator_id - the ID of the authenticator
-         *
-         * @returns {Promise} fulfilled after the credentials are returned, or
-         *                    rejected in the cases the WebDriver command
-         *                    errors. Returns an array of [Credential
-         *                    Parameters]{@link
-         *                    https://w3c.github.io/webauthn/#credential-parameters}
-         *
-         */
         get_credentials: function(authenticator_id, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Remove a credential stored in an authenticator
-         *
-         * @param {String} authenticator_id - the ID of the authenticator
-         * @param {String} credential_id - the ID of the credential
-         *
-         * @returns {Promise} fulfilled after the credential is removed, or
-         *                    rejected in the cases the WebDriver command
-         *                    errors.
-         *
-         */
         remove_credential: function(authenticator_id, credential_id, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Removes all the credentials stored in a virtual authenticator
-         *
-         * @param {String} authenticator_id - the ID of the authenticator
-         *
-         * @returns {Promise} fulfilled after the credentials are removed, or
-         *                    rejected in the cases the WebDriver command
-         *                    errors.
-         *
-         */
         remove_all_credentials: function(authenticator_id, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Sets the User Verified flag on an authenticator
-         *
-         * @param {String} authenticator_id - the ID of the authenticator
-         * @param {boolean} uv - the User Verified flag
-         *
-         */
         set_user_verified: function(authenticator_id, uv, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },
 
-        /**
-         * Sets the storage access policy for a third-party origin when loaded
-         * in the current first party context
-         */
         set_storage_access: function(origin, embedding_origin, blocked, context=null) {
             return Promise.reject(new Error("unimplemented"));
         },

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -691,6 +691,9 @@ class ConnectionlessBaseProtocolPart(BaseProtocolPart):
     def set_window(self, handle):
         pass
 
+    def window_handles(self):
+        return []
+
 
 class ConnectionlessProtocol(Protocol):
     implements = [ConnectionlessBaseProtocolPart]
@@ -787,6 +790,7 @@ class CallbackHandler(object):
 
     def process_action(self, url, payload):
         action = payload["action"]
+        cmd_id = payload["id"]
         self.logger.debug("Got action: %s" % action)
         try:
             action_handler = self.actions[action]
@@ -797,21 +801,21 @@ class CallbackHandler(object):
                 result = action_handler(payload)
         except self.unimplemented_exc:
             self.logger.warning("Action %s not implemented" % action)
-            self._send_message("complete", "error", "Action %s not implemented" % action)
+            self._send_message(cmd_id, "complete", "error", "Action %s not implemented" % action)
         except Exception:
             self.logger.warning("Action %s failed" % action)
             self.logger.warning(traceback.format_exc())
-            self._send_message("complete", "error")
+            self._send_message(cmd_id, "complete", "error")
             raise
         else:
             self.logger.debug("Action %s completed with result %s" % (action, result))
             return_message = {"result": result}
-            self._send_message("complete", "success", json.dumps(return_message))
+            self._send_message(cmd_id, "complete", "success", json.dumps(return_message))
 
         return False, None
 
-    def _send_message(self, message_type, status, message=None):
-        self.protocol.testdriver.send_message(message_type, status, message=message)
+    def _send_message(self, cmd_id, message_type, status, message=None):
+        self.protocol.testdriver.send_message(cmd_id, message_type, status, message=message)
 
 
 class ActionContext(object):
@@ -820,28 +824,20 @@ class ActionContext(object):
         self.protocol = protocol
         self.context = context
         self.initial_window = None
-        self.switched_frame = False
 
     def __enter__(self):
         if self.context is None:
             return
 
-        window_id = self.context[0]
-        if window_id:
-            self.initial_window = self.protocol.base.current_window
-            self.logger.debug("Switching to window %s" % window_id)
-            self.protocol.testdriver.switch_to_window(window_id)
-
-        for frame_id in self.context[1:]:
-            self.switched_frame = True
-            self.logger.debug("Switching to frame %s" % frame_id)
-            self.protocol.testdriver.switch_to_frame(frame_id)
+        self.initial_window = self.protocol.base.current_window
+        self.logger.debug("Switching to window %s" % self.context)
+        self.protocol.testdriver.switch_to_window(self.context)
 
     def __exit__(self, *args):
-        if self.initial_window is not None:
-            self.logger.debug("Switching back to initial window")
-            self.protocol.base.set_window(self.initial_window)
-            self.initial_window = None
-        elif self.switched_frame:
-            self.protocol.testdriver.switch_to_frame(None)
-        self.switched_frame = False
+        if self.context is None:
+            return
+
+        self.logger.debug("Switching back to initial window")
+        self.protocol.base.set_window(self.initial_window)
+        self.protocol.testdriver._switch_to_frame(None)
+        self.initial_window = None

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -103,6 +103,9 @@ class MarionetteBaseProtocolPart(BaseProtocolPart):
     def set_window(self, handle):
         _switch_to_window(self.marionette, handle)
 
+    def window_handles(self):
+        return self.marionette.window_handles
+
     def load(self, url):
         self.marionette.navigate(url)
 
@@ -460,8 +463,9 @@ class MarionetteTestDriverProtocolPart(TestDriverProtocolPart):
     def setup(self):
         self.marionette = self.parent.marionette
 
-    def send_message(self, message_type, status, message=None):
+    def send_message(self, cmd_id, message_type, status, message=None):
         obj = {
+            "cmd_id": cmd_id,
             "type": "testdriver-%s" % str(message_type),
             "status": str(status)
         }
@@ -469,23 +473,11 @@ class MarionetteTestDriverProtocolPart(TestDriverProtocolPart):
             obj["message"] = str(message)
         self.parent.base.execute_script("window.postMessage(%s, '*')" % json.dumps(obj))
 
-    def switch_to_window(self, window_id):
-        if window_id is None:
-            return
-
-        for window_handle in self.marionette.window_handles:
-            _switch_to_window(self.marionette, window_handle)
-            try:
-                handle_window_id = self.marionette.execute_script("return window.name")
-            except errors.JavascriptException:
-                continue
-            if str(handle_window_id) == window_id:
-                return
-
-        raise Exception("Window with id %s not found" % window_id)
-
-    def switch_to_frame(self, frame_number):
+    def _switch_to_frame(self, frame_number):
         self.marionette.switch_to_frame(frame_number)
+
+    def _switch_to_parent_frame(self):
+        self.marionette.switch_to_parent_frame()
 
 
 class MarionetteCoverageProtocolPart(CoverageProtocolPart):

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -61,6 +61,9 @@ class SeleniumBaseProtocolPart(BaseProtocolPart):
     def set_window(self, handle):
         self.webdriver.switch_to_window(handle)
 
+    def window_handles(self):
+        return self.webdriver.window_handles
+
     def load(self, url):
         self.webdriver.get(url)
 
@@ -200,8 +203,9 @@ class SeleniumTestDriverProtocolPart(TestDriverProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
 
-    def send_message(self, message_type, status, message=None):
+    def send_message(self, cmd_id, message_type, status, message=None):
         obj = {
+            "cmd_id": cmd_id,
             "type": "testdriver-%s" % str(message_type),
             "status": str(status)
         }

--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -76,6 +76,9 @@ class ServoBaseProtocolPart(BaseProtocolPart):
     def set_window(self, handle):
         pass
 
+    def window_handles(self):
+        return []
+
     def load(self, url):
         pass
 

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -61,6 +61,9 @@ class WebDriverBaseProtocolPart(BaseProtocolPart):
     def set_window(self, handle):
         self.webdriver.window_handle = handle
 
+    def window_handles(self):
+        return self.webdriver.handles
+
     def load(self, url):
         self.webdriver.url = url
 
@@ -214,8 +217,9 @@ class WebDriverTestDriverProtocolPart(TestDriverProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
 
-    def send_message(self, message_type, status, message=None):
+    def send_message(self, cmd_id, message_type, status, message=None):
         obj = {
+            "cmd_id": cmd_id,
             "type": "testdriver-%s" % str(message_type),
             "status": str(status)
         }
@@ -223,23 +227,11 @@ class WebDriverTestDriverProtocolPart(TestDriverProtocolPart):
             obj["message"] = str(message)
         self.webdriver.execute_script("window.postMessage(%s, '*')" % json.dumps(obj))
 
-    def switch_to_window(self, window_id):
-        if window_id is None:
-            return
-
-        for window_handle in self.webdriver.handles:
-            self.webdriver.window_handle = window_handle
-            try:
-                handle_window_id = self.webdriver.execute_script("return window.name")
-            except client.JavascriptErrorException:
-                continue
-            if str(handle_window_id) == window_id:
-                return
-
-        raise Exception("Window with id %s not found" % window_id)
-
-    def switch_to_frame(self, frame_number):
+    def _switch_to_frame(self, frame_number):
         self.webdriver.switch_frame(frame_number)
+
+    def _switch_to_parent_frame(self):
+        self.webdriver.switch_frame("parent")
 
 
 class WebDriverGenerateTestReportProtocolPart(GenerateTestReportProtocolPart):

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -1,9 +1,13 @@
 "use strict";
 
-(function(){
-    let pending_resolve = null;
-    let pending_reject = null;
+(function() {
+    const is_test_context = window.__wptrunner_message_queue !== undefined;
+    const pending = new Map();
+
     let result = null;
+    let ctx_cmd_id = 0;
+    let testharness_context = null;
+
     window.addEventListener("message", function(event) {
         const data = event.data;
 
@@ -11,29 +15,70 @@
             return;
         }
 
-        if (data.type !== "testdriver-complete") {
-            return;
-        }
-
-        if (data.status === "success") {
-            result = JSON.parse(data.message).result;
-            pending_resolve(result);
-        } else {
-            pending_reject(`${data.status}: ${data.message}`);
+        if (is_test_context && data.type === "testdriver-command") {
+            const command = data.message;
+            const ctx_id = command.cmd_id;
+            delete command.cmd_id;
+            const cmd_id = window.__wptrunner_message_queue.push(command);
+            let on_success = (data) => {
+                data.type = "testdriver-complete";
+                data.cmd_id = ctx_id;
+                event.source.postMessage(data, "*");
+            };
+            let on_failure = (data) => {
+                data.type = "testdriver-complete";
+                data.cmd_id = ctx_id;
+                event.source.postMessage(data, "*");
+            };
+            pending.set(cmd_id, [on_success, on_failure]);
+        } else if (data.type === "testdriver-complete") {
+            const cmd_id = data.cmd_id;
+            const [on_success, on_failure] = pending.get(cmd_id);
+            pending.clear(cmd_id);
+            const resolver = data.status === "success" ? on_success : on_failure;
+            resolver(data);
+            if (is_test_context) {
+                window.__wptrunner_process_next_event();
+            }
         }
     });
 
-    let last_window_id = 0;
+    // Code copied from /common/utils.js
+    function rand_int(bits) {
+        if (bits < 1 || bits > 53) {
+            throw new TypeError();
+        } else {
+            if (bits >= 1 && bits <= 30) {
+                return 0 | ((1 << bits) * Math.random());
+            } else {
+                var high = (0 | ((1 << (bits - 30)) * Math.random())) * (1 << 30);
+                var low = 0 | ((1 << 30) * Math.random());
+                return  high + low;
+            }
+        }
+    }
+
+    function to_hex(x, length) {
+        var rv = x.toString(16);
+        while (rv.length < length) {
+            rv = "0" + rv;
+        }
+        return rv;
+    }
+
     function get_window_id(win) {
-        if (win === window) {
+        if (win == window && is_test_context) {
             return null;
         }
-        // This is a hack until some implementations support proper window ids
-        // It won't work cross-frame
-        if (!win.name) {
-            win.name = "__wptrunner_window " + last_window_id++;
+        if (!win.__wptrunner_id) {
+            // generate a uuid
+            win.__wptrunner_id = [to_hex(rand_int(32), 8),
+                                  to_hex(rand_int(16), 4),
+                                  to_hex(0x4000 | rand_int(12), 4),
+                                  to_hex(0x8000 | rand_int(14), 4),
+                                  to_hex(rand_int(48), 12)].join("-");
         }
-        return win.name;
+        return win.__wptrunner_id;
     }
 
     const get_context = function(element) {
@@ -44,23 +89,7 @@
         if (!elementWindow) {
             throw new Error("Browsing context for element was detached");
         }
-        let top = elementWindow.top;
-        if (elementWindow === window) {
-            if (top !== window) {
-                throw new Error("Can't load testdriver in a frame");
-            }
-            // For the current window just return null
-            return null;
-        }
-        let rv = [];
-        let currentWindow = elementWindow;
-        while (currentWindow !== top) {
-            rv.push(Array.prototype.indexOf.call(currentWindow.parent.frames, currentWindow));
-            currentWindow = currentWindow.parent;
-        }
-        rv.push(top !== window ? get_window_id(top) : null);
-        rv.reverse();
-        return rv;
+        return elementWindow;
     };
 
     const get_selector = function(element) {
@@ -93,43 +122,60 @@
         return selector;
     };
 
+    const create_action = function(name, props) {
+        let cmd_id;
+        const action_msg = {type: "action",
+                            action: name,
+                            ...props};
+        if (action_msg.context) {
+          action_msg.context = get_window_id(action_msg.context);
+        }
+        if (is_test_context) {
+            cmd_id = window.__wptrunner_message_queue.push(action_msg);
+        } else {
+            if (testharness_context === null) {
+                throw new Error("Tried to run in a non-testharness window without a call to set_test_context");
+            }
+            cmd_id = ctx_cmd_id++;
+            action_msg.cmd_id = cmd_id;
+            window.test_driver.message_test({type: "testdriver-command",
+                                             message: action_msg});
+        }
+        const pending_promise = new Promise(function(resolve, reject) {
+            const on_success = data => {
+                result = JSON.parse(data.message).result;
+                resolve(result);
+            };
+            const on_failure = data => {
+                reject(`${data.status}: ${data.message}`);
+            };
+            pending.set(cmd_id, [on_success, on_failure]);
+        });
+        return pending_promise;
+    };
+
     window.test_driver_internal.in_automation = true;
 
+    window.test_driver_internal.set_test_context = function(context) {
+        if (window.__wptrunner_message_queue) {
+            throw new Error("Tried to set testharness context in a window containing testharness.js");
+        }
+        testharness_context = context;
+    };
+
     window.test_driver_internal.click = function(element) {
-        const context = get_context(element);
         const selector = get_selector(element);
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "click",
-                                               selector,
-                                               context});
-        return pending_promise;
+        const context = get_context(element);
+        return create_action("click", {selector, context});
     };
 
     window.test_driver_internal.send_keys = function(element, keys) {
         const selector = get_selector(element);
         const context = get_context(element);
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "send_keys",
-                                               selector,
-                                               keys,
-                                               context});
-        return pending_promise;
+        return create_action("send_keys", {selector, keys, context});
     };
 
-    window.test_driver_internal.action_sequence = function(actions) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        let context = null;
+    window.test_driver_internal.action_sequence = function(actions, context=null) {
         for (let actionSequence of actions) {
             if (actionSequence.type == "pointer") {
                 for (let action of actionSequence.actions) {
@@ -145,111 +191,42 @@
                 }
             }
         }
-        window.__wptrunner_message_queue.push({type: "action",
-                                               action: "action_sequence",
-                                               actions,
-                                               context});
-        return pending_promise;
+        return create_action("action_sequence", {actions, context});
     };
 
-    window.test_driver_internal.generate_test_report = function(message) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "generate_test_report",
-                                               message});
-        return pending_promise;
+    window.test_driver_internal.generate_test_report = function(message, context=null) {
+        return create_action("generate_test_report", {message, context});
     };
 
-    window.test_driver_internal.set_permission = function(permission_params) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "set_permission",
-                                               permission_params});
-        return pending_promise;
+    window.test_driver_internal.set_permission = function(permission_params, context=null) {
+        return create_action("set_permission", {permission_params, context});
     };
 
-    window.test_driver_internal.add_virtual_authenticator = function(config) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "add_virtual_authenticator",
-                                               config});
-        return pending_promise;
+    window.test_driver_internal.add_virtual_authenticator = function(config, context=null) {
+        return create_action("add_virtual_authenticator", {config, context});
     };
 
-    window.test_driver_internal.remove_virtual_authenticator = function(authenticator_id) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "remove_virtual_authenticator",
-                                               authenticator_id});
-        return pending_promise;
+    window.test_driver_internal.remove_virtual_authenticator = function(authenticator_id, context=null) {
+        return create_action("remove_virtual_authenticator", {authenticator_id, context});
     };
 
-    window.test_driver_internal.add_credential = function(authenticator_id, credential) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "add_credential",
-                                               authenticator_id, credential});
-        return pending_promise;
+    window.test_driver_internal.add_credential = function(authenticator_id, credential, context=null) {
+        return create_action("add_credential", {authenticator_id, credential, context});
     };
 
-    window.test_driver_internal.get_credentials = function(authenticator_id) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "get_credentials",
-                                               authenticator_id});
-        return pending_promise;
+    window.test_driver_internal.get_credentials = function(authenticator_id, context=null) {
+        return create_action("get_credentials", {authenticator_id, context});
     };
 
-    window.test_driver_internal.remove_credential = function(authenticator_id, credential_id) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "remove_credential",
-                                               authenticator_id,
-                                               credential_id});
-        return pending_promise;
+    window.test_driver_internal.remove_credential = function(authenticator_id, credential_id, context=null) {
+        return create_action("remove_credential", {authenticator_id, credential_id, context});
     };
 
-    window.test_driver_internal.remove_all_credentials = function(authenticator_id) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "remove_all_credentials",
-                                               authenticator_id});
-        return pending_promise;
+    window.test_driver_internal.remove_all_credentials = function(authenticator_id, context=null) {
+        return create_action("remove_all_credentials", {authenticator_id, context});
     };
 
-    window.test_driver_internal.set_user_verified = function(authenticator_id, uv) {
-        const pending_promise = new Promise(function(resolve, reject) {
-            pending_resolve = resolve;
-            pending_reject = reject;
-        });
-        window.__wptrunner_message_queue.push({"type": "action",
-                                               "action": "set_user_verified",
-                                               authenticator_id,
-                                               uv});
-        return pending_promise;
+    window.test_driver_internal.set_user_verified = function(authenticator_id, uv, context=null) {
+        return create_action("set_user_verified", {authenticator_id, uv, context});
     };
 })();

--- a/tools/wptrunner/wptrunner/testharnessreport.js
+++ b/tools/wptrunner/wptrunner/testharnessreport.js
@@ -1,11 +1,15 @@
 class MessageQueue {
   constructor() {
+    this.item_id = 0;
     this._queue = [];
   }
 
   push(item) {
+    let cmd_id = this.item_id++;
+    item.id = cmd_id;
     this._queue.push(item);
     __wptrunner_process_next_event();
+    return cmd_id;
   }
 
   shift() {


### PR DESCRIPTION
Adds support for using testdriver in cross-origin scenarios in which
it's possible to postMessage between the window invoking the action
and the test window (this means it doesn't work for rel=noopener
windows).

There are several changes here:

 * All testdriver commands that don't accept an element argument
 accept a context argument which is a Window in which to run the
 command.

 * testdriver.js can be loaded in a window that doesn't contain
 testharness.js. In such a window the code must call
 test_driver.set_test_context() with a handle for the top-level test
 window. After doing this it can use testdriver like normal, and can
 use test_driver.messge_test() to postMessge data to the test window.

* Since there are now multiple windows able to use testdriver, the
single active command is replaced with a map of commands, and each
command gets an id that's passed up to the harness and used to
identify the response.