### PR TITLE
Remove sorting and de-duplication in media queries.

### DIFF
--- a/css/cssom/serialize-media-rule.html
+++ b/css/cssom/serialize-media-rule.html
@@ -132,9 +132,9 @@ test(function(t) {
   );
   assert_equals(
     sheet.cssRules[1].cssText,
-    '@media screen and (color) and (max-width: 0px) {\n}'
+    '@media screen and (max-width: 0px) and (color) {\n}'
   );
-}, 'features - lexicographical sorting');
+}, 'features - no lexicographical sorting');
 
 test(function(t) {
   var sheet = makeSheet(t);


### PR DESCRIPTION
This was removed from the spec per resolution[1] and incompatible with
never media queries. Improves interop with Gecko which have not seen any
issues with the different serialization.

Removed fast/media test which is covered by existing wpt tests.

[1] https://github.com/w3c/csswg-drafts/issues/5627#issuecomment-712475204

Bug: 1138859
Change-Id: I1483008c81df90f8277dcad7e90c8036c5cc019b
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2478992
Reviewed-by: Xiaocheng Hu <xiaochengh@chromium.org>
Commit-Queue: Rune Lillesveen <futhark@chromium.org>
Cr-Commit-Position: refs/heads/master@{#819090}