### PR TITLE
[mediacapture-record] Add tests for MediaRecorder.start()

### DIFF
--- a/mediacapture-record/MediaRecorder-start.html
+++ b/mediacapture-record/MediaRecorder-start.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+  <title>MediaRecorder Start</title>
+  <link rel="help" href="https://w3c.github.io/mediacapture-record/MediaRecorder.html#dom-mediarecorder-start">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="200" height="200">
+</canvas>
+<script>
+    function createVideoStream() {
+        canvas.getContext('2d');
+        return canvas.captureStream();
+    }
+
+    test(t => {
+        const mimeType = [ 'audio/aac', 'audio/ogg', 'audio/webm' ].find(MediaRecorder.isTypeSupported);
+        const mediaRecorder = new MediaRecorder(createVideoStream(), {mimeType});
+        assert_throws_dom("NotSupportedError", () => mediaRecorder.start());
+    }, "MediaRecorder cannot record the stream using the current configuration");
+</script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a test for the `start()` method of a `MediaRecorder`. The test checks that it throws a `NotSupportedError` in case the given stream contains a track that can't be recorded with the specified `mimeType`.

The corresponding part of the spec is here: https://w3c.github.io/mediacapture-record/MediaRecorder.html#dom-mediarecorder-start

> 13. For each track in tracks, if the User Agent cannot record the track using the current configuration, then throw a NotSupportedError DOMException and abort these steps.

This is my first WPT contribution. Please let me know if there is anything I need to change.