### PR TITLE
Move gitignore cache to a custom bytes-based format

### DIFF
--- a/tools/gitignore/gitignore.py
+++ b/tools/gitignore/gitignore.py
@@ -228,9 +228,10 @@ class PathFilter(object):
                ):
         # type: (...) -> Iterable[Tuple[bytes, List[Tuple[bytes, T]], List[Tuple[bytes, T]]]]
         empty = {}  # type: Dict[Any, Any]
+        replace_seperator = ensure_binary(os.path.sep) != b"/"
         for dirpath, dirnames, filenames in iterator:
             orig_dirpath = dirpath
-            if ensure_binary(os.path.sep) != b"/":
+            if replace_seperator:
                 dirpath = dirpath.replace(ensure_binary(os.path.sep), b"/")
 
             keep_dirs = []  # type: List[Tuple[bytes, T]]


### PR DESCRIPTION
JSON isn't a good fit for this use case since we are allowing paths to be any byte sequence
and JSON tries to enforce unicode. Instead just use a line-based format
 path NULL ignored LF