### PR TITLE
[Taskcluster] Switch wpt run on CI to Python 3 only

### DIFF
--- a/tools/ci/taskcluster-run.py
+++ b/tools/ci/taskcluster-run.py
@@ -62,7 +62,7 @@ def main(product, channel, commit_range, wpt_args):
     )
     logger.addHandler(handler)
 
-    subprocess.call(['python', './wpt', 'manifest-download'])
+    subprocess.call(['python3', './wpt', 'manifest-download'])
 
     if commit_range:
         logger.info(
@@ -88,7 +88,7 @@ def main(product, channel, commit_range, wpt_args):
     if product == "servo" and "--test-type=wdspec" in wpt_args:
         wpt_args = [item for item in wpt_args if not item.startswith("--processes")]
 
-    command = ["python", "./wpt", "run"] + wpt_args + [product]
+    command = ["python3", "./wpt", "run"] + wpt_args + [product]
 
     logger.info("Executing command: %s" % " ".join(command))
     with open("/home/test/artifacts/checkrun.md", "a") as f:


### PR DESCRIPTION
See the RFC: https://github.com/web-platform-tests/rfcs/pull/65

This affects:
* On push: Full test-suite runs.
* On pull-request:
    * The with-pr affected-results check.
    * The without-pr affected-results check.
    * The stability checks.