### PR TITLE
Remove erroneous assertion on pendingRemoteDescription

### DIFF
--- a/webrtc/RTCPeerConnection-setLocalDescription-pranswer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-pranswer.html
@@ -103,7 +103,6 @@
           assert_session_desc_similar(pc.pendingLocalDescription, pranswer);
           assert_equals(pc.currentLocalDescription, null);
 
-          assert_equals(pc.pendingRemoteDescription, null);
 
           assert_array_equals(states, ['have-remote-offer', 'have-local-pranswer']);
         });


### PR DESCRIPTION
The test expected pendingRemoteDescription to be both null and non-null; kept the right one