### PR TITLE
[css-text] Added 1 overflowing hanging spaces at end of line test

### DIFF
--- a/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-021-ref.html
+++ b/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-021-ref.html
@@ -23,14 +23,14 @@
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically and if there is a yellow stripe that juts outside the black-bordered rectangles.
+  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically and if each black-bordered rectangles do not generate an horizontal scrollbar.
 
-    <div id="reference">Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
+    <div>Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
 Dolor<br>
 &nbsp;&nbsp;&nbsp;sit amet. <br>
 consectetur</div>
 
-    <div id="reference">Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
+    <div>Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
 Dolor<br>
 &nbsp;&nbsp;&nbsp;sit amet. <br>
 consectetur</div>

--- a/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-021-ref.html
+++ b/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-021-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      line-height: 1.25; /* computes to 40px */
+      margin-bottom: 0.25em;
+      width: 16ch;
+    }
+
+  span
+    {
+      background-color: yellow;
+    }
+  </style>
+
+  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically and if there is a yellow stripe that juts outside the black-bordered rectangles.
+
+    <div id="reference">Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
+Dolor<br>
+&nbsp;&nbsp;&nbsp;sit amet. <br>
+consectetur</div>
+
+    <div id="reference">Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
+Dolor<br>
+&nbsp;&nbsp;&nbsp;sit amet. <br>
+consectetur</div>

--- a/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-021-ref.html
+++ b/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-021-ref.html
@@ -15,6 +15,7 @@
       line-height: 1.25; /* computes to 40px */
       margin-bottom: 0.25em;
       width: 16ch;
+      overflow: hidden;
     }
 
   span
@@ -23,7 +24,7 @@
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically and if each black-bordered rectangles do not generate an horizontal scrollbar.
+  <p>Test passes if the characters inside each black-bordered rectangle is laid out identically and if each black-bordered rectangle does not generate a horizontal scrollbar.
 
     <div>Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
 Dolor<br>

--- a/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-021-ref.html
+++ b/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-021-ref.html
@@ -24,7 +24,7 @@
     }
   </style>
 
-  <p>Test passes if the characters inside each black-bordered rectangle is laid out identically and if each black-bordered rectangle does not generate a horizontal scrollbar.
+  <p>Test passes if the characters inside each black-bordered rectangle are laid out identically and if each black-bordered rectangle does not generate a horizontal scrollbar.
 
     <div>Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
 Dolor<br>

--- a/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-021.html
+++ b/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-021.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text Test: Overflowing hanging spaces should be ink overflow</title>
+
+  <!--
+
+  Issue 4297: [css-text-3] Hanging spaces can't be scrollable overflow
+  https://github.com/w3c/csswg-drafts/issues/4297
+
+  Resolution:
+  Hanging spaces are ink overflow by default.
+  UAs may make them scrollable overflow when
+  they think that would be useful.
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#hanging">
+  <link rel="match" href="reference/white-space-pre-wrap-trailing-spaces-021-ref.html">
+
+  <meta content="should" name="flags">
+  <meta content="This test checks that overflowing hanging spaces at end of line should be treated as ink overflow." name="assert">
+
+  <style>
+  div
+    {
+      border: black solid 2px;
+      font-family: monospace;
+      font-size: 32px;
+      line-height: 1.25; /* computes to 40px */
+      margin-bottom: 0.25em;
+      width: 16ch;
+    }
+
+  span
+    {
+      background-color: yellow;
+    }
+
+  div#test
+    {
+      white-space: pre-wrap;
+    }
+
+  div#reference
+    {
+      white-space: normal;
+    }
+  </style>
+
+  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically and if there is a yellow stripe that juts outside the black-bordered rectangles.
+
+  <div id="test">Lorem ipsum.<span>        </span>Dolor
+   sit amet. <br>consectetur</div>
+
+  <div id="reference">Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
+Dolor<br>
+&nbsp;&nbsp;&nbsp;sit amet. <br>
+consectetur</div>

--- a/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-021.html
+++ b/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-021.html
@@ -18,10 +18,11 @@
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
   <link rel="help" href="https://www.w3.org/TR/css-text-3/#hanging">
+  <link rel="help" href="https://www.w3.org/TR/css-overflow-3/#ink">
   <link rel="match" href="reference/white-space-pre-wrap-trailing-spaces-021-ref.html">
 
   <meta content="should" name="flags">
-  <meta content="This test checks that overflowing hanging spaces at end of line should be treated as ink overflow." name="assert">
+  <meta content="This test checks that overflowing hanging spaces at end of line are treated as ink overflow. The overflowing hanging spaces at end of line should not extend the scrollable overflow area of the tested box. Therefore the no horizontal scrollbar condition of the test." name="assert">
 
   <style>
   div
@@ -41,6 +42,7 @@
 
   div#test
     {
+      overflow: auto;
       white-space: pre-wrap;
     }
 
@@ -50,12 +52,12 @@
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically and if there is a yellow stripe that juts outside the black-bordered rectangles.
+  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically and if each black-bordered rectangles do not generate an horizontal scrollbar.
 
   <div id="test">Lorem ipsum.<span>        </span>Dolor
    sit amet. <br>consectetur</div>
 
-  <div id="reference">Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
+  <div id="reference">Lorem&nbsp;ipsum.<span>&nbsp;&nbsp;&nbsp;&nbsp;</span><br>
 Dolor<br>
 &nbsp;&nbsp;&nbsp;sit amet. <br>
 consectetur</div>

--- a/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-021.html
+++ b/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-021.html
@@ -52,7 +52,7 @@
     }
   </style>
 
-  <p>Test passes if the characters inside of each black-bordered rectangles are laid out identically and if each black-bordered rectangles do not generate an horizontal scrollbar.
+  <p>Test passes if the characters inside each black-bordered rectangle are laid out identically and if each black-bordered rectangle does not generate a horizontal scrollbar.
 
   <div id="test">Lorem ipsum.<span>        </span>Dolor
    sit amet. <br>consectetur</div>


### PR DESCRIPTION
/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-021.html  
/css/css-text/white-space/reference/white-space-pre-wrap-trailing-spaces-021-ref.html

This spun from [Issue 4297](https://github.com/w3c/csswg-drafts/issues/4297)

Basically, overflowing hanging white spaces at end of line of block with 'white-space: pre-wrap' should be paintable and should act like ink overflow.

At my website, the files are:

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/white-space-pre-wrap-trailing-spaces-021.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/reference/white-space-pre-wrap-trailing-spaces-021-ref.html