### PR TITLE
Remove invalid relative import in vcs.py

### DIFF
--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -9,11 +9,9 @@ from six.moves.collections_abc import MutableMapping
 
 from .utils import git
 
-try:
-    from ..gitignore import gitignore
-except ValueError:
-    # relative import beyond toplevel throws *ValueError*!
-    from gitignore import gitignore  # type: ignore
+# Cannot do `from ..gitignore import gitignore` because
+# relative import beyond toplevel throws *ImportError*!
+from gitignore import gitignore  # type: ignore
 
 
 MYPY = False


### PR DESCRIPTION
It was introduced by e98eee5aec6, but absolute import alone works on both Py2/3.

Closes #26071 