### PR TITLE
 pr_preview.py: Fix bug handling 204 in DELETE

### DIFF
--- a/tools/ci/pr_preview.py
+++ b/tools/ci/pr_preview.py
@@ -64,6 +64,8 @@ def gh_request(method_name, url, body=None, media_type=None):
 
     resp.raise_for_status()
 
+    if resp.status_code == 204:
+        return None
     return resp.json()
 
 class GitHubRateLimitException(Exception):

--- a/tools/ci/tests/test_pr_preview.py
+++ b/tools/ci/tests/test_pr_preview.py
@@ -549,9 +549,9 @@ def test_update_mirror_refs_delete_collaborator():
             }
         )),
         (Requests.get_rate, Responses.no_limit),
-        (Requests.ref_delete_trusted, (200, {})),
+        (Requests.ref_delete_trusted, (204, None)),
         (Requests.get_rate, Responses.no_limit),
-        (Requests.ref_delete_open, (200, {})),
+        (Requests.ref_delete_open, (204, None)),
     ]
 
     method_threw, actual_traffic = update_mirror_refs(


### PR DESCRIPTION
GitHub sends a 204 No Content for deleting a ref, but we assume there is
always a body and try to grab the JSON. Check for 204 before doing so,
and just return None in that case.