### PR TITLE
[wptrunner/chromium] De-dupe merged expected statuses

### DIFF
--- a/tools/wptrunner/wptrunner/formatters/chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/chromium.py
@@ -172,7 +172,7 @@ class ChromiumFormatter(base.BaseFormatter):
         to the actual status if it's not.
 
         If the test has multiple statuses, it will have other statuses listed as
-        "known_intermittent" in |data|. If these exist, they will be appended to
+        "known_intermittent" in |data|. If these exist, they will be added to
         the returned status with spaced in between.
 
         :param str actual_status: the actual status of the test
@@ -181,8 +181,9 @@ class ChromiumFormatter(base.BaseFormatter):
         """
         expected_statuses = self._map_status_name(data["expected"]) if "expected" in data else actual_status
         if data.get("known_intermittent"):
-            expected_statuses += " " + " ".join(
-                [self._map_status_name(other_status) for other_status in data["known_intermittent"]])
+            all_statsues = {self._map_status_name(other_status) for other_status in data["known_intermittent"]}
+            all_statsues.add(expected_statuses)
+            expected_statuses = " ".join(sorted(all_statsues))
         return expected_statuses
 
     def suite_start(self, data):

--- a/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
+++ b/tools/wptrunner/wptrunner/formatters/tests/test_chromium.py
@@ -426,8 +426,8 @@ def test_flaky_test_expected(capfd):
     test_obj = output_json["tests"]["t1"]
     # The test's statuses are all mapped, changing ERROR->FAIL and OK->PASS
     assert test_obj["actual"] == "FAIL"
-    # All the possible statuses are concatenated together into expected.
-    assert test_obj["expected"] == "PASS FAIL TIMEOUT"
+    # All the possible statuses are merged and sorted together into expected.
+    assert test_obj["expected"] == "FAIL PASS TIMEOUT"
     # ...this is not a regression or unexpected because the actual status is one
     # of the expected ones
     assert "is_regression" not in test_obj
@@ -462,7 +462,7 @@ def test_flaky_test_unexpected(capfd):
     test_obj = output_json["tests"]["t1"]
     # The test's statuses are all mapped, changing ERROR->FAIL and OK->PASS
     assert test_obj["actual"] == "FAIL"
-    # All the possible statuses are concatenated together into expected.
+    # All the possible statuses are merged and sorted together into expected.
     assert test_obj["expected"] == "PASS TIMEOUT"
     # ...this is a regression and unexpected because the actual status is not
     # one of the expected ones
@@ -534,6 +534,37 @@ def test_known_intermittent_empty(capfd):
     # anywhere.
     assert test_obj["actual"] == "PASS"
     assert test_obj["expected"] == "PASS"
+
+
+def test_known_intermittent_duplicate(capfd):
+    # If the known_intermittent list already contains the expected status,
+    # we don't want to have duplicate statuses in the end.
+
+    # Set up the handler.
+    output = StringIO()
+    logger = structuredlog.StructuredLogger("test_a")
+    logger.add_handler(handlers.StreamHandler(output, ChromiumFormatter()))
+
+    # Note the known_intermittent list already contains the expected status.
+    logger.suite_start(["t1"], run_info={}, time=123)
+    logger.test_start("t1")
+    logger.test_end("t1", status="OK", expected="OK", known_intermittent=["OK", "ERROR"])
+    logger.suite_end()
+
+    # Check nothing got output to stdout/stderr.
+    # (Note that mozlog outputs exceptions during handling to stderr!)
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    # Check the actual output of the formatter.
+    output.seek(0)
+    output_json = json.load(output)
+
+    test_obj = output_json["tests"]["t1"]
+    assert test_obj["actual"] == "PASS"
+    # No duplicate "PASS" in "expected".
+    assert test_obj["expected"] == "FAIL PASS"
 
 
 def test_reftest_screenshots(capfd):


### PR DESCRIPTION
Merge expected and known_intermittent into a set and sort it to produce
stable, unique expected statuses.

* known_intermittent from mozlog seems to always include the expected
status, so we could technically just discard "expected", but using a set
is easy enough and may better guard against future surprises.