### PR TITLE
Fix #26115: avoid new test name default leading to new duplicates

### DIFF
--- a/resources/test/tests/functional/no-title.html
+++ b/resources/test/tests/functional/no-title.html
@@ -15,6 +15,7 @@
   test(function(){assert_true(true, '1')});
   test(()=>assert_true(true, '2'));
   test(() => assert_true(true, '3'));
+  test(() => assert_true(true, '3'));  // test duplicate behaviour
   test(() => {
       assert_true(true, '4');
   });
@@ -52,6 +53,12 @@
     {
       "status_string": "PASS",
       "name": "assert_true(true, '3')",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "assert_true(true, '3') 1",
       "properties": {},
       "message": null
     },

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -8,7 +8,7 @@ passenv=DISPLAY # Necessary for the spawned GeckoDriver process to connect to
                 # the appropriate display.
 deps =
   html5lib
-  pytest>=2.9
+  pytest>=2.9,<6 # pinned to <6 due to https://github.com/web-platform-tests/wpt/issues/26132
   pyvirtualdisplay
   six
   requests

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -520,6 +520,8 @@ policies and contribution forms [3].
             Object.prototype.toString.call(worker) == '[object ServiceWorker]';
     }
 
+    var seen_func_name = Object.create(null);
+
     function get_test_name(func, name)
     {
         if (name) {
@@ -537,8 +539,17 @@ policies and contribution forms [3].
                 var trimmed = (arrow[1] !== undefined ? arrow[1] : arrow[2]).trim();
                 // drop trailing ; if there's no earlier ones
                 trimmed = trimmed.replace(/^([^;]*)(;\s*)+$/, "$1");
-                // ignore this if it's then empty
-                if (trimmed) return trimmed;
+
+                if (trimmed) {
+                    // add a suffix if we already have this string
+                    if (seen_func_name[trimmed]) {
+                        trimmed = trimmed + " " + seen_func_name[trimmed];
+                        seen_func_name[trimmed]++;
+                    } else {
+                        seen_func_name[trimmed] = 1;
+                    }
+                    return trimmed;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #26115, workaround #26132