### PR TITLE
[testharness.js] Fix bug in new get_test_name function

### DIFF
--- a/resources/test/tests/functional/no-title.html
+++ b/resources/test/tests/functional/no-title.html
@@ -21,6 +21,7 @@
   test(() => { assert_true(true, '5') });
   test(() => { assert_true(true, '6') }   );
   test(() => { assert_true(true, '7'); });
+  test(() => {});
 </script>
 <script type="text/json" id="expected">
 {
@@ -68,6 +69,12 @@
     {
       "status_string": "PASS",
       "name": "assert_true(true, '7')",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title",
       "properties": {},
       "message": null
     }

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -530,7 +530,7 @@ policies and contribution forms [3].
             var func_code = func.toString();
 
             // Try and match with brackets, but fallback to matching without
-            var arrow = func_code.match(/^\(\)\s*=>\s*(?:{(.*)}\s*|(.*))$/);
+            var arrow = func_code.match(/^\(\)\s*=>\s*(?:{(.+)}\s*|(.*))$/);
 
             // Check for JS line separators
             if (arrow !== null && !/[\u000A\u000D\u2028\u2029]/.test(func_code)) {


### PR DESCRIPTION
The previous logic would throw on an empty test body, e.g. `test(() =>
{});`. Such a test isn't very logical (often used when the author should
be using a crashtest), but testharness.js shouldn't throw for it.

To fix this, we only accept non-empty function bodies.