### PR TITLE
[input] Test some edge-cases for valueAsNumber with type number

### DIFF
--- a/html/semantics/forms/the-input-element/input-valueasnumber.html
+++ b/html/semantics/forms/the-input-element/input-valueasnumber.html
@@ -120,11 +120,16 @@
    testValueAsNumberGetter("number", numberInput, [
      ["", NaN],
      ["123", 123],
-     ["123.456", 123.456]
+     ["123.456", 123.456],
+     ["1e3", 1000],
+     ["1e", NaN],
+     ["-123", -123]
    ]);
    testValueAsNumberSetter("number", numberInput, [
      [123, "123"],
-     [123.456, "123.456"]
+     [123.456, "123.456"],
+     [1e3, "1000"],
+     [-123, "-123"]
    ]);
 
    const rangeInput = document.getElementById("input_range");


### PR DESCRIPTION
There are some edge-cases (negatives, exponent notation, and invalid values) for `input type="number"` `valueAsNumber` that are not currently covered by WPT tests.

I've checked these locally in Chrome, Firefox, and WebKit (Epiphany) and the updated tests pass.