### PR TITLE
[Azure Pipelines] Fix `wpt test-jobs` failures

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -79,7 +79,8 @@ jobs:
   steps:
   - template: tools/ci/azure/checkout.yml
   - script: |
-      set -e; set -o pipefail
+      set -euo pipefail
+      git fetch origin
       ./wpt test-jobs | while read job; do
         echo "$job"
         echo "##vso[task.setvariable variable=$job;isOutput=true]true";

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
   - template: tools/ci/azure/checkout.yml
   - script: |
       set -euo pipefail
-      git fetch origin
+      git fetch --depth 50 --quiet origin master
       ./wpt test-jobs | while read job; do
         echo "$job"
         echo "##vso[task.setvariable variable=$job;isOutput=true]true";

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -79,6 +79,7 @@ jobs:
   steps:
   - template: tools/ci/azure/checkout.yml
   - script: |
+      set -e; set -o pipefail
       ./wpt test-jobs | while read job; do
         echo "$job"
         echo "##vso[task.setvariable variable=$job;isOutput=true]true";

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -107,7 +107,12 @@ def branch_point():
         #   branch point and the merge base)
         #
         # In either case, fall back to using the merge base as the branch point.
-        merge_base = git("merge-base", "HEAD", "origin/master")
+        import subprocess
+        try:
+            merge_base = git("merge-base", "HEAD", "origin/master")
+        except subprocess.CalledProcessError as e:
+            print(e.output)
+            raise e
         if (branch_point is None or
             (branch_point != merge_base and
              not git("log", "--oneline", "%s..%s" % (merge_base, branch_point)).strip())):

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -107,12 +107,7 @@ def branch_point():
         #   branch point and the merge base)
         #
         # In either case, fall back to using the merge base as the branch point.
-        import subprocess
-        try:
-            merge_base = git("merge-base", "HEAD", "origin/master")
-        except subprocess.CalledProcessError as e:
-            print(e.output)
-            raise e
+        merge_base = git("merge-base", "HEAD", "origin/master")
         if (branch_point is None or
             (branch_point != merge_base and
              not git("log", "--oneline", "%s..%s" % (merge_base, branch_point)).strip())):


### PR DESCRIPTION
For some reason, Azure Pipelines is not consistently fetching `origin/master`, which
results in a failing `wpt test-jobs` command. Even worse, we didn't catch the failure
because our script pipes the outcome of `./wpt test-jobs` and doesn't set `pipefail`!

This PR works around the `origin/master` problem by explicitly fetching it, and also
adds the appropriate bash `set` command to fail on pipes and other errors.

Fixes #26448