### PR TITLE
Python 3: Remove xfail comments

### DIFF
--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -195,7 +195,7 @@ class TestFunctionHandler(TestUsingServer):
         assert resp.read() == b""
 
 
-@pytest.mark.xfail((3,) <= sys.version_info < (3, 6), reason="wptserve only works on Py2")
+@pytest.mark.xfail((3,) <= sys.version_info < (3, 6), reason="wptserve only works on Py2 and Py3.6+")
 class TestJSONHandler(TestUsingServer):
     def test_json_0(self):
         @wptserve.handlers.json_handler

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -195,7 +195,6 @@ class TestFunctionHandler(TestUsingServer):
         assert resp.read() == b""
 
 
-@pytest.mark.xfail((3,) <= sys.version_info < (3, 6), reason="wptserve only works on Py2 and Py3.6+")
 class TestJSONHandler(TestUsingServer):
     def test_json_0(self):
         @wptserve.handlers.json_handler


### PR DESCRIPTION
Maybe we can just remove this whole line as we are only supporting 2.7+ for Py2 and Py3.6+ for Py3?