### PR TITLE
Avoid harness error in font-face-range-order.html

### DIFF
--- a/css/css-fonts/font-face-range-order.html
+++ b/css/css-fonts/font-face-range-order.html
@@ -20,15 +20,12 @@ src: local(Ahem);
 }
 </style>
 <script>
-  async_test(function(t) {
-    document.fonts.load("12px reversed-range-test").then((fonts) => {
-      t.step( () => {
-        assert_equals(fonts[0].stretch, "200% 50%", "Stretch value must be returned as specified.");
-        assert_equals(fonts[0].style, "oblique 90deg -90deg", "Style value must be returned as specified.");
-        assert_equals(fonts[0].weight, "900 100", "Weight value must be returned as specified.");
-      });
-      t.done()
-    })});
+  promise_test(async (t) => {
+    const fonts = await document.fonts.load("12px reversed-range-test");
+    assert_equals(fonts[0].stretch, "200% 50%", "Stretch value must be returned as specified.");
+    assert_equals(fonts[0].style, "oblique 90deg -90deg", "Style value must be returned as specified.");
+    assert_equals(fonts[0].weight, "900 100", "Weight value must be returned as specified.");
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
There's current a harness error + timeout in Edge and Safari:
https://wpt.fyi/results/css/css-fonts/font-face-range-order.html?run_id=703650002&run_id=695420001&run_id=717940003&run_id=710590002

With this change, the hope is the error will instead fail the test.