### PR TITLE
Added a test for clip-path with zoom.

### DIFF
--- a/css/css-masking/clip-path/clip-path-path-interpolation-with-zoom.html
+++ b/css/css-masking/clip-path/clip-path-path-interpolation-with-zoom.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+  <title>CSS Masking: Test clip-path nonzero path interpolation</title>
+  <link rel="help" href="https://drafts.csswg.org/css-shapes-2/#funcdef-path">
+  <link rel="match" href="reference/clip-path-path-interpolation-001-ref.html">
+  <meta name="assert" content="The clip-path property takes the basic shape
+	'path()' for clipping. Test the interpolation of nonzero
+        path function.">
+  <style>
+    @keyframes anim {
+      from {
+        clip-path: path(nonzero, 'M20,20h60 v60 h-60z M30,30 h40 v40 h-40z');
+      }
+      to {
+        clip-path: path(nonzero, 'M50,50h50 v50 h-50z M20,20 h50 v50 h-50z');
+      }
+    }
+    #rect {
+      width: 100px;
+      zoom: 3;
+      height: 100px;
+      background-color: green;
+      animation: anim 10s -5s paused linear;
+    }
+  </style>
+</head>
+<body>
+  <div id="rect"></div>
+</body>
+<script>
+  requestAnimationFrame(() => {
+    document.documentElement.classList.remove('reftest-wait');
+  });
+</script>
+</html>

--- a/css/css-masking/clip-path/clip-path-path-with-zoom-hittest.html
+++ b/css/css-masking/clip-path/clip-path-path-with-zoom-hittest.html
@@ -6,15 +6,20 @@
   <link rel="help" href="https://drafts.csswg.org/css-shapes-2/#funcdef-path">
   <link rel="match" href="reference/clip-path-path-with-zoom-ref.html">
   <meta name="assert" content="The path gets zoomed together with the content">
+  <script>
+    function onload() {
+      const nodes = [
+        document.elementFromPoint(20, 20),
+        document.elementFromPoint(150, 20),
+        document.elementFromPoint(180, 180)
+      ].map(node => node.id || node.tagName)
+      log.innerText = nodes.join(';')
+
+    }
+  </script>
 </head>
 <style>
-  #red {
-    position: absolute;
-    width: 100px;
-    height: 100px;
-    background: red;
-  }
-  #rect {
+  #triangle {
     width: 100px;
     height: 100px;
     background-color: green;
@@ -22,8 +27,8 @@
     zoom: 2;
   }
 </style>
-<body>
-  <div id="red"></div>
-  <div id="rect"></div>
+<body onload="onload()">
+  <div id="triangle"></div>
+  <output id="log"></output>
 </body>
 </html>

--- a/css/css-masking/clip-path/clip-path-path-with-zoom.html
+++ b/css/css-masking/clip-path/clip-path-path-with-zoom.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Masking: Test clip-path property when the page is zoomed</title>
+  <link rel="author" title="Noam Rosenthal" href="mailto:noam@webkit.org">
+  <link rel="help" href="https://drafts.csswg.org/css-shapes-2/#funcdef-path">
+  <link rel="match" href="reference/clip-path-path-with-zoom-ref.html">
+  <meta name="assert" content="The path gets zoomed together with the content">
+</head>
+<style>
+  #red {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+  #rect {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    clip-path: path(nonzero, 'M0 0, L100 0, L0 100, L 0 0');
+    zoom: 2;
+  }
+</style>
+<body>
+  <p>The test passes if you see a green triangle and no red.</p>
+  <div id="red"></div>
+  <div id="rect"></div>
+</body>
+</html>

--- a/css/css-masking/clip-path/clip-path-path-with-zoom.html
+++ b/css/css-masking/clip-path/clip-path-path-with-zoom.html
@@ -10,8 +10,8 @@
 <style>
   #red {
     position: absolute;
-    width: 100px;
-    height: 100px;
+    width: 50px;
+    height: 50px;
     background: red;
   }
   #rect {
@@ -19,11 +19,12 @@
     height: 100px;
     background-color: green;
     clip-path: path(nonzero, 'M0 0, L100 0, L0 100, L 0 0');
+  }
+  body {
     zoom: 2;
   }
 </style>
 <body>
-  <p>The test passes if you see a green triangle and no red.</p>
   <div id="red"></div>
   <div id="rect"></div>
 </body>

--- a/css/css-masking/clip-path/reference/clip-path-path-interpolation-with-zoom-ref.html
+++ b/css/css-masking/clip-path/reference/clip-path-path-interpolation-with-zoom-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Masking: Reference for clip-path's path nonzero interpolation</title>
+  <style type="text/css">
+    #rect {
+      width: 300px;
+      height: 300px;
+      background-color: green;
+      clip-path: path('M105,105 H270 V270 H105Z M75,75 H210 V210 H75Z');
+    }
+
+  </style>
+</head>
+<body>
+  <div id="rect"></div>
+</body>
+</html>

--- a/css/css-masking/clip-path/reference/clip-path-path-with-zoom-hittest-ref.html
+++ b/css/css-masking/clip-path/reference/clip-path-path-with-zoom-hittest-ref.html
@@ -4,26 +4,18 @@
   <title>CSS Masking: Test clip-path property when the page is zoomed</title>
   <link rel="author" title="Noam Rosenthal" href="mailto:noam@webkit.org">
   <link rel="help" href="https://drafts.csswg.org/css-shapes-2/#funcdef-path">
-  <link rel="match" href="reference/clip-path-path-with-zoom-ref.html">
   <meta name="assert" content="The path gets zoomed together with the content">
 </head>
 <style>
-  #red {
-    position: absolute;
-    width: 100px;
-    height: 100px;
-    background: red;
-  }
-  #rect {
-    width: 100px;
-    height: 100px;
+  #triangle {
+    width: 200px;
+    height: 200px;
     background-color: green;
-    clip-path: path(nonzero, 'M0 0, L100 0, L0 100, L 0 0');
-    zoom: 2;
+    clip-path: path(nonzero, 'M0 0, L200 0, L0 200, L 0 0');
   }
 </style>
 <body>
-  <div id="red"></div>
-  <div id="rect"></div>
+  <div id="triangle"></div>
+  <output id="log">triangle;triangle;BODY</output>
 </body>
 </html>

--- a/css/css-masking/clip-path/reference/clip-path-path-with-zoom-ref.html
+++ b/css/css-masking/clip-path/reference/clip-path-path-with-zoom-ref.html
@@ -4,12 +4,6 @@
   <title>CSS Masking: Test clip-path property when the page is zoomed</title>
 </head>
 <style>
-  #red {
-    position: absolute;
-    width: 100px;
-    height: 100px;
-    background: red;
-  }
   #rect {
     width: 200px;
     height: 200px;
@@ -18,7 +12,6 @@
   }
 </style>
 <body>
-  <p>The test passes if you see a green triangle and no red.</p>
   <div id="red"></div>
   <div id="rect"></div>
 </body>

--- a/css/css-masking/clip-path/reference/clip-path-path-with-zoom-ref.html
+++ b/css/css-masking/clip-path/reference/clip-path-path-with-zoom-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Masking: Test clip-path property when the page is zoomed</title>
+</head>
+<style>
+  #red {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background: red;
+  }
+  #rect {
+    width: 200px;
+    height: 200px;
+    background: green;
+    clip-path: path(nonzero, 'M0 0, L200 0, L0 200');
+  }
+</style>
+<body>
+  <p>The test passes if you see a green triangle and no red.</p>
+  <div id="red"></div>
+  <div id="rect"></div>
+</body>
+</html>


### PR DESCRIPTION
The page zoom should apply to the clip-path and not just the contents.