### PR TITLE
Fix duplicate test name in webaudio/the-audio-api/the-audioworklet-in…

### DIFF
--- a/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-constructor-options.https.html
+++ b/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-constructor-options.https.html
@@ -137,7 +137,7 @@
         const options1 = {channelInterpretation: 'foobar'};
         should(
             () => new AudioWorkletNode(context, 'dummy', options1),
-            'Creating AudioWorkletNode with channelCountMode "foobar"')
+            'Creating AudioWorkletNode with channelInterpretation "foobar"')
             .throw(TypeError);
 
         task.done();


### PR DESCRIPTION
…terface/audioworkletnode-constructor-options.https.html

Fix a copy/paste error that led to a duplicate test name.