### PR TITLE
Added 2 tests involving boundary between 2 characters

### DIFF
--- a/css/css-text/word-break/break-boundary-2-chars-001.html
+++ b/css/css-text/word-break/break-boundary-2-chars-001.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text Test: soft wrap opportunity at boundary between two characters</title>
+
+  <!--
+
+  CSS3 Text, §5.1 Line breaking details, 7th bullet, 2nd sentence
+  https://www.w3.org/TR/css-text-3/#line-break-details
+
+  "
+  For soft wrap opportunities defined by the boundary between
+  two characters, the white-space property on the nearest
+  common ancestor of the two characters controls breaking
+  "
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#word-break-property">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#line-break-details">
+  <link rel="match" href="reference/word-break/break-boundary-2-chars-001-ref.html">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that the word-break property does not apply to a run of text that is styled with 'white-space: pre' because the word-break property has no rendering effect in cases where lines of text are not allowed to break. Between the 'c' and 'x' and between the 'z' and 'd', there must be a line break because the 'white-space' declaration in effect in the nearest common ancestor of each of these pairs of two characters allows text wrapping." name="assert">
+
+  <style>
+  div
+    {
+      display: inline-block;
+      font-size: 32px;
+      margin-right: 5ch;
+      width: 0;
+      word-break: break-all;
+    }
+
+  span
+    {
+      white-space: pre;
+    }
+
+  div#first-sub-test
+    {
+      white-space: normal;
+    }
+
+  div#second-sub-test
+    {
+      white-space: pre-wrap;
+    }
+
+  div#third-sub-test
+    {
+      white-space: break-spaces;
+    }
+
+  div#fourth-sub-test
+    {
+      white-space: pre-line;
+    }
+  </style>
+
+  <div id="first-sub-test">abc<span>xyz</span>def</div><div id="second-sub-test">abc<span>xyz</span>def</div><div id="third-sub-test">abc<span>xyz</span>def</div><div id="fourth-sub-test">abc<span>xyz</span>def</div>

--- a/css/css-text/word-break/break-boundary-2-chars-001.html
+++ b/css/css-text/word-break/break-boundary-2-chars-001.html
@@ -20,7 +20,7 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#word-break-property">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#line-break-details">
-  <link rel="match" href="reference/word-break/break-boundary-2-chars-001-ref.html">
+  <link rel="match" href="reference/break-boundary-2-chars-001-ref.html">
 
   <meta content="" name="flags">
   <meta content="This test checks that the word-break property does not apply to a run of text that is styled with 'white-space: pre' because the word-break property has no rendering effect in cases where lines of text are not allowed to break. Between the 'c' and 'x' and between the 'z' and 'd', there must be a line break because the 'white-space' declaration in effect in the nearest common ancestor of each of these pairs of two characters allows text wrapping." name="assert">

--- a/css/css-text/word-break/break-boundary-2-chars-002.html
+++ b/css/css-text/word-break/break-boundary-2-chars-002.html
@@ -6,7 +6,7 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#word-break-property">
-  <link rel="match" href="reference/word-break/break-boundary-2-chars-002-ref.html">
+  <link rel="match" href="reference/break-boundary-2-chars-002-ref.html">
 
   <meta content="" name="flags">
   <meta content="The word-break property can only apply when the 'white-space' value allow text wrapping, when line breaking opportunities are preserved. Therefore, 'word-break: break-all' must not cause any text wrapping in both cases of this test. There must be no wrapping between the 'c' and the 'x' and there must be no wrapping between the 'z' and the 'd'." name="assert">

--- a/css/css-text/word-break/break-boundary-2-chars-002.html
+++ b/css/css-text/word-break/break-boundary-2-chars-002.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text Test: soft wrap opportunity at boundary between two characters</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#word-break-property">
+  <link rel="match" href="reference/word-break/break-boundary-2-chars-002-ref.html">
+
+  <meta content="" name="flags">
+  <meta content="The word-break property can only apply when the 'white-space' value allow text wrapping, when line breaking opportunities are preserved. Therefore, 'word-break: break-all' must not cause any text wrapping in both cases of this test. There must be no wrapping between the 'c' and the 'x' and there must be no wrapping between the 'z' and the 'd'." name="assert">
+
+  <!--
+
+  white-space values that DISallow text wrapping:
+  { pre , nowrap }
+
+  -->
+
+  <style>
+  div
+    {
+      display: inline-block;
+      font-size: 32px;
+      margin-right: 10ch;
+      width: 0;
+      word-break: normal;
+    }
+
+  span
+    {
+      word-break: break-all;
+    }
+
+  div#first-sub-test
+    {
+      white-space: pre;
+    }
+
+  div#second-sub-test
+    {
+      white-space: nowrap;
+    }
+  </style>
+
+  <div id="first-sub-test">abc<span>xyz</span>def</div>
+
+  <div id="second-sub-test">abc<span>xyz</span>def</div>

--- a/css/css-text/word-break/reference/break-boundary-2-chars-001-ref.html
+++ b/css/css-text/word-break/reference/break-boundary-2-chars-001-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      display: inline-block;
+      font-size: 32px;
+      margin-right: 5ch;
+      white-space: pre;
+      width: 0;
+    }
+  </style>
+
+  <div>a<br>b<br>c<br>xyz<br>d<br>e<br>f</div><div>a<br>b<br>c<br>xyz<br>d<br>e<br>f</div><div>a<br>b<br>c<br>xyz<br>d<br>e<br>f</div><div>a<br>b<br>c<br>xyz<br>d<br>e<br>f</div>

--- a/css/css-text/word-break/reference/break-boundary-2-chars-002-ref.html
+++ b/css/css-text/word-break/reference/break-boundary-2-chars-002-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      display: inline-block;
+      font-size: 32px;
+      margin-right: 10ch;
+      white-space: normal;
+      width: 0;
+    }
+
+  </style>
+
+  <div>abcxyzdef</div>
+
+  <div>abcxyzdef</div>


### PR DESCRIPTION
css/css-text/word-break/break-boundary-2-chars-001.html 
css/css-text/word-break/reference/break-boundary-2-chars-001-ref.html 
css/css-text/word-break/break-boundary-2-chars-002.html 
css/css-text/word-break/reference/break-boundary-2-chars-002-ref.html

I read [Issue 3897](https://github.com/w3c/csswg-drafts/issues/3897) and
I am able to come up with those 2 tests.

On my website, the files are:

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/word-break/break-boundary-2-chars-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/word-break/reference/break-boundary-2-chars-001-ref.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/word-break/break-boundary-2-chars-002.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/word-break/reference/break-boundary-2-chars-002-ref.html

Browser support:

Firefox 85.0a1 buildID=20201211093444 and Chromium 83.0.4103.116 pass break-boundary-2-chars-**001**.html 
Epiphany 3.32.1.2 (WebKitGTK+ 2.30.3) fails break-boundary-2-chars-**001**.html .

Chromium 83.0.4103.116 and Epiphany 3.32.1.2 (WebKitGTK+ 2.30.3) pass break-boundary-2-chars-**002**.html 
Firefox 85.0a1 buildID=20201211093444 fails break-boundary-2-chars-**002**.html .