### PR TITLE
Test that border-image-width extends into padding given no border area (e.g. via border-style: none)

### DIFF
--- a/css/css-backgrounds/border-image-width-should-extend-to-padding-ref.html
+++ b/css/css-backgrounds/border-image-width-should-extend-to-padding-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>
+  `border-image-width` should extend into padding given an empty border area via `border-style: none`
+</title>
+<style>
+    div {
+        width: 136px;
+        height: 136px;
+        margin: 20px;
+        background-color: silver;
+        border-image-source: linear-gradient(blue, orange);
+        border-image-slice: 32;
+        border-image-repeat: repeat;
+        border-style: solid;
+        border-width: 32px;
+    }
+</style>
+
+Test passes if a 200x200px (content + padding + border) box with a 32px border-image is rendered.
+<div></div>
+

--- a/css/css-backgrounds/border-image-width-should-extend-to-padding.html
+++ b/css/css-backgrounds/border-image-width-should-extend-to-padding.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Tyler Wilcock" href="mailto:twilco.o@protonmail.com">
+<link rel="help" href="https://www.w3.org/TR/2017/CR-css-backgrounds-3-20171017/#the-border-image-width">
+
+<!-- Editorial of the spec.
+ > Since by default a border image is only drawn in the border area, by default a border-style of none will make
+ > it disappear. However, the border-image-outset and border-image-width values can alter the “border” area into
+ > which the border image is drawn, extending it into the padding area (in the case of border-image-widths greater
+ > than the border-width) or extending it outside the border edge (in the case of border-image-outset greater than zero).
+-->
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/655#issuecomment-331059128">
+<link rel="match" href="border-image-width-should-extend-to-padding-ref.html">
+<title>
+  `border-image-width` should extend into padding given an empty border area via `border-style: none`
+</title>
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+        margin: 20px;
+        background-color: silver;
+        border-image-source: linear-gradient(blue, orange);
+        border-image-slice: 32;
+        border-image-repeat: repeat;
+        border-image-width: 32px;
+        border-style: none;
+    }
+</style>
+
+Test passes if a 200x200px (content + padding + border) box with a 32px border-image is rendered.
+<div></div>
+

--- a/css/css-backgrounds/border-image-width-should-extend-to-padding.html
+++ b/css/css-backgrounds/border-image-width-should-extend-to-padding.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel="author" title="Tyler Wilcock" href="mailto:twilco.o@protonmail.com">
-<link rel="help" href="https://www.w3.org/TR/2017/CR-css-backgrounds-3-20171017/#the-border-image-width">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-image-width">
 
 <!-- Editorial of the spec.
  > Since by default a border image is only drawn in the border area, by default a border-style of none will make


### PR DESCRIPTION
When there is no border area (e.g. resulting from `border-style: none`), border-images with `border-image-width` should render into the padding / content area of the box.

Spec: https://www.w3.org/TR/2017/CR-css-backgrounds-3-20171017/#propdef-border-image-width

Editorial of the spec: https://github.com/w3c/csswg-drafts/issues/655#issuecomment-331059128

(emphasis mine)

> Since by default a border image is only drawn in the border area, by default a border-style of none will make it disappear. **_However, the border-image-outset and border-image-width values can alter the “border” area into which the border image is drawn, extending it into the padding area (in the case of border-image-widths greater than the border-width) or extending it outside the border edge (in the case of border-image-outset greater than zero)._**

WebKit and Gecko exhibit this behavior, Chromium does not.

![border-image-should-extend-into-padding](https://user-images.githubusercontent.com/6610100/97785284-13f55900-1b72-11eb-95bc-7d73c65ef163.png)
