### PR TITLE
Add test for user scroll interrupts smooth scroll

### DIFF
--- a/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
+++ b/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
@@ -45,6 +45,7 @@ window.addEventListener("load", pageLoaded.step_func_done(function () {
         assert_equals(scrollingElement.scrollTop, 0);
 
         scrollNode(scrollingElement, "scroll", "smooth", 0, elementToRevealTop);
+        assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Smooth scroll shouldn't reach the destination immediately.");
         // Send RIGHT key to scrollingElement. It should stop the smooth scrolling and trigger another scrolling.
         window.test_driver.send_keys(scrollingElement, '\ue014');
 
@@ -52,7 +53,7 @@ window.addEventListener("load", pageLoaded.step_func_done(function () {
             assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "The vertical smooth scroll should be interrupted.");
             assert_greater_than(scrollingElement.scrollLeft, 0, "RIGHT key should trigger a horizontal scroll.");
         });
-    }, "RIGHT key event aborts an ongoing vertical smooth scrolling and triggers a horizontal scrolling");
+    }, "Aborting a smooth scroll with a keyboard event that causes another scroll");
 
     promise_test(() => {
         resetScroll(scrollingElement);
@@ -61,13 +62,14 @@ window.addEventListener("load", pageLoaded.step_func_done(function () {
         assert_equals(scrollingElement.scrollTop, 0);
 
         scrollNode(scrollingElement, "scroll", "smooth", 0, elementToRevealTop);
+        assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Smooth scroll shouldn't reach the destination immediately.");
         // Send LEFT key to scrollingElement. It should stop the smooth scrolling and not trigger other scrolling.
         window.test_driver.send_keys(scrollingElement, '\ue012');
 
         return waitForScrollEnd(scrollingElement).then(() => {
             assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "The vertical smooth scroll should be interrupted.");
-            assert_equals(scrollingElement.scrollLeft, 0, "LEFT key doesn't trigger a horizontal scroll.");
+            assert_equals(scrollingElement.scrollLeft, 0, "LEFT key doesn't trigger horizontal scroll because the scroll position is already at the scroll limit.");
         });
-    }, "LEFT key event aborts an ongoing vertical smooth scrolling but does not trigger other scrolling");
+    }, "Aborting a smooth scroll with a keyboard event that does not causes another scroll");
 }));
 </script>

--- a/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
+++ b/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
@@ -1,13 +1,13 @@
-<!DOCTYPE html><!-- webkit-test-runner [ experimental:CSSOMViewSmoothScrollingEnabled=true ] -->
+<!DOCTYPE html>
 <title>Testing scroll-behavior: smooth and user scrolls on the root of the main frame</title>
 <meta name="timeout" content="long" />
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#concept-smooth-scroll">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="support/scroll-behavior.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<script src="support/scroll-behavior.js"></script>
 <style>
     body {
         margin: 0;
@@ -49,10 +49,10 @@ window.addEventListener("load", pageLoaded.step_func_done(function () {
         window.test_driver.send_keys(scrollingElement, '\ue014');
 
         return waitForScrollEnd(scrollingElement).then(() => {
-            assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
-            assert_greater_than(scrollingElement.scrollLeft, 0, "Final value of scrollLeft");
+            assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "The vertical smooth scroll should be interrupted.");
+            assert_greater_than(scrollingElement.scrollLeft, 0, "RIGHT key should trigger a horizontal scroll.");
         });
-    }, "RIGHT Keyboard event aborts an ongoing vertical smooth scrolling and triggers a horizontal scrolling");
+    }, "RIGHT key event aborts an ongoing vertical smooth scrolling and triggers a horizontal scrolling");
 
     promise_test(() => {
         resetScroll(scrollingElement);
@@ -65,9 +65,9 @@ window.addEventListener("load", pageLoaded.step_func_done(function () {
         window.test_driver.send_keys(scrollingElement, '\ue012');
 
         return waitForScrollEnd(scrollingElement).then(() => {
-            assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
-            assert_equals(scrollingElement.scrollLeft, 0, "Final value of scrollLeft");
+            assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "The vertical smooth scroll should be interrupted.");
+            assert_equals(scrollingElement.scrollLeft, 0, "LEFT key doesn't trigger a horizontal scroll.");
         });
-    }, "LEFT Keyboard event aborts an ongoing vertical smooth scrolling but does not trigger other scrolling");
+    }, "LEFT key event aborts an ongoing vertical smooth scrolling but does not trigger other scrolling");
 }));
 </script>

--- a/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
+++ b/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ experimental:CSSOMViewSmoothScrollingEnabled=true ] -->
 <title>Testing scroll-behavior: smooth and user scrolls on the root of the main frame</title>
 <meta name="timeout" content="long" />
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#concept-smooth-scroll">
@@ -29,8 +29,8 @@
 </div>
 <script>
 var pageLoaded = async_test("Page loaded");
-var scrollingElement, styledElement, elementToRevealTop;
 window.addEventListener("load", pageLoaded.step_func_done(function () {
+    var scrollingElement, styledElement, elementToRevealTop;
     scrollingElement = document.scrollingElement;
     styledElement = document.documentElement;
     pageContent.style.width = (10 + window.innerWidth) * 5 + "px";
@@ -45,13 +45,14 @@ window.addEventListener("load", pageLoaded.step_func_done(function () {
         assert_equals(scrollingElement.scrollTop, 0);
 
         scrollNode(scrollingElement, "scroll", "smooth", 0, elementToRevealTop);
-        // Send DOWN key to scrollingElement. It should stop the smooth scrolling and trigger another scrolling.
-        window.test_driver.send_keys(scrollingElement, '\ue015');
+        // Send RIGHT key to scrollingElement. It should stop the smooth scrolling and trigger another scrolling.
+        window.test_driver.send_keys(scrollingElement, '\ue014');
 
         return waitForScrollEnd(scrollingElement).then(() => {
-            assert_between_exclusive(scrollingElement.scrollTop, 0, elementToRevealTop, "Final value of scrollTop");
+            assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
+            assert_greater_than(scrollingElement.scrollLeft, 0, "Final value of scrollLeft");
         });
-    }, "DOWN Keyboard event aborts an ongoing smooth scrolling and triggers another scrolling");
+    }, "RIGHT Keyboard event aborts an ongoing vertical smooth scrolling and triggers a horizontal scrolling");
 
     promise_test(() => {
         resetScroll(scrollingElement);
@@ -60,12 +61,13 @@ window.addEventListener("load", pageLoaded.step_func_done(function () {
         assert_equals(scrollingElement.scrollTop, 0);
 
         scrollNode(scrollingElement, "scroll", "smooth", 0, elementToRevealTop);
-        // Send UP key to scrollingElement. It should stop the smooth scrolling and not trigger other scrolling.
-        window.test_driver.send_keys(scrollingElement, '\ue013');
+        // Send LEFT key to scrollingElement. It should stop the smooth scrolling and not trigger other scrolling.
+        window.test_driver.send_keys(scrollingElement, '\ue012');
 
         return waitForScrollEnd(scrollingElement).then(() => {
-            assert_equals(scrollingElement.scrollTop, 0, "Final value of scrollTop");
+            assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
+            assert_equals(scrollingElement.scrollLeft, 0, "Final value of scrollLeft");
         });
-    }, "UP Keyboard event aborts an ongoing smooth scrolling but does not trigger other scrolling");
+    }, "LEFT Keyboard event aborts an ongoing vertical smooth scrolling but does not trigger other scrolling");
 }));
 </script>

--- a/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
+++ b/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
@@ -2,12 +2,12 @@
 <title>Testing scroll-behavior: smooth and user scrolls on the root of the main frame</title>
 <meta name="timeout" content="long" />
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#concept-smooth-scroll">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <script src="support/scroll-behavior.js"></script>
-<script src="../../resources/testdriver.js"></script>
-<script src="../../resources/testdriver-actions.js"></script>
-<script src="../../resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <style>
     body {
         margin: 0;

--- a/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
+++ b/css/cssom-view/user-scroll-interrupts-smooth-scroll.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<title>Testing scroll-behavior: smooth and user scrolls on the root of the main frame</title>
+<meta name="timeout" content="long" />
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#concept-smooth-scroll">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="support/scroll-behavior.js"></script>
+<script src="../../resources/testdriver.js"></script>
+<script src="../../resources/testdriver-actions.js"></script>
+<script src="../../resources/testdriver-vendor.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .autoBehavior {
+        scroll-behavior: auto;
+    }
+
+    .smoothBehavior {
+        scroll-behavior: smooth;
+    }
+</style>
+<div id="log">
+</div>
+<div id="pageContent" style="position: absolute; left: 0; top: 0;">
+    <div id="elementToReveal"
+        style="position: absolute; display: inline-block; width: 10px; height: 15px; background: black;"></div>
+</div>
+<script>
+var pageLoaded = async_test("Page loaded");
+var scrollingElement, styledElement, elementToRevealTop;
+window.addEventListener("load", pageLoaded.step_func_done(function () {
+    scrollingElement = document.scrollingElement;
+    styledElement = document.documentElement;
+    pageContent.style.width = (10 + window.innerWidth) * 5 + "px";
+    pageContent.style.height = (20 + window.innerHeight) * 6 + "px";
+    elementToRevealTop = (20 + window.innerHeight) * 4;
+    elementToReveal.style.top = elementToRevealTop + "px";
+
+    promise_test(() => {
+        resetScroll(scrollingElement);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingElement.scrollLeft, 0);
+        assert_equals(scrollingElement.scrollTop, 0);
+
+        scrollNode(scrollingElement, "scroll", "smooth", 0, elementToRevealTop);
+        // Send DOWN key to scrollingElement. It should stop the smooth scrolling and trigger another scrolling.
+        window.test_driver.send_keys(scrollingElement, '\ue015');
+
+        return waitForScrollEnd(scrollingElement).then(() => {
+            assert_between_exclusive(scrollingElement.scrollTop, 0, elementToRevealTop, "Final value of scrollTop");
+        });
+    }, "DOWN Keyboard event aborts an ongoing smooth scrolling and triggers another scrolling");
+
+    promise_test(() => {
+        resetScroll(scrollingElement);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingElement.scrollLeft, 0);
+        assert_equals(scrollingElement.scrollTop, 0);
+
+        scrollNode(scrollingElement, "scroll", "smooth", 0, elementToRevealTop);
+        // Send UP key to scrollingElement. It should stop the smooth scrolling and not trigger other scrolling.
+        window.test_driver.send_keys(scrollingElement, '\ue013');
+
+        return waitForScrollEnd(scrollingElement).then(() => {
+            assert_equals(scrollingElement.scrollTop, 0, "Final value of scrollTop");
+        });
+    }, "UP Keyboard event aborts an ongoing smooth scrolling but does not trigger other scrolling");
+}));
+</script>


### PR DESCRIPTION
Hi,
According to https://www.w3.org/TR/cssom-view-1/#smooth-scroll-aborted,  the programmatic smooth scroll should be interrupted by a user scroll.
This patch tests smooth scroll is interrupted by keyboard scroll.