### PR TITLE
webdriver: handle events with Unidentified key code

### DIFF
--- a/webdriver/tests/perform_actions/support/refine.py
+++ b/webdriver/tests/perform_actions/support/refine.py
@@ -9,6 +9,11 @@ def get_events(session):
             key = e["key"]
             hex_suffix = key[key.index("+") + 1:]
             e["key"] = unichr(int(hex_suffix, 16))
+
+        # WebKit sets code as 'Unidentified' for unidentified key codes, but
+        # tests expect ''.
+        if "code" in e and e["code"] == "Unidentified":
+            e["code"] = ""
     return events
 
 


### PR DESCRIPTION
WebKit sets the event key code as Unidentified as per the spec (see
https://www.w3.org/TR/uievents-code/), but WebDriver tests expect an
empty string for the case of unidentified key codes. This patch changes
the code to an empty string when Unidentified is found.