### PR TITLE
[wpt] Use the new dest paths of Chrome on macOS

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -646,10 +646,10 @@ class Chrome(Browser):
             # No Canary on Linux.
             return find_executable(name)
         if uname[0] == "Darwin":
-            if channel == "canary":
-                return "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
-            # All other channels share the same path on macOS.
-            return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+            suffix = ""
+            if channel in ("beta", "dev", "canary"):
+                suffix = " " + channel.capitalize()
+            return "/Applications/Google Chrome%s.app/Contents/MacOS/Google Chrome%s" % (suffix, suffix)
         if uname[0] == "Windows":
             path = os.path.expandvars(r"$SYSTEMDRIVE\Program Files (x86)\Google\Chrome\Application\chrome.exe")
             if not os.path.exists(path):


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask-versions/pull/9867
https://blog.chromium.org/2017/08/run-multiple-versions-of-chrome-side-by.html

Different channels of Chrome now have their own installation paths on
macOS.

This should fix the test failures on Azure Pipelines.