### PR TITLE
[CORS-RFC1918] Add top-level directory.

### DIFF
--- a/cors-rfc1918/META.yml
+++ b/cors-rfc1918/META.yml
@@ -1,0 +1,5 @@
+spec: https://wicg.github.io/cors-rfc1918/
+suggested_reviewers:
+  - letitz
+  - camillelamy
+  - mikewest

--- a/cors-rfc1918/README.md
+++ b/cors-rfc1918/README.md
@@ -1,0 +1,8 @@
+# CORS-RFC1918 tests
+
+This directory contains tests for CORS-RFC1918. See also:
+
+* [The specification](https://wicg.github.io/cors-rfc1918/)
+* [The repository](https://github.com/WICG/cors-rfc1918/)
+* [Open issues](https://github.com/WICG/cors-rfc1918/issues/)
+* Additional tests: ../fetch/cors-rfc1918/


### PR DESCRIPTION
This PR defines a new top-level directory for web platform tests of the [CORS-RFC1918 spec](https://wicg.github.io/cors-rfc1918/). If and when the spec gets merged into other specs (HTML, Fetch, WebSockets), the tests might migrate to the respective directories. For now at least, it seems simpler to keep them centralized.