### PR TITLE
Python3: Remove xfail for wpt unit tests in PY3

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -44,9 +44,6 @@ def get_persistent_manifest_path():
 
 @pytest.fixture(scope="module", autouse=True)
 def init_manifest():
-    # See https://github.com/pypa/virtualenv/issues/1710
-    if sys.version_info[0] >= 3 and platform.system() == "Windows":
-        pytest.xfail(reason="virtualenv activation fails in Windows for python3")
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["manifest", "--no-download",
                        "--path", get_persistent_manifest_path()])

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -1,6 +1,5 @@
 import errno
 import os
-import platform
 import shutil
 import socket
 import subprocess


### PR DESCRIPTION
Tests in test_wpt.py for PY3 were marked as xfail due to virtualenv
activation issue (https://github.com/pypa/virtualenv/issues/1710)
This issue has now been solved.