### PR TITLE
Add more tests for invalid "scale" CSS property values.

### DIFF
--- a/css/css-transforms/parsing/scale-parsing-invalid.html
+++ b/css/css-transforms/parsing/scale-parsing-invalid.html
@@ -14,6 +14,10 @@
 test_invalid_value("scale", "100px");
 
 test_invalid_value("scale", "100 200 300 400");
+
+test_invalid_value("scale", "1 junk");
+test_invalid_value("scale", "1 2 junk");
+test_invalid_value("scale", "1 2 3 junk");
 </script>
 </body>
 </html>


### PR DESCRIPTION
 We need to check that junk for optional values makes the whole value invalid, even if values parsed correctly up to this point. Additionally, percentage values were deemed correct but the [specification for scale](https://www.w3.org/TR/css-transforms-2/#propdef-scale) says `none | <number>{1,3}`.