### PR TITLE
Add Symbol.unscopables lexical scope test of compiled event handlers

### DIFF
--- a/html/webappapis/scripting/events/compile-event-handler-symbol-unscopables.html
+++ b/html/webappapis/scripting/events/compile-event-handler-symbol-unscopables.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<meta charset="UTF-8" />
+<title>Inline event handler scopes exclude unscopable properties</title>
+<link rel="author" title="ExE Boss" href="https://ExE-Boss.tech" />
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+  "use strict";
+  window.testVariable = {};
+</script>
+
+<!-- test case 1: element, document, and window -->
+<div id="test1_target" onclick='
+  "use strict";
+
+  window.testResults.testVariable = testVariable;
+'></div>
+
+<script>
+  "use strict";
+
+  test(() => {
+    const results = window.testResults = {};
+
+    // (document[Symbol.unscopables] ||= {}).testVariable = true;
+    let documentUnscopables = document[Symbol.unscopables];
+    if (!documentUnscopables) {
+      documentUnscopables = {};
+      document[Symbol.unscopables] = documentUnscopables;
+    }
+
+    documentUnscopables.testVariable = true;
+    document.testVariable = "FAIL (document)";
+
+    document.getElementById("test1_target").click();
+    assert_equals(results.testVariable, window.testVariable);
+  }, "unscopable `document.testVariable` doesn't shadow `window.testVariable`");
+
+  test(() => {
+    const results = window.testResults = {};
+    const element = document.getElementById("test1_target");
+
+    // (element[Symbol.unscopables] ||= {}).testVariable = true;
+    let elementUnscopables = element[Symbol.unscopables];
+    if (!elementUnscopables) {
+      elementUnscopables = {};
+      element[Symbol.unscopables] = elementUnscopables;
+    }
+
+    elementUnscopables.testVariable = true;
+    element.testVariable = "FAIL (element)";
+
+    element.click();
+    assert_equals(results.testVariable, window.testVariable);
+  }, "unscopable `element.testVariable` doesn't shadow `window.testVariable`");
+</script>
+
+<!-- test case 2: element, form owner, document, and window -->
+<form id="test2_form_owner" onsubmit="return false;">
+  <!-- <button> is a form-associated element and has a form owner.
+      https://html.spec.whatwg.org/C/#form-associated-element -->
+  <button id="test2_target" onclick='
+    "use strict";
+
+    window.testResults.testVariable = testVariable;
+  '></button>
+</form>
+
+<script>
+  "use strict";
+
+  test(() => {
+    const results = window.testResults = {};
+    const element = document.getElementById("test2_target");
+    const formOwner = document.getElementById("test2_form_owner");
+
+    // (formOwner[Symbol.unscopables] ||= {}).testVariable = true;
+    let formOwnerUnscopables = formOwner[Symbol.unscopables];
+    if (!formOwnerUnscopables) {
+      formOwnerUnscopables = {};
+      formOwner[Symbol.unscopables] = formOwnerUnscopables;
+    }
+
+    formOwnerUnscopables.testVariable = true;
+    formOwner.testVariable = "FAIL (formOwner)";
+
+    element.click();
+    assert_equals(results.testVariable, window.testVariable);
+  }, "unscopable `formOwner.testVariable` doesn't shadow `window.testVariable`")
+</script>

--- a/html/webappapis/scripting/events/compile-event-handler-symbol-unscopables.html
+++ b/html/webappapis/scripting/events/compile-event-handler-symbol-unscopables.html
@@ -24,14 +24,7 @@
   test(() => {
     const results = window.testResults = {};
 
-    // (document[Symbol.unscopables] ||= {}).testVariable = true;
-    let documentUnscopables = document[Symbol.unscopables];
-    if (!documentUnscopables) {
-      documentUnscopables = {};
-      document[Symbol.unscopables] = documentUnscopables;
-    }
-
-    documentUnscopables.testVariable = true;
+    document[Symbol.unscopables].testVariable = true;
     document.testVariable = "FAIL (document)";
 
     document.getElementById("test1_target").click();
@@ -42,14 +35,7 @@
     const results = window.testResults = {};
     const element = document.getElementById("test1_target");
 
-    // (element[Symbol.unscopables] ||= {}).testVariable = true;
-    let elementUnscopables = element[Symbol.unscopables];
-    if (!elementUnscopables) {
-      elementUnscopables = {};
-      element[Symbol.unscopables] = elementUnscopables;
-    }
-
-    elementUnscopables.testVariable = true;
+    element[Symbol.unscopables].testVariable = true;
     element.testVariable = "FAIL (element)";
 
     element.click();
@@ -76,14 +62,7 @@
     const element = document.getElementById("test2_target");
     const formOwner = document.getElementById("test2_form_owner");
 
-    // (formOwner[Symbol.unscopables] ||= {}).testVariable = true;
-    let formOwnerUnscopables = formOwner[Symbol.unscopables];
-    if (!formOwnerUnscopables) {
-      formOwnerUnscopables = {};
-      formOwner[Symbol.unscopables] = formOwnerUnscopables;
-    }
-
-    formOwnerUnscopables.testVariable = true;
+    formOwner[Symbol.unscopables].testVariable = true;
     formOwner.testVariable = "FAIL (formOwner)";
 
     element.click();


### PR DESCRIPTION
**Step 9** of [**get the current value of the event handler**][getting-the-current-value-of-the-event-handler] initialises the [`ObjectEnvironment` records][object-environment-records] without setting the `withEnvironment` flag to `true`, which is required to make the `ObjectEnvironment` respect `Symbol.unscopables`.

As such, inline event handlers are required to include unscopable properties.

## See also:

- [<code>ObjectEnvironment.HasBinding(<var>n</var>)</code>][object-environment-records-hasbinding-n]
- [`WithStatement` Evaluation][with-statement-runtime-semantics-evaluation]
- <https://github.com/whatwg/html/issues/6079>
- <https://github.com/whatwg/html/pull/6086>

[getting-the-current-value-of-the-event-handler]: https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler
[object-environment-records]: https://tc39.es/ecma262/#sec-object-environment-records
[object-environment-records-hasbinding-n]: https://tc39.es/ecma262/#sec-object-environment-records-hasbinding-n
[with-statement-runtime-semantics-evaluation]: https://tc39.es/ecma262/#sec-with-statement-runtime-semantics-evaluation