### PR TITLE
[css-flexbox] Use /fonts/ahem.css over similar support/ahem.css

### DIFF
--- a/css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001-ref.html
+++ b/css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001-ref.html
@@ -12,8 +12,7 @@
   <title>CSS Reftest Reference</title>
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css" />
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
     body {
       margin: 0;

--- a/css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001.html
+++ b/css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001.html
@@ -17,8 +17,7 @@
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-baselines">
   <link rel="match" href="flexbox-baseline-align-self-baseline-vert-001-ref.html">
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css" />
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
     body {
       margin: 0;

--- a/css/css-flexbox/flexbox-baseline-empty-001-ref.html
+++ b/css/css-flexbox/flexbox-baseline-empty-001-ref.html
@@ -10,8 +10,7 @@
   <title>CSS Reftest Reference</title>
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css" />
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
     body {
       font: 20px Ahem;

--- a/css/css-flexbox/flexbox-baseline-empty-001a.html
+++ b/css/css-flexbox/flexbox-baseline-empty-001a.html
@@ -20,8 +20,7 @@
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-baselines">
   <link rel="match" href="flexbox-baseline-empty-001-ref.html">
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css" />
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
     body {
       font: 20px Ahem;

--- a/css/css-flexbox/flexbox-baseline-empty-001b.html
+++ b/css/css-flexbox/flexbox-baseline-empty-001b.html
@@ -20,8 +20,7 @@
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-baselines">
   <link rel="match" href="flexbox-baseline-empty-001-ref.html">
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css" />
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
     body {
       font: 20px Ahem;

--- a/css/css-flexbox/flexbox-baseline-multi-item-vert-001-ref.html
+++ b/css/css-flexbox/flexbox-baseline-multi-item-vert-001-ref.html
@@ -12,8 +12,7 @@
   <title>CSS Reftest Reference</title>
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css" />
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
     body {
       margin: 0;

--- a/css/css-flexbox/flexbox-baseline-multi-item-vert-001a.html
+++ b/css/css-flexbox/flexbox-baseline-multi-item-vert-001a.html
@@ -18,8 +18,7 @@
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-baselines">
   <link rel="match" href="flexbox-baseline-multi-item-vert-001-ref.html">
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css" />
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
     body {
       margin: 0;

--- a/css/css-flexbox/flexbox-baseline-multi-item-vert-001b.html
+++ b/css/css-flexbox/flexbox-baseline-multi-item-vert-001b.html
@@ -18,8 +18,7 @@
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-baselines">
   <link rel="match" href="flexbox-baseline-multi-item-vert-001-ref.html">
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css" />
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
     body {
       margin: 0;

--- a/css/css-flexbox/flexbox-flex-basis-content-001-ref.html
+++ b/css/css-flexbox/flexbox-flex-basis-content-001-ref.html
@@ -8,8 +8,7 @@
   <title>CSS Reftest Reference</title>
   <meta charset="utf-8">
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-flex-basis-content-001a.html
+++ b/css/css-flexbox/flexbox-flex-basis-content-001a.html
@@ -12,8 +12,7 @@
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
   <link rel="match" href="flexbox-flex-basis-content-001-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-flex-basis-content-001b.html
+++ b/css/css-flexbox/flexbox-flex-basis-content-001b.html
@@ -13,8 +13,7 @@
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
   <link rel="match" href="flexbox-flex-basis-content-001-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-flex-basis-content-002-ref.html
+++ b/css/css-flexbox/flexbox-flex-basis-content-002-ref.html
@@ -8,8 +8,7 @@
   <title>CSS Reftest Reference</title>
   <meta charset="utf-8">
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-flex-basis-content-002a.html
+++ b/css/css-flexbox/flexbox-flex-basis-content-002a.html
@@ -12,8 +12,7 @@
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
   <link rel="match" href="flexbox-flex-basis-content-002-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-flex-basis-content-002b.html
+++ b/css/css-flexbox/flexbox-flex-basis-content-002b.html
@@ -13,8 +13,7 @@
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
   <link rel="match" href="flexbox-flex-basis-content-002-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-whitespace-handling-002-ref.xhtml
+++ b/css/css-flexbox/flexbox-whitespace-handling-002-ref.xhtml
@@ -12,7 +12,7 @@
   <head>
     <title>CSS Reftest Reference</title>
     <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com"/>
-    <link rel="stylesheet" type="text/css" href="support/ahem.css" />
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
     <style>
       div { height: 100px; }
       div.flexbox {

--- a/css/css-flexbox/flexbox-whitespace-handling-002.xhtml
+++ b/css/css-flexbox/flexbox-whitespace-handling-002.xhtml
@@ -14,7 +14,7 @@
     <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com"/>
     <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-items"/>
     <link rel="match" href="flexbox-whitespace-handling-002-ref.xhtml"/>
-    <link rel="stylesheet" type="text/css" href="support/ahem.css" />
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
     <style>
       div { height: 100px; }
       div.flexbox {

--- a/css/css-flexbox/flexbox-writing-mode-010-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-010-ref.html
@@ -8,8 +8,7 @@
   <title>CSS Reftest Reference</title>
   <meta charset="utf-8">
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: block;

--- a/css/css-flexbox/flexbox-writing-mode-010.html
+++ b/css/css-flexbox/flexbox-writing-mode-010.html
@@ -14,8 +14,7 @@
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
   <link rel="match" href="flexbox-writing-mode-010-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-writing-mode-011-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-011-ref.html
@@ -8,8 +8,7 @@
   <title>CSS Reftest Reference</title>
   <meta charset="utf-8">
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: block;

--- a/css/css-flexbox/flexbox-writing-mode-011.html
+++ b/css/css-flexbox/flexbox-writing-mode-011.html
@@ -14,8 +14,7 @@
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
   <link rel="match" href="flexbox-writing-mode-011-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-writing-mode-012-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-012-ref.html
@@ -8,8 +8,7 @@
   <title>CSS Reftest Reference</title>
   <meta charset="utf-8">
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: block;

--- a/css/css-flexbox/flexbox-writing-mode-012.html
+++ b/css/css-flexbox/flexbox-writing-mode-012.html
@@ -15,8 +15,7 @@
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
   <link rel="match" href="flexbox-writing-mode-012-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-writing-mode-013-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-013-ref.html
@@ -8,8 +8,7 @@
   <title>CSS Reftest Reference</title>
   <meta charset="utf-8">
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: block;

--- a/css/css-flexbox/flexbox-writing-mode-013.html
+++ b/css/css-flexbox/flexbox-writing-mode-013.html
@@ -14,8 +14,7 @@
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
   <link rel="match" href="flexbox-writing-mode-013-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-writing-mode-014-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-014-ref.html
@@ -8,8 +8,7 @@
   <title>CSS Reftest Reference</title>
   <meta charset="utf-8">
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: block;

--- a/css/css-flexbox/flexbox-writing-mode-014.html
+++ b/css/css-flexbox/flexbox-writing-mode-014.html
@@ -14,8 +14,7 @@
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
   <link rel="match" href="flexbox-writing-mode-014-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/flexbox-writing-mode-015-ref.html
+++ b/css/css-flexbox/flexbox-writing-mode-015-ref.html
@@ -8,8 +8,7 @@
   <title>CSS Reftest Reference</title>
   <meta charset="utf-8">
   <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: block;

--- a/css/css-flexbox/flexbox-writing-mode-015.html
+++ b/css/css-flexbox/flexbox-writing-mode-015.html
@@ -15,8 +15,7 @@
   <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
   <link rel="match" href="flexbox-writing-mode-015-ref.html">
-  <link rel="stylesheet" type="text/css" href="support/ahem.css">
-  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
   <style>
   .container {
     display: flex;

--- a/css/css-flexbox/support/ahem.css
+++ b/css/css-flexbox/support/ahem.css
@@ -1,4 +1,0 @@
-@font-face {
-  font-family: "Ahem";
-  src: url(/fonts/Ahem.ttf);
-}

--- a/lint.ignore
+++ b/lint.ignore
@@ -74,7 +74,6 @@ AHEM COPY: fonts/ahem-extra/AHEM_*.TTF
 # https://github.com/web-platform-tests/wpt/issues/8615
 AHEM COPY: css/vendor-imports/mozilla/mozilla-central-reftests/*/Ahem.ttf
 CSS-COLLIDING-SUPPORT-NAME: css/vendor-imports/mozilla/mozilla-central-reftests/*/ahem.css
-CSS-COLLIDING-SUPPORT-NAME: css/css-flexbox/support/ahem.css
 
 ## Test exclusions ##
 


### PR DESCRIPTION
As a drive-by fix, make use of XHTML-style `<link />` markup more
consistent within tests, usually dropping it.