### PR TITLE
Change the WebDriver client to provide a known type for window/new

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -581,7 +581,7 @@ class Session(object):
         return self.send_session_command("GET", "source")
 
     @command
-    def new_window(self, type_hint="window"):
+    def new_window(self, type_hint="tab"):
         body = {"type": type_hint}
         value = self.send_session_command("POST", "window/new", body)
 

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -581,7 +581,7 @@ class Session(object):
         return self.send_session_command("GET", "source")
 
     @command
-    def new_window(self, type_hint=None):
+    def new_window(self, type_hint="window"):
         body = {"type": type_hint}
         value = self.send_session_command("POST", "window/new", body)
 


### PR DESCRIPTION
See also: https://github.com/w3c/webdriver/issues/1551. At the moment
the spec implies that any type is allowed, but implementations largely
enforce restrictions similar to elsewhere in the spec. Notably, Safari
returns error with error code invalid argument when the type is null.

This ensures the default is something that's well-defined, and allows
for potential edge-cases such as null to be tested separately. Tests for
these edge-cases should be written after the spec issue is resolved.