### PR TITLE
Fix mimetype subtest expectation

### DIFF
--- a/mimesniff/mime-types/resources/mime-types.json
+++ b/mimesniff/mime-types/resources/mime-types.json
@@ -285,7 +285,7 @@
   },
   {
     "input": "x/x;\n\r\t x=x\n\r\t ;x=y",
-    "output": "x/x;x=x"
+    "output": "x/x;x=y"
   },
   "Latin1",
   {


### PR DESCRIPTION
In this subtest, the first parameter name contains trailing
whitespace, which is not acceptable for one of the conditions
in [1]. So fix the expected result to contain only the second
parameter, which is valid.

[1] https://mimesniff.spec.whatwg.org/#parse-a-mime-type Step 11.10