### PR TITLE
[appmanifest] add display-override member tests

### DIFF
--- a/appmanifest/display-override-member/display-override-member-media-feature-browser-manual.html
+++ b/appmanifest/display-override-member/display-override-member-media-feature-browser-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Test "browser" in display-override member + media feature</title>
+<link rel="help" href="https://w3c.github.io/manifest/#dom-displaymodetype-browser" />
+<link rel="help" href="https://w3c.github.io/manifest/#the-display-mode-media-feature" />
+<link rel="manifest" href="display-override-member-media-feature-browser.webmanifest" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<h1>Test "browser" in display-override member + media feature</h1>
+<style>
+  .fail {
+    background-color: red;
+  }
+
+  @media all and (display-mode: browser) {
+    body {
+      background-color: green;
+    }
+  }
+</style>
+<script>
+const browser = matchMedia("(display-mode: browser)");
+
+browser.onchange = () => {
+  if (browser.matches) {
+    document.body.classList.remove("fail");
+  }
+}
+
+if (!browser.matches) {
+  document.body.classList.add("fail");
+}
+</script>
+<p>
+  To pass, the background color must be green after installing.
+</p>

--- a/appmanifest/display-override-member/display-override-member-media-feature-browser.webmanifest
+++ b/appmanifest/display-override-member/display-override-member-media-feature-browser.webmanifest
@@ -1,0 +1,3 @@
+{
+    "display_override": [ "browser" ]
+}

--- a/appmanifest/display-override-member/display-override-member-media-feature-browser.webmanifest.headers
+++ b/appmanifest/display-override-member/display-override-member-media-feature-browser.webmanifest.headers
@@ -1,0 +1,1 @@
+Content-Type: application/manifest+json; charset=utf-8

--- a/appmanifest/display-override-member/display-override-member-media-feature-fullscreen-manual.html
+++ b/appmanifest/display-override-member/display-override-member-media-feature-fullscreen-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Test "fullscreen" in display-override member + media feature</title>
+<link rel="help" href="https://w3c.github.io/manifest/#dom-displaymodetype-fullscreen" />
+<link rel="help" href="https://w3c.github.io/manifest/#the-display-mode-media-feature" />
+<link rel="manifest" href="display-override-member-media-feature-fullscreen.webmanifest" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<h1>Test "fullscreen" in display-override member + media feature</h1>
+<style>
+  .fail {
+    background-color: red;
+  }
+
+  @media all and (display-mode: fullscreen) {
+    body {
+      background-color: green;
+    }
+  }
+</style>
+<script>
+const fullscreen = matchMedia("(display-mode: fullscreen)");
+
+fullscreen.onchange = () => {
+  if (fullscreen.matches) {
+    document.body.classList.remove("fail");
+  }
+}
+
+if (!fullscreen.matches) {
+  document.body.classList.add("fail");
+}
+</script>
+<p>
+  To pass, the background color must be green after installing.
+</p>

--- a/appmanifest/display-override-member/display-override-member-media-feature-fullscreen.webmanifest
+++ b/appmanifest/display-override-member/display-override-member-media-feature-fullscreen.webmanifest
@@ -1,0 +1,3 @@
+{
+    "display_override": [ "fullscreen" ]
+}

--- a/appmanifest/display-override-member/display-override-member-media-feature-fullscreen.webmanifest.headers
+++ b/appmanifest/display-override-member/display-override-member-media-feature-fullscreen.webmanifest.headers
@@ -1,0 +1,1 @@
+Content-Type: application/manifest+json; charset=utf-8

--- a/appmanifest/display-override-member/display-override-member-media-feature-minimal-ui-manual.html
+++ b/appmanifest/display-override-member/display-override-member-media-feature-minimal-ui-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Test "minimal-ui" in display-override member + media feature</title>
+<link rel="help" href="https://w3c.github.io/manifest/#dom-displaymodetype-minimal-ui" />
+<link rel="help" href="https://w3c.github.io/manifest/#the-display-mode-media-feature" />
+<link rel="manifest" href="display-override-member-media-feature-minimal-ui.webmanifest" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<h1>Test "minimal-ui" in display-override member + media feature</h1>
+<style>
+  .fail {
+    background-color: red;
+  }
+
+  @media all and (display-mode: minimal-ui) {
+    body {
+      background-color: green;
+    }
+  }
+</style>
+<script>
+const minimalUi = matchMedia("(display-mode: minimal-ui)");
+
+minimalUi.onchange = () => {
+  if (minimalUi.matches) {
+    document.body.classList.remove("fail");
+  }
+}
+
+if (!minimalUi.matches) {
+  document.body.classList.add("fail");
+}
+</script>
+<p>
+  To pass, the background color must be green after installing.
+</p>

--- a/appmanifest/display-override-member/display-override-member-media-feature-minimal-ui.webmanifest
+++ b/appmanifest/display-override-member/display-override-member-media-feature-minimal-ui.webmanifest
@@ -1,0 +1,3 @@
+{
+    "display_override": [ "minimal-ui" ]
+}

--- a/appmanifest/display-override-member/display-override-member-media-feature-minimal-ui.webmanifest.headers
+++ b/appmanifest/display-override-member/display-override-member-media-feature-minimal-ui.webmanifest.headers
@@ -1,0 +1,1 @@
+Content-Type: application/manifest+json; charset=utf-8

--- a/appmanifest/display-override-member/display-override-member-media-feature-standalone-manual.html
+++ b/appmanifest/display-override-member/display-override-member-media-feature-standalone-manual.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Test "standalone" in display-override member + media feature</title>
+<link rel="help" href="https://w3c.github.io/manifest/#the-display-mode-media-feature" />
+<link rel="help" href="https://w3c.github.io/manifest/#dom-displaymodetype-standalone" />
+<link rel="manifest" href="display-override-member-media-feature-standalone.webmanifest" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<h1>Test "standalone" in display-override member + media feature</h1>
+<style>
+  .fail {
+    background-color: red;
+  }
+
+  @media all and (display-mode: standalone) {
+    body {
+      background-color: green;
+    }
+  }
+</style>
+<script>
+const standalone = matchMedia("(display-mode: standalone)");
+
+standalone.onchange = () => {
+  if (standalone.matches) {
+    document.body.classList.remove("fail");
+  }
+}
+
+if (!standalone.matches) {
+  document.body.classList.add("fail");
+}
+</script>
+<p>
+  To pass, the background color must be green after installing.
+</p>

--- a/appmanifest/display-override-member/display-override-member-media-feature-standalone-overrides-browser-manual.html
+++ b/appmanifest/display-override-member/display-override-member-media-feature-standalone-overrides-browser-manual.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<title>Test "standalone" in display-override member + "browser" in display member + media feature</title>
+<link rel="help" href="https://w3c.github.io/manifest#display-member" />
+<link rel="help" href="https://w3c.github.io/manifest/#the-display-mode-media-feature" />
+<link rel="help" href="https://w3c.github.io/manifest/#dom-displaymodetype-browser" />
+<link rel="help" href="https://w3c.github.io/manifest/#dom-displaymodetype-standalone" />
+<link rel="manifest" href="display-override-member-media-feature-standalone-overrides-browser.webmanifest" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<h1>Test "standalone" in display-override member + "browser" in display member + media feature</h1>
+<style>
+  .fail {
+    background-color: red;
+  }
+
+  @media all and (display-mode: standalone) {
+    body {
+      background-color: green;
+    }
+  }
+</style>
+<script>
+const standalone = matchMedia("(display-mode: standalone)");
+
+standalone.onchange = () => {
+  if (standalone.matches) {
+    document.body.classList.remove("fail");
+  }
+}
+
+if (!standalone.matches) {
+  document.body.classList.add("fail");
+}
+</script>
+<p>
+  To pass, the background color must be green after installing.
+</p>

--- a/appmanifest/display-override-member/display-override-member-media-feature-standalone-overrides-browser.webmanifest
+++ b/appmanifest/display-override-member/display-override-member-media-feature-standalone-overrides-browser.webmanifest
@@ -1,0 +1,4 @@
+{
+    "display": "browser",
+    "display_override": [ "standalone" ]
+}

--- a/appmanifest/display-override-member/display-override-member-media-feature-standalone-overrides-browser.webmanifest.headers
+++ b/appmanifest/display-override-member/display-override-member-media-feature-standalone-overrides-browser.webmanifest.headers
@@ -1,0 +1,1 @@
+Content-Type: application/manifest+json; charset=utf-8

--- a/appmanifest/display-override-member/display-override-member-media-feature-standalone.webmanifest
+++ b/appmanifest/display-override-member/display-override-member-media-feature-standalone.webmanifest
@@ -1,0 +1,3 @@
+{
+    "display_override": [ "standalone" ]
+}

--- a/appmanifest/display-override-member/display-override-member-media-feature-standalone.webmanifest.headers
+++ b/appmanifest/display-override-member/display-override-member-media-feature-standalone.webmanifest.headers
@@ -1,0 +1,1 @@
+Content-Type: application/manifest+json; charset=utf-8


### PR DESCRIPTION
Adding manual WPT tests for new display-override field. 
PR to add new field to manifest spec is here: https://github.com/w3c/manifest/pull/932