### PR TITLE
Do not test non-exposed event constructors

### DIFF
--- a/dom/events/EventTarget-dispatchEvent.html
+++ b/dom/events/EventTarget-dispatchEvent.html
@@ -18,6 +18,12 @@ test(function() {
 }, "Calling dispatchEvent(null).")
 
 for (var alias in aliases) {
+  var  constructorName = aliases[alias];
+  if (!window[alias]) {
+    // The event isn't exposed, and this would trigger a "NotSupportedError" DOMException.
+    continue;
+  }
+  
   test(function() {
     var e = document.createEvent(alias)
     assert_equals(e.type, "", "Event type should be empty string before initialization")

--- a/dom/events/EventTarget-dispatchEvent.html
+++ b/dom/events/EventTarget-dispatchEvent.html
@@ -18,7 +18,7 @@ test(function() {
 }, "Calling dispatchEvent(null).")
 
 for (var alias in aliases) {
-  var  constructorName = aliases[alias];
+  var constructorName = aliases[alias];
   if (!window[alias]) {
     // The event isn't exposed, and this would trigger a "NotSupportedError" DOMException.
     continue;


### PR DESCRIPTION
As seen from https://wpt.fyi/results/dom/events/EventTarget-dispatchEvent.html?label=master&label=experimental&aligned all browsers fail TouchEvent for this test