### PR TITLE
Use Ahem font in tests

### DIFF
--- a/css/css-flexbox/flexbox_stf-table-singleline-2.html
+++ b/css/css-flexbox/flexbox_stf-table-singleline-2.html
@@ -3,6 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-items">
 <link rel="match" href="flexbox_stf-table-singleline-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 #test {
 	background: blue;
@@ -15,6 +16,7 @@ div div {
 	display: flex;
 }
 p {
+	font-family: Ahem;
 	margin: 1em 0;
 	width: 200px;
 }

--- a/css/css-flexbox/flexbox_stf-table-singleline-ref.html
+++ b/css/css-flexbox/flexbox_stf-table-singleline-ref.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <title>flexbox | singleline flexcontainer versus stf :: table</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 div, p {
+	font-family: Ahem;
 	display: inline-block;
 }
 p {

--- a/css/css-flexbox/flexbox_stf-table-singleline.html
+++ b/css/css-flexbox/flexbox_stf-table-singleline.html
@@ -3,6 +3,7 @@
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-items">
 <link rel="match" href="flexbox_stf-table-singleline-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 #test {
 	background: red;
@@ -15,6 +16,7 @@ div div {
 	display: flex;
 }
 p {
+	font-family: Ahem;
 	margin: 1em 0;
 	width: 200px;
 }


### PR DESCRIPTION
These two tests are failing in some WebKit ports due to 1px differences in font rendering (see [this bug](https://bugs.webkit.org/show_bug.cgi?id=216770)).

Let's use the Ahem font since the actual characters are totally irrelevant for the test.