### PR TITLE
Trying to improve selection-contenteditable-011.html and its reference

### DIFF
--- a/css/css-pseudo/reference/selection-contenteditable-011-ref.html
+++ b/css/css-pseudo/reference/selection-contenteditable-011-ref.html
@@ -16,6 +16,33 @@
     }
   </style>
 
+  <script>
+  function startReference()
+  {
+  document.getElementById("ref").focus();
+  /*
+  Some browsers, like Chromium 80+, will transfer focus
+  to a selected element like a contenteditable div and
+  therefore style the border of such element according
+  to the user agent stylesheet rule:
+  :focus {outline: -webkit-focus-ring-color auto 1px;} .
+  So, we deliberately trigger such focus with the focus()
+  method in the reference file.
+  */
+  document.getElementById("ref").style.caretColor = "yellow";
+  /*
+  When a contenteditable element is focused in Firefox
+  82+, then the caret becomes visible and blinking and
+  it is painted with the ::selected's color which is
+  the green color in this case. We therefore counter,
+  neutralize this by resetting the caret's color to the
+  background color.
+  */
+  }
+  </script>
+
+  <body onload="startReference();">
+
   <p>Test passes if each glyph of "Selected Text" is green with a yellow background and if there is <strong>no red</strong>.
 
-  <div contenteditable="true" id="test">Selected Text</div>
+  <div contenteditable="true" id="ref">Selected Text</div>

--- a/css/css-pseudo/selection-contenteditable-011.html
+++ b/css/css-pseudo/selection-contenteditable-011.html
@@ -35,15 +35,6 @@
   /* Then we set the range boundaries to the children of div#test */
   window.getSelection().addRange(targetRange);
   /* Finally, we now select such range of content */
-  document.getElementById("test").blur();
-  /*
-  Some browsers, like Chromium 80+, will
-  transfer focus to a selected element
-  like a contenteditable div and
-  therefore style the border of
-  such element. We remove such
-  focus with the blur() method.
-  */
   }
   </script>
 


### PR DESCRIPTION
This is a followup to
https://github.com/web-platform-tests/wpt/pull/25642

selection-contenteditable-011.html 
reference/selection-contenteditable-011-ref.html 

As discussed in 
https://github.com/web-platform-tests/wpt/pull/25642#pullrequestreview-499076577
it may be better to focus() the contenteditable element in the reference file instead... which I am going to do in this PR.

I had to add
document.getElementById("test").style.caretColor = "yellow";
to work around a side effect of focus-ing a contenteditable element in Firefox. 

**Browsers (Chromium, Firefox, Safari) do not behave exactly the same when select()-ing a contenteditable element (and [select()-ing a text input](https://wpt.fyi/results/css/css-pseudo/selection-input-011.html?label=master) or [select()-ing a textarea element](https://wpt.fyi/results/css/css-pseudo/selection-textarea-011.html?label=master)).**

I hope to flatten, to smooth out these differences with the added code of the current PR.

Over at my website, the correspondent files are:

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/selection-contenteditable-011-newer.html

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/selection-contenteditable-011-newer-ref.html