### PR TITLE
[url] Add a few url tests to cover cases that were not tested before.

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -4618,7 +4618,7 @@
     "search": "",
     "hash": ""
   },
-  "# unknown scheme with non-URL characters in the path",
+  "# unknown scheme with non-URL characters",
   {
     "input": "wow:\uFFFF",
     "base": "about:blank",
@@ -4632,6 +4632,21 @@
     "port": "",
     "pathname": "%EF%BF%BF",
     "search": "",
+    "hash": ""
+  },
+  {
+    "input": "http://example.com/\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF?\uD800\uD801\uDFFE\uDFFF\uFDD0\uFDCF\uFDEF\uFDF0\uFFFE\uFFFF",
+    "base": "about:blank",
+    "href": "http://example.com/%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF?%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF",
+    "origin": "http://example.com",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "example.com",
+    "hostname": "example.com",
+    "port": "",
+    "pathname": "/%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF",
+    "search": "?%EF%BF%BD%F0%90%9F%BE%EF%BF%BD%EF%B7%90%EF%B7%8F%EF%B7%AF%EF%B7%B0%EF%BF%BE%EF%BF%BF",
     "hash": ""
   },
   "Forbidden host code points",
@@ -5246,6 +5261,34 @@
     "hash": ""
   },
   {
+    "input": "/",
+    "base": "file://h/C:/a/b",
+    "href": "file://h/C:/",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "h",
+    "hostname": "h",
+    "port": "",
+    "pathname": "/C:/",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "/",
+    "base": "file://h/a/b",
+    "href": "file://h/",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "h",
+    "hostname": "h",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  },
+  {
     "input": "//d:",
     "base": "file:///C:/a/b",
     "href": "file:///d:",
@@ -5629,6 +5672,20 @@
   {
     "input": "C|",
     "base": "file://host/dir/file",
+    "href": "file://host/C:",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "host",
+    "hostname": "host",
+    "port": "",
+    "pathname": "/C:",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "C|",
+    "base": "file://host/D:/dir1/dir2/file",
     "href": "file://host/C:",
     "protocol": "file:",
     "username": "",


### PR DESCRIPTION
The first tests around edge cases of the U_IS_UNICODE_CHAR macro,
which my younger and more naive self used until http://trac.webkit.org/r267963
and Chrome seems to do something similar.

The second and third test what happens when parsing terminates in the file slash
state with relative file URLs with and without windows drive letters, which
terminal state I forgot in my initial implementation of file host copying in
http://trac.webkit.org/r267896

The last verifies that using a windows drive letter as a relative file URL path
removes all of the base URL's path including any drive letter it may have.
This is something I was unsure about when implementing r267964 but matches the
behavior of IE and Edge.