### PR TITLE
Add tags to commits pushed to epoch branches

### DIFF
--- a/tools/ci/epochs_update.sh
+++ b/tools/ci/epochs_update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -eux -o pipefail
 
 SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
 WPT_ROOT=$SCRIPT_DIR/../..
@@ -32,11 +32,18 @@ main () {
             exit 1
         fi
         git branch "${EPOCH_BRANCH_NAME}" "${EPOCH_SHA}"
+
+        # Only set epoch tag if is not already tagged from a previous run.
+        if ! git tag --points-at "${EPOCH_SHA}" | grep "${EPOCH_BRANCH_NAME}"; then
+            EPOCH_STAMP="$(date +%Y-%m-%d_%HH)"
+            git tag "${EPOCH_BRANCH_NAME}/${EPOCH_STAMP}" "${EPOCH_SHA}"
+        fi
+
         ALL_BRANCHES_NAMES="${ALL_BRANCHES_NAMES} ${EPOCH_BRANCH_NAME}"
     done
     # This is safe because `git push` will by default fail for a non-fast-forward
     # push, for example if the remote branch is ahead of the local branch.
-    git push ${REMOTE} ${ALL_BRANCHES_NAMES}
+    git push --tags ${REMOTE} ${ALL_BRANCHES_NAMES}
 }
 
 cd $WPT_ROOT


### PR DESCRIPTION
This `epoch/` branches are used to trigger the CI runs. However, identifying which commit of that branch triggered the run on a given day of the past is not trivial. There are several variables at play, like the timezone of the bot running the action which complicates this.

For example on #26097 I was unable to identify the commit that triggered the taskcluster run on epochs/daily for october 12. 

So I think it is a good idea that we start tagging the commits pushed to this branches.

The format for the tags proposed here is the name of the branch with the date (year-month-day_hour). Example:
```
epochs/daily/2020-10-14_22H
epochs/six_hourly/2020-10-14_22H
epochs/three_hourly/2020-10-14_22H
epochs/twelve_hourly/2020-10-14_22H
epochs/weekly/2020-10-14_22H
```

This will be helpful to exactly identify which commits where pushed to the `epoch/` branches on a given date.
