### PR TITLE
[webdriver]: click elements in Shadow DOM

### DIFF
--- a/webdriver/tests/element_click/shadow_dom.py
+++ b/webdriver/tests/element_click/shadow_dom.py
@@ -39,11 +39,11 @@ def test_inside_element_click(session):
     shadow_root = session.find.css("custom-checkbox-element", all=False)
     element = session.execute_script("return arguments[0].shadowRoot.querySelector('input')", args=(shadow_root,))
     pre_checked = get_element_attribute(session, element, 'checked')
-    assert_success(pre_checked, None)
+    assert pre_checked.body["value"] is None
     click_response = element_click(session, element)
     assert_success(click_response)
     post_checked = get_element_attribute(session, element, 'checked')
-    assert_success(post_checked, 'true')
+    assert post_checked.body["value"] == 'true'
 
 def get_nested_shadow_checkbox_dom():
     return inline("""<custom-nested-checkbox-element></custom-nested-checkbox-element></div>
@@ -80,8 +80,8 @@ def test_inside_element_click(session):
     inner_shadow_root = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')", args=(shadow_root,))
     element = session.execute_script("return arguments[0].shadowRoot.querySelector('input')", args=(inner_shadow_root,))
     pre_checked = get_element_attribute(session, element, 'checked')
-    assert_success(pre_checked, None)
+    assert pre_checked.body["value"] is None
     click_response = element_click(session, element)
     assert_success(click_response)
     post_checked = get_element_attribute(session, element, 'checked')
-    assert_success(post_checked, 'true')
+    assert post_checked.body["value"] == 'true'

--- a/webdriver/tests/element_click/shadow_dom.py
+++ b/webdriver/tests/element_click/shadow_dom.py
@@ -87,23 +87,23 @@ def test_nested_shadow_element_click(session):
     session.url = get_nested_shadow_checkbox_dom()
     outer_custom_element = session.find.css("custom-nested-checkbox-element", all=False)
     inner_custom_element = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')", args=(outer_custom_element,))
-    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
-    assert is_checked == False
+    is_pre_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
+    assert is_pre_checked == False
     response = element_click(session, outer_custom_element)
     assert_success(response)
-    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
-    assert is_checked == True
+    is_post_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
+    assert is_post_checked == True
 
 def test_nested_shadow_element_click_inner(session):
     session.url = get_nested_shadow_checkbox_dom()
     outer_custom_element = session.find.css("custom-nested-checkbox-element", all=False)
     inner_custom_element = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')", args=(outer_custom_element,))
-    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
-    assert is_checked == False
+    is_pre_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
+    assert is_pre_checked == False
     response = element_click(session, inner_custom_element)
     assert_success(response)
-    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
-    assert is_checked == True
+    is_post_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
+    assert is_post_checked == True
 
 def test_inside_nested_element_click_checkbox(session):
     session.url = get_nested_shadow_checkbox_dom()

--- a/webdriver/tests/element_click/shadow_dom.py
+++ b/webdriver/tests/element_click/shadow_dom.py
@@ -1,11 +1,14 @@
 from tests.support.asserts import assert_error, assert_success
 from tests.support.inline import inline
+import pytest
+
 
 def element_click(session, element):
     return session.transport.send(
         "POST", "session/{session_id}/element/{element_id}/click".format(
             session_id=session.session_id,
             element_id=element.id))
+
 
 def get_checkbox_dom():
     return inline("""
@@ -27,38 +30,33 @@ def get_checkbox_dom():
                 });
         </script>""")
 
-def test_shadow_element_click(session):
+
+@pytest.mark.parametrize("click_on", ["custom_element", "checkbox_element"])
+def test_shadow_element_click(session, click_on):
     session.url = get_checkbox_dom()
     custom_element = session.find.css("custom-checkbox-element", all=False)
-    is_pre_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(custom_element,))
+    checkbox_element = session.execute_script("return arguments[0].shadowRoot.querySelector('input')",
+                                              args=(custom_element,))
+    is_pre_checked = session.execute_script("return arguments[0].checked",
+                                            args=(checkbox_element,))
     assert is_pre_checked == False
-    response = element_click(session, custom_element)
+    response = element_click(session, locals()[click_on])
     assert_success(response)
-    is_post_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(custom_element,))
+    is_post_checked = session.execute_script("return arguments[0].checked",
+                                             args=(checkbox_element,))
     assert is_post_checked == True
 
-
-def test_inside_element_click(session):
-    session.url = get_checkbox_dom()
-    custom_element = session.find.css("custom-checkbox-element", all=False)
-    checkbox_element = session.execute_script("return arguments[0].shadowRoot.querySelector('input')", args=(custom_element,))
-    is_pre_checked = session.execute_script("return arguments[0].checked", args=(checkbox_element,))
-    assert is_pre_checked == False
-    click_response = element_click(session, checkbox_element)
-    assert_success(click_response)
-    is_post_checked = session.execute_script("return arguments[0].checked", args=(checkbox_element,))
-    assert is_post_checked == True
 
 def get_nested_shadow_checkbox_dom():
     return inline("""
         <style>
-            custom-nested-checkbox-element {
+            custom-nesting-element {
                 display:block; width:20px; height:20px;
             }
         </style>
-        <custom-nested-checkbox-element></custom-nested-checkbox-element>
+        <custom-nesting-element></custom-nesting-element>
         <script>
-         customElements.define('custom-nested-checkbox-element',
+         customElements.define('custom-nesting-element',
                 class extends HTMLElement {
                     constructor() {
                             super();
@@ -83,36 +81,20 @@ def get_nested_shadow_checkbox_dom():
                 });
         </script>""")
 
-def test_nested_shadow_element_click(session):
-    session.url = get_nested_shadow_checkbox_dom()
-    outer_custom_element = session.find.css("custom-nested-checkbox-element", all=False)
-    inner_custom_element = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')", args=(outer_custom_element,))
-    is_pre_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
-    assert is_pre_checked == False
-    response = element_click(session, outer_custom_element)
-    assert_success(response)
-    is_post_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
-    assert is_post_checked == True
 
-def test_nested_shadow_element_click_inner(session):
+@pytest.mark.parametrize("click_on", ["outer_element", "inner_element", "checkbox_element"])
+def test_nested_shadow_element_click(session, click_on):
     session.url = get_nested_shadow_checkbox_dom()
-    outer_custom_element = session.find.css("custom-nested-checkbox-element", all=False)
-    inner_custom_element = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')", args=(outer_custom_element,))
-    is_pre_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
+    outer_element = session.find.css("custom-nesting-element", all=False)
+    inner_element = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')",
+                                           args=(outer_element,))
+    checkbox_element = session.execute_script("return arguments[0].shadowRoot.querySelector('input')",
+                                              args=(inner_element,))
+    is_pre_checked = session.execute_script("return arguments[0].checked",
+                                            args=(checkbox_element,))
     assert is_pre_checked == False
-    response = element_click(session, inner_custom_element)
-    assert_success(response)
-    is_post_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
-    assert is_post_checked == True
-
-def test_inside_nested_element_click_checkbox(session):
-    session.url = get_nested_shadow_checkbox_dom()
-    outer_custom_element = session.find.css("custom-nested-checkbox-element", all=False)
-    inner_custom_element = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')", args=(outer_custom_element,))
-    checkbox_element = session.execute_script("return arguments[0].shadowRoot.querySelector('input')", args=(inner_custom_element,))
-    is_pre_checked = session.execute_script("return arguments[0].checked", args=(checkbox_element,))
-    assert is_pre_checked == False
-    click_response = element_click(session, checkbox_element)
+    click_response = element_click(session, locals()[click_on])
     assert_success(click_response)
-    is_post_checked = session.execute_script("return arguments[0].checked", args=(checkbox_element,))
+    is_post_checked = session.execute_script("return arguments[0].checked",
+                                             args=(checkbox_element,))
     assert is_post_checked == True

--- a/webdriver/tests/element_click/shadow_dom.py
+++ b/webdriver/tests/element_click/shadow_dom.py
@@ -15,7 +15,7 @@ def get_element_attribute(session, element, attr):
             attr=attr))
 
 def get_checkbox_dom():
-    return inline("""<custom-checkbox-element></custom-checkbox-element></div>
+    return inline("""<custom-checkbox-element></custom-checkbox-element>
         <script>
             customElements.define('custom-checkbox-element',
                 class extends HTMLElement {
@@ -46,7 +46,7 @@ def test_inside_element_click(session):
     assert post_checked.body["value"] == 'true'
 
 def get_nested_shadow_checkbox_dom():
-    return inline("""<custom-nested-checkbox-element></custom-nested-checkbox-element></div>
+    return inline("""<custom-nested-checkbox-element></custom-nested-checkbox-element>
         <script>
          customElements.define('custom-nested-checkbox-element',
                 class extends HTMLElement {

--- a/webdriver/tests/element_click/shadow_dom.py
+++ b/webdriver/tests/element_click/shadow_dom.py
@@ -30,12 +30,12 @@ def get_checkbox_dom():
 def test_shadow_element_click(session):
     session.url = get_checkbox_dom()
     custom_element = session.find.css("custom-checkbox-element", all=False)
-    is_pre_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(custom_element,))    
+    is_pre_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(custom_element,))
     assert is_pre_checked == False
     response = element_click(session, custom_element)
     assert_success(response)
-    is_post_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(custom_element,))    
-    assert is_post_checked == True 
+    is_post_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(custom_element,))
+    assert is_post_checked == True
 
 
 def test_inside_element_click(session):
@@ -87,22 +87,22 @@ def test_nested_shadow_element_click(session):
     session.url = get_nested_shadow_checkbox_dom()
     outer_custom_element = session.find.css("custom-nested-checkbox-element", all=False)
     inner_custom_element = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')", args=(outer_custom_element,))
-    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))    
+    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
     assert is_checked == False
     response = element_click(session, outer_custom_element)
     assert_success(response)
-    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))    
+    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
     assert is_checked == True
 
 def test_nested_shadow_element_click_inner(session):
     session.url = get_nested_shadow_checkbox_dom()
     outer_custom_element = session.find.css("custom-nested-checkbox-element", all=False)
     inner_custom_element = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')", args=(outer_custom_element,))
-    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))    
+    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
     assert is_checked == False
     response = element_click(session, inner_custom_element)
     assert_success(response)
-    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))    
+    is_checked = session.execute_script("return arguments[0].shadowRoot.querySelector('input').checked", args=(inner_custom_element,))
     assert is_checked == True
 
 def test_inside_nested_element_click_checkbox(session):

--- a/webdriver/tests/element_click/shadow_dom.py
+++ b/webdriver/tests/element_click/shadow_dom.py
@@ -1,0 +1,75 @@
+from tests.support.asserts import assert_error, assert_success
+from tests.support.inline import inline
+
+def element_click(session, element):
+    return session.transport.send(
+        "POST", "session/{session_id}/element/{element_id}/click".format(
+            session_id=session.session_id,
+            element_id=element.id))
+
+def get_element_attribute(session, element, attr):
+    return session.transport.send(
+        "GET", "session/{session_id}/element/{element_id}/attribute/{attr}".format(
+            session_id=session.session_id,
+            element_id=element.id,
+            attr=attr))
+
+def get_button_dom():
+    return inline(""" <custom-button-element></custom-button-element></div>
+        <script>
+            customElements.define('custom-button-element',
+                class extends HTMLElement {
+                    constructor() {
+                            super();
+                            this.attachShadow({mode: 'open'}).innerHTML = `
+                                <div><input type="checkbox"/></div>
+                            `;
+                        }
+                });
+        </script>""")
+
+def test_shadow_element_click(session):
+    session.url = get_button_dom()
+    element = session.find.css("custom-button-element", all=False)
+    response = element_click(session, element)
+    assert_success(response)
+
+def test_inside_element_click(session):
+    session.url = get_button_dom()
+    shadow_root = session.find.css("custom-button-element", all=False)
+    element = session.execute_script("return arguments[0].shadowRoot.querySelector('input')", args=(shadow_root,))
+    pre_checked = get_element_attribute(session, element, 'checked')
+    assert_success(pre_checked, None)
+    click_response = element_click(session, element)
+    assert_success(click_response)
+    post_checked = get_element_attribute(session, element, 'checked')
+    assert_success(post_checked, 'true')
+
+def get_custom_select_dom():
+    return inline(""" <custom-select-element></custom-select-element> <div id="clicked">false</div>
+        <script>
+            customElements.define('custom-select-element',
+                class extends HTMLElement {
+                    constructor() {
+                            super();
+                            this.attachShadow({mode: 'open'}).innerHTML = `
+                                <select>
+                                    <option>first</option>
+                                    <option>second</option>
+                                </select>
+                            `;                          
+                        }
+                });
+        </script>""")
+
+def test_shadow_option_element_click_inside(session):
+    session.url = get_custom_select_dom()
+    shadow_root = session.find.css("custom-select-element", all=False)
+    options = session.execute_script("return arguments[0].shadowRoot.querySelectorAll('option');", args=(shadow_root,))
+
+    assert options[0].selected
+    assert not options[1].selected
+
+    options[1].click()
+    assert not options[0].selected
+    assert options[1].selected

--- a/webdriver/tests/element_click/shadow_dom.py
+++ b/webdriver/tests/element_click/shadow_dom.py
@@ -15,7 +15,13 @@ def get_element_attribute(session, element, attr):
             attr=attr))
 
 def get_checkbox_dom():
-    return inline("""<custom-checkbox-element></custom-checkbox-element>
+    return inline("""
+        <style>
+            custom-checkbox-element {
+                display:block; width:20px; height:20px
+            }
+        </style>
+        <custom-checkbox-element></custom-checkbox-element>
         <script>
             customElements.define('custom-checkbox-element',
                 class extends HTMLElement {
@@ -46,13 +52,24 @@ def test_inside_element_click(session):
     assert post_checked.body["value"] == 'true'
 
 def get_nested_shadow_checkbox_dom():
-    return inline("""<custom-nested-checkbox-element></custom-nested-checkbox-element>
+    return inline("""
+        <style>
+            custom-nested-checkbox-element {
+                display:block; width:20px; height:20px
+            }
+        </style>
+        <custom-nested-checkbox-element></custom-nested-checkbox-element>
         <script>
          customElements.define('custom-nested-checkbox-element',
                 class extends HTMLElement {
                     constructor() {
                             super();
                             this.attachShadow({mode: 'open'}).innerHTML = `
+                                <style>
+                                    custom-checkbox-element {
+                                        display:block; width:20px; height:20px
+                                    }
+                                </style>
                                 <div><custom-checkbox-element></custom-checkbox-element></div>
                             `;
                         }

--- a/webdriver/tests/element_click/shadow_dom.py
+++ b/webdriver/tests/element_click/shadow_dom.py
@@ -91,7 +91,7 @@ def test_nested_shadow_element_click(session):
     response = element_click(session, element)
     assert_success(response)
 
-def test_inside_element_click(session):
+def test_inside_nested_element_click(session):
     session.url = get_nested_shadow_checkbox_dom()
     shadow_root = session.find.css("custom-nested-checkbox-element", all=False)
     inner_shadow_root = session.execute_script("return arguments[0].shadowRoot.querySelector('custom-checkbox-element')", args=(shadow_root,))

--- a/webdriver/tests/element_click/shadow_dom.py
+++ b/webdriver/tests/element_click/shadow_dom.py
@@ -18,7 +18,7 @@ def get_checkbox_dom():
     return inline("""
         <style>
             custom-checkbox-element {
-                display:block; width:20px; height:20px
+                display:block; width:20px; height:20px;
             }
         </style>
         <custom-checkbox-element></custom-checkbox-element>
@@ -55,7 +55,7 @@ def get_nested_shadow_checkbox_dom():
     return inline("""
         <style>
             custom-nested-checkbox-element {
-                display:block; width:20px; height:20px
+                display:block; width:20px; height:20px;
             }
         </style>
         <custom-nested-checkbox-element></custom-nested-checkbox-element>
@@ -67,7 +67,7 @@ def get_nested_shadow_checkbox_dom():
                             this.attachShadow({mode: 'open'}).innerHTML = `
                                 <style>
                                     custom-checkbox-element {
-                                        display:block; width:20px; height:20px
+                                        display:block; width:20px; height:20px;
                                     }
                                 </style>
                                 <div><custom-checkbox-element></custom-checkbox-element></div>


### PR DESCRIPTION
I've added tests for clicking elements inside of shadow DOM in the WebDriver tests.

Currently they don't pass in WebKit ([Bug](https://bugs.webkit.org/show_bug.cgi?id=209233)), but pass in Firefox and Chrome.

I'd be happy to get some pointers to maybe make the tests a bit less verbose.