### PR TITLE
Fix echo-content-escaped.py again

### DIFF
--- a/FileAPI/file/resources/echo-content-escaped.py
+++ b/FileAPI/file/resources/echo-content-escaped.py
@@ -5,12 +5,15 @@ from wptserve.utils import isomorphic_encode
 # As a convenience, CRLF newlines are left as is.
 
 def escape_byte(byte):
-    # Iterating over a 'bytes' type gives ints, so convert to bytes.
-    byte = bytes([byte])
-    if b"\0" <= byte <= b"\x1F" or byte >= b"\x7F":
-        return b"\\x%02x" % ord(byte)
-    if byte == b"\\":
-        return b"\\\\"
+    # Iterating over a binary string gives different types in Py2 & Py3.
+    # Py3: bytes -> int
+    # Py2: str -> str (of length 1), so we convert it to int
+    if type(byte) is not int:
+        byte = ord(byte)
+    if 0 <= byte <= 0x1F or byte >= 0x7F:
+        return rb"\x%02x" % byte
+    if byte == ord(rb"\"):
+        return rb"\\"
     return byte
 
 def main(request, response):

--- a/FileAPI/file/resources/echo-content-escaped.py
+++ b/FileAPI/file/resources/echo-content-escaped.py
@@ -8,11 +8,10 @@ def escape_byte(byte):
     # Iterating over a binary string gives different types in Py2 & Py3.
     # Py3: bytes -> int
     # Py2: str -> str (of length 1), so we convert it to int
-    if type(byte) is not int:
-        byte = ord(byte)
-    if 0 <= byte <= 0x1F or byte >= 0x7F:
-        return b"\\x%02x" % byte
-    if byte == ord(b"\\"):
+    code = byte if type(byte) is int else ord(byte)
+    if 0 <= code <= 0x1F or code >= 0x7F:
+        return b"\\x%02x" % code
+    if code == ord(b"\\"):
         return b"\\\\"
     return byte
 

--- a/FileAPI/file/resources/echo-content-escaped.py
+++ b/FileAPI/file/resources/echo-content-escaped.py
@@ -11,9 +11,9 @@ def escape_byte(byte):
     if type(byte) is not int:
         byte = ord(byte)
     if 0 <= byte <= 0x1F or byte >= 0x7F:
-        return rb"\x%02x" % byte
-    if byte == ord(rb"\"):
-        return rb"\\"
+        return b"\\x%02x" % byte
+    if byte == ord(b"\\"):
+        return b"\\\\"
     return byte
 
 def main(request, response):


### PR DESCRIPTION
The fix in #26615 only works in Py3.

This time we make it compatible with Py2 & Py3.