### PR TITLE
Remove 'Remote' concept in pr_preview.py

### DIFF
--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -107,35 +107,6 @@ class Project(object):
         self._github_project = github_project
 
     @guard('core')
-    def get_pull_request(self, number):
-        url = '{}/repos/{}/pulls/{}'.format(
-            self._host, self._github_project, number
-        )
-
-        logger.info('Fetching Pull Request %s', number)
-        return gh_request('GET', url)
-
-    @guard('search')
-    def get_pull_requests(self, updated_since):
-        window_start = time.strftime('%Y-%m-%dT%H:%M:%SZ', updated_since)
-        url = '{}/search/issues?q=repo:{}+is:pr+updated:>{}'.format(
-            self._host, self._github_project, window_start
-        )
-
-        logger.info(
-            'Searching for Pull Requests updated since %s', window_start
-        )
-
-        data = gh_request('GET', url)
-
-        logger.info('Found %d Pull Requests', len(data['items']))
-
-        if data['incomplete_results']:
-            raise Exception('Incomplete results')
-
-        return {pr['number']: pr for pr in data['items']}
-
-    @guard('core')
     def create_ref(self, refspec, revision):
         url = '{}/repos/{}/git/refs'.format(self._host, self._github_project)
 
@@ -147,6 +118,23 @@ class Project(object):
         })
 
     @guard('core')
+    def get_ref_revision(self, refspec):
+        url = '{}/repos/{}/git/refs/{}'.format(
+            self._host, self._github_project, refspec
+        )
+
+        logger.info('Fetching ref "%s"', refspec)
+
+        try:
+            body = gh_request('GET', url)
+            logger.info('Ref data: %s', json.dumps(body, indent=2))
+            return body['object']['sha']
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                return None
+            raise e
+
+    @guard('core')
     def update_ref(self, refspec, revision):
         url = '{}/repos/{}/git/refs/{}'.format(
             self._host, self._github_project, refspec
@@ -155,6 +143,16 @@ class Project(object):
         logger.info('Updating ref "%s" (%s)', refspec, revision)
 
         gh_request('PATCH', url, {'sha': revision})
+
+    @guard('core')
+    def delete_ref(self, refspec):
+        url = '{}/repos/{}/git/refs/{}'.format(
+            self._host, self._github_project, refspec
+        )
+
+        logger.info('Deleting ref "%s"', refspec)
+
+        gh_request('DELETE', url)
 
     @guard('core')
     def create_deployment(self, pull_request, revision):
@@ -206,73 +204,6 @@ class Project(object):
             'environment_url': environment_url
         }, 'application/vnd.github.ant-man-preview+json')
 
-class Remote(object):
-    def __init__(self, github_project):
-        # The repository in the GitHub Actions environment is configured with
-        # a remote whose URL uses unauthenticated HTTPS, making it unsuitable
-        # for pushing changes.
-        self._token = os.environ['GITHUB_TOKEN']
-
-    def _git(self, command):
-        return subprocess.check_output([
-            'git',
-            '-c',
-            'credential.username=github-actions',
-            '-c',
-            'credential.password={}'.format(self._token),
-        ] + command)
-
-    def get_revision(self, refspec):
-        output = self._git([
-            'ls-remote',
-            'origin',
-            'refs/{}'.format(refspec)
-        ])
-
-        if not output:
-            return None
-
-        return output.decode('utf-8').split()[0]
-
-    def delete_ref(self, refspec):
-        full_ref = 'refs/{}'.format(refspec)
-
-        logger.info('Deleting ref "%s"', refspec)
-
-        self._git([
-            'push',
-            'origin',
-            '--delete',
-            full_ref
-        ])
-
-    def get_pull_requests_with_open_ref(self):
-        '''Returns pull requests that have an open ref.
-
-        This checks for all refs that match the pattern 'refs/prs-open/{pr}',
-        and then returns them as a list of pull request numbers. Note that this
-        method does not query github; this is only the open pull requests as
-        far as WPT knows.
-        '''
-
-        refspec = 'refs/prs-open/*'
-
-        logger.info('Fetching all ref names matching "%s"', refspec)
-
-        output = self._git([
-            'ls-remote',
-            'origin',
-            refspec,
-        ])
-
-        if not output:
-            return []
-
-        ref_names = [line.split()[1] for line in output.decode('utf-8').splitlines()]
-        logger.info('%s ref names found', len(ref_names))
-        return [int(ref_name.split('/')[2]) for ref_name in ref_names]
-
-
 def is_open(pull_request):
     return not pull_request['closed_at']
 
@@ -306,7 +237,7 @@ def is_deployed(host, deployment):
     logger.info('Response text: %s', response.text.strip())
     return response.text.strip() == deployment['sha']
 
-def update_mirror_refs(project, remote, pull_request):
+def update_mirror_refs(project, pull_request):
     '''Update the WPT refs that control mirroring of this pull request.
 
     Two sets of refs are used to control wptpr.live's mirroring of pull
@@ -327,11 +258,10 @@ def update_mirror_refs(project, remote, pull_request):
         **pull_request
     )
     refspec_open = 'prs-open/{number}'.format(**pull_request)
-    revision_latest = remote.get_revision(
-        'pull/{number}/head'.format(**pull_request)
-    )
-    revision_trusted = remote.get_revision(refspec_trusted)
-    revision_open = remote.get_revision(refspec_open)
+
+    revision_latest = pull_request['head']['sha']
+    revision_trusted = project.get_ref_revision(refspec_trusted)
+    revision_open = project.get_ref_revision(refspec_open)
 
     if should_be_mirrored(project, pull_request):
         logger.info('Pull Request should be mirrored')
@@ -351,10 +281,10 @@ def update_mirror_refs(project, remote, pull_request):
     logger.info('Pull Request should not be mirrored')
 
     if not has_mirroring_label(pull_request) and revision_trusted is not None:
-        remote.delete_ref(refspec_trusted)
+        project.delete_ref(refspec_trusted)
 
     if revision_open is not None and not is_open(pull_request):
-        remote.delete_ref(refspec_open)
+        project.delete_ref(refspec_open)
 
     # No revision to be deployed to wptpr.live
     return None
@@ -394,7 +324,6 @@ def deploy(project, target, pull_request, revision, timeout):
 
 def main(host, github_project, target, timeout):
     project = Project(host, github_project)
-    remote = Remote(github_project)
 
     with open(os.environ['GITHUB_EVENT_PATH']) as handle:
         data = json.load(handle)
@@ -405,7 +334,7 @@ def main(host, github_project, target, timeout):
 
     logger.info('Processing Pull Request #%(number)d', pull_request)
 
-    revision_to_mirror = update_mirror_refs(project, remote, pull_request)
+    revision_to_mirror = update_mirror_refs(project, pull_request)
     if revision_to_mirror:
         deploy(project, target, pull_request, revision_to_mirror, timeout)
 

--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -12,7 +12,6 @@ import argparse
 import json
 import logging
 import os
-import subprocess
 import time
 
 import requests

--- a/tools/ci/tests/test_pr_preview.py
+++ b/tools/ci/tests/test_pr_preview.py
@@ -268,7 +268,7 @@ def deploy(pr_num, revision, expected_github_traffic, expected_preview_traffic):
 def test_update_mirror_refs_fail_rate_limited():
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
@@ -299,7 +299,7 @@ def test_synchronize_ignore_closed():
     # No existing refs, but a closed PR event comes in. Nothing should happen.
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
@@ -322,7 +322,7 @@ def test_synchronize_ignore_closed():
 def test_update_mirror_refs_collaborator():
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
@@ -349,7 +349,7 @@ def test_update_mirror_refs_collaborator():
 def test_update_mirror_refs_ignore_collaborator_bot():
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         'labels': [],
         'user': {'login': 'chromium-wpt-export-bot'},
         'author_association': 'COLLABORATOR',
@@ -372,7 +372,7 @@ def test_update_mirror_refs_ignore_collaborator_bot():
 def test_update_mirror_refs_ignore_untrusted_contributor():
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'CONTRIBUTOR',
@@ -395,7 +395,7 @@ def test_update_mirror_refs_ignore_untrusted_contributor():
 def test_update_mirror_refs_trusted_contributor():
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         # user here is a contributor (untrusted), but the issue
         # has been labelled as safe.
         'labels': [{'name': 'safe for preview'}],
@@ -424,7 +424,7 @@ def test_update_mirror_refs_trusted_contributor():
 def test_synchronize_sync_bot_with_label():
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         # user here is a bot which is normally not mirrored,
         # but the issue has been labelled as safe.
         'labels': [{'name': 'safe for preview'}],
@@ -453,7 +453,7 @@ def test_synchronize_sync_bot_with_label():
 def test_update_mirror_refs_update_collaborator():
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
@@ -464,14 +464,14 @@ def test_update_mirror_refs_update_collaborator():
         (Requests.ref_get_trusted, (
             200,
             {
-                'object': { 'sha': 'def234' },
+                'object': {'sha': 'def234' },
             }
         )),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_get_open, (
             200,
             {
-                'object': { 'sha': 'def234' },
+                'object': {'sha': 'def234' },
             }
         )),
         (Requests.get_rate, Responses.no_limit),
@@ -490,7 +490,7 @@ def test_update_mirror_refs_update_collaborator():
 def test_synchronize_update_member():
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         'labels': [],
         'user': {'login': 'jgraham'},
         'author_association': 'MEMBER',
@@ -501,14 +501,14 @@ def test_synchronize_update_member():
         (Requests.ref_get_trusted, (
             200,
             {
-                'object': { 'sha': 'def234' },
+                'object': {'sha': 'def234' },
             }
         )),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_get_open, (
             200,
             {
-                'object': { 'sha': 'def234' },
+                'object': {'sha': 'def234' },
             }
         )),
         (Requests.get_rate, Responses.no_limit),
@@ -527,7 +527,7 @@ def test_synchronize_update_member():
 def test_update_mirror_refs_delete_collaborator():
     pull_request = {
         'number': 45,
-        'head': { 'sha': 'abc123' },
+        'head': {'sha': 'abc123'},
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
@@ -538,14 +538,14 @@ def test_update_mirror_refs_delete_collaborator():
         (Requests.ref_get_trusted, (
             200,
             {
-                'object': { 'sha': 'def234' },
+                'object': {'sha': 'def234' },
             }
         )),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_get_open, (
             200,
             {
-                'object': { 'sha': 'def234' },
+                'object': {'sha': 'def234' },
             }
         )),
         (Requests.get_rate, Responses.no_limit),

--- a/tools/ci/tests/test_pr_preview.py
+++ b/tools/ci/tests/test_pr_preview.py
@@ -464,14 +464,14 @@ def test_update_mirror_refs_update_collaborator():
         (Requests.ref_get_trusted, (
             200,
             {
-                'object': {'sha': 'def234' },
+                'object': {'sha': 'def234'},
             }
         )),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_get_open, (
             200,
             {
-                'object': {'sha': 'def234' },
+                'object': {'sha': 'def234'},
             }
         )),
         (Requests.get_rate, Responses.no_limit),
@@ -481,7 +481,7 @@ def test_update_mirror_refs_update_collaborator():
     ]
 
     method_threw, actual_traffic = update_mirror_refs(
-        pull_request, expected_traffic 
+        pull_request, expected_traffic
     )
 
     assert not method_threw
@@ -501,14 +501,14 @@ def test_synchronize_update_member():
         (Requests.ref_get_trusted, (
             200,
             {
-                'object': {'sha': 'def234' },
+                'object': {'sha': 'def234'},
             }
         )),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_get_open, (
             200,
             {
-                'object': {'sha': 'def234' },
+                'object': {'sha': 'def234'},
             }
         )),
         (Requests.get_rate, Responses.no_limit),
@@ -538,14 +538,14 @@ def test_update_mirror_refs_delete_collaborator():
         (Requests.ref_get_trusted, (
             200,
             {
-                'object': {'sha': 'def234' },
+                'object': {'sha': 'def234'},
             }
         )),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_get_open, (
             200,
             {
-                'object': {'sha': 'def234' },
+                'object': {'sha': 'def234'},
             }
         )),
         (Requests.get_rate, Responses.no_limit),

--- a/tools/ci/tests/test_pr_preview.py
+++ b/tools/ci/tests/test_pr_preview.py
@@ -128,11 +128,23 @@ class Requests(object):
         '/repos/test-org/test-repo/git/refs',
         {'ref':'refs/prs-trusted-for-preview/45'}
     )
+    ref_get_open = (
+        'GET', '/repos/test-org/test-repo/git/refs/prs-open/45', {}
+    )
+    ref_get_trusted = (
+        'GET', '/repos/test-org/test-repo/git/refs/prs-trusted-for-preview/45', {}
+    )
     ref_update_open = (
         'PATCH', '/repos/test-org/test-repo/git/refs/prs-open/45', {}
     )
     ref_update_trusted = (
         'PATCH', '/repos/test-org/test-repo/git/refs/prs-trusted-for-preview/45', {}
+    )
+    ref_delete_open = (
+        'DELETE', '/repos/test-org/test-repo/git/refs/prs-open/45', {}
+    )
+    ref_delete_trusted = (
+        'DELETE', '/repos/test-org/test-repo/git/refs/prs-trusted-for-preview/45', {}
     )
     deployment_get = ('GET', '/repos/test-org/test-repo/deployments', {})
     deployment_create = ('POST', '/repos/test-org/test-repo/deployments', {})
@@ -170,12 +182,10 @@ class Responses(object):
 
 
 @contextlib.contextmanager
-def temp_repo(change_dir=False):
+def temp_repo():
     original_dir = os.getcwd()
     directory = tempfile.mkdtemp()
-
-    if change_dir:
-        os.chdir(directory)
+    os.chdir(directory)
 
     try:
         subprocess.check_call(['git', 'init'], cwd=directory)
@@ -199,62 +209,31 @@ def temp_repo(change_dir=False):
 
         yield directory
     finally:
-        if change_dir:
-            os.chdir(original_dir)
-
+        os.chdir(original_dir)
         shutil.rmtree(
             directory, ignore_errors=False, onerror=handle_remove_readonly
         )
 
-def update_mirror_refs(pull_request, expected_traffic, refs={}):
+def update_mirror_refs(pull_request, expected_traffic):
     os.environ['GITHUB_TOKEN'] = 'c0ffee'
 
     github_server = MockServer((TEST_HOST, 0), expected_traffic)
     github_port = github_server.server_address[1]
-    remote_refs = {}
 
     method_threw = False
-    with temp_repo(change_dir=True), temp_repo() as remote_repo, github_server:
-        subprocess.check_call(
-            ['git', 'commit', '--allow-empty', '-m', 'first'],
-            cwd=remote_repo
-        )
-        subprocess.check_call(
-            ['git', 'commit', '--allow-empty', '-m', 'second'],
-            cwd=remote_repo
-        )
-        subprocess.check_call(['git', 'remote', 'add', 'origin', remote_repo])
-
-        for name, value in refs.items():
-            subprocess.check_call(
-                ['git', 'update-ref', name, value],
-                cwd=remote_repo
-            )
-
-        subprocess.check_call(['git', 'remote', '-v'])
+    with temp_repo(), github_server:
         project = pr_preview.Project(
             'http://{}:{}'.format(TEST_HOST, github_port),
             'test-org/test-repo',
         )
-        remote = pr_preview.Remote('test-org/test-repo')
         try:
-            pr_preview.update_mirror_refs(project, remote, pull_request)
+            pr_preview.update_mirror_refs(project, pull_request)
         except pr_preview.GitHubRateLimitException:
             method_threw = True
-
-        lines = subprocess.check_output(['git', 'ls-remote', 'origin'])
-        for line in lines.decode('utf-8').strip().split('\n'):
-            revision, ref = line.split()
-
-            if not ref or ref in ('HEAD', 'refs/heads/master'):
-                continue
-
-            remote_refs[ref] = revision
 
     return (
         method_threw,
         github_server.actual_traffic,
-        remote_refs,
     )
 
 
@@ -289,6 +268,7 @@ def deploy(pr_num, revision, expected_github_traffic, expected_preview_traffic):
 def test_update_mirror_refs_fail_rate_limited():
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
@@ -308,7 +288,7 @@ def test_update_mirror_refs_fail_rate_limited():
         ))
     ]
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
+    method_threw, actual_traffic = update_mirror_refs(
         pull_request, expected_traffic
     )
 
@@ -319,14 +299,20 @@ def test_synchronize_ignore_closed():
     # No existing refs, but a closed PR event comes in. Nothing should happen.
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
         'closed_at': '2019-10-28',
     }
-    expected_traffic = []
+    expected_traffic = [
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_trusted, (404, {})),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_open, (404, {})),
+    ]
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
+    method_threw, actual_traffic = update_mirror_refs(
         pull_request, expected_traffic
     )
 
@@ -336,6 +322,7 @@ def test_synchronize_ignore_closed():
 def test_update_mirror_refs_collaborator():
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
@@ -343,12 +330,16 @@ def test_update_mirror_refs_collaborator():
     }
     expected_traffic = [
         (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_trusted, (404, {})),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_open, (404, {})),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_create_open, (200, {})),
+        (Requests.get_rate, Responses.no_limit),
         (Requests.ref_create_trusted, (200, {})),
     ]
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
+    method_threw, actual_traffic, = update_mirror_refs(
         pull_request, expected_traffic
     )
 
@@ -358,14 +349,20 @@ def test_update_mirror_refs_collaborator():
 def test_update_mirror_refs_ignore_collaborator_bot():
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         'labels': [],
         'user': {'login': 'chromium-wpt-export-bot'},
         'author_association': 'COLLABORATOR',
         'closed_at': None,
     }
-    expected_traffic = []
+    expected_traffic = [
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_trusted, (404, {})),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_open, (404, {})),
+    ]
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
+    method_threw, actual_traffic = update_mirror_refs(
         pull_request, expected_traffic
     )
 
@@ -375,14 +372,20 @@ def test_update_mirror_refs_ignore_collaborator_bot():
 def test_update_mirror_refs_ignore_untrusted_contributor():
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'CONTRIBUTOR',
         'closed_at': None,
     }
-    expected_traffic = []
+    expected_traffic = [
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_trusted, (404, {})),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_open, (404, {})),
+    ]
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
+    method_threw, actual_traffic = update_mirror_refs(
         pull_request, expected_traffic
     )
 
@@ -392,6 +395,7 @@ def test_update_mirror_refs_ignore_untrusted_contributor():
 def test_update_mirror_refs_trusted_contributor():
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         # user here is a contributor (untrusted), but the issue
         # has been labelled as safe.
         'labels': [{'name': 'safe for preview'}],
@@ -401,12 +405,16 @@ def test_update_mirror_refs_trusted_contributor():
     }
     expected_traffic = [
         (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_trusted, (404, {})),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_open, (404, {})),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_create_open, (200, {})),
+        (Requests.get_rate, Responses.no_limit),
         (Requests.ref_create_trusted, (200, {})),
     ]
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
+    method_threw, actual_traffic = update_mirror_refs(
         pull_request, expected_traffic
     )
 
@@ -416,6 +424,7 @@ def test_update_mirror_refs_trusted_contributor():
 def test_synchronize_sync_bot_with_label():
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         # user here is a bot which is normally not mirrored,
         # but the issue has been labelled as safe.
         'labels': [{'name': 'safe for preview'}],
@@ -425,12 +434,16 @@ def test_synchronize_sync_bot_with_label():
     }
     expected_traffic = [
         (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_trusted, (404, {})),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_open, (404, {})),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_create_open, (200, {})),
+        (Requests.get_rate, Responses.no_limit),
         (Requests.ref_create_trusted, (200, {})),
     ]
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
+    method_threw, actual_traffic = update_mirror_refs(
         pull_request, expected_traffic
     )
 
@@ -440,6 +453,7 @@ def test_synchronize_sync_bot_with_label():
 def test_update_mirror_refs_update_collaborator():
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
@@ -447,18 +461,27 @@ def test_update_mirror_refs_update_collaborator():
     }
     expected_traffic = [
         (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_trusted, (
+            200,
+            {
+                'object': { 'sha': 'def234' },
+            }
+        )),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_open, (
+            200,
+            {
+                'object': { 'sha': 'def234' },
+            }
+        )),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_update_open, (200, {})),
+        (Requests.get_rate, Responses.no_limit),
         (Requests.ref_update_trusted, (200, {})),
     ]
-    refs = {
-        'refs/pull/45/head': 'HEAD',
-        'refs/prs-open/45': 'HEAD~',
-        'refs/prs-trusted-for-preview/45': 'HEAD~'
-    }
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
-        pull_request, expected_traffic, refs
+    method_threw, actual_traffic = update_mirror_refs(
+        pull_request, expected_traffic 
     )
 
     assert not method_threw
@@ -467,6 +490,7 @@ def test_update_mirror_refs_update_collaborator():
 def test_synchronize_update_member():
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         'labels': [],
         'user': {'login': 'jgraham'},
         'author_association': 'MEMBER',
@@ -474,18 +498,27 @@ def test_synchronize_update_member():
     }
     expected_traffic = [
         (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_trusted, (
+            200,
+            {
+                'object': { 'sha': 'def234' },
+            }
+        )),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_open, (
+            200,
+            {
+                'object': { 'sha': 'def234' },
+            }
+        )),
         (Requests.get_rate, Responses.no_limit),
         (Requests.ref_update_open, (200, {})),
+        (Requests.get_rate, Responses.no_limit),
         (Requests.ref_update_trusted, (200, {}))
     ]
-    refs = {
-        'refs/pull/45/head': 'HEAD',
-        'refs/prs-open/45': 'HEAD~',
-        'refs/prs-trusted-for-preview/45': 'HEAD~'
-    }
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
-        pull_request, expected_traffic, refs
+    method_threw, actual_traffic = update_mirror_refs(
+        pull_request, expected_traffic
     )
 
     assert not method_threw
@@ -494,25 +527,39 @@ def test_synchronize_update_member():
 def test_update_mirror_refs_delete_collaborator():
     pull_request = {
         'number': 45,
+        'head': { 'sha': 'abc123' },
         'labels': [],
         'user': {'login': 'stephenmcgruer'},
         'author_association': 'COLLABORATOR',
         'closed_at': 2019-10-30,
     }
-    expected_traffic = []
-    refs = {
-        'refs/pull/45/head': 'HEAD',
-        'refs/prs-open/45': 'HEAD~',
-        'refs/prs-trusted-for-preview/45': 'HEAD~'
-    }
+    expected_traffic = [
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_trusted, (
+            200,
+            {
+                'object': { 'sha': 'def234' },
+            }
+        )),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_get_open, (
+            200,
+            {
+                'object': { 'sha': 'def234' },
+            }
+        )),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_delete_trusted, (200, {})),
+        (Requests.get_rate, Responses.no_limit),
+        (Requests.ref_delete_open, (200, {})),
+    ]
 
-    method_threw, actual_traffic, remote_refs = update_mirror_refs(
-        pull_request, expected_traffic, refs
+    method_threw, actual_traffic = update_mirror_refs(
+        pull_request, expected_traffic
     )
 
     assert not method_threw
     assert same_members(expected_traffic, actual_traffic)
-    assert list(remote_refs) == ['refs/pull/45/head']
 
 def test_deploy_fail_rate_limited():
     expected_github_traffic = [


### PR DESCRIPTION
There are GitHub APIs for getting and deleting refs, which is all
Remote was used for anymore. Simplify things to just the Project, and do
all changes via the GitHub APIs.