### PR TITLE
WebSocket constructor throws in case of blocked port

### DIFF
--- a/websockets/Create-blocked-port.any.js
+++ b/websockets/Create-blocked-port.any.js
@@ -76,9 +76,7 @@ async_test(t => {
   6669, // irc (alternate)
   6697, // irc+tls
 ].forEach(blockedPort => {
-  async_test(t => {
-    const ws = CreateWebSocketWithBlockedPort(blockedPort)
-    ws.onerror = t.step_func_done()
-    ws.onopen = t.unreached_func()
+  test(() => {
+    assert_throws_dom("SecurityError", () => CreateWebSocketWithBlockedPort(blockedPort));
   }, "WebSocket blocked port test " + blockedPort)
 })


### PR DESCRIPTION
This appears to be consistent across browsers as per https://wpt.fyi/results/websockets/Create-blocked-port.any.html?label=experimental&label=master&aligned