### PR TITLE
Fix ordering mismatch in trailing-ogham-003.html

### DIFF
--- a/css/css-text/white-space/trailing-ogham-003.html
+++ b/css/css-text/white-space/trailing-ogham-003.html
@@ -18,6 +18,6 @@ div {
 
 <p>Test passes if the content of the blue and orange boxes is identical to that of the black box.
 
-<div class=end-of-element>᚛ᚑᚌᚐᚋ᚜<br>᚛ᚑᚌᚐᚋ᚜&#x1680;</div>
 <div class=br>᚛ᚑᚌᚐᚋ᚜&#x1680;<br>᚛ᚑᚌᚐᚋ᚜</div>
+<div class=end-of-element>᚛ᚑᚌᚐᚋ᚜<br>᚛ᚑᚌᚐᚋ᚜&#x1680;</div>
 <div class=ref>᚛ᚑᚌᚐᚋ᚜<br>᚛ᚑᚌᚐᚋ᚜</div>


### PR DESCRIPTION
The order of the test elements (or, equivalently, the colors of their borders) are swapped relative to the reference, resulting in a spurious mismatch even if the text is rendered correctly.