### PR TITLE
Python3: Enable HTTP2 support for python 3

### DIFF
--- a/infrastructure/metadata/infrastructure/server/http2-context.sub.h2.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/http2-context.sub.h2.any.js.ini
@@ -1,17 +1,5 @@
 [http2-context.sub.h2.any.sharedworker.html]
   bug: https://bugs.webkit.org/show_bug.cgi?id=149850
   expected:
-    if product == "safari" or product == "epiphany" or product == "webkit" or python_version == 3: ERROR
-
-[http2-context.sub.h2.any.serviceworker.html]
-  expected:
-    if python_version == 3: ERROR
-
-[http2-context.sub.h2.any.html]
-  expected:
-    if python_version == 3: ERROR
-
-[http2-context.sub.h2.any.worker.html]
-  expected:
-    if python_version == 3: ERROR
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR
 

--- a/infrastructure/metadata/infrastructure/server/http2-context.sub.h2.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/http2-context.sub.h2.any.js.ini
@@ -1,4 +1,17 @@
 [http2-context.sub.h2.any.sharedworker.html]
   bug: https://bugs.webkit.org/show_bug.cgi?id=149850
   expected:
-    if product == "safari" or product == "epiphany" or product == "webkit": ERROR
+    if product == "safari" or product == "epiphany" or product == "webkit" or python_version == 3: ERROR
+
+[http2-context.sub.h2.any.serviceworker.html]
+  expected:
+    if python_version == 3: ERROR
+
+[http2-context.sub.h2.any.html]
+  expected:
+    if python_version == 3: ERROR
+
+[http2-context.sub.h2.any.worker.html]
+  expected:
+    if python_version == 3: ERROR
+

--- a/infrastructure/metadata/infrastructure/server/http2-context.sub.h2.any.js.ini
+++ b/infrastructure/metadata/infrastructure/server/http2-context.sub.h2.any.js.ini
@@ -1,17 +1,4 @@
 [http2-context.sub.h2.any.sharedworker.html]
   bug: https://bugs.webkit.org/show_bug.cgi?id=149850
   expected:
-    if product == "safari" or product == "epiphany" or product == "webkit" or python_version == 3: ERROR
-
-[http2-context.sub.h2.any.serviceworker.html]
-  expected:
-    if python_version == 3: ERROR
-
-[http2-context.sub.h2.any.html]
-  expected:
-    if python_version == 3: ERROR
-
-[http2-context.sub.h2.any.worker.html]
-  expected:
-    if python_version == 3: ERROR
-
+    if product == "safari" or product == "epiphany" or product == "webkit": ERROR

--- a/infrastructure/metadata/infrastructure/server/wpt-server-http.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/server/wpt-server-http.sub.html.ini
@@ -18,28 +18,3 @@
   [HTTPS protocol, punycode subdomain #2]
     expected:
       if product == "epiphany" or product == "webkit": FAIL
-
-  [H2 protocol, no subdomain]
-    expected:
-      if python_version == 3: FAIL
-
-  [H2 protocol, www subdomain #1]
-    expected:
-      if python_version == 3: FAIL
-
-  [H2 protocol, www subdomain #2]
-    expected:
-      if python_version == 3: FAIL
-
-  [H2 protocol, www subdomain #3]
-    expected:
-      if python_version == 3: FAIL
-
-  [H2 protocol, punycode subdomain #1]
-    expected:
-      if python_version == 3: FAIL
-
-  [H2 protocol, punycode subdomain #2]
-    expected:
-      if python_version == 3: FAIL
-

--- a/infrastructure/metadata/infrastructure/server/wpt-server-http.sub.html.ini
+++ b/infrastructure/metadata/infrastructure/server/wpt-server-http.sub.html.ini
@@ -18,3 +18,28 @@
   [HTTPS protocol, punycode subdomain #2]
     expected:
       if product == "epiphany" or product == "webkit": FAIL
+
+  [H2 protocol, no subdomain]
+    expected:
+      if python_version == 3: FAIL
+
+  [H2 protocol, www subdomain #1]
+    expected:
+      if python_version == 3: FAIL
+
+  [H2 protocol, www subdomain #2]
+    expected:
+      if python_version == 3: FAIL
+
+  [H2 protocol, www subdomain #3]
+    expected:
+      if python_version == 3: FAIL
+
+  [H2 protocol, punycode subdomain #1]
+    expected:
+      if python_version == 3: FAIL
+
+  [H2 protocol, punycode subdomain #2]
+    expected:
+      if python_version == 3: FAIL
+

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -532,7 +532,7 @@ def start_servers(host, ports, paths, routes, bind_address, config, **kwargs):
         # If trying to start HTTP/2.0 server, check compatibility
         if scheme == 'h2' and not http2_compatible():
             logger.error('Cannot start HTTP/2.0 server as the environment is not compatible. ' +
-                         'Requires Python 2.7.10+ (< 3.0) and OpenSSL 1.0.2+')
+                         'Requires Python 2.7.10+ or 3.6+ and OpenSSL 1.0.2+')
             continue
 
         for port in ports:

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -320,16 +320,16 @@ class TestH2Handler(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 203
-        assert resp.headers['test'][0] == 'passed'
-        assert resp.read() == ''
+        assert resp.headers['test'][0] == b'passed'
+        assert resp.read() == b''
 
     def test_only_main(self):
         self.conn.request("GET", '/test_tuple_3.py')
         resp = self.conn.get_response()
 
         assert resp.status == 202
-        assert resp.headers['Content-Type'][0] == 'text/html'
-        assert resp.headers['X-Test'][0] == 'PASS'
+        assert resp.headers['Content-Type'][0] == b'text/html'
+        assert resp.headers['X-Test'][0] == b'PASS'
         assert resp.read() == b'PASS'
 
     def test_handle_data(self):
@@ -344,7 +344,7 @@ class TestH2Handler(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 203
-        assert resp.headers['test'][0] == 'passed'
+        assert resp.headers['test'][0] == b'passed'
         assert resp.read() == b'!dlrow olleh'
 
     def test_no_main_or_handlers(self):
@@ -366,16 +366,16 @@ class TestH2Handler(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 203
-        assert resp.headers['test'][0] == 'passed'
-        assert resp.read() == ''
+        assert resp.headers['test'][0] == b'passed'
+        assert resp.read() == b''
 
         # 2nd .py resource
         self.conn.request("GET", '/test_tuple_3.py')
         resp = self.conn.get_response()
 
         assert resp.status == 202
-        assert resp.headers['Content-Type'][0] == 'text/html'
-        assert resp.headers['X-Test'][0] == 'PASS'
+        assert resp.headers['Content-Type'][0] == b'text/html'
+        assert resp.headers['X-Test'][0] == b'PASS'
         assert resp.read() == b'PASS'
 
         # 3rd .py resource
@@ -383,8 +383,8 @@ class TestH2Handler(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 203
-        assert resp.headers['test'][0] == 'passed'
-        assert resp.read() == ''
+        assert resp.headers['test'][0] == b'passed'
+        assert resp.read() == b''
 
 
 class TestWorkersHandler(TestWrapperHandlerUsingServer):

--- a/tools/wptserve/tests/functional/test_response.py
+++ b/tools/wptserve/tests/functional/test_response.py
@@ -206,7 +206,7 @@ class TestH2Response(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 202
-        assert [x for x in resp.headers.items()] == [('server', 'test-h2'), ('test', 'PASS')]
+        assert [x for x in resp.headers.items()] == [(b'server', b'test-h2'), (b'test', b'PASS')]
         assert resp.read() == data
 
     def test_push(self):
@@ -248,12 +248,12 @@ class TestH2Response(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 202
-        assert [x for x in resp.headers.items()] == [('server', 'test-h2'), ('test', 'PASS')]
+        assert [x for x in resp.headers.items()] == [(b'server', b'test-h2'), (b'test', b'PASS')]
         assert resp.read() == data
 
         push_promise = next(self.conn.get_pushes())
         push = push_promise.get_response()
-        assert push_promise.path == '/push-test'
+        assert push_promise.path == b'/push-test'
         assert push.status == 203
         assert push.read() == push_data
 
@@ -273,7 +273,7 @@ class TestH2Response(TestUsingH2Server):
     def test_file_like_response(self):
         @wptserve.handlers.handler
         def handler(request, response):
-            content = BytesIO("Hello, world!")
+            content = BytesIO(b"Hello, world!")
             response.content = content
 
         route = ("GET", "/h2test/test_file_like_response", handler)
@@ -282,7 +282,7 @@ class TestH2Response(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 200
-        assert resp.read() == "Hello, world!"
+        assert resp.read() == b"Hello, world!"
 
     def test_list_response(self):
         @wptserve.handlers.handler
@@ -295,7 +295,7 @@ class TestH2Response(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 200
-        assert resp.read() == "helloworld"
+        assert resp.read() == b"helloworld"
 
     def test_content_longer_than_frame_size(self):
         @wptserve.handlers.handler
@@ -312,7 +312,7 @@ class TestH2Response(TestUsingH2Server):
         assert resp.status == 200
         payload_size = int(resp.headers['payload_size'][0])
         assert payload_size
-        assert resp.read() == "a" * (payload_size + 5)
+        assert resp.read() == b"a" * (payload_size + 5)
 
     def test_encode(self):
         @wptserve.handlers.handler
@@ -343,8 +343,8 @@ class TestH2Response(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 204
-        assert resp.headers['server'][0] == 'TEST-H2'
-        assert resp.read() == ''
+        assert resp.headers['server'][0] == b'TEST-H2'
+        assert resp.read() == b''
 
     def test_raw_header_frame_invalid(self):
         @wptserve.handlers.handler
@@ -370,7 +370,7 @@ class TestH2Response(TestUsingH2Server):
         self.server.router.register(*route)
         sid = self.conn.request(route[0], route[1])
 
-        assert self.conn.streams[sid]._read() == 'Hello world'
+        assert self.conn.streams[sid]._read() == b'Hello world'
 
     def test_raw_header_continuation_frame(self):
         @wptserve.handlers.handler
@@ -389,8 +389,8 @@ class TestH2Response(TestUsingH2Server):
         resp = self.conn.get_response()
 
         assert resp.status == 204
-        assert resp.headers['server'][0] == 'TEST-H2'
-        assert resp.read() == ''
+        assert resp.headers['server'][0] == b'TEST-H2'
+        assert resp.read() == b''
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -451,8 +451,8 @@ class H2ResponseWriter(object):
         secondary_headers = []  # Non ':' prefixed headers are to be added afterwards
 
         for header, value in headers:
-            # h2_header by default is unicode in PY3
-            # header key on the other hand is bytes
+            # h2_headers are native strings.
+            # header key on the other hand is bytes.
             header = self.decode(header)
             if isinstance(value, binary_type):
                 value = self.decode(value)

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -451,9 +451,11 @@ class H2ResponseWriter(object):
         secondary_headers = []  # Non ':' prefixed headers are to be added afterwards
 
         for header, value in headers:
-            # h2_headers are native strings.
-            # header key on the other hand is bytes.
-            header = self.decode(header)
+            # h2_headers are native strings
+            # header field names are strings of ASCII
+            if isinstance(header, binary_type):
+                header = header.decode('ascii')
+            # value in headers can be either string or integer
             if isinstance(value, binary_type):
                 value = self.decode(value)
             if header in h2_headers:

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -26,7 +26,7 @@ from .logger import get_logger
 from .request import Server, Request, H2Request
 from .response import Response, H2Response
 from .router import Router
-from .utils import HTTPException
+from .utils import HTTPException, isomorphic_decode
 from .constants import h2_headers
 
 # We need to stress test that browsers can send/receive many headers (there is
@@ -506,11 +506,13 @@ class H2Headers(dict):
     def __init__(self, headers):
         self.raw_headers = OrderedDict()
         for key, val in headers:
+            key = isomorphic_decode(key)
+            val = isomorphic_decode(val)
             self.raw_headers[key] = val
             dict.__setitem__(self, self._convert_h2_header_to_h1(key), val)
 
     def _convert_h2_header_to_h1(self, header_key):
-        if header_key[1:] in h2_headers and header_key[0] == ':':
+        if header_key[1:] in h2_headers and header_key[:1] == ':':
             return header_key[1:]
         else:
             return header_key

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -512,7 +512,7 @@ class H2Headers(dict):
             dict.__setitem__(self, self._convert_h2_header_to_h1(key), val)
 
     def _convert_h2_header_to_h1(self, header_key):
-        if header_key[1:] in h2_headers and header_key[:1] == ':':
+        if header_key[1:] in h2_headers and header_key[0] == ':':
             return header_key[1:]
         else:
             return header_key

--- a/tools/wptserve/wptserve/utils.py
+++ b/tools/wptserve/wptserve/utils.py
@@ -152,8 +152,9 @@ def get_port(host=''):
     return port
 
 def http2_compatible():
-    # Currently, the HTTP/2.0 server is only working in python 2.7.10+ and OpenSSL 1.0.2+
+    # Currently, the HTTP/2.0 server is only working in python 2.7.10+ or 3.6+ and OpenSSL 1.0.2+
     import ssl
     ssl_v = ssl.OPENSSL_VERSION_INFO
-    return ((sys.version_info[0] == 2 and sys.version_info[1] == 7 and sys.version_info[2] >= 10) and
-            (ssl_v[0] == 1 and (ssl_v[1] == 1 or (ssl_v[1] == 0 and ssl_v[2] >= 2))))
+    py_v = sys.version_info
+    return (((py_v[0] == 2 and py_v[1] == 7 and py_v[2] >= 10) or (py_v[0] == 3 and py_v[1] >= 6)) and
+        (ssl_v[0] == 1 and (ssl_v[1] == 1 or (ssl_v[1] == 0 and ssl_v[2] >= 2))))


### PR DESCRIPTION
This CL is based on PR 25661 by stephenmcgruer.
Only small changes were made here.

Original PR: https://github.com/web-platform-tests/wpt/pull/25661