### PR TITLE
[docs] Relocate recommendation on git usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,6 @@ that modify sensitive resources (such as `.py`). The latter require
 someone with merge access to comment with "LGTM" or "w3c-test:mirror" to
 indicate the pull request has been checked.
 
-Branches
-========
-
-In the vast majority of cases the **only** upstream branch that you
-should need to care about is `master`. If you see other branches in
-the repository, you can generally safely ignore them.
-
 Contributing
 ============
 

--- a/docs/writing-tests/github-intro.md
+++ b/docs/writing-tests/github-intro.md
@@ -83,6 +83,10 @@ which is commonly referred to as the "upstream" repository. Synchronizing your
 forked repository with the upstream repository will keep your forked local copy
 up-to-date with the latest commits.
 
+In the vast majority of cases, the **only** upstream branch that you should
+need to care about is `master`. If you see other branches in the repository,
+you can generally safely ignore them.
+
 1.  On the command line, navigate to to the directory where your forked copy of
     the repository is located.
 
@@ -99,13 +103,16 @@ up-to-date with the latest commits.
 4.  To pull in changes in the original repository that are not present in your
     local repository first fetch them:
 
-        $ git fetch upstream
+        $ git fetch -p upstream
 
     Then merge them into your local repository:
 
         $ git merge upstream/master
 
-    For additional information, please see the [GitHub docs][github-fork-docs].
+    We recommend using `-p` to "prune" the outdated branches that would
+    otherwise accumulate in your local repository.
+
+For additional information, please see the [GitHub docs][github-fork-docs].
 
 ## Configure your environment
 


### PR DESCRIPTION
Further reduce the size of the project's README file, and extend the
relevant documentation with the distinct recommendation that would
otherwise be lost.

This is in service of gh-5289

Closes #20285

Co-authored-by: jugglinmike <mike@mikepennisi.com>