### PR TITLE
Add test for image-orientation in a cross-origin context.

### DIFF
--- a/css/css-images/image-orientation/image-orientation-none-cross-origin-canvas.html
+++ b/css/css-images/image-orientation/image-orientation-none-cross-origin-canvas.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Images Module Level 3: image-orientation: none</title>
+<script src=/common/get-host-info.sub.js></script>
+<link rel="author" title="Noam Rosenthal" href="mailto:noam@webkit.org">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/5165">
+<link rel="match" href="reference/image-orientation-none-cross-origin-ref.html">
+<meta name=fuzzy content="10;100">
+<style>
+    img {display: none}
+    canvas {
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<script>
+    const src1 = 'support/exif-orientation-1-ul.jpg';
+    const src2 = 'support/exif-orientation-3-lr.jpg';
+    function toCors(src) {
+        return src.replace(new URL(src).origin, get_host_info().HTTP_REMOTE_ORIGIN)
+    }
+    function createImage({cors, src, orientation}) {
+        const img = document.createElement('img');
+        img.src = src
+        if (cors)
+            img.src = toCors(img.src)
+        img.style.imageOrientation = orientation
+        img.style.display = 'none'
+        document.body.appendChild(img)
+        return img
+    }
+
+    window.onload = () => {
+        const images = {
+            red: [
+                createImage({cors: true, src: src2, orientation: 'from-image', shouldBeRotated: true}),
+                createImage({cors: true, src: src2, orientation: 'none', shouldBeRotated: true}),
+                createImage({cors: false, src: src2, orientation: 'from-image', shouldBeRotated: true}),
+            ],
+            green: [
+                createImage({cors: true, src: src1, orientation: 'from-image', shouldBeRotated: false}),
+                createImage({cors: true, src: src1, orientation: 'none', shouldBeRotated: false}),
+                createImage({cors: false, src: src1, orientation: 'from-image', shouldBeRotated: false}),
+                createImage({cors: false, src: src1, orientation: 'none', shouldBeRotated: false}),
+                createImage({cors: false, src: src2, orientation: 'none', shouldBeRotated: false}),
+            ]
+        }
+
+        const dimension = 5
+
+        Object.keys(images).forEach(key => {
+            const p = document.createElement('p')
+            p.innerText = `The following canvases should be ${key}`
+            document.body.appendChild(p)
+            images[key].forEach(image => {
+                const canvas = document.createElement('canvas')
+                canvas.width = canvas.height = dimension
+                const ctx = canvas.getContext('2d')
+                ctx.drawImage(image, 0, 0)
+                document.body.appendChild(canvas)
+            })
+        })
+
+    }
+
+</script>
+</head>
+<body>
+</body>
+<script>
+    [src1, src2].forEach(src => {
+        const img = document.createElement('img')
+        img.src = src
+        const imgCors = document.createElement('img')
+        imgCors.src = src
+        imgCors.src = toCors(imgCors.src)
+        document.body.appendChild(img)
+        document.body.appendChild(imgCors)
+    })
+</script>
+</html>

--- a/css/css-images/image-orientation/image-orientation-none-cross-origin-canvas.html
+++ b/css/css-images/image-orientation/image-orientation-none-cross-origin-canvas.html
@@ -13,6 +13,7 @@
     canvas {
         width: 100px;
         height: 100px;
+        margin: 10px;
     }
 </style>
 <script>
@@ -21,46 +22,40 @@
     function toCors(src) {
         return src.replace(new URL(src).origin, get_host_info().HTTP_REMOTE_ORIGIN)
     }
-    function createImage({cors, src, orientation}) {
+    function createImage({cors, src, orientation, shouldBeRotated}) {
         const img = document.createElement('img');
         img.src = src
         if (cors)
             img.src = toCors(img.src)
         img.style.imageOrientation = orientation
         img.style.display = 'none'
+        img.dataset.shouldBeRotated = shouldBeRotated
         document.body.appendChild(img)
         return img
     }
 
     window.onload = () => {
-        const images = {
-            red: [
-                createImage({cors: true, src: src2, orientation: 'from-image', shouldBeRotated: true}),
-                createImage({cors: true, src: src2, orientation: 'none', shouldBeRotated: true}),
-                createImage({cors: false, src: src2, orientation: 'from-image', shouldBeRotated: true}),
-            ],
-            green: [
-                createImage({cors: true, src: src1, orientation: 'from-image', shouldBeRotated: false}),
-                createImage({cors: true, src: src1, orientation: 'none', shouldBeRotated: false}),
-                createImage({cors: false, src: src1, orientation: 'from-image', shouldBeRotated: false}),
-                createImage({cors: false, src: src1, orientation: 'none', shouldBeRotated: false}),
-                createImage({cors: false, src: src2, orientation: 'none', shouldBeRotated: false}),
-            ]
-        }
+        const images = [
+            createImage({cors: true, src: src2, orientation: 'from-image', shouldBeRotated: true}),
+            createImage({cors: true, src: src2, orientation: 'none', shouldBeRotated: true}),
+            createImage({cors: false, src: src2, orientation: 'from-image', shouldBeRotated: true}),
+            createImage({cors: true, src: src1, orientation: 'from-image', shouldBeRotated: false}),
+            createImage({cors: true, src: src1, orientation: 'none', shouldBeRotated: false}),
+            createImage({cors: false, src: src1, orientation: 'from-image', shouldBeRotated: false}),
+            createImage({cors: false, src: src1, orientation: 'none', shouldBeRotated: false}),
+            createImage({cors: false, src: src2, orientation: 'none', shouldBeRotated: false}),
+        ]
 
-        const dimension = 5
+        const dimension = 1
 
-        Object.keys(images).forEach(key => {
-            const p = document.createElement('p')
-            p.innerText = `The following canvases should be ${key}`
-            document.body.appendChild(p)
-            images[key].forEach(image => {
-                const canvas = document.createElement('canvas')
-                canvas.width = canvas.height = dimension
-                const ctx = canvas.getContext('2d')
-                ctx.drawImage(image, 0, 0)
-                document.body.appendChild(canvas)
-            })
+        images.forEach(image => {
+            const canvas = document.createElement('canvas')
+            canvas.width = canvas.height = dimension
+            const ctx = canvas.getContext('2d')
+            const sx = image.dataset.shouldBeRotated === 'true' ? image.width * .8 : 0
+            const sy = image.dataset.shouldBeRotated === 'true' ? image.height * .8 : 0
+            ctx.drawImage(image, sx, sy, 1, 1, 0, 0, dimension, dimension)
+            document.body.appendChild(canvas)
         })
 
     }
@@ -68,6 +63,7 @@
 </script>
 </head>
 <body>
+    <p>You should see 8 green rectangles, no red.</p>
 </body>
 <script>
     [src1, src2].forEach(src => {

--- a/css/css-images/image-orientation/image-orientation-none-cross-origin.html
+++ b/css/css-images/image-orientation/image-orientation-none-cross-origin.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Images Module Level 3: image-orientation: none</title>
+<script src=/common/get-host-info.sub.js></script>
+<link rel="author" title="Noam Rosenthal" href="mailto:noam@webkit.org">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/5165">
+<link rel="match" href="reference/image-orientation-none-cross-origin-ref.html">
+<meta name=fuzzy content="10;100">
+<style>
+    body {
+        overflow: hidden;
+        image-orientation: none;
+    }
+    div {
+        display: inline-block;
+        width: 100px;
+        vertical-align: top;
+    }
+</style>
+</head>
+<body>
+    <p>The following images should not be identical.</p>
+    <p>The image should not rotate respecting their EXIF orientation because
+       image-orientation: none is specified.</p>
+    <div><img src="support/exif-orientation-3-lr.jpg"/></div>
+
+    <p>This image should rotate respecting their EXIF orientation because
+       image-orientation: none should be effectively ignored for opaque (cross-origin) images.</p>
+    <div><img id="corsImage" src="support/exif-orientation-3-lr.jpg"/></div>
+    <script>
+        const img = document.getElementById('corsImage')
+        img.src = img.src.replace(new URL(img.src).origin, get_host_info().HTTP_REMOTE_ORIGIN)
+    </script>
+</body>
+</html>

--- a/css/css-images/image-orientation/reference/image-orientation-none-cross-origin-canvas-ref.html
+++ b/css/css-images/image-orientation/reference/image-orientation-none-cross-origin-canvas-ref.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Images Module Level 3: image-orientation: none</title>
+<link rel="author" title="Noam Rosenthal" href="mailto:noam@webkit.org">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/5165">
+<meta name=fuzzy content="10;100">
+<style>
+    body {
+        overflow: hidden;
+        image-orientation: none;
+    }
+    img {display: none}
+    canvas {
+        width: 100px;
+        height: 100px;
+    }
+    .no-orient { image-orientation: none; }
+</style>
+<body>
+</body>
+<script>
+    function createImage({cors, src, orientation}) {
+        const img = document.createElement('img');
+        img.src = src
+        return img
+    }
+
+    const src1 = '../support/exif-orientation-1-ul.jpg';
+    const src2 = '../support/exif-orientation-3-lr.jpg';
+    [src1, src2].forEach(src => {
+        const img = document.createElement('img')
+        img.src = src
+
+        document.body.appendChild(img)
+    })
+
+    window.onload = async () => {
+        const images = {
+            red: new Array(3).fill(createImage({src: src2})),
+            green: new Array(5).fill(createImage({src: src1}))
+        }
+
+        await Promise.all([])
+
+        const dimension = 5
+
+        Object.keys(images).forEach(key => {
+            const p = document.createElement('p')
+            p.innerText = `The following canvases should be ${key}`
+            document.body.appendChild(p)
+            images[key].forEach(image => {
+                const canvas = document.createElement('canvas')
+                canvas.width = canvas.height = dimension
+                const ctx = canvas.getContext('2d')
+                ctx.drawImage(image, 0, 0)
+                document.body.appendChild(canvas)
+            })
+        })
+
+    }
+</script>
+</head>
+</html>

--- a/css/css-images/image-orientation/reference/image-orientation-none-cross-origin-canvas-ref.html
+++ b/css/css-images/image-orientation/reference/image-orientation-none-cross-origin-canvas-ref.html
@@ -15,49 +15,28 @@
     canvas {
         width: 100px;
         height: 100px;
+        margin: 10px;
     }
     .no-orient { image-orientation: none; }
 </style>
 <body>
+    <p>You should see 8 green rectangles, no red.</p>
 </body>
 <script>
-    function createImage({cors, src, orientation}) {
-        const img = document.createElement('img');
-        img.src = src
-        return img
-    }
+    const img = document.createElement('img')
+    img.src = '../support/exif-orientation-1-ul.jpg'
 
-    const src1 = '../support/exif-orientation-1-ul.jpg';
-    const src2 = '../support/exif-orientation-3-lr.jpg';
-    [src1, src2].forEach(src => {
-        const img = document.createElement('img')
-        img.src = src
+    document.body.appendChild(img)
 
-        document.body.appendChild(img)
-    })
-
-    window.onload = async () => {
-        const images = {
-            red: new Array(3).fill(createImage({src: src2})),
-            green: new Array(5).fill(createImage({src: src1}))
+    const dimension = 5
+    window.onload = () => {
+        for (let i = 0; i < 8; ++i) {
+            const canvas = document.createElement('canvas')
+            canvas.width = canvas.height = dimension
+            const ctx = canvas.getContext('2d')
+            ctx.drawImage(img, 0, 0)
+            document.body.appendChild(canvas)
         }
-
-        await Promise.all([])
-
-        const dimension = 5
-
-        Object.keys(images).forEach(key => {
-            const p = document.createElement('p')
-            p.innerText = `The following canvases should be ${key}`
-            document.body.appendChild(p)
-            images[key].forEach(image => {
-                const canvas = document.createElement('canvas')
-                canvas.width = canvas.height = dimension
-                const ctx = canvas.getContext('2d')
-                ctx.drawImage(image, 0, 0)
-                document.body.appendChild(canvas)
-            })
-        })
 
     }
 </script>

--- a/css/css-images/image-orientation/reference/image-orientation-none-cross-origin-ref.html
+++ b/css/css-images/image-orientation/reference/image-orientation-none-cross-origin-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Noam Rosenthal" href="mailto:noam@webkit.org">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/5165">
+<meta name=fuzzy content="10;100">
+<style>
+    body {
+        overflow: hidden;
+        image-orientation: none;
+    }
+    div {
+        display: inline-block;
+        width: 100px;
+        vertical-align: top;
+    }
+</style>
+</head>
+<body>
+    <p>The following images should not be identical.</p>
+    <p>The image should not rotate respecting their EXIF orientation because
+       image-orientation: none is specified.</p>
+    <div><img src="../support/exif-orientation-3-lr.jpg"/></div>
+
+    <p>This image should rotate respecting their EXIF orientation because
+       image-orientation: none should be effectively ignored for opaque (cross-origin) images.</p>
+    <div><img src="../support/exif-orientation-3-lr.jpg" style="image-orientation: from-image" /></div>
+</body>
+</html>


### PR DESCRIPTION
See https://github.com/w3c/csswg-drafts/issues/5165

image-orientation: none should effectively be ignored for cross-origin images.