### PR TITLE
Read and write state file as binary

### DIFF
--- a/tools/wptrunner/wptrunner/update/state.py
+++ b/tools/wptrunner/wptrunner/update/state.py
@@ -97,7 +97,7 @@ class SavedState(BaseState):
         try:
             if not os.path.isfile(cls.filename):
                 return None
-            with open(cls.filename) as f:
+            with open(cls.filename, "rb") as f:
                 try:
                     rv = pickle.load(f)
                     logger.debug("Loading data %r" % (rv._data,))
@@ -111,7 +111,7 @@ class SavedState(BaseState):
 
     def save(self):
         """Write the state to disk"""
-        with open(self.filename, "w") as f:
+        with open(self.filename, "wb") as f:
             pickle.dump(self, f)
 
     def clear(self):


### PR DESCRIPTION
This stores a pickle of the current state, so it clearly ought to be read and
written in binary mode