### PR TITLE
Rationalise CSS (IDL) namespace tests

### DIFF
--- a/css/css-conditional/js/CSS-supports.html
+++ b/css/css-conditional/js/CSS-supports.html
@@ -5,29 +5,63 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-    test(function () {
-        // https://drafts.csswg.org/css-conditional/#dom-css-supports
-        // https://drafts.csswg.org/css-conditional/#typedef-supports-condition
-        assert_equals(CSS.supports("color: red"), true, "CSS.supports: Single-argument form allows for declarations without enclosing parentheses");
-        assert_equals(CSS.supports("(color: red) and (color: blue)"), true, "CSS.supports: Complex conditions allowed");
-        assert_equals(CSS.supports("not (foobar)"), true, "CSS.supports: general_enclosed still parses");
-        assert_equals(CSS.supports("color: something-pointless var(--foo)"), true, "Variable references always parse");
-        assert_equals(CSS.supports("color: something-pointless(var(--foo))"), true, "Variable references in an unknown function always parse");
-    }, "CSS.supports, one argument form");
-    test(function () {
-        // https://drafts.csswg.org/css-conditional/#dom-css-supports
-        // https://drafts.csswg.org/css-conditional/#dfn-support
-        assert_equals(CSS.supports("color", "red"), true, "CSS.supports: two argument form succeeds for known property");
-        assert_equals(CSS.supports("unknownproperty", "blah"), false, "CSS.supports: two argument form fails for unknown property");
-        assert_equals(CSS.supports("width", "blah"), false, "CSS.supports: two argument form fails for invalid value");
-        assert_equals(CSS.supports("--foo", "blah"), true, "CSS.supports: two argument form succeeds for custom property");
-    }, "CSS.supports, two argument form");
-    test(function () {
-        assert_equals(CSS.supports("selector(div)"), true, "CSS.supports: selector() function accepts a selector");
-        assert_equals(CSS.supports("selector(div, div)"), false, "CSS.supports: selector() function doesn't accept a selector list");
-        assert_equals(CSS.supports("selector(::-webkit-unknown-pseudo-element)"), false, "CSS.supports: selector() function rejects unknown webkit pseudo-elements.");
-        assert_equals(CSS.supports("selector(::before)"), true, "CSS.supports: selector() function accepts known pseudo-elements");
-        assert_equals(CSS.supports("selector(div + .c)"), true, "CSS.supports: selector() with simple combinators");
-        assert_equals(CSS.supports("selector(div | .c)"), false, "CSS.supports: selector() with unknown combinators");
-    }, "CSS.supports, selector function");
+  test(function() {
+    assert_equals(CSS.supports("color: red"), true);
+  }, "Single-argument form allows for declarations without enclosing parentheses");
+
+  test(function() {
+    assert_equals(CSS.supports("(color: red) and (color: blue)"), true);
+  }, "Complex conditions allowed");
+
+  test(function() {
+    assert_equals(CSS.supports("not (foobar)"), true);
+  }, "general_enclosed still parses");
+
+  test(function() {
+    assert_equals(CSS.supports("color: something-pointless var(--foo)"), true);
+  }, "Variable references always parse");
+
+  test(function() {
+    assert_equals(CSS.supports("color: something-pointless(var(--foo))"), true);
+  }, "Variable references in an unknown function always parse");
+
+  test(function() {
+    assert_equals(CSS.supports("color", "red"), true);
+  }, "two argument form succeeds for known property");
+
+  test(function() {
+    assert_equals(CSS.supports("unknownproperty", "blah"), false);
+  }, "two argument form fails for unknown property");
+
+  test(function() {
+    assert_equals(CSS.supports("width", "blah"), false);
+  }, "two argument form fails for invalid value");
+
+  test(function() {
+    assert_equals(CSS.supports("--foo", "blah"), true);
+  }, "two argument form succeeds for custom property");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(div)"), true);
+  }, "selector() function accepts a selector");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(div, div)"), false);
+  }, "selector() function doesn't accept a selector list");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(::-webkit-unknown-pseudo-element)"), false);
+  }, "selector() function rejects unknown webkit pseudo-elements.");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(::before)"), true);
+  }, "selector() function accepts known pseudo-elements");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(div + .c)"), true);
+  }, "selector() with simple combinators");
+
+  test(function() {
+    assert_equals(CSS.supports("selector(div | .c)"), false);
+  }, "selector() with unknown combinators");
 </script>

--- a/css/css-conditional/js/CSS-supports.html
+++ b/css/css-conditional/js/CSS-supports.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>CSSOM - CSS interface</title>
-<link rel="help" href="https://drafts.csswg.org/cssom/#the-css.escape()-method">
+<title>CSS.supports</title>
+<link rel="help" href="https://drafts.csswg.org/css-conditional/#dom-css-supports">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/css/cssom/CSS.html
+++ b/css/cssom/CSS.html
@@ -6,21 +6,6 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
     test(function () {
-        // https://drafts.csswg.org/cssom/#dom-css-escape
-        // https://drafts.csswg.org/cssom/#serialize-an-identifier
-        assert_equals(CSS.escape("hello world"), "hello\\ world", "CSS.escape: spaces get escaped with backslashes");
-        assert_equals(CSS.escape("hello\0world"), "hello\u{FFFD}world", "CSS.escape: NULL get replaced with U+FFFD REPLACEMENT CHARACTER");
-        assert_equals(CSS.escape("hello0world"), "hello0world", "CSS.escape: Numbers within string preserved");
-        assert_equals(CSS.escape("hello\x10world"), "hello\\10 world", "CSS.escape: Values between \\x01 and \\x1f are unicode escaped");
-        assert_equals(CSS.escape("hello\\world"), "hello\\\\world", "CSS.escape: Backslashes get backslash-escaped");
-        assert_equals(CSS.escape("hello\u{1234}world"), "hello\u{1234}world", "CSS.escape: Code points greater than U+0080 are preserved");
-        assert_equals(CSS.escape("hello\x7Fworld"), "hello\\7f world", "CSS.escape: Some code points less than U+0080 are unicode-escaped");
-        assert_equals(CSS.escape("-"), "\\-", "CSS.escape: Single dash escaped");
-        assert_equals(CSS.escape("0foo"), "\\30 foo", "CSS.escape: Numbers at the beginning of an ident get unicode escaped");
-        assert_equals(CSS.escape("-0foo"), "-\\30 foo", "CSS.escape: Numbers at the beginning of an ident after single hyphen get unicode escaped");
-        assert_equals(CSS.escape("--0foo"), "--0foo", "CSS.escape: Numbers at the beginning of an ident after multiple hyphens do not get unicode escaped");
-    }, "CSS.escape");
-    test(function () {
         // https://drafts.csswg.org/css-conditional/#dom-css-supports
         // https://drafts.csswg.org/css-conditional/#typedef-supports-condition
         assert_equals(CSS.supports("color: red"), true, "CSS.supports: Single-argument form allows for declarations without enclosing parentheses");

--- a/css/cssom/escape.html
+++ b/css/cssom/escape.html
@@ -85,6 +85,10 @@ test(function() {
   assert_equals(CSS.escape('abcdefghijklmnopqrstuvwxyz'), 'abcdefghijklmnopqrstuvwxyz');
   assert_equals(CSS.escape('ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
 
+  assert_equals(CSS.escape("hello\\world"), "hello\\\\world", "Backslashes get backslash-escaped");
+  assert_equals(CSS.escape("hello\u{1234}world"), "hello\u{1234}world", "Code points greater than U+0080 are preserved");
+  assert_equals(CSS.escape("-"), "\\-", "CSS.escape: Single dash escaped");
+
   assert_equals(CSS.escape('\x20\x21\x78\x79'), '\\ \\!xy');
 }, "Various tests");
 


### PR DESCRIPTION
`CSS.supports` is defined in `css-conditional` so should be tested there; `CSS.escape` we had two files largely testing the same thing.