### PR TITLE
Tiny corrections in comments of background-attachment-350.html test

### DIFF
--- a/css/css-backgrounds/background-attachment-350.html
+++ b/css/css-backgrounds/background-attachment-350.html
@@ -46,7 +46,7 @@
   +-----------------------+
   |+----------+           |
   || +------+ |           |
-  || |  red | |           | <-- bottom right of scrolling box
+  || |  red | |           | <== bottom right of scrolling box
   || |square| |           |     when background-image dimensions
   || |      | |           |     are the same as the element's
   || +------+ |           |     viewport dimensions
@@ -54,7 +54,7 @@
   |                       |
   |                       |
   |               +------+|
-  |               |  red || <-- bottom right of scrollable area
+  |               |  red || <== bottom right of scrollable area
   |               |square||     which is outside of the viewport
   |               |      ||     area and which is clipped due
   |               +------+|     to 'overflow: hidden'

--- a/css/css-backgrounds/background-attachment-350.html
+++ b/css/css-backgrounds/background-attachment-350.html
@@ -43,21 +43,22 @@
 
   <!--
 
-  +-----------------------+
-  |+----------+           |
-  || +------+ |           |
+(0px, 0px)              (200px, 0px)
+  +.......................+
+  |+..........+           |
+  || +......+ |           |
   || |  red | |           | <== bottom right of scrolling box
   || |square| |           |     when background-image dimensions
   || |      | |           |     are the same as the element's
-  || +------+ |           |     viewport dimensions
-   +----------+           |
+  || +......+ |           |     viewport dimensions
+   +..........+           |
   |                       |
-  |                       |
-  |               +------+|
+  |               +......+|
   |               |  red || <== bottom right of scrollable area
   |               |square||     which is outside of the viewport
   |               |      ||     area and which is clipped due
-  |               +------+|     to 'overflow: hidden'
-  +-----------------------+
+  |               +......+|     to 'overflow: hidden'
+  +.......................+
+(0px, 200px)            (200px, 200px)
 
   -->


### PR DESCRIPTION
background-attachment-350.html

HTML5 comment syntax requires to avoid using "--" inside comments.