### PR TITLE
Webkit export of https://bugs.webkit.org/show_bug.cgi?id=217414

### DIFF
--- a/user-timing/measure-l3.any.js
+++ b/user-timing/measure-l3.any.js
@@ -17,12 +17,12 @@ test(function() {
   performance.clearMarks();
   performance.clearMeasures();
   const markEntry = performance.mark("mark", {startTime: 123});
-  const endMin = performance.now();
+  const endMin = Number(performance.now().toFixed(2));
   const measureEntry = performance.measure("A", "mark", undefined);
-  const endMax = performance.now();
+  const endMax = Number(performance.now().toFixed(2));
   assert_equals(measureEntry.startTime, markEntry.startTime);
-  assert_greater_than_equal(endTime(measureEntry), endMin);
-  assert_greater_than_equal(endMax, endTime(measureEntry));
+  assert_greater_than_equal(Number(endTime(measureEntry).toFixed(2)), endMin);
+  assert_greater_than_equal(endMax, Number(endTime(measureEntry).toFixed(2)));
 }, "When the start mark is given and the end is unprovided, the start time of the measure entry should be the start mark's time, the end should be now.");
 
 test(function() {


### PR DESCRIPTION
Sometimes the test fails due to a failed comparison:

```diff
Diff: https://build.webkit.org/results/GTK-Linux-64-bit-Release-Tests/r268725%20(16529)/imported/w3c/web-platform-tests/user-timing/measure-l3.any.worker-diff.txt

--- /home/buildbot/worker/gtk-linux-64-release-tests/build/layout-test-results/imported/w3c/web-platform-tests/user-timing/measure-l3.any.worker-expected.txt
+++ /home/buildbot/worker/gtk-linux-64-release-tests/build/layout-test-results/imported/w3c/web-platform-tests/user-timing/measure-l3.any.worker-actual.txt
@@ -1,5 +1,5 @@

 PASS When the end mark is given and the start is unprovided, the end time of the measure entry should be the end mark's time, the start time should be 0.
-PASS When the start mark is given and the end is unprovided, the start time of the measure entry should be the start mark's time, the end should be now.
+FAIL When the start mark is given and the end is unprovided, the start time of the measure entry should be the start mark's time, the end should be now. assert_greater_than_equal: expected a number greater than or equal to 36.00000000000001 but got 36
 PASS When start and end mark are both given, the start time and end time of the measure entry should be the the marks' time, repectively
```

To fix the issue I compare values using `assert_approx_equals` with a margin error of 0.1.