### PR TITLE
Trying to improve selection-[ input | textarea ]-011 reference files

### DIFF
--- a/css/css-pseudo/reference/selection-input-011-ref.html
+++ b/css/css-pseudo/reference/selection-input-011-ref.html
@@ -19,6 +19,33 @@
     }
   </style>
 
+  <script>
+  function startReference()
+  {
+  document.getElementById("ref").focus();
+  /*
+  Some browsers, like Chromium 80+ or Safari 14+, will
+  transfer focus to a selected element like a text input
+  and therefore style the border of such element according
+  to an user agent stylesheet rule, such as:
+  :focus {outline: -webkit-focus-ring-color auto 1px;} .
+  So, we deliberately trigger such focus with the focus()
+  method in the reference file.
+  */
+  document.getElementById("ref").style.caretColor = "yellow";
+  /*
+  When a text input element is focused in Firefox
+  82+, then the caret becomes visible and blinking and
+  it is painted with the ::selected's color which is
+  the green color in this case. We therefore counter,
+  neutralize this by resetting the caret's color to the
+  background color.
+  */
+  }
+  </script>
+
+  <body onload="startReference();">
+
   <p>Test passes if each glyph of "Selected Text" is green with a yellow background and if there is <strong>no red</strong>.
 
-  <div><input type="text" value="Selected Text"></div>
+  <div><input id="ref" type="text" value="Selected Text"></div>

--- a/css/css-pseudo/reference/selection-input-011-ref.html
+++ b/css/css-pseudo/reference/selection-input-011-ref.html
@@ -22,25 +22,28 @@
   <script>
   function startReference()
   {
-  document.getElementById("ref").focus();
-  /*
-  Some browsers, like Chromium 80+ or Safari 14+, will
-  transfer focus to a selected element like a text input
-  and therefore style the border of such element according
-  to an user agent stylesheet rule, such as:
-  :focus {outline: -webkit-focus-ring-color auto 1px;} .
-  So, we deliberately trigger such focus with the focus()
-  method in the reference file.
-  */
-  document.getElementById("ref").style.caretColor = "yellow";
-  /*
-  When a text input element is focused in Firefox
-  82+, then the caret becomes visible and blinking and
-  it is painted with the ::selected's color which is
-  the green color in this case. We therefore counter,
-  neutralize this by resetting the caret's color to the
-  background color.
-  */
+    /*
+    Some browsers, like Chromium 80+ or Safari 14+, will
+    transfer focus to a selected element like a text input
+    and therefore style the border of such element according
+    to an user agent stylesheet rule, such as:
+    :focus {outline: -webkit-focus-ring-color auto 1px;} .
+    So, we deliberately trigger such focus with the focus()
+    method in the reference file.
+    */
+
+    document.getElementById("ref").focus();
+
+    /*
+    When a text input element is focused in Firefox
+    82+, then the caret becomes visible and blinking and
+    it is painted with the ::selected's color which is
+    the green color in this case. We therefore counter,
+    neutralize this by resetting the caret's color to the
+    background color.
+    */
+
+    document.getElementById("ref").style.caretColor = "yellow";
   }
   </script>
 

--- a/css/css-pseudo/reference/selection-textarea-011-ref.html
+++ b/css/css-pseudo/reference/selection-textarea-011-ref.html
@@ -22,6 +22,33 @@
     }
   </style>
 
+  <script>
+  function startReference()
+  {
+  document.getElementById("ref").focus();
+  /*
+  Some browsers, like Chromium 80+ or Safari 14+, will
+  transfer focus to a selected element like a textarea
+  and therefore style the border of such element according
+  to an user agent stylesheet rule, such as:
+  :focus {outline: -webkit-focus-ring-color auto 1px;} .
+  So, we deliberately trigger such focus with the focus()
+  method in the reference file.
+  */
+  document.getElementById("ref").style.caretColor = "yellow";
+  /*
+  When a textarea element is focused in Firefox
+  82+, then the caret becomes visible and blinking and
+  it is painted with the ::selected's color which is
+  the green color in this case. We therefore counter,
+  neutralize this by resetting the caret's color to the
+  background color.
+  */
+  }
+  </script>
+
+  <body onload="startReference();">
+
   <p>Test passes if each glyph of both "Selected" is green with a yellow background and if there is <strong>no red</strong>.
 
-  <div><textarea rows="2" cols="8">Selected Selected </textarea></div>
+  <div><textarea id="ref" rows="2" cols="8">Selected Selected </textarea></div>

--- a/css/css-pseudo/reference/selection-textarea-011-ref.html
+++ b/css/css-pseudo/reference/selection-textarea-011-ref.html
@@ -25,25 +25,29 @@
   <script>
   function startReference()
   {
-  document.getElementById("ref").focus();
-  /*
-  Some browsers, like Chromium 80+ or Safari 14+, will
-  transfer focus to a selected element like a textarea
-  and therefore style the border of such element according
-  to an user agent stylesheet rule, such as:
-  :focus {outline: -webkit-focus-ring-color auto 1px;} .
-  So, we deliberately trigger such focus with the focus()
-  method in the reference file.
-  */
-  document.getElementById("ref").style.caretColor = "yellow";
-  /*
-  When a textarea element is focused in Firefox
-  82+, then the caret becomes visible and blinking and
-  it is painted with the ::selected's color which is
-  the green color in this case. We therefore counter,
-  neutralize this by resetting the caret's color to the
-  background color.
-  */
+    /*
+    Some browsers, like Chromium 80+ or Safari 14+, will
+    transfer focus to a selected element like a textarea
+    and therefore style the border of such element according
+    to an user agent stylesheet rule, such as:
+    :focus {outline: -webkit-focus-ring-color auto 1px;} .
+    So, we deliberately trigger such focus with the focus()
+    method in the reference file.
+    */
+
+    document.getElementById("ref").focus();
+
+    /*
+    When a textarea element is focused in Firefox
+    82+, then the caret becomes visible and blinking and
+    it is painted with the ::selected's color which is
+    the green color in this case. We therefore counter,
+    neutralize this by resetting the caret's color to the
+    background color.
+    */
+
+    document.getElementById("ref").style.caretColor = "yellow";
+
   }
   </script>
 


### PR DESCRIPTION
reference/selection-input-011-ref.html 
reference/selection-textarea-011-ref.html

The improvements in this PR are of the same nature 
as in: https://github.com/web-platform-tests/wpt/pull/26245

Browsers (Chromium, Firefox, Safari) do not behave exactly the same when select()-ing form control elements like a text input or a textarea.

The code involved in this PR aims at flattening, smoothing out the differences.

We deliberately focus the form controls (text input, 
textarea) in the reference files (with focus()) hoping 
to trigger the same user agent style sheet rule that
governs, that styles focusable elements, for example:

`:focus {outline: -webkit-focus-ring-color auto 1px;} `

which can be found in Chromium-based browsers.

Over at my website, the correspondent files are:

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/selection-input-011-newer.html

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/reference/selection-input-011-ref-newer.html

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/selection-textarea-011-newer.html

http://www.gtalbot.org/BrowserBugsSection/CSS4Pseudo/reference/selection-textarea-011-ref-newer.html