### PR TITLE
[wptrunner] Fix bug in testdriver-extra.js

### DIFF
--- a/infrastructure/testdriver/click-multiple.html
+++ b/infrastructure/testdriver/click-multiple.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver multiple consecutive clicks</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<button type="button" id="button1">Button 1</button>
+<button type="button" id="button2">Button 2</button>
+<button type="button" id="button3">Button 3</button>
+
+<script>
+buttons = [
+  document.getElementById("button1"),
+  document.getElementById("button2"),
+  document.getElementById("button3"),
+];
+
+promise_test(async t => {
+  clicked = [false, false, false];
+  for (let i = 0; i < buttons.length; i++) {
+    buttons[i].addEventListener("click", () => {
+      clicked[i] = true;
+    });
+  }
+
+  await Promise.all([
+    test_driver.click(buttons[0]),
+    test_driver.click(buttons[1]),
+    test_driver.click(buttons[2]),
+  ]);
+
+  assert_true(clicked[0]);
+  assert_true(clicked[1]);
+  assert_true(clicked[2]);
+});
+</script>

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -34,7 +34,7 @@
         } else if (data.type === "testdriver-complete") {
             const cmd_id = data.cmd_id;
             const [on_success, on_failure] = pending.get(cmd_id);
-            pending.clear(cmd_id);
+            pending.delete(cmd_id);
             const resolver = data.status === "success" ? on_success : on_failure;
             resolver(data);
             if (is_test_context) {


### PR DESCRIPTION
We accidentally used pending.clear(cmd_id) instead of
pending.delete(cmd_id). Map.clear doesn't actually take any arguments,
but of course this is javascript so it doesn't mind that we're passing
it extra arguments. This would then accidentally clear the entire map
rather than just delete the processed command.