### PR TITLE
[wpt] Accept 1 version ahead for ChromeDriver for Chrome Dev

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -661,7 +661,7 @@ class Chrome(Browser):
     def find_webdriver(self, venv_path=None, channel=None, browser_binary=None):
         return find_executable("chromedriver")
 
-    def webdriver_supports_browser(self, webdriver_binary, browser_binary):
+    def webdriver_supports_browser(self, webdriver_binary, browser_binary, browser_channel):
         chromedriver_version = self.webdriver_version(webdriver_binary)
         if not chromedriver_version:
             self.logger.warning(
@@ -676,9 +676,17 @@ class Chrome(Browser):
             return True
 
         # Check that the ChromeDriver version matches the Chrome version.
-        chromedriver_major = chromedriver_version.split('.')[0]
-        browser_major = browser_version.split('.')[0]
+        chromedriver_major = int(chromedriver_version.split('.')[0])
+        browser_major = int(browser_version.split('.')[0])
         if chromedriver_major != browser_major:
+            # There is no official ChromeDriver release for the dev channel -
+            # it switches between beta and tip-of-tree, so we accept version+1
+            # too for dev.
+            if browser_channel == "dev" and chromedriver_major == (browser_major + 1):
+                self.logger.debug(
+                    "Accepting ChromeDriver %s for Chrome/Chromium Dev %s" %
+                    (chromedriver_version, browser_version))
+                return True
             self.logger.warning(
                 "ChromeDriver %s does not match Chrome/Chromium %s" %
                 (chromedriver_version, browser_version))

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -345,7 +345,7 @@ class Chrome(BrowserSetup):
             if not kwargs["install_webdriver"]:
                 webdriver_binary = self.browser.find_webdriver()
                 if webdriver_binary and not self.browser.webdriver_supports_browser(
-                        webdriver_binary, kwargs["binary"]):
+                        webdriver_binary, kwargs["binary"], browser_channel):
                     webdriver_binary = None
 
             if webdriver_binary is None:

--- a/tools/wpt/tests/test_browser.py
+++ b/tools/wpt/tests/test_browser.py
@@ -80,25 +80,34 @@ def test_chrome_webdriver_supports_browser():
     # ChromeDriver binary cannot be called.
     chrome = browser.Chrome(logger)
     chrome.webdriver_version = mock.MagicMock(return_value=None)
-    assert not chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome')
+    assert not chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome', 'stable')
 
     # Browser binary cannot be called.
     chrome = browser.Chrome(logger)
     chrome.webdriver_version = mock.MagicMock(return_value='70.0.1')
     chrome.version = mock.MagicMock(return_value=None)
-    assert chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome')
+    assert chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome', 'stable')
 
     # Browser version matches.
     chrome = browser.Chrome(logger)
     chrome.webdriver_version = mock.MagicMock(return_value='70.0.1')
     chrome.version = mock.MagicMock(return_value='70.1.5')
-    assert chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome')
+    assert chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome', 'stable')
 
     # Browser version doesn't match.
     chrome = browser.Chrome(logger)
     chrome.webdriver_version = mock.MagicMock(return_value='70.0.1')
     chrome.version = mock.MagicMock(return_value='69.0.1')
-    assert not chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome')
+    assert not chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome', 'stable')
+
+    # The dev channel switches between beta and ToT ChromeDriver, so is sometimes
+    # a version behind its ChromeDriver. As such, we accept browser version + 1 there.
+    chrome = browser.Chrome(logger)
+    chrome.webdriver_version = mock.MagicMock(return_value='70.0.1')
+    chrome.version = mock.MagicMock(return_value='70.1.0')
+    assert chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome', 'dev')
+    chrome.webdriver_version = mock.MagicMock(return_value='71.0.1')
+    assert chrome.webdriver_supports_browser('/usr/bin/chromedriver', '/usr/bin/chrome', 'dev')
 
 
 # On Windows, webdriver_version directly calls _get_fileversion, so there is no


### PR DESCRIPTION
ChromeDriver does not release officially for the Dev channel, so for
Chrome Dev we bounce back and forward between beta (same major version)
and tip-of-tree (major version + 1).