### PR TITLE
 Ensure we set a testdriver context when running in a non-test window 

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -852,7 +852,7 @@ class ActionContext(object):
 
         self.initial_window = self.protocol.base.current_window
         self.logger.debug("Switching to window %s" % self.context)
-        self.protocol.testdriver.switch_to_window(self.context)
+        self.protocol.testdriver.switch_to_window(self.context, self.initial_window)
 
     def __exit__(self, *args):
         if self.context is None:
@@ -860,5 +860,4 @@ class ActionContext(object):
 
         self.logger.debug("Switching back to initial window")
         self.protocol.base.set_window(self.initial_window)
-        self.protocol.testdriver._switch_to_frame(None)
         self.initial_window = None

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -402,10 +402,11 @@ class TestDriverProtocolPart(ProtocolPart):
             except Exception:
                 pass
             frame_count = self.parent.base.execute_script("return window.length")
-            # None here makes us switch back to the parent after we've processed all the subframes
-            stack.append(None)
             if frame_count:
-                stack.extend(reversed(range(0, frame_count)))
+                for frame_id in reversed(range(0, frame_count)):
+                    # None here makes us switch back to the parent after we've processed the frame
+                    stack.append(None)
+                    stack.append(frame_id)
             first = False
 
         raise Exception("Window with id %s not found" % wptrunner_id)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -383,13 +383,14 @@ class TestDriverProtocolPart(ProtocolPart):
             initial_window = self.parent.base.current_window
 
         stack = [str(item) for item in self.parent.base.window_handles()]
+        first = True
         while stack:
             item = stack.pop()
             if item is None:
                 self._switch_to_parent_frame()
                 continue
             elif isinstance(item, str):
-                if item != initial_window:
+                if not first or item != initial_window:
                     self.parent.base.set_window(item)
             else:
                 self._switch_to_frame(item)
@@ -405,6 +406,7 @@ class TestDriverProtocolPart(ProtocolPart):
             stack.append(None)
             if frame_count:
                 stack.extend(reversed(range(0, frame_count)))
+            first = False
 
         raise Exception("Window with id %s not found" % wptrunner_id)
 

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -371,12 +371,16 @@ class TestDriverProtocolPart(ProtocolPart):
         :param str message: Additional data to add to the message."""
         pass
 
-    def switch_to_window(self, wptrunner_id):
+    def switch_to_window(self, wptrunner_id, initial_window=None):
         """Switch to a window given a wptrunner window id
 
-        :param str wptrunner_id: window id"""
+        :param str wptrunner_id: Testdriver-specific id for the target window
+        :param str initial_window: WebDriver window id for the test window"""
         if wptrunner_id is None:
             return
+
+        if initial_window is None:
+            initial_window = self.parent.base.current_window
 
         stack = [str(item) for item in self.parent.base.window_handles()]
         while stack:
@@ -385,7 +389,8 @@ class TestDriverProtocolPart(ProtocolPart):
                 self._switch_to_parent_frame()
                 continue
             elif isinstance(item, str):
-                self.parent.base.set_window(item)
+                if item != initial_window:
+                    self.parent.base.set_window(item)
             else:
                 self._switch_to_frame(item)
 

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -136,6 +136,9 @@
             if (testharness_context === null) {
                 throw new Error("Tried to run in a non-testharness window without a call to set_test_context");
             }
+            if (action_msg.context === null) {
+                action_msg.context = get_window_id(window);
+            }
             cmd_id = ctx_cmd_id++;
             action_msg.cmd_id = cmd_id;
             window.test_driver.message_test({type: "testdriver-command",


### PR DESCRIPTION
    testdriver can be used outside the test window in two ways:
    
    * By passing in a context parameter pointing to another window in
    which the commands should be run.
    
    * By loading testdriver in the other window and having it postMessage
    commands back to the top window.
    
    For the first case the context parameter being null means "run the
    command in the test window". However we were also passing null in the
    second case when the command should be run in the window where
    testdriver was loaded. That meant the command was actually run in the
    test window rather than the target. It just so happened this didn't
    cause test failures in Chrome and Firefox because of the specific
    choice of commands in the tests. But it did in Firefox with site
    isolation enabled and Safari and would for a different set of tests.
    
    The fix is to ensure that the context is always set when postMessaging
    a command to the top-level window.
