### PR TITLE
Pass fake path directly to cookieStore

### DIFF
--- a/cookie-store/cookieStore_delete_arguments.tentative.https.any.js
+++ b/cookie-store/cookieStore_delete_arguments.tentative.https.any.js
@@ -123,14 +123,8 @@ promise_test(async testCase => {
 }, 'cookieStore.delete with missing / at the end of path');
 
 promise_test(async testCase => {
-  const currentUrl = new URL(self.location.href);
-  const currentPath = currentUrl.pathname;
-  const currentDirectory =
-      currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
-  const invalidPath = currentDirectory.substr(1);
-
   await promise_rejects_js(testCase, TypeError, cookieStore.delete(
-      { name: 'cookie-name', path: invalidPath }));
+      { name: 'cookie-name', path: 'something/' }));
 }, 'cookieStore.delete with path that does not start with /');
 
 promise_test(async testCase => {


### PR DESCRIPTION
Hi!

I'm running the `cookieStore` tests from WPT against [a polyfill I'm maintaining](https://github.com/mkay581/cookie-store). I'm essentially pulling the cookie store tests into my repo and executing them there using the karma test runner.

The problem I'm facing is that I run the tests on a root URL that doesn't have a path and in the test `cookieStore.delete with path that does not start with /`, `invalidPath` gets set to an empty string. Passing `''` to `cookieStore.delete` doesn't throw an error and the test fails.

When I started to change the test, I figured we don't even need to do all the URL parsing since we simply want to pass a string to `cookieStore` that doesn't start with a forward slash and verify that an error is thrown.