### PR TITLE
Remove ResponseWriter.flush() and explicit_flush

### DIFF
--- a/element-timing/resources/progressive-image.py
+++ b/element-timing/resources/progressive-image.py
@@ -19,7 +19,6 @@ def main(request, response):
     # Read from the beginning, |numInitial| bytes.
     first = body[:numInitial]
     response.writer.write_content(first)
-    response.writer.flush()
 
     time.sleep(sleepTime)
 

--- a/eventsource/resources/message2.py
+++ b/eventsource/resources/message2.py
@@ -4,7 +4,6 @@ def main(request, response):
     response.headers.set(b'Content-Type', b'text/event-stream')
     response.headers.set(b'Cache-Control', b'no-cache')
 
-    response.explicit_flush = True
     response.write_status_headers()
 
     while True:
@@ -31,5 +30,4 @@ def main(request, response):
         response.writer.write(u"data:end")
         response.writer.write(u"\n\n")
 
-        response.writer.flush()
         time.sleep(2)

--- a/html/semantics/scripting-1/the-script-element/moving-between-documents/resources/moving-between-documents-iframe.py
+++ b/html/semantics/scripting-1/the-script-element/moving-between-documents/resources/moving-between-documents-iframe.py
@@ -47,7 +47,6 @@ def main(request, response):
   response.writer.write(u"%x\r\n" % len(body))
   response.writer.write(body)
   response.writer.write(u"\r\n")
-  response.writer.flush()
 
   body = u""
 
@@ -101,4 +100,3 @@ def main(request, response):
 
   response.writer.write(u"0\r\n")
   response.writer.write(u"\r\n")
-  response.writer.flush()

--- a/resource-timing/SyntheticResponse.py
+++ b/resource-timing/SyntheticResponse.py
@@ -43,8 +43,6 @@ def main(request, response):
                 response.writer.end_headers()
             else:
                 statusSent = True
-        elif arg == b"flush":
-            response.writer.flush()
 
 #        else:
 #            error "  INVALID ARGUMENT %s" % arg

--- a/service-workers/service-worker/navigation-preload/resources/chunked-encoding-scope.py
+++ b/service-workers/service-worker/navigation-preload/resources/chunked-encoding-scope.py
@@ -14,7 +14,6 @@ def main(request, response):
             response.writer.write(u"%s\n%s\n" % (len(str(idx)), idx))
         else:
             response.writer.write(u"%s\r\n%s\r\n" % (len(str(idx)), idx))
-        response.writer.flush()
         time.sleep(0.001)
 
     response.writer.write(u"0\r\n\r\n")

--- a/service-workers/service-worker/resources/invalid-chunked-encoding-with-flush.py
+++ b/service-workers/service-worker/resources/invalid-chunked-encoding-with-flush.py
@@ -5,7 +5,5 @@ def main(request, response):
     response.write_status_headers()
 
     time.sleep(1)
-    response.explicit_flush = True
 
     response.writer.write(b"XX\r\n\r\n")
-    response.writer.flush()

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -718,7 +718,7 @@ class ResponseWriter(object):
         for name, f in [("Server", self._handler.version_string),
                         ("Date", self._handler.date_time_string)]:
             if not self._seen_header(name):
-                sucess = self.write_header(name, f())
+                success = self.write_header(name, f())
 
         if (isinstance(self._response.content, (binary_type, text_type)) and
             not self._seen_header("content-length")):

--- a/xhr/resources/echo-method.py
+++ b/xhr/resources/echo-method.py
@@ -14,4 +14,3 @@ Content-type: text/plain
 Content-Length: {}
 
 {}'''.format(len(content), content))
-    response.writer.flush()


### PR DESCRIPTION
The reliable way to detect aliveness of a socket is to check
wfile.write(). flush() is either not necessary (in Python 2)
or non-functional (in Python 3), and should be removed for clarity.

Detailed explaination can be found at:
https://github.com/web-platform-tests/wpt/issues/24719