### PR TITLE
[testharness.js] Fix bug in get_test_name

### DIFF
--- a/resources/test/tests/functional/no-title.html
+++ b/resources/test/tests/functional/no-title.html
@@ -16,6 +16,7 @@
   test(()=>assert_true(true, '2'));
   test(() => assert_true(true, '3'));
   test(() => assert_true(true, '3'));  // test duplicate behaviour
+  test(() => assert_true(true, '3'));  // test duplicate behaviour
   test(() => {
       assert_true(true, '4');
   });
@@ -59,6 +60,12 @@
     {
       "status_string": "PASS",
       "name": "assert_true(true, '3') 1",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "assert_true(true, '3') 2",
       "properties": {},
       "message": null
     },

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -543,8 +543,8 @@ policies and contribution forms [3].
                 if (trimmed) {
                     // add a suffix if we already have this string
                     if (seen_func_name[trimmed]) {
-                        seen_func_name[trimmed]++;
-                        trimmed = trimmed + " " + seen_func_name[trimmed];
+                        let current_count = seen_func_name[trimmed]++;
+                        trimmed = trimmed + " " + current_count;
                     } else {
                         seen_func_name[trimmed] = 1;
                     }

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -541,14 +541,15 @@ policies and contribution forms [3].
                 trimmed = trimmed.replace(/^([^;]*)(;\s*)+$/, "$1");
 
                 if (trimmed) {
-                    // add a suffix if we already have this string
+                    let name = trimmed;
                     if (seen_func_name[trimmed]) {
-                        let current_count = seen_func_name[trimmed]++;
-                        trimmed = trimmed + " " + current_count;
+                        // This subtest name already exists, so add a suffix.
+                        name += " " + seen_func_name[trimmed];
                     } else {
-                        seen_func_name[trimmed] = 1;
+                        seen_func_name[trimmed] = 0;
                     }
-                    return trimmed;
+                    seen_func_name[trimmed] += 1;
+                    return name;
                 }
             }
         }

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -543,8 +543,8 @@ policies and contribution forms [3].
                 if (trimmed) {
                     // add a suffix if we already have this string
                     if (seen_func_name[trimmed]) {
-                        trimmed = trimmed + " " + seen_func_name[trimmed];
                         seen_func_name[trimmed]++;
+                        trimmed = trimmed + " " + seen_func_name[trimmed];
                     } else {
                         seen_func_name[trimmed] = 1;
                     }


### PR DESCRIPTION
The duplicate detection code previously mutated 'trimmed' before
checking the duplicate-detection cache, so repeated subtest names would
all just get '1' appended, rather than 1, 2, 3, ...