### PR TITLE
[wptrunner] Drop useAutomationExtension from Chrome options

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -51,7 +51,6 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
                     }
                 }
             },
-            "useAutomationExtension": False,
             "excludeSwitches": ["enable-automation"],
             "w3c": True
         }


### PR DESCRIPTION
This option has been removed since Chrome 85, which was the previous
stable version, so it should be safe to remove it now.

This stops ChromeDriver from complaining:
[WARNING]: Deprecated chrome option is ignored: useAutomationExtension