### PR TITLE
Safer style reset for abspos dialog layout tests

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/abspos-dialog-layout.html
+++ b/html/semantics/interactive-elements/the-dialog-element/abspos-dialog-layout.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset=utf-8>
 <meta name="viewport" content="user-scalable=no">
 <title>Tests layout of absolutely positioned modal dialogs.</title>
 <script src="/resources/testharness.js"></script>
@@ -55,6 +56,8 @@ function checkVerticallyCentered(dialog) {
 
 function reset() {
     document.body.style.width = "auto";
+    dialog.style.top = null;
+    dialog.style.height = null;
     if (dialog.open)
         dialog.close();
     dialog.remove();
@@ -104,9 +107,6 @@ test(function() {
     dialog.style.height = '20000px';
     dialog.showModal();
     assert_equals(dialog.getBoundingClientRect().top, 0);
-
-    // Set back original value to 'height'.
-    dialog.style.height = 'fit-content';
 }, "A tall dialog should be positioned at the top of the viewport.");
 
 test(function() {
@@ -167,9 +167,6 @@ test(function() {
     dialog.close();
     dialog.showModal();
     assert_equals(dialog.getBoundingClientRect().top, expectedTop);
-
-    // Set back original value to 'top'.
-    dialog.style.top = '0';
 }, "Dialog's specified position should survive after close() and showModal().");
 
 test(function() {


### PR DESCRIPTION
As written, if these tests fail, then the line to reset back to the initial state never runs, leading to the style changes bleeding between tests. This happens to not cause any issues currently, but might pose a risk if more tests are added.

There's already a cleanup step that is guaranteed to run after every test, so it's better to move the style resets to run as part of that.

Also, setting `height = 'fit-content'` is a silent no-op in browsers that don't support `fit-content` (or support it with a prefix, like `-moz-fit-content`), so the best way to reset back to default styles is to assign `null`.

/cc @bfgeek 