### PR TITLE
Remove CSS Transitions tests for discrete properties

### DIFF
--- a/css/css-transitions/support/properties.js
+++ b/css/css-transitions/support/properties.js
@@ -84,10 +84,13 @@ var values = {
             shadow: ['rgba(0,0,0,0.1) 5px 6px 7px', 'rgba(10,10,10,0.9) 5px 6px 7px']
         };
     },
-    'visibility': function() {
-        // http://www.w3.org/TR/CSS2/visufx.html#visibility
+    'auto': function(property) {
+        var types = properties[property] || unspecified_properties[property];
+        var val = values[types[0]](property);
+        var key = Object.keys(val).shift();
         return {
-            keyword: ['visible', 'hidden', {discrete: true}]
+            to: [val[key][1], 'auto'],
+            from: ['auto', val[key][1]]
         };
     },
     // types reqired for non-specified properties
@@ -138,19 +141,6 @@ var values = {
     'transform': function() {
         return {
             rotate: ['rotate(10deg)', 'rotate(20deg)']
-        };
-    },
-    'position': function() {
-        return {
-            'static to absolute': ['static', 'absolute', {discrete: true}],
-            'relative to absolute': ['relative', 'absolute', {discrete: true}],
-            'absolute to fixed': ['absolute', 'fixed', {discrete: true}]
-        };
-    },
-    'display': function() {
-        return {
-            'static to absolute': ['none', 'block', {discrete: true}],
-            'block to inline-block': ['block', 'inline-block', {discrete: true}]
         };
     }
 };
@@ -215,7 +205,6 @@ var properties = {
 
     'vertical-align': ['length', 'percentage'],
     'opacity': ['number[0,1]'],
-    'visibility': ['visibility'],
     'z-index': ['integer']
 };
 
@@ -265,9 +254,7 @@ var unspecified_properties = {
     'outline-radius-topleft': ['length', 'percentage'],
     'outline-radius-topright': ['length', 'percentage'],
     'outline-radius-bottomright': ['length', 'percentage'],
-    'outline-radius-bottomleft': ['length', 'percentage'],
-    'display': ['display'],
-    'position': ['position']
+    'outline-radius-bottomleft': ['length', 'percentage']
 };
 
 /*


### PR DESCRIPTION
Properties with a "discrete" animation type, such as "display", "position" and "visibility" cannot yield CSS Transitions, as specified by section 3 [Starting of transitions](https://drafts.csswg.org/css-transitions/#starting) of the CSS Transitions specification:

> When comparing the before-change style and after-change style for a given property, the property values are transitionable if they have an animation type that is neither not animatable nor discrete.

This addresses issue #26822 and is an issue found while fixing [WebKit bug 219692](https://bugs.webkit.org/show_bug.cgi?id=219692).