### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=217316

### DIFF
--- a/mediacapture-record/MediaRecorder-error.html
+++ b/mediacapture-record/MediaRecorder-error.html
@@ -38,7 +38,7 @@
         let recorder = new MediaRecorder(video);
         recorder.onerror = t.step_func(mediaRecorderErrorEvent => {
             assert_true(mediaRecorderErrorEvent instanceof MediaRecorderErrorEvent, 'the type of event should be MediaRecorderErrorEvent');
-            assert_equals(mediaRecorderErrorEvent.error.name, 'UnknownError', 'the type of error should be UnknownError when track has been added or removed');
+            assert_equals(mediaRecorderErrorEvent.error.name, 'InvalidModificationError', 'the type of error should be InvalidModificationError when track has been added or removed');
             assert_true(mediaRecorderErrorEvent.isTrusted, 'isTrusted should be true when the event is created by C++');
             assert_equals(recorder.state, "inactive", "MediaRecorder has been stopped after adding a track to stream");
             t.done();
@@ -57,7 +57,7 @@
         let recorder = new MediaRecorder(video);
         recorder.onerror = t.step_func(mediaRecorderErrorEvent => {
             assert_true(mediaRecorderErrorEvent instanceof MediaRecorderErrorEvent, 'the type of event should be MediaRecorderErrorEvent');
-            assert_equals(mediaRecorderErrorEvent.error.name, 'UnknownError', 'the type of error should be UnknownError when track has been added or removed');
+            assert_equals(mediaRecorderErrorEvent.error.name, 'InvalidModificationError', 'the type of error should be InvalidModificationError when track has been added or removed');
             assert_true(mediaRecorderErrorEvent.isTrusted, 'isTrusted should be true when the event is created by C++');
             assert_equals(recorder.state, "inactive", "MediaRecorder has been stopped after removing a track from stream");
             t.done();

--- a/mediacapture-record/MediaRecorder-stop.html
+++ b/mediacapture-record/MediaRecorder-stop.html
@@ -115,6 +115,44 @@
             new Promise(r => t.step_timeout(r, 0))]);
     }, "MediaRecorder will fire an exception when stopped after having just been spontaneously stopped");
 
+    promise_test(async t => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const recorder = new MediaRecorder(stream);
+        let events = [];
+        const startPromise = new Promise(resolve => recorder.onstart = resolve);
+        const stopPromise = new Promise(resolve => recorder.onstop = resolve);
+
+        startPromise.then(() => events.push("start"));
+        stopPromise.then(() => events.push("stop"));
+
+        recorder.start();
+        recorder.stop();
+
+        await stopPromise;
+        assert_array_equals(events, ["start", "stop"]);
+    }, "MediaRecorder will fire start event even if stopped synchronously");
+
+    promise_test(async t => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const recorder = new MediaRecorder(stream);
+        let events = [];
+        const startPromise = new Promise(resolve => recorder.onstart = resolve);
+        const stopPromise = new Promise(resolve => recorder.onstop = resolve);
+        const errorPromise = new Promise(resolve => recorder.onerror = resolve);
+        const dataPromise = new Promise(resolve => recorder.ondataavailable = resolve);
+
+        startPromise.then(() => events.push("start"));
+        stopPromise.then(() => events.push("stop"));
+        errorPromise.then(() => events.push("error"));
+        dataPromise.then(() => events.push("data"));
+
+        recorder.start();
+        stream.removeTrack(stream.getAudioTracks()[0]);
+
+        await stopPromise;
+        assert_array_equals(events, ["start", "error", "data", "stop"]);
+    }, "MediaRecorder will fire start event even if a track is removed synchronously");
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
WebKit export from bug: [Make sure to fire the correct set of events in case MediaRecorder stream has track changes](https://bugs.webkit.org/show_bug.cgi?id=217316)