### PR TITLE
[Python3] Make echo-content-escaped.py py3-compliant

### DIFF
--- a/FileAPI/file/resources/echo-content-escaped.py
+++ b/FileAPI/file/resources/echo-content-escaped.py
@@ -5,6 +5,8 @@ from wptserve.utils import isomorphic_encode
 # As a convenience, CRLF newlines are left as is.
 
 def escape_byte(byte):
+    # Iterating over a 'bytes' type gives ints, so convert to bytes.
+    byte = bytes([byte])
     if b"\0" <= byte <= b"\x1F" or byte >= b"\x7F":
         return b"\\x%02x" % ord(byte)
     if byte == b"\\":


### PR DESCRIPTION
Iterating over a 'bytes' object in Python gives ints, not bytes, and in
Python 3 it is a type error to compare ints to bytes like this method
does. Cast back to bytes to avoid the error.