### PR TITLE
[css-backgrounds] Add test ensuring border-image is displayed with a transparent border-color

### DIFF
--- a/css/css-backgrounds/border-image-displayed-with-transparent-border-color-ref.html
+++ b/css/css-backgrounds/border-image-displayed-with-transparent-border-color-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>
+  border-color: transparent should not hide the border-image
+</title>
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+        margin: 20px;
+        background-color: silver;
+        border-image-source: url('./support/100x100-blue-and-orange.png');
+        border-image-slice: 32;
+        border-image-repeat: repeat;
+        border-style: solid;
+        border-width: 32px;
+    }
+</style>
+
+This box should have a visible blue-orange border-image.
+<div></div>
+

--- a/css/css-backgrounds/border-image-displayed-with-transparent-border-color.html
+++ b/css/css-backgrounds/border-image-displayed-with-transparent-border-color.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Tyler Wilcock" href="mailto:twilco.o@protonmail.com">
+<link rel="help" href="https://www.w3.org/TR/2017/CR-css-backgrounds-3-20171017/#border-images">
+<link rel="match" href="border-image-displayed-with-transparent-border-color-ref.html">
+<title>
+  border-color: transparent should not hide the border-image
+</title>
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+        margin: 20px;
+        background-color: silver;
+        border-image-source: url('./support/100x100-blue-and-orange.png');
+        border-image-slice: 32;
+        border-image-repeat: repeat;
+        border-style: solid;
+        border-width: 32px;
+    }
+</style>
+
+This box should have a visible blue-orange border-image.
+<div style="border-color: transparent;"></div>
+


### PR DESCRIPTION
A transparent `border-color` should not prevent a `border-image` from being rendered, but this is the case in WebKit today.  Gecko and Chromium do not exhibit this behavior.

![Picture showing WebKit not rendering blue-orange linear-gradient border-image while Chromium and Firefox do.](https://user-images.githubusercontent.com/6610100/97783471-05a14000-1b66-11eb-9ea7-cd5cdf006b59.png)

WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=217900

Spec: https://www.w3.org/TR/2017/CR-css-backgrounds-3-20171017/#border-images
