### PR TITLE
[testdriver.js] Add WebDriver support for testdriver freeze command

### DIFF
--- a/infrastructure/testdriver/freeze.html
+++ b/infrastructure/testdriver/freeze.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver freeze method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<script>
+var is_child_frozen = false;
+var test = async_test('Test freeze callback.');
+window.open('freeze_child.html', 'Child Window');
+
+function set_child_frozen(is_frozen) {
+  is_child_frozen = is_frozen;
+}
+
+function freeze_child(child_window) {
+  test_driver
+    .freeze(child_window)
+    .then(() => {
+      assert_true(is_child_frozen);
+      test.done();
+    })
+    .catch(test.unreached_func("freeze failed"));
+}
+
+</script>

--- a/infrastructure/testdriver/freeze_child.html
+++ b/infrastructure/testdriver/freeze_child.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Frozen Window</title>
+<h1>This window will be frozen</h1>
+<script>
+
+window.document.addEventListener("freeze", () => {
+  window.opener.set_child_frozen(true);
+});
+
+window.document.addEventListener("resume", () => {
+  window.opener.set_child_frozen(false);
+});
+
+onload = function() {
+  window.opener.freeze_child(window);
+};
+
+</script>

--- a/lifecycle/freeze.html
+++ b/lifecycle/freeze.html
@@ -3,6 +3,8 @@
 <title>TestDriver freeze method</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 
 <script>
 var test = async_test('Test freeze callback.');
@@ -63,6 +65,10 @@ function step_fail(name) {
   test.step(() => assert_unreached('During onfreeze: ' + name + ' failed to behave as expected.'));
   if (total_steps == 0)
     test.done();
+}
+
+function freeze_child(child_window) {
+  test_driver.freeze(child_window);
 }
 
 test.step_timeout(() => {

--- a/lifecycle/resources/window.html
+++ b/lifecycle/resources/window.html
@@ -1,8 +1,6 @@
 <!doctype html>
 <html>
 <head><title>Frozen Window</title></head>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
 <script src="/common/utils.js"></script>
 <body>
 <h1>This window will be frozen</h1>
@@ -76,7 +74,7 @@ window.document.addEventListener("freeze", () => {
 
 onload = function() {
   window.opener.add_step(freezingStepName);
-  test_driver.freeze();
+  window.opener.freeze_child(window);
 };
 
 </script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -190,7 +190,7 @@
          *                    in case the WebDriver command errors
          */
         freeze: function(context=null) {
-            return window.test_driver_internal.freeze();
+            return window.test_driver_internal.freeze(context);
         },
 
         /**

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -175,7 +175,7 @@
         },
 
         /**
-         * Freeze the current page
+         * Freeze a page
          *
          * The freeze function transitions the page from the HIDDEN state to
          * the FROZEN state as described in {@link

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -62,6 +62,18 @@ class GenerateTestReportAction(object):
         self.logger.debug("Generating test report: %s" % message)
         self.protocol.generate_test_report.generate_test_report(message)
 
+
+class FreezeAction(object):
+    name = "freeze"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        self.protocol.freeze.freeze()
+
+
 class SetPermissionAction(object):
     name = "set_permission"
 
@@ -174,6 +186,7 @@ actions = [ClickAction,
            SendKeysAction,
            ActionSequenceAction,
            GenerateTestReportAction,
+           FreezeAction,
            SetPermissionAction,
            AddVirtualAuthenticatorAction,
            RemoveVirtualAuthenticatorAction,

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -24,6 +24,7 @@ from .protocol import (BaseProtocolPart,
                        ActionSequenceProtocolPart,
                        TestDriverProtocolPart,
                        GenerateTestReportProtocolPart,
+                       FreezeProtocolPart,
                        SetPermissionProtocolPart,
                        VirtualAuthenticatorProtocolPart)
 from ..testrunner import Stop
@@ -243,6 +244,14 @@ class WebDriverGenerateTestReportProtocolPart(GenerateTestReportProtocolPart):
         self.webdriver.send_session_command("POST", "reporting/generate_test_report", json_message)
 
 
+class WebDriverFreezeProtocolPart(FreezeProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def freeze(self):
+        return self.webdriver.send_session_command("POST", "goog/page/freeze")
+
+
 class WebDriverSetPermissionProtocolPart(SetPermissionProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -292,6 +301,7 @@ class WebDriverProtocol(Protocol):
                   WebDriverActionSequenceProtocolPart,
                   WebDriverTestDriverProtocolPart,
                   WebDriverGenerateTestReportProtocolPart,
+                  WebDriverFreezeProtocolPart,
                   WebDriverSetPermissionProtocolPart,
                   WebDriverVirtualAuthenticatorProtocolPart]
 

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -310,6 +310,18 @@ class GenerateTestReportProtocolPart(ProtocolPart):
         pass
 
 
+class FreezeProtocolPart(ProtocolPart):
+    """Protocol part for performing a trusted freeze of a page"""
+    __metaclass__ = ABCMeta
+
+    name = "freeze"
+
+    @abstractmethod
+    def freeze(self):
+        """Freeze the page."""
+        pass
+
+
 class SetPermissionProtocolPart(ProtocolPart):
     """Protocol part for setting permissions"""
     __metaclass__ = ABCMeta

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -198,6 +198,10 @@
         return create_action("generate_test_report", {message, context});
     };
 
+    window.test_driver_internal.freeze = function(context=null) {
+        return create_action("freeze", {context});
+    };
+
     window.test_driver_internal.set_permission = function(permission_params, context=null) {
         return create_action("set_permission", {permission_params, context});
     };


### PR DESCRIPTION
This adds page freeze support for the WebDriver executor to get the
existing lifecycle freeze test to work. This also adds a testdriver
infrastructure test for the freeze.

Closes https://github.com/web-platform-tests/wpt/pull/16396

Co-authored-by: Scott Haseley <shaseley@chromium.org>