### PR TITLE
Test that dynamic import() is disallowed in paint worklets

### DIFF
--- a/css/css-paint-api/dynamic-import-ref.html
+++ b/css/css-paint-api/dynamic-import-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<canvas id ="output" width="100" height="100" style="background: blue;"></canvas>
+<script>
+"use strict";
+const canvas = document.getElementById('output');
+const ctx = canvas.getContext('2d');
+
+ctx.fillStyle = 'green';
+ctx.fillRect(0, 0, 100, 100);
+</script>

--- a/css/css-paint-api/dynamic-import.html
+++ b/css/css-paint-api/dynamic-import.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="help" href="https://html.spec.whatwg.org/#hostimportmoduledynamically(referencingscriptormodule,-specifier,-promisecapability)">
+<link rel="match" href="dynamic-import-ref.html">
+<style>
+#output {
+    width: 100px;
+    height: 100px;
+    background-image: paint(rects);
+    background-color: blue;
+}
+</style>
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/worklet-reftest.js"></script>
+<body>
+<div id="output"></div>
+
+<script id="code" type="text/worklet">
+registerPaint('rects', class {
+    async paint(ctx, geom) {
+        ctx.fillStyle = 'red';
+        try {
+          await import('./resources/imported-module.mjs');
+        } catch (e) {
+          if (e.constructor === TypeError) {
+            ctx.fillStyle = 'green';
+          }
+        }
+        ctx.fillRect(0, 0, geom.width, geom.height);
+    }
+});
+</script>
+
+<script>
+"use strict";
+importWorkletAndTerminateTestAfterAsyncPaint(CSS.paintWorklet, document.getElementById('code').textContent);
+</script>

--- a/css/css-paint-api/resources/imported-module.mjs
+++ b/css/css-paint-api/resources/imported-module.mjs
@@ -1,0 +1,2 @@
+// This doesn't need to contain anything. If it's dynamically import()ed
+// successfully, the test fails.

--- a/html/README.md
+++ b/html/README.md
@@ -3,7 +3,7 @@
 This directory contains tests for [HTML](https://html.spec.whatwg.org/multipage/).
 
 Sub-directory names should be based on the URL of the corresponding part of the
-multipage-version specification. For example, The URL of
+multipage-version specification. For example, the URL of
 "8.3 Base64 utility methods" is [https://html.spec.whatwg.org/multipage/webappapis.html#atob](https://html.spec.whatwg.org/multipage/webappapis.html#atob). So the directory in WPT is [webappapis/atob/](/html/webappapis/atob).
 
 For historical reasons, parts of HTML have their own directories:
@@ -17,4 +17,5 @@ For historical reasons, parts of HTML have their own directories:
 * [/websockets](/websockets)
 * [/webstorage](/webstorage)
 * [/workers](/workers)
+* [/worklets](/worklets)
 * [/x-frame-options](/x-frame-options)

--- a/worklets/META.yml
+++ b/worklets/META.yml
@@ -1,3 +1,4 @@
-spec: https://drafts.css-houdini.org/worklets/
+spec: https://html.spec.whatwg.org/multipage/worklets.html
 suggested_reviewers:
   - bfgeek
+  - domenic

--- a/worklets/README.md
+++ b/worklets/README.md
@@ -1,1 +1,1 @@
-These are the tests for the [Worklets Level 1 spec](https://drafts.css-houdini.org/worklets/).
+These are the tests for the [Worklets](https://html.spec.whatwg.org/multipage/worklets.html) section of the HTML Standard.


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/6070.