### PR TITLE
Add tests for WebDriver Async Session Creation

### DIFF
--- a/webdriver/tests/new_session/async.py
+++ b/webdriver/tests/new_session/async.py
@@ -1,0 +1,25 @@
+# META: timeout=long
+
+import pytest
+
+from .conftest import product, flatten
+
+from tests.support.asserts import assert_success
+from tests.new_session.support.create import valid_data
+
+
+@pytest.mark.parametrize("key,value", flatten(product(*item) for item in valid_data))
+def test_valid(new_session, add_browser_capabilities, key, value):
+    new_async_session_response, get_session_response = new_async_session(
+        {"capabilities": {
+            "alwaysMatch": add_browser_capabilities({key: value})}})
+    assert_success(new_async_session_response)
+    assert_success(get_session_response)
+
+@pytest.mark.parametrize("key,value", flatten(product(*item) for item in valid_data))
+def test_get_session(get_session, add_browser_capabilities, key, value):
+    bodyValue = get_session(
+        {"capabilities": {
+            "alwaysMatch": add_browser_capabilities({key: value})}})
+    assert "sessionId" in bodyValue
+    assert "capabilities" in bodyValue

--- a/webdriver/tests/new_session/conftest.py
+++ b/webdriver/tests/new_session/conftest.py
@@ -2,13 +2,31 @@ import pytest
 
 from webdriver.transport import HTTPWireProtocol
 
-
 def product(a, b):
     return [(a, item) for item in b]
 
 
 def flatten(l):
     return [item for x in l for item in x]
+
+
+class Test_Setup():
+    def __init__(self, configuration, url_prefix="/"):
+        self.transport = HTTPWireProtocol(
+            configuration["host"], configuration["port"], url_prefix=url_prefix,
+        )
+
+    def new_session(self, body):
+        return self.transport.send("POST", "session", body)
+
+    def get_session(self, session_id):
+        return self.transport.send("GET", "session/{}".format(session_id))
+
+    def delete_session(self, session_id):
+        self.transport.send("DELETE", "session/{}".format(session_id))
+
+    def new_session(self, body):
+        return self.transport.send("POST", "session/async", body)
 
 
 @pytest.fixture(name="add_browser_capabilities")
@@ -50,13 +68,7 @@ def fixture_new_session(request, configuration, current_session):
      same test.
     """
     custom_session = {}
-
-    transport = HTTPWireProtocol(
-        configuration["host"], configuration["port"], url_prefix="/",
-    )
-
-    def _delete_session(session_id):
-        transport.send("DELETE", "session/{}".format(session_id))
+    setup = Test_Setup(configuration)
 
     def new_session(body, delete_existing_session=False):
         # If there is an active session from the global session fixture,
@@ -67,12 +79,63 @@ def fixture_new_session(request, configuration, current_session):
         if delete_existing_session:
             _delete_session(custom_session["session"]["sessionId"])
 
-        response = transport.send("POST", "session", body)
+        response = setup.new_session(body)
         if response.status == 200:
             custom_session["session"] = response.body["value"]
         return response, custom_session.get("session", None)
 
     yield new_session
+
+    if custom_session.get("session") is not None:
+        setup.delete_session(custom_session["session"]["sessionId"])
+        custom_session = None
+
+@pytest.fixture(name="new_async_session")
+def fixture_new_async_session(request, configuration):
+    """Start a new async session for tests which themselves test creating new sessions.
+
+    :param body: The content of the body for the new session POST request.
+    """
+    custom_session = {}
+    setup = Test_Setup(configuration)
+
+    def init_async_session(body)
+        new_async_session_response = setup.new_session(body)
+        if new_async_session_response.status == 200:
+            custom_session["creation"] = new_async_session_response.body["value"]
+
+        get_session_response = setup.get_session(custom_session["creation"]["sessionCreationId"])
+        if get_session_response.status == 200:
+            custom_session["session"] = get_session_response.body["value"]
+
+        assert custom_session["creation"]["sessionCreationId"] == custom_session["session"]["sessionId"]
+        return new_async_session_response, get_session_response
+
+    yield init_async_session
+
+    if custom_session.get("session") is not None:
+        setup.delete_session(custom_session["session"]["sessionId"])
+        custom_session = None
+
+@pytest.fixture(name="get_session")
+def fixture_get_session(request, configuration):
+    """Start a new session and get session information
+
+    :param body: The content of the body for the new session POST request.
+    """
+    custom_session = {}
+    setup = Test_Setup(configuration)
+
+    def get_session(body):
+        new_session_response = setup.new_session(body)
+        get_session_response = setup.get_session(response.body["value"]["sessionCreationId"])
+
+        if get_session_response.status == 200:
+            custom_session["session"] = get_session_response.body["value"]
+
+        return get_session_response.body["value"]
+
+    yield get_session
 
     if custom_session.get("session") is not None:
         _delete_session(custom_session["session"]["sessionId"])


### PR DESCRIPTION
This patch adds tests for Async Session Creation, proposed in: https://github.com/w3c/webdriver/pull/1561