### PR TITLE
Handle empty arrow functions when determining name in testharness.js

### DIFF
--- a/resources/test/tests/functional/no-title.html
+++ b/resources/test/tests/functional/no-title.html
@@ -25,6 +25,10 @@
   test(() => { });
   test(() => {;;;;});
   test(() => { ; ; ; ; });
+  test(()=>{});
+  test(()=>{ });
+  test(()=>{;;;;});
+  test(()=>{ ; ; ; ; });
 </script>
 <script type="text/json" id="expected">
 {
@@ -96,6 +100,30 @@
     {
       "status_string": "PASS",
       "name": "Tests with no title 5",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title 6",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title 7",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title 8",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title 9",
       "properties": {},
       "message": null
     }

--- a/resources/test/tests/functional/no-title.html
+++ b/resources/test/tests/functional/no-title.html
@@ -21,6 +21,9 @@
   test(() => { assert_true(true, '5') });
   test(() => { assert_true(true, '6') }   );
   test(() => { assert_true(true, '7'); });
+  test(() => {});
+  test(() => {;;;;});
+  test(() => { ; ; ; ; });
 </script>
 <script type="text/json" id="expected">
 {
@@ -68,6 +71,24 @@
     {
       "status_string": "PASS",
       "name": "assert_true(true, '7')",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title 2",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title 3",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title 4",
       "properties": {},
       "message": null
     }

--- a/resources/test/tests/functional/no-title.html
+++ b/resources/test/tests/functional/no-title.html
@@ -22,6 +22,7 @@
   test(() => { assert_true(true, '6') }   );
   test(() => { assert_true(true, '7'); });
   test(() => {});
+  test(() => { });
   test(() => {;;;;});
   test(() => { ; ; ; ; });
 </script>
@@ -89,6 +90,12 @@
     {
       "status_string": "PASS",
       "name": "Tests with no title 4",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Tests with no title 5",
       "properties": {},
       "message": null
     }

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -534,9 +534,9 @@ policies and contribution forms [3].
 
             // Check for JS line separators
             if (arrow !== null && !/[\u000A\u000D\u2028\u2029]/.test(func_code)) {
-                var trimmed = arrow[arrow.length].trim();
+                var trimmed = (arrow[1] !== undefined ? arrow[1] : arrow[2]).trim();
                 // drop trailing ; if there's no earlier ones
-                if (/^[^;]*(;+\s*)+$/.test(trimmed)) trimmed = trimmed.substring(0, trimmed.length - 1);
+                trimmed = trimmed.replace(/^([^;]*)(;\s*)+$/, "$1");
                 // ignore this if it's then empty
                 if (trimmed) return trimmed;
             }

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -534,10 +534,11 @@ policies and contribution forms [3].
 
             // Check for JS line separators
             if (arrow !== null && !/[\u000A\u000D\u2028\u2029]/.test(func_code)) {
-                var trimmed = (arrow[1] || arrow[2]).trim();
-                // drop a trailing ; if it's the only one
-                if (/^[^;]*;$/.test(trimmed)) trimmed = trimmed.substring(0, trimmed.length - 1);
-                return trimmed;
+                var trimmed = arrow[arrow.length].trim();
+                // drop trailing ; if there's no earlier ones
+                if (/^[^;]*(;+\s*)+$/.test(trimmed)) trimmed = trimmed.substring(0, trimmed.length - 1);
+                // ignore this if it's then empty
+                if (trimmed) return trimmed;
             }
         }
 


### PR DESCRIPTION
Fixes #26098, fixes https://github.com/web-platform-tests/wpt/commit/cbbc48732b24557ed2b291c2de83e81790f35042#commitcomment-43200210 (which isn't a bug @mstensho, I didn't get any notification about that! 😠).