### PR TITLE
[wptrunner] Add --mojojs-path flag (Chrome-only)

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -570,19 +570,21 @@ class Chrome(Browser):
             chrome_version = chrome_version.split(' ')[0]
             url = "https://storage.googleapis.com/chrome-wpt-mojom/%s/linux64/mojojs.zip" % chrome_version
 
-        last_url_file = os.path.join(dest, "mojojs", "gen", "DOWNLOADED_FROM")
+        extracted = os.path.join(dest, "mojojs", "gen")
+        last_url_file = os.path.join(extracted, "DOWNLOADED_FROM")
         if os.path.exists(last_url_file):
             with open(last_url_file, "rt") as f:
                 last_url = f.read().strip()
             if last_url == url:
                 self.logger.info("Mojo bindings already up to date")
-                return
-            rmtree(os.path.join(dest, "mojojs", "gen"))
+                return extracted
+            rmtree(extracted)
 
         self.logger.info("Downloading Mojo bindings from %s" % url)
         unzip(get(url).raw, dest)
         with open(last_url_file, "wt") as f:
             f.write(url)
+        return extracted
 
     def _chromedriver_platform_string(self):
         platform = self.platforms.get(uname[0])

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -322,16 +322,21 @@ class Chrome(BrowserSetup):
                 kwargs["binary"] = binary
             else:
                 raise WptrunError("Unable to locate Chrome binary")
+
+        if kwargs["mojojs_path"]:
+            kwargs["enable_mojojs"] = True
+            logger.info("--mojojs-path is provided, enabling MojoJS")
         # TODO(Hexcles): Enable this everywhere when Chrome 86 becomes stable.
-        if browser_channel in self.experimental_channels:
+        elif browser_channel in self.experimental_channels:
             try:
-                self.browser.install_mojojs(
+                path = self.browser.install_mojojs(
                     dest=self.venv.path,
                     channel=browser_channel,
                     browser_binary=kwargs["binary"],
                 )
+                kwargs["mojojs_path"] = path
                 kwargs["enable_mojojs"] = True
-                logger.info("MojoJS enabled")
+                logger.info("MojoJS enabled automatically (mojojs_path: %s)" % path)
             except Exception as e:
                 logger.error("Cannot enable MojoJS: %s" % e)
 

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -55,7 +55,7 @@ class TestEnvironment(object):
     websockets servers"""
     def __init__(self, test_paths, testharness_timeout_multipler,
                  pause_after_test, debug_info, options, ssl_config, env_extras,
-                 enable_quic=False, serve_mojojs=False):
+                 enable_quic=False, mojojs_path=None):
         self.test_paths = test_paths
         self.server = None
         self.config_ctx = None
@@ -72,7 +72,7 @@ class TestEnvironment(object):
         self.env_extras_cms = None
         self.ssl_config = ssl_config
         self.enable_quic = enable_quic
-        self.serve_mojojs = serve_mojojs
+        self.mojojs_path = mojojs_path
 
     def __enter__(self):
         self.config_ctx = self.build_config()
@@ -217,9 +217,8 @@ class TestEnvironment(object):
         if "/" not in self.test_paths:
             del route_builder.mountpoint_routes["/"]
 
-        if self.serve_mojojs:
-            # TODO(Hexcles): Properly pass venv.path in.
-            route_builder.add_mount_point("/gen/", "_venv2/mojojs/gen")
+        if self.mojojs_path:
+            route_builder.add_mount_point("/gen/", self.mojojs_path)
 
         return route_builder.get_routes()
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -314,8 +314,10 @@ scheme host and port.""")
 
     servo_group = parser.add_argument_group("Chrome-specific")
     servo_group.add_argument("--enable-mojojs", action="store_true", default=False,
-                             help="Enable MojoJS for testing. Mojo bindings need to be available in "
-                             "_venv2/mojojs.")
+                             help="Enable MojoJS for testing")
+    servo_group.add_argument("--mojojs-path",
+                             help="Path to mojojs gen/ directory. If it is not specified, `wpt run` "
+                             "will download and extract mojojs.zip into _venv2/mojojs/gen.")
 
     sauce_group = parser.add_argument_group("Sauce Labs-specific")
     sauce_group.add_argument("--sauce-browser", dest="sauce_browser",

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -314,7 +314,9 @@ scheme host and port.""")
 
     servo_group = parser.add_argument_group("Chrome-specific")
     servo_group.add_argument("--enable-mojojs", action="store_true", default=False,
-                             help="Enable MojoJS for testing")
+                             help="Enable MojoJS for testing. Note that this flag is usally "
+                             "enabled automatically by `wpt run`, if it succeeds in downloading "
+                             "the right version of mojojs.zip or if --mojojs-path is specified.")
     servo_group.add_argument("--mojojs-path",
                              help="Path to mojojs gen/ directory. If it is not specified, `wpt run` "
                              "will download and extract mojojs.zip into _venv2/mojojs/gen.")

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -213,6 +213,8 @@ def run_tests(config, test_paths, product, **kwargs):
                                                                        run_info,
                                                                        **kwargs)
 
+        mojojs_path = kwargs["mojojs_path"] if kwargs["enable_mojojs"] else None
+
         recording.set(["startup", "start_environment"])
         with env.TestEnvironment(test_paths,
                                  testharness_timeout_multipler,
@@ -222,7 +224,7 @@ def run_tests(config, test_paths, product, **kwargs):
                                  ssl_config,
                                  env_extras,
                                  kwargs["enable_quic"],
-                                 kwargs["enable_mojojs"]) as test_environment:
+                                 mojojs_path) as test_environment:
             recording.set(["startup", "ensure_environment"])
             try:
                 test_environment.ensure_started()


### PR DESCRIPTION
This flag overrides the default mojojs.zip download behaviour, and
instructs wptrunner to serve Mojo bindings from the given path instead.
This is useful to run wptrunner in Chromium CI where Mojo bindings are
already available in out/<build>/gen.