### PR TITLE
Cookies: modernize http-state directory

### DIFF
--- a/cookies/http-state/attribute-tests.html
+++ b/cookies/http-state/attribute-tests.html
@@ -10,14 +10,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/charset-tests.html
+++ b/cookies/http-state/charset-tests.html
@@ -9,14 +9,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/chromium-tests.html
+++ b/cookies/http-state/chromium-tests.html
@@ -9,14 +9,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/comma-tests.html
+++ b/cookies/http-state/comma-tests.html
@@ -9,14 +9,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/domain-tests.html
+++ b/cookies/http-state/domain-tests.html
@@ -10,14 +10,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/general-tests.html
+++ b/cookies/http-state/general-tests.html
@@ -10,14 +10,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/mozilla-tests.html
+++ b/cookies/http-state/mozilla-tests.html
@@ -9,14 +9,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/name-tests.html
+++ b/cookies/http-state/name-tests.html
@@ -10,14 +10,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/ordering-tests.html
+++ b/cookies/http-state/ordering-tests.html
@@ -9,14 +9,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/path-tests.html
+++ b/cookies/http-state/path-tests.html
@@ -10,14 +10,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 

--- a/cookies/http-state/resources/all-tests.html.py-str
+++ b/cookies/http-state/resources/all-tests.html.py-str
@@ -9,7 +9,7 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
+  <body>
     <h1>Cookie Tests</h1>
     This page is a debug page for cookie tests. To run a test in isolation,
     append "?debug=" and the test id to this URL. E.g. to debug "value0001", use
@@ -51,17 +51,10 @@
     Below, all tests are running. The Log contains messages (e.g. when cookies
     are left over) and the IFrames list preserves all requested files and shows
     which cookies were expected to show. <br>
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
-    <!-- No element should come after this - the test harness appends the result
-    here when it finished running all of them. -->
+    <div id="log"></div>
+    <div id="iframes"></div>
 
-    <script type="text/javascript">
+    <script>
       setup({ explicit_timeout: true });
 
       const TEST_CASES = [%s];

--- a/cookies/http-state/resources/debugging-single-test.html.py-str
+++ b/cookies/http-state/resources/debugging-single-test.html.py-str
@@ -8,24 +8,14 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="cookie-http-state-template.js"></script>
-    <style type="text/css">
-        .scrollable {
-            height:150px;
-            overflow-y:scroll;
-        }
-    </style>
   </head>
   <body>
-    <h3>Log</h3>
-    <div id="log" class="scrollable"></div>
-    <h3>IFrame</h3>
-    <div id="iframes" class="toggleable scrollable"></div>
-    <h3>Test Results</h3>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 
       promise_test(createCookieTest("%s"), "DEBUG");
-
     </script>
   </body>
 </html>

--- a/cookies/http-state/value-tests.html
+++ b/cookies/http-state/value-tests.html
@@ -9,14 +9,9 @@
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/cookie-http-state-template.js"></script>
   </head>
-  <body style="background:#EEE">
-    <h3>Log</h3>
-    <div id="log" style="height:50px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>IFrames</h3>
-    <div id="iframes" style="height:170px; overflow-y:scroll; background: #FFF">
-    </div>
-    <h3>Test Results</h3>
+  <body>
+    <div id="log"></div>
+    <div id="iframes"></div>
     <script>
       setup({ explicit_timeout: true });
 


### PR DESCRIPTION
Letting web-platform-tests take care of rendering the result pages makes these a lot more legible.