### PR TITLE
[wptserve] Make .headers work with generated tests

### DIFF
--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -13,6 +13,7 @@ from .base import TestWrapperHandlerUsingServer
 
 from serve import serve
 
+
 class TestFileHandler(TestUsingServer):
     def test_GET(self):
         resp = self.request("/document.txt")
@@ -388,8 +389,8 @@ class TestH2Handler(TestUsingH2Server):
 
 
 class TestWorkersHandler(TestWrapperHandlerUsingServer):
-    dummy_js_files = {'foo.worker.js': b'',
-                      'foo.any.js': b''}
+    dummy_files = {'foo.worker.js': b'',
+                   'foo.any.js': b''}
 
     def test_any_worker_html(self):
         self.run_wrapper_test('foo.any.worker.html',
@@ -401,7 +402,7 @@ class TestWorkersHandler(TestWrapperHandlerUsingServer):
 
 
 class TestWindowHandler(TestWrapperHandlerUsingServer):
-    dummy_js_files = {'foo.window.js': b''}
+    dummy_files = {'foo.window.js': b''}
 
     def test_window_html(self):
         self.run_wrapper_test('foo.window.html',
@@ -409,15 +410,19 @@ class TestWindowHandler(TestWrapperHandlerUsingServer):
 
 
 class TestAnyHtmlHandler(TestWrapperHandlerUsingServer):
-    dummy_js_files = {'foo.any.js': b''}
+    dummy_files = {'foo.any.js': b'',
+                   'foo.any.js.headers': b'X-Foo: 1',
+                   '__dir__.headers': b'X-Bar: 2'}
 
     def test_any_html(self):
         self.run_wrapper_test('foo.any.html',
-                              'text/html', serve.AnyHtmlHandler)
+                              'text/html',
+                              serve.AnyHtmlHandler,
+                              headers=[('X-Foo', '1'), ('X-Bar', '2')])
 
 
 class TestSharedWorkersHandler(TestWrapperHandlerUsingServer):
-    dummy_js_files = {'foo.any.js': b'// META: global=sharedworker\n'}
+    dummy_files = {'foo.any.js': b'// META: global=sharedworker\n'}
 
     def test_any_sharedworkers_html(self):
         self.run_wrapper_test('foo.any.sharedworker.html',
@@ -425,7 +430,7 @@ class TestSharedWorkersHandler(TestWrapperHandlerUsingServer):
 
 
 class TestServiceWorkersHandler(TestWrapperHandlerUsingServer):
-    dummy_js_files = {'foo.any.js': b'// META: global=serviceworker\n'}
+    dummy_files = {'foo.any.js': b'// META: global=serviceworker\n'}
 
     def test_serviceworker_html(self):
         self.run_wrapper_test('foo.any.serviceworker.html',
@@ -433,7 +438,7 @@ class TestServiceWorkersHandler(TestWrapperHandlerUsingServer):
 
 
 class TestAnyWorkerHandler(TestWrapperHandlerUsingServer):
-    dummy_js_files = {'bar.any.js': b''}
+    dummy_files = {'bar.any.js': b''}
 
     def test_any_work_js(self):
         self.run_wrapper_test('bar.any.worker.js', 'text/javascript',

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -170,9 +170,9 @@ def wrap_pipeline(path, request, response):
 def load_headers(request, path):
     """Loads headers from files for a given path.
 
-    Attempt to load both the neighbouring __dir__{.sub}.headers and
-    PATH{.sub}.headers (apply template substituition if needed); results are
-    concatenated in this order.
+    Attempts to load both the neighbouring __dir__{.sub}.headers and
+    PATH{.sub}.headers (applying template substitution if needed); results are
+    concatenated in that order.
     """
     def _load(request, path):
         headers_path = path + ".sub.headers"

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -32,7 +32,6 @@ def guess_content_type(path):
     return "application/octet-stream"
 
 
-
 def filesystem_path(base_path, request, url_base="/"):
     if base_path is None:
         base_path = request.doc_root
@@ -52,6 +51,7 @@ def filesystem_path(base_path, request, url_base="/"):
         raise HTTPException(404)
 
     return new_path
+
 
 class DirectoryHandler(object):
     def __init__(self, base_path=None, url_base="/"):
@@ -121,6 +121,7 @@ class DirectoryHandler(object):
                    {"link": link, "name": escape(item), "class": class_,
                     "headers": dot_headers_markup})
 
+
 def parse_qs(qs):
     """Parse a query string given as a string argument (data of type
     application/x-www-form-urlencoded). Data are returned as a dictionary. The
@@ -140,7 +141,12 @@ def parse_qs(qs):
         rv[name].append(value)
     return dict(rv)
 
+
 def wrap_pipeline(path, request, response):
+    """Applies pipelines to a response.
+
+    Pipelines are specified in the filename (.sub.) or the query param (?pipe).
+    """
     query = parse_qs(request.url_parts.query)
     pipe_string = ""
 
@@ -159,6 +165,36 @@ def wrap_pipeline(path, request, response):
         response = Pipeline(pipe_string)(request, response)
 
     return response
+
+
+def load_headers(request, path):
+    """Loads headers from files for a given path.
+
+    Attempt to load both the neighbouring __dir__{.sub}.headers and
+    PATH{.sub}.headers (apply template substituition if needed); results are
+    concatenated in this order.
+    """
+    def _load(request, path):
+        headers_path = path + ".sub.headers"
+        if os.path.exists(headers_path):
+            use_sub = True
+        else:
+            headers_path = path + ".headers"
+            use_sub = False
+
+        try:
+            with open(headers_path, "rb") as headers_file:
+                data = headers_file.read()
+        except IOError:
+            return []
+        else:
+            if use_sub:
+                data = template(request, data, escape_type="none")
+            return [tuple(item.strip() for item in line.split(b":", 1))
+                    for line in data.splitlines() if line]
+
+    return (_load(request, os.path.join(os.path.dirname(path), "__dir__")) +
+            _load(request, path))
 
 
 class FileHandler(object):
@@ -197,32 +233,12 @@ class FileHandler(object):
             raise HTTPException(404)
 
     def get_headers(self, request, path):
-        rv = (self.load_headers(request, os.path.join(os.path.dirname(path), "__dir__")) +
-              self.load_headers(request, path))
+        rv = load_headers(request, path)
 
         if not any(key.lower() == b"content-type" for (key, _) in rv):
             rv.insert(0, (b"Content-Type", guess_content_type(path).encode("ascii")))
 
         return rv
-
-    def load_headers(self, request, path):
-        headers_path = path + ".sub.headers"
-        if os.path.exists(headers_path):
-            use_sub = True
-        else:
-            headers_path = path + ".headers"
-            use_sub = False
-
-        try:
-            with open(headers_path, "rb") as headers_file:
-                data = headers_file.read()
-        except IOError:
-            return []
-        else:
-            if use_sub:
-                data = template(request, data, escape_type="none")
-            return [tuple(item.strip() for item in line.split(b":", 1))
-                    for line in data.splitlines() if line]
 
     def get_data(self, response, path, byte_ranges):
         """Return either the handle to a file, or a string containing
@@ -312,7 +328,6 @@ class PythonScriptHandler(object):
 
         self._set_path_and_load_file(request, response, func)
 
-
     def frame_handler(self, request):
         """
         This creates a FunctionHandler with one or more of the handling functions.
@@ -340,7 +355,9 @@ class PythonScriptHandler(object):
             return handler
         return self._set_path_and_load_file(request, None, func)
 
+
 python_script_handler = PythonScriptHandler()
+
 
 class FunctionHandler(object):
     def __init__(self, func):
@@ -370,9 +387,10 @@ class FunctionHandler(object):
             wrap_pipeline('', request, response)
 
 
-#The generic name here is so that this can be used as a decorator
+# The generic name here is so that this can be used as a decorator
 def handler(func):
     return FunctionHandler(func)
+
 
 class JsonHandler(object):
     def __init__(self, func):
@@ -395,8 +413,10 @@ class JsonHandler(object):
         response.headers.set("Content-Length", length)
         return value
 
+
 def json_handler(func):
     return JsonHandler(func)
+
 
 class AsIsHandler(object):
     def __init__(self, base_path=None, url_base="/"):
@@ -414,7 +434,9 @@ class AsIsHandler(object):
         except IOError:
             raise HTTPException(404)
 
+
 as_is_handler = AsIsHandler()
+
 
 class BasicAuthHandler(object):
     def __init__(self, handler, user, password):
@@ -442,7 +464,9 @@ class BasicAuthHandler(object):
                 return response
             return self.handler(request, response)
 
+
 basic_auth_handler = BasicAuthHandler(file_handler, None, None)
+
 
 class ErrorHandler(object):
     def __init__(self, status):
@@ -454,7 +478,7 @@ class ErrorHandler(object):
 
 class StringHandler(object):
     def __init__(self, data, content_type, **headers):
-        """Hander that reads a file from a path and substitutes some fixed data
+        """Handler that returns a fixed data string and headers
 
         :param data: String to use
         :param content_type: Content type header to server the response with
@@ -478,7 +502,9 @@ class StringHandler(object):
 
 class StaticHandler(StringHandler):
     def __init__(self, path, format_args, content_type, **headers):
-        """Hander that reads a file from a path and substitutes some fixed data
+        """Handler that reads a file from a path and substitutes some fixed data
+
+        Note that *.headers files have no effect in this handler.
 
         :param path: Path to the template file to use
         :param format_args: Dictionary of values to substitute into the template file


### PR DESCRIPTION
Honour *.headers (including *.sub.headers and __dir__{.sub}.headers)
when serving tests automatically generated from *.js files. The
documentation doesn't mention this exception and reasonable people would
assume *.headers work the same way as with static files. Add a
functional test, too.

Fixes https://crbug.com/1135559.

Drive-by: some stylistic changes and docstrings.