### PR TITLE
Check that contain strict and content compute to the longhands

### DIFF
--- a/css/css-contain/parsing/contain-computed.html
+++ b/css/css-contain/parsing/contain-computed.html
@@ -24,6 +24,8 @@ test_computed_value("contain", "size layout");
 test_computed_value("contain", "style paint");
 test_computed_value("contain", "layout style paint");
 test_computed_value("contain", "size layout style paint");
+test_computed_value("contain", "size layout paint", "strict");
+test_computed_value("contain", "layout paint", "content");
 </script>
 </body>
 </html>


### PR DESCRIPTION
They serialize back to the shorthand thanks to the shortest
serialization principle