### PR TITLE
[encoding] Add a test with a decoding error in the middle of a stream…

### DIFF
--- a/encoding/streams/decode-non-utf8.any.js
+++ b/encoding/streams/decode-non-utf8.any.js
@@ -26,6 +26,12 @@ const encodings = [
     invalid: [255]
   },
   {
+    name: 'ISO-2022-JP',
+    value: [65, 66, 67, 0x1B, 65, 66, 67],
+    expected: "ABC\u{fffd}ABC",
+    invalid: [0x0E]
+  },
+  {
     name: 'ISO-8859-14',
     value: [100, 240, 114],
     expected: "d\u{0175}r",


### PR DESCRIPTION
… chunk.

This test comes from http://trac.webkit.org/r266668 and is the only stream
decoding test that has an error in the middle of a chunk given to the decoder.
I had an implementation that passed all other tests then realized I had done it
all wrong and added this test that would have failed with my first implementation.