### PR TITLE
Fixes #26055: Add a testdriver.js API to delete all cookies.

### DIFF
--- a/docs/writing-tests/testdriver.md
+++ b/docs/writing-tests/testdriver.md
@@ -124,6 +124,14 @@ Note that if the element to be clicked does not have a unique ID, the
 document must not have any DOM mutations made between the function
 being called and the promise settling.
 
+## delete_all_cookies
+
+Usage: `test_driver.delete_all_cookies(context=null)`
+ * _context_: an optional WindowProxy for the browsing context in which to
+              perform the call.
+
+This function deletes all cookies for the current browsing context.
+
 ### send_keys
 
 Usage: `test_driver.send_keys(element, keys)`

--- a/infrastructure/testdriver/delete_all_cookies.html
+++ b/infrastructure/testdriver/delete_all_cookies.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver delete_all_cookies method</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+promise_test(async t => {
+  document.cookie = "test1=1";
+  document.cookie = "test2=2; path=/";
+  document.cookie = "test3=3; path=/cookies/resources";
+
+  return test_driver.delete_all_cookies().then(() => {
+    assert_true(document.cookie === "");
+  });
+}, "DOM-set cookies get deleted");
+
+promise_test(async t => {
+  const cookie = "test1=1";
+  const encoded = encodeURIComponent(cookie);
+  await fetch(`/cookies/resources/cookie.py?set=${encoded}`)
+
+  const cookie2 = "test2=2; path=/";
+  const encoded2 = encodeURIComponent(cookie2);
+  await fetch(`/cookies/resources/cookie.py?set=${encoded2}`)
+
+  const cookie3 = "test3=3; path=/cookies/resources";
+  const encoded3 = encodeURIComponent(cookie3);
+  await fetch(`/cookies/resources/cookie.py?set=${encoded3}`)
+
+  const cookie4 = "test4=4; HttpOnly";
+  const encoded4 = encodeURIComponent(cookie4);
+  await fetch(`/cookies/resources/cookie.py?set=${encoded4}`)
+
+  return test_driver.delete_all_cookies().then(() => {
+    assert_true(document.cookie === "");
+  });
+}, "HTTP-set cookies get deleted");
+</script>

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -147,6 +147,24 @@
         },
 
         /**
+         * Deletes all cookies.
+         *
+         * This matches the behaviour of the {@link
+         * https://w3c.github.io/webdriver/#delete-all-cookies|WebDriver
+         * Delete All Cookies command}.
+         *
+         * @param {WindowProxy} context - Browsing context in which
+         *                                to run the call, or null for the current
+         *                                browsing context.
+         *
+         * @returns {Promise} fulfilled after cookies are deleted, or rejected in
+         *                    the cases the WebDriver command errors
+         */
+        delete_all_cookies: function(context=null) {
+            return window.test_driver_internal.delete_all_cookies(context);
+        },
+
+        /**
          * Send keys to an element
          *
          * This matches the behaviour of the {@link
@@ -456,6 +474,10 @@
             return new Promise(function(resolve, reject) {
                 element.addEventListener("click", resolve);
             });
+        },
+
+        delete_all_cookies: function(context=null) {
+            return Promise.reject(new Error("unimplemented"));
         },
 
         send_keys: function(element, keys) {

--- a/tools/wptrunner/wptrunner/executors/actions.py
+++ b/tools/wptrunner/wptrunner/executors/actions.py
@@ -13,6 +13,18 @@ class ClickAction(object):
         self.protocol.click.element(element)
 
 
+class DeleteAllCookiesAction(object):
+    name = "delete_all_cookies"
+
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        self.logger.debug("Deleting all cookies")
+        self.protocol.cookies.delete_all_cookies()
+
+
 class SendKeysAction(object):
     name = "send_keys"
 
@@ -171,6 +183,7 @@ class SetUserVerifiedAction(object):
 
 
 actions = [ClickAction,
+           DeleteAllCookiesAction,
            SendKeysAction,
            ActionSequenceAction,
            GenerateTestReportAction,

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -33,6 +33,7 @@ from .protocol import (ActionSequenceProtocolPart,
                        StorageProtocolPart,
                        SelectorProtocolPart,
                        ClickProtocolPart,
+                       CookiesProtocolPart,
                        SendKeysProtocolPart,
                        TestDriverProtocolPart,
                        CoverageProtocolPart,
@@ -436,6 +437,15 @@ class MarionetteClickProtocolPart(ClickProtocolPart):
         return element.click()
 
 
+class MarionetteCookiesProtocolPart(CookiesProtocolPart):
+    def setup(self):
+        self.marionette = self.parent.marionette
+
+    def delete_all_cookies(self):
+        self.logger.info("Deleting all cookies")
+        return self.marionette.delete_all_cookies()
+
+
 class MarionetteSendKeysProtocolPart(SendKeysProtocolPart):
     def setup(self):
         self.marionette = self.parent.marionette
@@ -623,6 +633,7 @@ class MarionetteProtocol(Protocol):
                   MarionetteStorageProtocolPart,
                   MarionetteSelectorProtocolPart,
                   MarionetteClickProtocolPart,
+                  MarionetteCookiesProtocolPart,
                   MarionetteSendKeysProtocolPart,
                   MarionetteActionSequenceProtocolPart,
                   MarionetteTestDriverProtocolPart,

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -19,6 +19,7 @@ from .protocol import (BaseProtocolPart,
                        Protocol,
                        SelectorProtocolPart,
                        ClickProtocolPart,
+                       CookiesProtocolPart,
                        SendKeysProtocolPart,
                        ActionSequenceProtocolPart,
                        TestDriverProtocolPart)
@@ -183,6 +184,15 @@ class SeleniumClickProtocolPart(ClickProtocolPart):
         return element.click()
 
 
+class SeleniumCookiesProtocolPart(CookiesProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def delete_all_cookies(self):
+        self.logger.info("Deleting all cookies")
+        return self.webdriver.delete_all_cookies()
+
+
 class SeleniumSendKeysProtocolPart(SendKeysProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -219,6 +229,7 @@ class SeleniumProtocol(Protocol):
                   SeleniumTestharnessProtocolPart,
                   SeleniumSelectorProtocolPart,
                   SeleniumClickProtocolPart,
+                  SeleniumCookiesProtocolPart,
                   SeleniumSendKeysProtocolPart,
                   SeleniumTestDriverProtocolPart,
                   SeleniumActionSequenceProtocolPart]

--- a/tools/wptrunner/wptrunner/executors/executorwebdriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebdriver.py
@@ -20,6 +20,7 @@ from .protocol import (BaseProtocolPart,
                        Protocol,
                        SelectorProtocolPart,
                        ClickProtocolPart,
+                       CookiesProtocolPart,
                        SendKeysProtocolPart,
                        ActionSequenceProtocolPart,
                        TestDriverProtocolPart,
@@ -190,6 +191,15 @@ class WebDriverClickProtocolPart(ClickProtocolPart):
         return element.click()
 
 
+class WebDriverCookiesProtocolPart(CookiesProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def delete_all_cookies(self):
+        self.logger.info("Deleting all cookies")
+        return self.webdriver.send_session_command("DELETE", "cookie")
+
+
 class WebDriverSendKeysProtocolPart(SendKeysProtocolPart):
     def setup(self):
         self.webdriver = self.parent.webdriver
@@ -288,6 +298,7 @@ class WebDriverProtocol(Protocol):
                   WebDriverTestharnessProtocolPart,
                   WebDriverSelectorProtocolPart,
                   WebDriverClickProtocolPart,
+                  WebDriverCookiesProtocolPart,
                   WebDriverSendKeysProtocolPart,
                   WebDriverActionSequenceProtocolPart,
                   WebDriverTestDriverProtocolPart,

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -281,6 +281,18 @@ class ClickProtocolPart(ProtocolPart):
         pass
 
 
+class CookiesProtocolPart(ProtocolPart):
+    """Protocol part for managing cookies"""
+    __metaclass__ = ABCMeta
+
+    name = "cookies"
+
+    @abstractmethod
+    def delete_all_cookies(self):
+        """Delete all cookies."""
+        pass
+
+
 class SendKeysProtocolPart(ProtocolPart):
     """Protocol part for performing trusted clicks"""
     __metaclass__ = ABCMeta

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -169,6 +169,10 @@
         return create_action("click", {selector, context});
     };
 
+    window.test_driver_internal.delete_all_cookies = function(context=null) {
+        return create_action("delete_all_cookies", {context});
+    };
+
     window.test_driver_internal.send_keys = function(element, keys) {
         const selector = get_selector(element);
         const context = get_context(element);


### PR DESCRIPTION
This does not implement everything from https://w3c.github.io/webdriver/#cookies,
but it shouldn't be hard to add if needed.