### PR TITLE
Quirks: Add tests for "html fills viewport" and "body fills html"

### DIFF
--- a/quirks/body-fills-html-quirk-float.html
+++ b/quirks/body-fills-html-quirk-float.html
@@ -4,6 +4,7 @@
 <style>
 body {
   border: solid;
+  margin: 10px 11px 12px 14px;
   float: left;
 }
 span {

--- a/quirks/body-fills-html-quirk-inline.html
+++ b/quirks/body-fills-html-quirk-inline.html
@@ -4,6 +4,7 @@
 <style>
 body {
   border: solid;
+  margin: 10px 11px 12px 14px;
   display: inline-block;
 }
 span {

--- a/quirks/body-fills-html-quirk-positioned.html
+++ b/quirks/body-fills-html-quirk-positioned.html
@@ -4,6 +4,7 @@
 <style>
 body {
   border: solid;
+  margin: 10px 11px 12px 14px;
   position: absolute;
 }
 span {

--- a/quirks/body-fills-html-quirk-ref.html
+++ b/quirks/body-fills-html-quirk-ref.html
@@ -1,2 +1,4 @@
 <!DOCTYPE html>
-<div style="width: 100px; height: 100px; border: solid; background: green;"></div>
+<body style="margin: 10px 11px 12px 14px;">
+  <div style="width: 100px; height: 100px; border: solid; background: green;"></div>
+</body>

--- a/quirks/body-fills-html-quirk-ref2.html
+++ b/quirks/body-fills-html-quirk-ref2.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <body style="margin: 0">
-  <div
-    style="width: 200px; height: 200px; border: solid; box-sizing: border-box"
-  >
+  <div style="width: 175px; height: 178px; margin: 10px 11px 12px 14px; border: solid; box-sizing: border-box;">
     <div style="width: 100px; height: 100px; background: green"></div>
   </div>
 </body>

--- a/quirks/body-fills-html-quirk-ref2.html
+++ b/quirks/body-fills-html-quirk-ref2.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<body style="margin: 0">
+  <div
+    style="width: 200px; height: 200px; border: solid; box-sizing: border-box"
+  >
+    <div style="width: 100px; height: 100px; background: green"></div>
+  </div>
+</body>

--- a/quirks/body-fills-html-quirk-vertical.html
+++ b/quirks/body-fills-html-quirk-vertical.html
@@ -1,0 +1,23 @@
+<!DOCTYPE quirks-mode>
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-body-element-fills-the-html-element-quirk"/>
+<link rel="match" href="body-fills-html-quirk-ref2.html" />
+<style>
+  html {
+    width: 200px;
+    height: 200px;
+    writing-mode: vertical-lr;
+  }
+  body {
+    border: solid;
+    margin: 0;
+  }
+  span {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+<body>
+  <span></span>
+</body>

--- a/quirks/body-fills-html-quirk-vertical.html
+++ b/quirks/body-fills-html-quirk-vertical.html
@@ -9,7 +9,7 @@
   }
   body {
     border: solid;
-    margin: 0;
+    margin: 10px 11px 12px 14px;
   }
   span {
     display: inline-block;

--- a/quirks/body-fills-html-quirk.html
+++ b/quirks/body-fills-html-quirk.html
@@ -1,0 +1,22 @@
+<!DOCTYPE quirks-mode>
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-body-element-fills-the-html-element-quirk"/>
+<link rel="match" href="body-fills-html-quirk-ref2.html" />
+<style>
+  html {
+    width: 200px;
+    height: 200px;
+  }
+  body {
+    border: solid;
+    margin: 0;
+  }
+  span {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+<body>
+  <span></span>
+</body>

--- a/quirks/body-fills-html-quirk.html
+++ b/quirks/body-fills-html-quirk.html
@@ -8,7 +8,7 @@
   }
   body {
     border: solid;
-    margin: 0;
+    margin: 10px 11px 12px 14px;
   }
   span {
     display: inline-block;

--- a/quirks/html-fills-viewport-quirk-ref.html
+++ b/quirks/html-fills-viewport-quirk-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<body style="width: 100vw; height: 100vw; margin: 0; padding: 10px; box-sizing: border-box">
+  <div id="border" style="border: solid; width: 100%; height: 100%; box-sizing: border-box">
+    <div style="width: 100px; height: 100px; background: green"></div>
+  </div>
+</body>

--- a/quirks/html-fills-viewport-quirk-ref.html
+++ b/quirks/html-fills-viewport-quirk-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<body style="width: 100vw; height: 100vh; margin: 0; padding: 10px; box-sizing: border-box">
+<body style="width: 100vw; height: 100vh; margin: 0; padding: 10px 11px 12px 14px; box-sizing: border-box">
   <div id="border" style="border: solid; width: 100%; height: 100%; box-sizing: border-box">
     <div style="width: 100px; height: 100px; background: green"></div>
   </div>

--- a/quirks/html-fills-viewport-quirk-ref.html
+++ b/quirks/html-fills-viewport-quirk-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<body style="width: 100vw; height: 100vw; margin: 0; padding: 10px; box-sizing: border-box">
+<body style="width: 100vw; height: 100vh; margin: 0; padding: 10px; box-sizing: border-box">
   <div id="border" style="border: solid; width: 100%; height: 100%; box-sizing: border-box">
     <div style="width: 100px; height: 100px; background: green"></div>
   </div>

--- a/quirks/html-fills-viewport-quirk-vertical.html
+++ b/quirks/html-fills-viewport-quirk-vertical.html
@@ -7,7 +7,7 @@
 <style>
   html {
     border: solid;
-    margin: 10px;
+    margin: 10px 11px 12px 14px;
     direction: vertical-lr;
   }
   body {

--- a/quirks/html-fills-viewport-quirk-vertical.html
+++ b/quirks/html-fills-viewport-quirk-vertical.html
@@ -1,0 +1,25 @@
+<!DOCTYPE quirks-mode>
+<link
+  rel="help"
+  href="https://quirks.spec.whatwg.org/#the-html-element-fills-the-viewport-quirk"
+/>
+<link rel="match" href="html-fills-viewport-quirk-ref.html" />
+<style>
+  html {
+    border: solid;
+    margin: 10px;
+    direction: vertical-lr;
+  }
+  body {
+    margin: 0;
+  }
+  span {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+<body>
+  <span></span>
+</body>

--- a/quirks/html-fills-viewport-quirk.html
+++ b/quirks/html-fills-viewport-quirk.html
@@ -1,0 +1,24 @@
+<!DOCTYPE quirks-mode>
+<link
+  rel="help"
+  href="https://quirks.spec.whatwg.org/#the-html-element-fills-the-viewport-quirk"
+/>
+<link rel="match" href="html-fills-viewport-quirk-ref.html" />
+<style>
+  html {
+    border: solid;
+    margin: 10px;
+  }
+  body {
+    margin: 0;
+  }
+  span {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+<body>
+  <span></span>
+</body>

--- a/quirks/html-fills-viewport-quirk.html
+++ b/quirks/html-fills-viewport-quirk.html
@@ -7,7 +7,7 @@
 <style>
   html {
     border: solid;
-    margin: 10px;
+    margin: 10px 11px 12px 14px;
   }
   body {
     margin: 0;


### PR DESCRIPTION
The "`html` fills viewport" quirk wasn't tested at all; and the tests for "`body` fills `html`" only covered the exceptions to the quirk rather than the cases where it should apply. This PR adds the missing coverage.