### PR TITLE
Add test for lazy iframe loading with scripting off

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-in-script-disabled-iframe.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-in-script-disabled-iframe.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head>
+<title>Iframes with loading='lazy' in script disabled iframe are not handled
+       as 'lazy'</title>
+<link rel="help" href="https://github.com/scott-little/lazyload">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+
+<div style="height:1000vh;"></div>
+<iframe id="iframe" sandbox="allow-same-origin"
+        src="resources/iframe-loading-lazy-in-viewport.html">
+</iframe>
+<script>
+promise_test(async t => {
+  await new Promise(resolve => iframe.addEventListener("load", resolve));
+
+  const inner_iframe = iframe.contentDocument.querySelector("iframe");
+
+  assert_equals(inner_iframe.contentDocument.body.textContent.trim(), 'Subframe',
+              "lazy-load iframe shouldn't be honored in script disabled iframe");
+});
+</script>

--- a/html/semantics/embedded-content/the-iframe-element/resources/iframe-loading-lazy-in-viewport.html
+++ b/html/semantics/embedded-content/the-iframe-element/resources/iframe-loading-lazy-in-viewport.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<iframe id="iframe" loading="lazy" src="subframe.html"></iframe>


### PR DESCRIPTION
When lazy loading an iframe in a context where scripting
is off loading should be eager [1].

[1] https://html.spec.whatwg.org/#will-lazy-load-element-steps (Step 1)