### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=219270

### DIFF
--- a/html/browsers/history/the-location-interface/location-prevent-extensions.html
+++ b/html/browsers/history/the-location-interface/location-prevent-extensions.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>[[PreventExtensions]] on a Location object should return false</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/history.html#location-preventextensions">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  assert_throws_js(TypeError, () => {
+    Object.preventExtensions(location);
+  });
+}, "Object.preventExtensions throws a TypeError");
+
+test(() => {
+  assert_false(Reflect.preventExtensions(location));
+}, "Reflect.preventExtensions returns false");
+</script>

--- a/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
+++ b/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
@@ -379,7 +379,11 @@ addTest(function(win) {
                    "preventExtensions on cross-origin Window should throw");
   assert_throws_js(TypeError, function() { Object.preventExtensions(win.location) },
                    "preventExtensions on cross-origin Location should throw");
-}, "[[PreventExtensions]] should throw for cross-origin objects");
+  assert_false(Reflect.preventExtensions(win),
+              "Reflect.preventExtensions on cross-origin Window");
+  assert_false(Reflect.preventExtensions(win.location),
+              "Reflect.preventExtensions on cross-origin Location");
+}, "[[PreventExtensions]] should return false cross-origin objects");
 
 /*
  * [[GetOwnProperty]]

--- a/html/browsers/the-windowproxy-exotic-object/windowproxy-prevent-extensions.html
+++ b/html/browsers/the-windowproxy-exotic-object/windowproxy-prevent-extensions.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>[[PreventExtensions]] on a WindowProxy object should return false</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-preventextensions">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  assert_throws_js(TypeError, () => {
+    Object.preventExtensions(window);
+  });
+}, "Object.preventExtensions throws a TypeError");
+
+test(() => {
+  assert_false(Reflect.preventExtensions(window));
+}, "Reflect.preventExtensions returns false");
+</script>


### PR DESCRIPTION
This upstream reviewed change adds coverage for `Reflect.preventExtensions` with [`Location`](https://html.spec.whatwg.org/multipage/history.html#location-preventextensions) and [`WindowProxy`](https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-preventextensions) objects.