### PR TITLE
Fix #17577: Check runners deal with lone surrogates in test output

### DIFF
--- a/infrastructure/metadata/infrastructure/testharness/lone-surrogates.html.ini
+++ b/infrastructure/metadata/infrastructure/testharness/lone-surrogates.html.ini
@@ -1,0 +1,7 @@
+[lone-surrogates.html]
+  [failing test with lone surrogate in assert]
+    expected: FAIL
+
+  [failing test with lone surrogate U+d800 in name]
+    expected: FAIL
+

--- a/infrastructure/testharness/lone-surrogates.html
+++ b/infrastructure/testharness/lone-surrogates.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<title>test behaviour with lone surrogates</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(() => assert_true(true), "passing test with lone surrogate \uD800 in name");
+  test(() => assert_true(false), "failing test with lone surrogate \uD800 in name");
+  test(() => assert_true(true, "lone \uD800 surrogate"), "passing test with lone surrogate in assert");
+  test(() => assert_true(false, "lone \uD800 surrogate"), "failing test with lone surrogate in assert");
+</script>

--- a/resources/test/tests/unit/helpers.js
+++ b/resources/test/tests/unit/helpers.js
@@ -11,7 +11,7 @@ function test_failure(fn, name) {
       if (err instanceof AssertionError) {
         return;
       }
-      throw new AssertionError('Expected an AssertionError, but');
+      throw new AssertionError('Expected an AssertionError, but' + err);
     }
     throw new AssertionError(
       'Expected an AssertionError, but no error was thrown'

--- a/resources/test/tests/unit/unpaired-surrogates.html
+++ b/resources/test/tests/unit/unpaired-surrogates.html
@@ -114,6 +114,7 @@ promise_test(() => {
         test(() => {}, 'U+d800U+d801 must be sanitized: \ud800\ud801');
         test(() => {}, 'U+dfff must be sanitized: \udfff');
         test(() => {}, 'U+dc00U+d800U+dc00U+d800 must be sanitized: \udc00\ud800\udc00\ud800');
+        test(() => {}, 'U+dbffU+dfffU+dfff must be sanitized: \udbff\udfff\udfff');
         test(() => {}, 'after');
       }
     ).then(({harness, tests}) => {
@@ -128,6 +129,10 @@ promise_test(() => {
       );
       assert_equals(
         tests['U+dc00U+d800U+dc00U+d800 must be sanitized: U+dc00\ud800\udc00U+d800'],
+        'PASS'
+      );
+      assert_equals(
+        tests['U+dbffU+dfffU+dfff must be sanitized: U+dbffU+dfffU+dfff'],
         'PASS'
       );
       assert_equals(tests.after, 'PASS');

--- a/resources/test/tests/unit/unpaired-surrogates.html
+++ b/resources/test/tests/unit/unpaired-surrogates.html
@@ -132,7 +132,7 @@ promise_test(() => {
         'PASS'
       );
       assert_equals(
-        tests['U+dbffU+dfffU+dfff must be sanitized: U+dbffU+dfffU+dfff'],
+        tests['U+dbffU+dfffU+dfff must be sanitized: \udbff\udfffU+dfff'],
         'PASS'
       );
       assert_equals(tests.after, 'PASS');

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2956,22 +2956,16 @@ policies and contribution forms [3].
     }
 
     function sanitize_unpaired_surrogates(str) {
-        return str.replace(/([\ud800-\udbff])(?![\udc00-\udfff])/g,
-                           function(_, unpaired)
-                           {
-                               return code_unit_str(unpaired);
-                           })
-                  // This replacement is intentionally implemented without an
-                  // ES2018 negative lookbehind assertion to support runtimes
-                  // which do not yet implement that language feature.
-                  .replace(/(^|[^\ud800-\udbff])([\udc00-\udfff])/g,
-                           function(_, previous, unpaired) {
-                              if (/[\udc00-\udfff]/.test(previous)) {
-                                  previous = code_unit_str(previous);
-                              }
-
-                              return previous + code_unit_str(unpaired);
-                           });
+        return str.replace(
+            /([\ud800-\udbff]+)(?![\udc00-\udfff])|(^|[^\ud800-\udbff])([\udc00-\udfff]+)/g,
+            function(_, low, prefix, high) {
+                var output = prefix || "";  // prefix may be undefined
+                var string = low || high;  // only one of these alternates can match
+                for (var i = 0; i < string.length; i++) {
+                    output += code_unit_str(string[i]);
+                }
+                return output;
+            });
     }
 
     function sanitize_all_unpaired_surrogates(tests) {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3600,7 +3600,7 @@ policies and contribution forms [3].
         if (expected_true !== true) {
             var msg = make_message(function_name, description,
                                    error, substitutions);
-            throw new AssertionError(msg)
+            throw new AssertionError(msg);
         }
     }
 

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3606,13 +3606,13 @@ policies and contribution forms [3].
         if (expected_true !== true) {
             var msg = make_message(function_name, description,
                                    error, substitutions);
-            throw new AssertionError(msg);
+            throw new AssertionError(msg)
         }
     }
 
     function AssertionError(message)
     {
-        this.message = message;
+        this.message = sanitize_unpaired_surrogates(message);
         this.stack = this.get_stack();
     }
     expose(AssertionError, "AssertionError");

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -3606,7 +3606,10 @@ policies and contribution forms [3].
 
     function AssertionError(message)
     {
-        this.message = sanitize_unpaired_surrogates(message);
+        if (typeof message == "string") {
+            message = sanitize_unpaired_surrogates(message);
+        }
+        this.message = message;
         this.stack = this.get_stack();
     }
     expose(AssertionError, "AssertionError");


### PR DESCRIPTION
Fixes #17577. See also https://github.com/w3c/webdriver/issues/1450 for more background on this.