### PR TITLE
Test top-level await in worklets

### DIFF
--- a/css/css-paint-api/top-level-await-ref.html
+++ b/css/css-paint-api/top-level-await-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<canvas id="output" width="100" height="100" style="background: blue;"></canvas>
+<script>
+"use strict";
+const canvas = document.getElementById('output');
+const ctx = canvas.getContext('2d');
+
+ctx.fillStyle = 'green';
+ctx.fillRect(0, 0, 100, 100);
+</script>

--- a/css/css-paint-api/top-level-await.https.html
+++ b/css/css-paint-api/top-level-await.https.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="help" href="https://html.spec.whatwg.org/#calling-scripts">
+<link rel="match" href="top-level-await-ref.html">
+<style>
+#output {
+    width: 100px;
+    height: 100px;
+    background-image: paint(rects);
+    background-color: blue;
+}
+</style>
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/worklet-reftest.js"></script>
+<body>
+<div id="output"></div>
+
+<script id="code" type="text/worklet">
+// This will cause a syntax error, and the paint processor will never get registered, in browsers
+// without top-level await support.
+await 1;
+
+registerPaint('rects', class {
+    async paint(ctx, geom) {
+        ctx.fillStyle = 'green';
+        ctx.fillRect(0, 0, geom.width, geom.height);
+    }
+});
+</script>
+
+<script>
+"use strict";
+importWorkletAndTerminateTestAfterAsyncPaint(CSS.paintWorklet, document.getElementById('code').textContent);
+</script>


### PR DESCRIPTION
Similar to https://github.com/web-platform-tests/wpt/pull/26175.

I tried to test the question discussed in https://github.com/whatwg/html/pull/4352#issuecomment-731062956 but since there's no way to delay for longer than a microtask, and the microtask queue gets emptied at the end of running a worklet script anyway, I couldn't do so.