### PR TITLE
worklets/resources/set-cookie.py fails to set cookies when same-origin

### DIFF
--- a/worklets/resources/set-cookie.py
+++ b/worklets/resources/set-cookie.py
@@ -1,9 +1,12 @@
 def main(request, response):
     name = request.GET.first(b"name")
     value = request.GET.first(b"value")
-    source_origin = request.headers.get(b"origin", None)
+    source_origin = request.headers.get(b"Origin", None)
 
     response_headers = [(b"Set-Cookie", name + b"=" + value),
-                        (b"Access-Control-Allow-Origin", source_origin),
                         (b"Access-Control-Allow-Credentials", b"true")]
+
+    if source_origin:
+        response_headers.append((b"Access-Control-Allow-Origin", source_origin))
+
     return (200, response_headers, u"")


### PR DESCRIPTION
It expects the "Origin" header to be present on the request but this is
not the case for same-origin requests. This is causing all same-origin
subtests in worklets/audio-worklet-credentials.https.html to fail in
Chrome.