### PR TITLE
Improve resources tests

### DIFF
--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -25,6 +25,7 @@ import webdriver
 
 def pytest_addoption(parser):
     parser.addoption("--binary", action="store", default=None, help="path to browser binary")
+    parser.addoption("--headless", action="store_true", default=False, help="run browser in headless mode")
 
 
 def pytest_collect_file(path, parent):
@@ -45,9 +46,11 @@ def pytest_configure(config):
     config.proc = subprocess.Popen(["geckodriver"])
     config.add_cleanup(config.proc.kill)
 
-    capabilities = {"alwaysMatch": {"acceptInsecureCerts": True}}
+    capabilities = {"alwaysMatch": {"acceptInsecureCerts": True, "moz:firefoxOptions": {}}}
     if config.getoption("--binary"):
-        capabilities["alwaysMatch"]["moz:firefoxOptions"] = {"binary": config.getoption("--binary")}
+        capabilities["alwaysMatch"]["moz:firefoxOptions"]["binary"] = config.getoption("--binary")
+    if config.getoption("--headless"):
+        capabilities["alwaysMatch"]["moz:firefoxOptions"]["args"] = ["--headless"]
 
     config.driver = webdriver.Session("localhost", 4444,
                                       capabilities=capabilities)

--- a/resources/test/wptserver.py
+++ b/resources/test/wptserver.py
@@ -24,6 +24,8 @@ class WPTServer(object):
     def start(self):
         self.devnull = open(os.devnull, 'w')
         wptserve_cmd = [os.path.join(self.wpt_root, 'wpt'), 'serve']
+        if sys.executable:
+            wptserve_cmd[0:0] = [sys.executable]
         logging.info('Executing %s' % ' '.join(wptserve_cmd))
         self.proc = subprocess.Popen(
             wptserve_cmd,


### PR DESCRIPTION
1. Make it possible to run headless
2. Use the same interpreter for the server process (rather than whatever `wpt serve` uses, which seems to fail given tox is running it with no `python` in the path?!)