### PR TITLE
Fix `wpt build-docs`

### DIFF
--- a/docs/commands.json
+++ b/docs/commands.json
@@ -3,6 +3,7 @@
     "path": "frontend.py",
     "script": "build",
     "help": "Build documentation",
+    "py3only": true,
     "virtualenv": true,
     "requirements": [
       "./requirements.txt"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,9 +92,10 @@ language = None
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
+    '**/.tox',
+    '**/.DS_Store',
+    '**/Thumbs.db',
     '_build',
-    'Thumbs.db',
-    '.DS_Store'
 ]
 
 from docs.wpt_lint_rules import WPTLintRules


### PR DESCRIPTION
1. Mark the command as py3only (since #26574).
2. Skip .tox, and fix other exclude patterns.