### PR TITLE
Added 2 white-space tests related to multi-columns container

### DIFF
--- a/css/css-text/white-space/multi-columns-ws-nowrap-001.html
+++ b/css/css-text/white-space/multi-columns-ws-nowrap-001.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text Test: 'white-space: nowrap', atomic inlines and multi-column layout</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-processing">
+  <link rel="match" href="reference/multi-columns-ws-nowrap-001-ref.html">
+
+  <!--
+  Date created: December 14th 2020
+  Last modified: December 16th 2020
+  -->
+
+  <!--
+
+  Inspired by
+  Bug 83395: white-space: nowrap breaks multi-column layout
+  https://bugs.webkit.org/show_bug.cgi?id=83395
+
+  -->
+
+  <meta content="" name="flags">
+
+  <style>
+  div
+    {
+      border: orange solid 4px;
+      column-gap: 2em;
+      column-width: 50px;
+      font-size: 32px;
+      margin-bottom: 8px;
+      orphans: 1;
+      widows: 1;
+      width: 500px; /* 500px is an entirely arbitrary number */
+    }
+
+  span
+    {
+      display: inline-block;
+      width: 50px;
+    }
+
+  div.test
+    {
+      white-space: nowrap;
+    }
+
+  div#i-table > span
+    {
+      display: inline-table
+    }
+
+  div#reference
+    {
+      white-space: normal;
+    }
+  </style>
+
+  <p>Test passes if the digits inside the 3 orange-bordered rectangles are <strong>distributed identically</strong>.
+
+  <div class="test" id="i-block"><span>1</span><span>2</span><span>3</span><span>4</span></div>
+
+  <div class="test" id="i-table"><span>1</span><span>2</span><span>3</span><span>4</span></div>
+
+  <div id="reference"><span>1</span><span>2</span><span>3</span><span>4</span></div>

--- a/css/css-text/white-space/multi-columns-ws-pre-001.html
+++ b/css/css-text/white-space/multi-columns-ws-pre-001.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text Test: 'white-space: pre', atomic inlines and multi-column layout</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#white-space-processing">
+  <link rel="match" href="reference/multi-columns-ws-pre-001-ref.html">
+
+  <!--
+  Date created: December 14th 2020
+  Last modified: December 16th 2020
+  -->
+
+  <meta content="" name="flags">
+
+  <style>
+  div
+    {
+      border: orange solid 4px;
+      column-gap: 0em;
+      column-width: 50px;
+      font-size: 32px;
+      margin-bottom: 8px;
+      orphans: 1;
+      widows: 1;
+      width: 500px; /* 500px is an entirely arbitrary number */
+    }
+
+  span
+    {
+      display: inline-block;
+      width: 50px;
+    }
+
+  div.test
+    {
+      white-space: pre;
+    }
+
+  div#i-table > span
+    {
+      display: inline-table
+    }
+
+  div#reference
+    {
+      white-space: normal;
+    }
+  </style>
+
+  <p>Test passes if the digits inside the 3 orange-bordered rectangles are <strong>distributed identically</strong>.
+
+  <div class="test" id="i-block"><span>1</span><span>2</span><span>3</span><span>4</span></div>
+
+  <div class="test" id="i-table"><span>1</span><span>2</span><span>3</span><span>4</span></div>
+
+  <div id="reference"><span>1</span><span>2</span><span>3</span><span>4</span></div>

--- a/css/css-text/white-space/reference/multi-columns-ws-nowrap-001-ref.html
+++ b/css/css-text/white-space/reference/multi-columns-ws-nowrap-001-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: orange solid 4px;
+      column-gap: 2em;
+      column-width: 50px;
+      font-size: 32px;
+      margin-bottom: 8px;
+      orphans: 1;
+      widows: 1;
+      width: 500px; /* 500px is an entirely arbitrary number */
+    }
+
+  span
+    {
+      display: inline-block;
+      width: 50px;
+    }
+  </style>
+
+  <p>Test passes if the digits inside the 3 orange-bordered rectangles are <strong>distributed identically</strong>.
+
+  <div><span>1</span><span>2</span><span>3</span><span>4</span></div>
+
+  <div><span>1</span><span>2</span><span>3</span><span>4</span></div>
+
+  <div><span>1</span><span>2</span><span>3</span><span>4</span></div>

--- a/css/css-text/white-space/reference/multi-columns-ws-pre-001-ref.html
+++ b/css/css-text/white-space/reference/multi-columns-ws-pre-001-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: orange solid 4px;
+      column-gap: 0em;
+      column-width: 50px;
+      font-size: 32px;
+      margin-bottom: 8px;
+      orphans: 1;
+      widows: 1;
+      width: 500px; /* 500px is an entirely arbitrary number */
+    }
+
+  span
+    {
+      display: inline-block;
+      width: 50px;
+    }
+  </style>
+
+  <p>Test passes if the digits inside the 3 orange-bordered rectangles are <strong>distributed identically</strong>.
+
+  <div><span>1</span><span>2</span><span>3</span><span>4</span></div>
+
+  <div><span>1</span><span>2</span><span>3</span><span>4</span></div>
+
+  <div><span>1</span><span>2</span><span>3</span><span>4</span></div>


### PR DESCRIPTION
css/css-text/white-space/multi-columns-ws-nowrap-001.html
css/css-text/white-space/reference/multi-columns-ws-nowrap-001-ref.html
css/css-text/white-space/multi-columns-ws-pre-001.html
css/css-text/white-space/reference/multi-columns-ws-pre-001-ref.html

These 2 tests verifies how multi-column containers handle 'white-space: pre' and 'white-space: nowrap' when involved with atomic inlines (inline-blocks and inline-tables). These 2 tests expose some implementation failures in Firefox 86, Chromium 89 and Epiphany 3.32.1.2 (WebKitGTK+ 2.30.3).

It appears that **browsers treat 'column-gap: 2em' as suppressible, cancelable white spaces**.

Over at my website, these files are:

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/multi-columns-ws-nowrap-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/reference/multi-columns-ws-nowrap-001-ref.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/multi-columns-ws-pre-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/reference/multi-columns-ws-pre-001-ref.html