### PR TITLE
[wpt] Fix tests/test_wpt.py::test_tests_affected_idlharness

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -326,7 +326,10 @@ def test_tests_affected_idlharness(capsys, manifest_dir):
         wpt.main(argv=["tests-affected", "--metadata", manifest_dir, "%s~..%s" % (commit, commit)])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
-    assert "webrtc-identity/idlharness.https.window.js\nwebrtc-insertable-streams/idlharness.https.window.js\nwebrtc-stats/idlharness.window.js\nwebrtc/idlharness.https.window.js\n" == out
+    assert ("webrtc-identity/idlharness.https.window.js\n" +
+            "webrtc-insertable-streams/idlharness.https.window.js\n" +
+            "webrtc-stats/idlharness.window.js\n" +
+            "webrtc/idlharness.https.window.js\n") == out
 
 
 @pytest.mark.slow  # this updates the manifest

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -326,7 +326,7 @@ def test_tests_affected_idlharness(capsys, manifest_dir):
         wpt.main(argv=["tests-affected", "--metadata", manifest_dir, "%s~..%s" % (commit, commit)])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
-    assert "webrtc-identity/idlharness.https.window.js\nwebrtc-stats/idlharness.window.js\nwebrtc/idlharness.https.window.js\n" == out
+    assert "webrtc-identity/idlharness.https.window.js\nwebrtc-insertable-streams/idlharness.https.window.js\nwebrtc-stats/idlharness.window.js\nwebrtc/idlharness.https.window.js\n" == out
 
 
 @pytest.mark.slow  # this updates the manifest


### PR DESCRIPTION
This test uses a real commit and real set of idlharness tests to
test the 'affected by' logic. When a new webrtc idlharness test
dependency was added, the list of dependent files changed and the test
started failing. Quick fix to unblock it is to just add the new test.

See https://github.com/web-platform-tests/wpt/pull/25774#issuecomment-700600138