### PR TITLE
Update Safari Technology Preview to 116

### DIFF
--- a/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/eventOrder.html.ini
@@ -1,3 +1,3 @@
 [eventOrder.html]
   expected:
-    if product == "safari" or product == "epiphany" or product == "webkit": ERROR
+    if product == "epiphany" or product == "webkit": ERROR

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPoints.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPoints.html.ini
@@ -1,3 +1,7 @@
 [multiTouchPoints.html]
   expected:
-    if product == "firefox" or product == "safari" or product == "epiphany" or product == "webkit": ERROR
+    if product == "firefox" or product == "epiphany" or product == "webkit": ERROR
+
+  [TestDriver actions: two touch points with one moving one pause]
+    expected:
+      if product == "safari": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsReleaseFirstPoint.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsReleaseFirstPoint.html.ini
@@ -1,3 +1,7 @@
 [multiTouchPointsReleaseFirstPoint.html]
   expected:
-    if product == "firefox" or product == "safari": ERROR
+    if product == "firefox": ERROR
+
+  [TestDriver actions: two touch points with one moving one pause]
+    expected:
+      if product == "safari": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsReleaseSecondPoint.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsReleaseSecondPoint.html.ini
@@ -1,3 +1,7 @@
 [multiTouchPointsReleaseSecondPoint.html]
   expected:
-    if product == "firefox" or product == "safari": ERROR
+    if product == "firefox": ERROR
+
+  [TestDriver actions: two touch points with one moving one pause]
+    expected:
+      if product == "safari": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsTwoTouchStarts.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsTwoTouchStarts.html.ini
@@ -1,3 +1,7 @@
 [multiTouchPointsTwoTouchStarts.html]
-   expected:
-     if product == "firefox" or product == "safari": ERROR
+  expected:
+    if product == "firefox": ERROR
+
+  [TestDriver actions: two touch points with one moving one pause]
+    expected:
+      if product == "safari": FAIL

--- a/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsWithPause.html.ini
+++ b/infrastructure/metadata/infrastructure/testdriver/actions/multiTouchPointsWithPause.html.ini
@@ -1,3 +1,7 @@
 [multiTouchPointsWithPause.html]
   expected:
-    if product == "firefox" or product == "safari": ERROR
+    if product == "firefox": ERROR
+
+  [TestDriver actions: two touch points with one moving one pause]
+    expected:
+      if product == "safari": FAIL

--- a/tools/ci/azure/safari-technology-preview.rb
+++ b/tools/ci/azure/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask "safari-technology-preview" do
   if MacOS.version <= :catalina
-    version "115,001-62651-20201022-6cd92e18-bfbe-48cc-9385-d84da8f3c24c"
-    sha256 "e4b29ac2a0d60e48bae7d9c635853ff7dadc59a82dd53f340b623eeb5538f657"
+    version "116,001-82546-20201119-d46bca22-a3dc-43c3-9fcf-29f7343956ac"
+    sha256 "37a631632e2d449ce5dfb117d0eb7fd14574f00ca306c27667ffbbe6b1c0bc68"
   else
-    version "115,001-62679-20201022-42e0d63a-527a-45af-beb1-02cd4095e341"
-    sha256 "815276ca814e49a6b2e8eb8429d6e6644de2db89527fbbce83cb9d69f54783f7"
+    version "116,001-69966-20201119-d87990cd-c094-40a8-a616-a4497506caed"
+    sha256 "64b82eb45729ee366272da25849039762c5382373ebedbad30168d80a06ec6b7"
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"


### PR DESCRIPTION
Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 116, 15611.1.5.3)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=2377&view=logs