### PR TITLE
[css-backgrounds] Non-visible border-style should prevent border-image from being rendered

### DIFF
--- a/css/css-backgrounds/border-image-with-non-visible-border-styles-ref.html
+++ b/css/css-backgrounds/border-image-with-non-visible-border-styles-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>
+  `border-image` shouldn't be rendered when the used-value of `border-width` is zero
+  due to a `none` or `hidden` `border-style`.
+</title>
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+        margin: 20px;
+        background-color: green;
+    }
+</style>
+
+<p>
+  Test passes if no red border-image is visible on any of the below boxes.
+</p>
+
+<div></div>
+<div></div>

--- a/css/css-backgrounds/border-image-with-non-visible-border-styles.html
+++ b/css/css-backgrounds/border-image-with-non-visible-border-styles.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Tyler Wilcock" href="mailto:twilco.o@protonmail.com">
+<link rel="help" href="https://www.w3.org/TR/2017/CR-css-backgrounds-3-20171017/#border-images">
+<!-- Editorial of the spec regarding the interaction of `border-image`, border-width`, and `border-style`: -->
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/655#issuecomment-331059128">
+<link rel="match" href="border-image-with-non-visible-border-styles-ref.html">
+<title>
+  `border-image` shouldn't be rendered when the used-value of `border-width` is zero
+  due to a `none` or `hidden` `border-style`.
+</title>
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+        margin: 20px;
+        background-color: green;
+        border-image-source: linear-gradient(darkred, crimson);
+        border-image-slice: 48;
+        border-image-repeat: repeat;
+        border-style: solid;
+        border-width: 48px;
+    }
+</style>
+
+<p>
+  Test passes if no red border-image is visible on any of the below boxes.
+</p>
+
+<div style="border-style: none;"></div>
+<div style="border-style: hidden;"></div>


### PR DESCRIPTION
Given a non-visible `border-style` such as `none` and `hidden`, `border-images` should not be rendered.

Spec: https://www.w3.org/TR/2017/CR-css-backgrounds-3-20171017/#border-images

Editorial: https://github.com/w3c/csswg-drafts/issues/655#issuecomment-331059128

(emphasis mine)
> So, border images override border-style in the sense that a border-style-specified border will not be drawn if a border image is specified. _**But to the extent that border-style influences the border-width it can affect whether the border image is visible or not.**_

Chromium and Gecko currently exhibit this behavior, and WebKit does not.

![WebKit erroneously displaying red border-image, Chromium and Gecko not displaying a border-image.](https://user-images.githubusercontent.com/6610100/97784188-b6114300-1b6a-11eb-855f-a24f8fb05496.png)
