### PR TITLE
Fix a CORS test error

### DIFF
--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -16,7 +16,7 @@ function cors(desc, scheme, subdomain, port) {
     subdomain = subdomain || "";
     const sameorigin = !scheme;
     let base = "";
-    if (sameorigin) {
+    if (!sameorigin) {
         base = `${scheme}://${subdomain}${location.hostname}:${port}${dirname(location.pathname)}`;
     }
     async_test((t) => {

--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -6,22 +6,19 @@
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src=/common/util.js></script>
+<script src=/common/utils.js></script>
 <script src=support.js?pipe=sub></script>
 <div id=log></div>
 
 <script>
-function cors(desc, scheme, subdomain, port) {
-    port = port || location.port;
-    subdomain = subdomain || "";
+function cors(desc, scheme, subdomain = "", port = location.port) {
     const sameorigin = !scheme;
-    let base = "";
-    if (!sameorigin) {
-        base = `${scheme}://${subdomain}${location.hostname}:${port}${dirname(location.pathname)}`;
-    }
+    const base =
+        sameorigin ? "" : `${scheme}://${subdomain}${location.hostname}:${port}${dirname(location.pathname)}`;
+
     async_test((t) => {
         const client = new XMLHttpRequest();
-        client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=none&${token()}`);
+        client.open("GET", `${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=none&${token()}`);
         client.send();
 
         client.onload = t.step_func_done(() => {
@@ -35,7 +32,7 @@ function cors(desc, scheme, subdomain, port) {
 
     async_test((t) => {
         const client = new XMLHttpRequest();
-        client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&${token()}`);
+        client.open("GET", `${base}resources/cors-makeheader.py?get_value=hest_er_best&${token()}`);
         client.send();
 
         client.onload = t.step_func_done(() => {

--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -6,48 +6,43 @@
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src=/common/util.js></script>
 <script src=support.js?pipe=sub></script>
 <div id=log></div>
 
 <script>
-
-var counter = 0;
-
 function cors(desc, scheme, subdomain, port) {
-    if (!scheme) {
-        var url = "";
-    } else {
-        if (!port) {
-            port = location.port;
-        }
-        var url = scheme + "://" + (subdomain ? subdomain + "." : "") + location.hostname + ":" + port + dirname(location.pathname)
+    port = port || location.port;
+    subdomain = subdomain || "";
+    const sameorigin = !scheme;
+    let base = "";
+    if (sameorigin) {
+        base = `${scheme}://${subdomain}${location.hostname}:${port}${dirname(location.pathname)}`;
     }
-    async_test(desc).step(function() {
+    async_test((t) => {
         var client = new XMLHttpRequest();
-        this.count = counter++;
+        const url = `${base}resources/cors-makeheader.py?get_value=hest_er_best`
+        client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=none&${token()}`);
 
-        client.open("GET", url + "resources/cors-makeheader.py?get_value=hest_er_best&origin=none&" + this.count);
-
-        client.onreadystatechange = this.step_func(function(e) {
-            // First request, test that it fails with no origin
-            if (client.readyState < 4) return;
-            if (!url)
-                assert_true(client.response.indexOf("hest_er_best") != -1, "Got response");
-            else
-                assert_false(!!client.response, "Got CORS-disallowed response");
-
-            client = new XMLHttpRequest();
-            client.open("GET", url + "resources/cors-makeheader.py?get_value=hest_er_best&" + this.count);
-            client.onreadystatechange = this.step_func(function(e) {
-                // Second request, test that it passes with the allowed-origin
-                if (client.readyState < 4) return;
-                assert_true(client.response.indexOf("hest_er_best") != -1, "Got CORS-allowed response");
-                this.done();
-            });
-            client.send();
+        client.onload = t.step_func(() => {
+            assert_true(sameorigin, "Cross origin request must be rejected.");
+            assert_true(client.response.includes("hest_er_best"), "Got response");
         });
-        client.send();
-    });
+        client.onerror = t.step_func_done(() => {
+            assert_false(sameorigin, "Same origin request must be accepted.");
+        });
+    }, `${desc}: origin: none`);
+
+    async_test((t) => {
+        var client = new XMLHttpRequest();
+        const url = `${base}resources/cors-makeheader.py?get_value=hest_er_best`
+        client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=echo&${token()}`);
+
+        client.onload = t.step_func_done(() => {
+            assert_true(client.response.includes("hest_er_best"), "Got response");
+        });
+        client.onerror = t.unreached_func("Should be accepted");
+    }, `${desc}: origin: echo`);
 }
 
 cors("Same domain basic usage");

--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -31,18 +31,18 @@ function cors(desc, scheme, subdomain, port) {
         client.onerror = t.step_func_done(() => {
             assert_false(sameorigin, "Same origin request must be accepted.");
         });
-    }, `${desc}: origin: none`);
+    }, `${desc}, origin: none`);
 
     async_test((t) => {
         const client = new XMLHttpRequest();
         const url = `${base}resources/cors-makeheader.py?get_value=hest_er_best`
-        client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=echo&${token()}`);
+        client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&${token()}`);
 
         client.onload = t.step_func_done(() => {
             assert_true(client.response.includes("hest_er_best"), "Got response");
         });
         client.onerror = t.unreached_func("Should be accepted");
-    }, `${desc}: origin: echo`);
+    }, `${desc}, origin: echo`);
 }
 
 cors("Same domain basic usage");

--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -21,8 +21,8 @@ function cors(desc, scheme, subdomain, port) {
     }
     async_test((t) => {
         const client = new XMLHttpRequest();
-        const url = `${base}resources/cors-makeheader.py?get_value=hest_er_best`
         client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=none&${token()}`);
+        client.send();
 
         client.onload = t.step_func_done(() => {
             assert_true(sameorigin, "Cross origin request must be rejected.");
@@ -35,8 +35,8 @@ function cors(desc, scheme, subdomain, port) {
 
     async_test((t) => {
         const client = new XMLHttpRequest();
-        const url = `${base}resources/cors-makeheader.py?get_value=hest_er_best`
         client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&${token()}`);
+        client.send();
 
         client.onload = t.step_func_done(() => {
             assert_true(client.response.includes("hest_er_best"), "Got response");

--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -20,7 +20,7 @@ function cors(desc, scheme, subdomain, port) {
         base = `${scheme}://${subdomain}${location.hostname}:${port}${dirname(location.pathname)}`;
     }
     async_test((t) => {
-        var client = new XMLHttpRequest();
+        const client = new XMLHttpRequest();
         const url = `${base}resources/cors-makeheader.py?get_value=hest_er_best`
         client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=none&${token()}`);
 
@@ -34,7 +34,7 @@ function cors(desc, scheme, subdomain, port) {
     }, `${desc}: origin: none`);
 
     async_test((t) => {
-        var client = new XMLHttpRequest();
+        const client = new XMLHttpRequest();
         const url = `${base}resources/cors-makeheader.py?get_value=hest_er_best`
         client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=echo&${token()}`);
 

--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -24,7 +24,7 @@ function cors(desc, scheme, subdomain, port) {
         const url = `${base}resources/cors-makeheader.py?get_value=hest_er_best`
         client.open("GET",`${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=none&${token()}`);
 
-        client.onload = t.step_func(() => {
+        client.onload = t.step_func_done(() => {
             assert_true(sameorigin, "Cross origin request must be rejected.");
             assert_true(client.response.includes("hest_er_best"), "Got response");
         });

--- a/cors/resources/cors-makeheader.py
+++ b/cors/resources/cors-makeheader.py
@@ -3,7 +3,7 @@ import json
 from wptserve.utils import isomorphic_decode
 
 def main(request, response):
-    origin = request.GET.first(b"origin", request.headers.get(b'origin'))
+    origin = request.GET.first(b"origin", request.headers.get(b'origin') or b'none')
 
     if b"check" in request.GET:
         token = request.GET.first(b"token")


### PR DESCRIPTION
The following statement throws when "origin" is specified neither
via URL query nor request headers.

```
request.GET.first(b"origin", request.headers.get(b'origin'))
```

Fix that by using "none" as the default value.

Clean up cors/basic.htm.

Fixes #26849.