### PR TITLE
Cookies: test non-UTF-8 bytes

### DIFF
--- a/cookies/bytes.window.js
+++ b/cookies/bytes.window.js
@@ -1,0 +1,9 @@
+promise_test(async t => {
+  t.add_cleanup(async () => { await fetch("resources/bytes.py?delete") });
+  let response = await fetch("resources/bytes.py?set");
+  assert_equals(await response.text(), "set");
+  response = await fetch("resources/bytes.py?get");
+  const get = await response.text();
+  const expected = "cookiesarebananas%3D%FFtest%FF"
+  assert_equals(get.search(expected), 0, `Needs to contain ${expected} but did not. Full value: ${get}`);
+}, "Cookie containing non-UTF-8 bytes");

--- a/cookies/resources/bytes.py
+++ b/cookies/resources/bytes.py
@@ -1,13 +1,13 @@
-import urllib
+from six.moves.urllib.parse import quote
 
 def main(request, response):
-    if "set" in request.GET:
+    if b"set" in request.GET:
         response.headers.append(b"Set-Cookie", b"cookiesarebananas=\xFFtest\xFF")
         response.content = "set"
-    elif "get" in request.GET:
-        response.content = urllib.quote(request.headers["Cookie"])
-    elif "delete" in request.GET:
-        request.headers.append(b"Set-Cookie", b"cookiesarebananas=meh;Max-Age=0")
+    elif b"get" in request.GET:
+        response.content = quote(request.headers[b"Cookie"])
+    elif b"delete" in request.GET:
+        response.headers.append(b"Set-Cookie", b"cookiesarebananas=meh;Max-Age=0")
         response.content = "delete"
 
-    response.headers.append(b"Content-Type", "text/plain")
+    response.headers.append(b"Content-Type", b"text/plain")

--- a/cookies/resources/bytes.py
+++ b/cookies/resources/bytes.py
@@ -1,0 +1,13 @@
+import urllib
+
+def main(request, response):
+    if "set" in request.GET:
+        response.headers.append(b"Set-Cookie", b"cookiesarebananas=\xFFtest\xFF")
+        response.content = "set"
+    elif "get" in request.GET:
+        response.content = urllib.quote(request.headers["Cookie"])
+    elif "delete" in request.GET:
+        request.headers.append(b"Set-Cookie", b"cookiesarebananas=meh;Max-Age=0")
+        response.content = "delete"
+
+    response.headers.append(b"Content-Type", "text/plain")


### PR DESCRIPTION
For https://github.com/httpwg/http-extensions/issues/1073.

I could not find a way to test this using the existing infrastructure (note that `document.cookie` does not support these kind of values). That might be another thing you want to look at @miketaylr? This approach isn't exactly great, but I wanted to at least capture this nuance somewhere.