### PR TITLE
Revised test to match behaviour in spec, as revised in issue #245

### DIFF
--- a/svg/painting/reftests/display-none-mask-ref.html
+++ b/svg/painting/reftests/display-none-mask-ref.html
@@ -8,12 +8,12 @@
 <body>
   <svg width="200" height="200">
     <foreignObject x="0" y="0" width="200" height="200">
-      <div style="width: 200px; height: 200px; background: red"></div>
+      <div style="width: 200px; height: 200px;"></div>
     </foreignObject>
   </svg>
   <svg width="200" height="200">
     <foreignObject x="0" y="0" width="200" height="200">
-      <div style="width: 200px; height: 200px; background: red"></div>
+      <div style="width: 200px; height: 200px; background: green"></div>
     </foreignObject>
   </svg>
   <svg width="200" height="200">
@@ -23,28 +23,28 @@
   </svg>
   <svg width="200" height="200">
     <foreignObject x="0" y="0" width="200" height="200">
-      <div style="width: 200px; height: 200px;"></div>
+      <div style="width: 200px; height: 200px; background: green"></div>
     </foreignObject>
   </svg>
 
   <!-- make sure masking actually works -->
   <svg width="200" height="200">
-      <rect x="0" y="0" width="100" height="50" fill="red"></rect>
-      <rect x="0" y="100" width="100" height="50" fill="red"></rect>
+      <rect x="0" y="0" width="100" height="50" fill="green"></rect>
+      <rect x="0" y="100" width="100" height="50" fill="green"></rect>
   </svg>
   <svg width="200" height="200">
-      <rect x="0" y="0" width="100" height="50" fill="red"></rect>
-      <rect x="0" y="100" width="100" height="50" fill="red"></rect>
+      <rect x="0" y="0" width="100" height="50" fill="green"></rect>
+      <rect x="0" y="100" width="100" height="50" fill="green"></rect>
   </svg>
 
   <!-- make sure masking works on active content -->
   <svg width="200" height="200">
-    <rect x="0" y="0" width="100" height="50" fill="red"></rect>
-    <rect x="0" y="100" width="100" height="50" fill="red"></rect>
+    <rect x="0" y="0" width="100" height="50" fill="green"></rect>
+    <rect x="0" y="100" width="100" height="50" fill="green"></rect>
   </svg>
   <svg width="200" height="200">
-    <rect x="0" y="0" width="100" height="50" fill="red"></rect>
-    <rect x="0" y="100" width="100" height="50" fill="red"></rect>
+    <rect x="0" y="0" width="100" height="50" fill="green"></rect>
+    <rect x="0" y="100" width="100" height="50" fill="green"></rect>
   </svg>
 </body>
 </html>

--- a/svg/painting/reftests/display-none-mask.html
+++ b/svg/painting/reftests/display-none-mask.html
@@ -3,28 +3,39 @@
 
 <head>
   <meta charset="UTF-8">
-  <link rel="match"  href="display-none-mask-ref.html" />
+  <title>Mask behaviour when mask image is missing or display:none</title>
+  <link rel="match"  href="display-none-mask-ref.html">
+  <link name="author" title="Timothy Nikkel" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1624532">
+  <link name="author" title="Mike Bremford" href="http://bfo.com"> <!-- edited 202010 -->
+  <link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-mask-image">
+  <link rel="help" href="https://drafts.fxtf.org/css-masking-1/#MaskElement">
+  <link rel="help" href="https://github.com/w3c/fxtf-drafts/issues/245">
+  <meta name="assert" content="A missing or invalid mask image is equivalent to transparent black (i.e. nothing is displayed). A mask with display:none is disabled (which is a change to the specified behaviour as of issue 245)">
 </head>
 
 <body>
   <svg width="200" height="200">
+    <!-- missing/invalid mask is equivalent to transparent black - nothing displayed -->
     <foreignObject x="0" y="0" width="200" height="200" style="mask: url('#notfound');">
       <div style="width: 200px; height: 200px; background: red"></div>
     </foreignObject>
   </svg>
   <svg width="200" height="200">
+    <!-- display:none on mask means mask is not applied (new in https://github.com/w3c/fxtf-drafts/issues/245) -->
     <foreignObject x="0" y="0" width="200" height="200" style="mask: url('#noneMask');">
-      <div style="width: 200px; height: 200px; background: red"></div>
+      <div style="width: 200px; height: 200px; background: green"></div>
     </foreignObject>
   </svg>
   <svg width="200" height="200">
     <foreignObject x="0" y="0" width="200" height="200">
+      <!-- missing/invalid mask is equivalent to transparent black - nothing displayed -->
       <div style="width: 200px; height: 200px; background: red; mask: url('#notfound');"></div>
     </foreignObject>
   </svg>
   <svg width="200" height="200">
     <foreignObject x="0" y="0" width="200" height="200">
-      <div style="width: 200px; height: 200px; background: red; mask: url('#noneMask');"></div>
+      <!-- display:none on mask means mask is not applied (new in https://github.com/w3c/fxtf-drafts/issues/245) -->
+      <div style="width: 200px; height: 200px; background: green; mask: url('#noneMask');"></div>
     </foreignObject>
   </svg>
 
@@ -45,24 +56,24 @@
       </mask>
     </defs>
     <foreignObject x="0" y="0" width="200" height="200" style="mask: url('#aMask');">
-      <div style="width: 200px; height: 200px; background: red;"></div>
+      <div style="width: 200px; height: 200px; background: green;"></div>
     </foreignObject>
   </svg>
   <svg width="200" height="200">
     <foreignObject x="0" y="0" width="200" height="200">
-      <div style="width: 200px; height: 200px; background: red; mask: url('#aMask');"></div>
+      <div style="width: 200px; height: 200px; background: green; mask: url('#aMask');"></div>
     </foreignObject>
   </svg>
 
   <!-- make sure masking works on active content -->
   <svg width="200" height="200">
     <foreignObject x="0" y="0" width="200" height="200" style="mask: url('#aMask');">
-      <div style="width: 200px; height: 200px; background: red; will-change: transform"></div>
+      <div style="width: 200px; height: 200px; background: green; will-change: transform"></div>
     </foreignObject>
   </svg>
   <svg width="200" height="200">
     <foreignObject x="0" y="0" width="200" height="200">
-      <div style="width: 200px; height: 200px; background: red; will-change: transform; mask: url('#aMask');"></div>
+      <div style="width: 200px; height: 200px; background: green; will-change: transform; mask: url('#aMask');"></div>
     </foreignObject>
   </svg>
 </body>


### PR DESCRIPTION
These tests originated at https://bugzilla.mozilla.org/show_bug.cgi?id=1624532

I can see they were to fix a regression in FF, but the tested behaviour doesn't match the specification:

* Masks that are _missing or invaild_ are treated as transparent black (ie. nothing is drawn)
* Masks that are _display:none_ are treated as if no mask was specified (note this is not as specified, but matches the resolution in https://github.com/w3c/fxtf-drafts/issues/245)

Also revised so no red is visible if the tests pass.

@tnikkel 