### PR TITLE
Use the test function as the default test name if it's a single-line arrow function

### DIFF
--- a/resources/test/tests/functional/no-title.html
+++ b/resources/test/tests/functional/no-title.html
@@ -1,0 +1,79 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
+<title>Tests with no title</title>
+<script src="../../variants.js"></script>
+</head>
+<script src="/resources/testharness.js"></script>
+
+<body>
+<h1>Tests with no title</h1>
+<div id="log"></div>
+<script>
+  test(function(){assert_true(true, '1')});
+  test(()=>assert_true(true, '2'));
+  test(() => assert_true(true, '3'));
+  test(() => {
+      assert_true(true, '4');
+  });
+  test(() => { assert_true(true, '5') });
+  test(() => { assert_true(true, '6') }   );
+  test(() => { assert_true(true, '7'); });
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "assert_true(true, '2')",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "assert_true(true, '3')",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title 1",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "assert_true(true, '5')",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "assert_true(true, '6')",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "assert_true(true, '7')",
+      "properties": {},
+      "message": null
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+</html>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3797,7 +3797,7 @@ policies and contribution forms [3].
     function get_title()
     {
         if ('document' in global_scope) {
-            //Don't use document.title to work around an Opera bug in XHTML documents
+            //Don't use document.title to work around an Opera/Presto bug in XHTML documents
             var title = document.getElementsByTagName("title")[0];
             if (title && title.firstChild && title.firstChild.data) {
                 return title.firstChild.data;

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -520,6 +520,30 @@ policies and contribution forms [3].
             Object.prototype.toString.call(worker) == '[object ServiceWorker]';
     }
 
+    function get_test_name(func, name)
+    {
+        if (name) {
+            return name;
+        }
+
+        if (func) {
+            var func_code = func.toString();
+
+            // Try and match with brackets, but fallback to matching without
+            var arrow = func_code.match(/^\(\)\s*=>\s*(?:{(.*)}\s*|(.*))$/);
+
+            // Check for JS line separators
+            if (arrow !== null && !/[\u000A\u000D\u2028\u2029]/.test(func_code)) {
+                var trimmed = (arrow[1] || arrow[2]).trim();
+                // drop a trailing ; if it's the only one
+                if (/^[^;]*;$/.test(trimmed)) trimmed = trimmed.substring(0, trimmed.length - 1);
+                return trimmed;
+            }
+        }
+
+        return test_environment.next_default_test_name();
+    }
+
     /*
      * API functions
      */
@@ -530,7 +554,7 @@ policies and contribution forms [3].
             tests.status.message = '`test` invoked after `promise_setup`';
             tests.complete();
         }
-        var test_name = name ? name : test_environment.next_default_test_name();
+        var test_name = get_test_name(func, name);
         var test_obj = new Test(test_name, properties);
         var value = test_obj.step(func, test_obj, test_obj);
 
@@ -566,7 +590,7 @@ policies and contribution forms [3].
             name = func;
             func = null;
         }
-        var test_name = name ? name : test_environment.next_default_test_name();
+        var test_name = get_test_name(func, name);
         var test_obj = new Test(test_name, properties);
         if (func) {
             var value = test_obj.step(func, test_obj, test_obj);
@@ -603,7 +627,7 @@ policies and contribution forms [3].
             name = func;
             func = null;
         }
-        var test_name = name ? name : test_environment.next_default_test_name();
+        var test_name = get_test_name(func, name);
         var test = new Test(test_name, properties);
         test._is_promise_test = true;
 


### PR DESCRIPTION
I don't really trust myself to have got the testharness.js functional tests right, but we'll see. Probably also needs some docs. Quite possibly also needs an RFC.

[This](https://wpt.fyi/results/?diff&filter=ADC&q=seq%28status%3Amissing%20status%3A%21missing%29%20or%20seq%28status%3A%21missing%20status%3Amissing%29%20&run_id=704190004&run_id=685060001) compares Firefox results for a slightly earlier version of this branch, and seems to not show any test names currently changing.