### PR TITLE
Made more robust 4 background-size tests

### DIFF
--- a/css/css-backgrounds/background-size-006.html
+++ b/css/css-backgrounds/background-size-006.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>CSS Backgrounds and Borders Test: background-size - one &lt;length&gt; value</title>
     <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/"> <!-- 2012-11-09 -->
-    <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-size" title="3.9. Sizing Images: the 'background-size' property">
+    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/"> <!-- 2012-11-09 and 2020-11-18 -->
+    <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-size" title="3.9 Sizing Images: the 'background-size' property">
     <link rel="match" href="reference/background-size-006-ref.html">
     <meta name="flags" content="image">
     <meta name="assert" content="Check if 'background-size' has only one length value, then such value is the width of the corresponding image and the second value (corresponding to the height of the background image) is assumed to be 'auto'. An 'auto' value for one dimension is resolved by using the image's intrinsic ratio (in this test, the image's intrinsic ratio is 1:1) and (multiplied by) the size of the other dimension. Therefore the used height of the background-size in this test should be 45px.">
@@ -16,7 +16,7 @@
             width: 45px;
         }
         #test-overlapping-green {
-            background-image: url(support/60x60-green.png);
+            background-image: url(support/1x1-green.png);
             background-repeat: no-repeat;
             background-size: 45px;
             bottom: 45px;

--- a/css/css-backgrounds/background-size-009.html
+++ b/css/css-backgrounds/background-size-009.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>CSS Backgrounds and Borders Test: background-size - one &lt;percentage&gt; value</title>
     <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/"> <!-- 2012-11-09 -->
-    <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-size" title="3.9. Sizing Images: the 'background-size' property">
+    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/"> <!-- 2012-11-09 and 2020-11-18  -->
+    <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-size" title="3.9 Sizing Images: the 'background-size' property">
     <link rel="match" href="reference/background-size-006-ref.html">
     <meta name="flags" content="image">
     <meta name="assert" content="Check if 'background-size' has only one percentage value, then such value is the width of the corresponding image and the second value (corresponding to the height of the background image) is assumed to be 'auto'. A percentage is relative to the dimensions of the background positioning area. An 'auto' value for one dimension is resolved by using the image's intrinsic ratio (in this test, the image's intrinsic ratio is 1:1) and (multiplied by) the size of the other dimension. Therefore the used height of the background-size in this test should be 45px.">
@@ -16,7 +16,7 @@
             width: 45px;
         }
         #test-overlapping-green {
-            background-image: url(support/60x60-green.png);
+            background-image: url(support/1x1-green.png);
             background-repeat: no-repeat;
             background-size: 45%;
             bottom: 45px;

--- a/css/css-backgrounds/background-size-014.html
+++ b/css/css-backgrounds/background-size-014.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>CSS Backgrounds and Borders Test: background-size - one auto keyword and one &lt;percentage&gt; values</title>
     <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/"> <!-- 2012-11-09 -->
-    <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-size" title="3.9. Sizing Images: the 'background-size' property">
+    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/"> <!-- 2012-11-09 and 2020-11-18  -->
+    <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-size" title="3.9 Sizing Images: the 'background-size' property">
     <link rel="match" href="reference/background-size-006-ref.html">
     <meta name="flags" content="image">
     <meta name="assert" content="Check if 'background-size' has one 'auto' and one percentage values, then the second value is the height of the corresponding background image and the first value (corresponding to the width of the background image) is resolved by using the image's intrinsic ratio (in this test, the image's intrinsic ratio is 1:1) and (multiplied by) the size of the other dimension. A percentage is relative to the dimensions of the background positioning area. Therefore the used width of the background-size in this test should be 45px.">
@@ -16,7 +16,7 @@
             width: 45px;
         }
         #test-overlapping-green {
-            background-image: url(support/60x60-green.png);
+            background-image: url(support/1x1-green.png);
             background-repeat: no-repeat;
             background-size: auto 45%;
             bottom: 45px;

--- a/css/css-backgrounds/background-size-017.html
+++ b/css/css-backgrounds/background-size-017.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>CSS Backgrounds and Borders Test: background-size - one &lt;length&gt; and one &lt;percentage&gt; values</title>
     <link rel="author" title="Intel" href="http://www.intel.com">
-    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/"> <!-- 2012-11-09 -->
-    <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-size" title="3.9. Sizing Images: the 'background-size' property">
+    <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/"> <!-- 2012-11-09 and 2020-11-18  -->
+    <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-size" title="3.9 Sizing Images: the 'background-size' property">
     <link rel="match" href="reference/background-size-006-ref.html">
     <meta name="flags" content="image">
     <meta name="assert" content="Check if 'background-size' has one length and one percentage values, then such values are the width and height of the corresponding background image. Therefore the used width and height of the background-size in this test should be 45px and 45px.">
@@ -16,7 +16,7 @@
             width: 45px;
         }
         #test-overlapping-green {
-            background-image: url(support/60x60-green.png);
+            background-image: url(support/1x1-green.png);
             background-repeat: no-repeat;
             background-size: 45px 45%;
             bottom: 45px;


### PR DESCRIPTION
background-size-006.html
background-size-009.html
background-size-014.html
background-size-017.html

In all 4 tests: **if the background-size property or background-size declaration is not supported or implemented by an UA**, then the 4 tests will pass if we only read the pass-fail-conditions sentence: a green 60x60 square will be displayed... but it will fail when compare to reference file. Solution, improvement in the PR: change, replace 'background-image: url(support/60x60-green.png)' with 'background-image: url(support/1x1-green.png)' so that **a filled 45x45 red square is displayed** along with a tiny 1x1 green square. The modifications in this patch **make things more clear for a human tester if and when the 4 tests fail**.