### PR TITLE
[css-text] Added 2 hanging-punctuation tests

### DIFF
--- a/css/css-text/hanging-punctuation/hanging-punctuation-block-bound-001.html
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-block-bound-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text Test: allowed ending hanging-punctuation does not affect block box boundary</title>
+
+  <!--
+
+  Issue 4222: [css-text-3] hanging-punctuation effect on inline/block bounds
+  https://github.com/w3c/csswg-drafts/issues/4222
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#hanging">
+  <link rel="match" href="reference/hanging-punctuation-block-bound-001-ref.html">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that hanging punctuations has no effect on the boundary of a block box. The background of a block box does not include hanging punctuations." name="assert">
+
+  <style>
+  div
+    {
+      background-color: lime;
+      border: black solid 3px;
+      font-family: monospace;
+      font-size: 60px;
+      line-height: 1.5em; /* computes to 90px */
+      hanging-punctuation: allow-end;
+      width: 240px;
+    }
+  </style>
+
+  <div>まだよくています。しかし特</div>

--- a/css/css-text/hanging-punctuation/hanging-punctuation-block-bound-001.html
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-block-bound-001.html
@@ -19,26 +19,11 @@
   <meta content="This test checks that hanging punctuations has no effect on the boundary of a block box. The background of a block box does not include hanging punctuations." name="assert">
 
   <style>
-  @font-face
-    {
-      font-family: "mplus-1p-regular";
-      src: url("/fonts/mplus-1p-regular.woff") format("woff");
-      /* filesize: 803300 bytes (784.5 KBytes) */
-    }
-
-  /* filesize of mplus-1p-regular.woff: 803300 bytes (784.5 KiloBytes) */
-
-  /*
-  mplus-1p-regular.ttf can be downloaded at, from
-
-  http://mplus-webfonts.osdn.jp/
-  */
-
   div
     {
       background-color: lime;
       border: black solid 3px;
-      font-family: "mplus-1p-regular";
+      font-family: monospace;
       font-size: 60px;
       line-height: 1.5em; /* computes to 90px */
       hanging-punctuation: allow-end;

--- a/css/css-text/hanging-punctuation/hanging-punctuation-block-bound-001.html
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-block-bound-001.html
@@ -19,11 +19,26 @@
   <meta content="This test checks that hanging punctuations has no effect on the boundary of a block box. The background of a block box does not include hanging punctuations." name="assert">
 
   <style>
+  @font-face
+    {
+      font-family: "mplus-1p-regular";
+      src: url("/fonts/mplus-1p-regular.woff") format("woff");
+      /* filesize: 803300 bytes (784.5 KBytes) */
+    }
+
+  /* filesize of mplus-1p-regular.woff: 803300 bytes (784.5 KiloBytes) */
+
+  /*
+  mplus-1p-regular.ttf can be downloaded at, from
+
+  http://mplus-webfonts.osdn.jp/
+  */
+
   div
     {
       background-color: lime;
       border: black solid 3px;
-      font-family: monospace;
+      font-family: "mplus-1p-regular";
       font-size: 60px;
       line-height: 1.5em; /* computes to 90px */
       hanging-punctuation: allow-end;

--- a/css/css-text/hanging-punctuation/hanging-punctuation-inline-bound-001.html
+++ b/css/css-text/hanging-punctuation/hanging-punctuation-inline-bound-001.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Text Test: allowed ending hanging-punctuation affect inline box boundary</title>
+
+  <!--
+
+  Issue 4222: [css-text-3] hanging-punctuation effect on inline/block bounds
+  https://github.com/w3c/csswg-drafts/issues/4222
+
+  -->
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-text-3/#hanging">
+  <link rel="match" href="reference/hanging-punctuation-inline-bound-001-ref.html">
+
+  <meta content="" name="flags">
+  <meta content="This test checks that background of inline boxes includes hanging punctuations and text-selecting (or highlighting) inline boxes will include hanging punctuations." name="assert">
+
+  <style>
+  div
+    {
+      font-family: monospace;
+      font-size: 60px;
+      line-height: 1.5em; /* computes to 90px */
+      hanging-punctuation: allow-end;
+      width: 245px;
+    }
+
+  span
+    {
+      background-color: lime;
+      border: black solid 3px;
+    }
+  </style>
+
+  <div><span>まだよくています。しかし特</span></div>

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-block-bound-001-ref.html
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-block-bound-001-ref.html
@@ -7,44 +7,42 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
-  @font-face
-    {
-      font-family: "mplus-1p-regular";
-      src: url("/fonts/mplus-1p-regular.woff") format("woff");
-      /* filesize: 803300 bytes (784.5 KBytes) */
-    }
-
-  /* filesize of mplus-1p-regular.woff: 803300 bytes (784.5 KiloBytes) */
-
-  /*
-  mplus-1p-regular.ttf can be downloaded at, from
-
-  http://mplus-webfonts.osdn.jp/
-  */
-
   div
     {
-      font-family: "mplus-1p-regular";
+      font-family: monospace;
       font-size: 60px;
       line-height: 1.5em; /* computes to 90px */
     }
 
-  div#block
+  /*
+  We draw the box (perfectly fitted to the content
+  in the block axis, because it has the same content)
+  but not the text.
+  */
+
+  div#box-drawn-under
     {
       background-color: lime;
       border: black solid 3px;
+      color: transparent;
+      position: absolute;
       width: 240px;
+      z-index: -1;
     }
 
-  div#full-stop
+  /*
+  We draw the text, but into a wider box so
+  the period will fit, and overlap it with
+  the previously-drawn box.
+  */
+
+  div#text-drawn-over
     {
-      bottom: 183px; /* border-bottom-width + 2 line boxes */
-      display: inline;
-      left: 243px; /* content width + border-width */
-      position: relative;
+      border: transparent solid 3px;
+      width: 300px;
     }
   </style>
 
-  <div id="block">まだよく<br>ています<br>しかし特</div>
+   <div id="box-drawn-under">まだよく<br>ています。</div>
 
-  <div id="full-stop">。</div>
+   <div id="text-drawn-over">まだよく<br>ています。<br>しかし特</div>

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-block-bound-001-ref.html
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-block-bound-001-ref.html
@@ -7,9 +7,24 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
 
   <style>
+  @font-face
+    {
+      font-family: "mplus-1p-regular";
+      src: url("/fonts/mplus-1p-regular.woff") format("woff");
+      /* filesize: 803300 bytes (784.5 KBytes) */
+    }
+
+  /* filesize of mplus-1p-regular.woff: 803300 bytes (784.5 KiloBytes) */
+
+  /*
+  mplus-1p-regular.ttf can be downloaded at, from
+
+  http://mplus-webfonts.osdn.jp/
+  */
+
   div
     {
-      font-family: monospace;
+      font-family: "mplus-1p-regular";
       font-size: 60px;
       line-height: 1.5em; /* computes to 90px */
     }

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-block-bound-001-ref.html
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-block-bound-001-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      font-family: monospace;
+      font-size: 60px;
+      line-height: 1.5em; /* computes to 90px */
+    }
+
+  div#block
+    {
+      background-color: lime;
+      border: black solid 3px;
+      width: 240px;
+    }
+
+  div#full-stop
+    {
+      bottom: 183px; /* border-bottom-width + 2 line boxes */
+      display: inline;
+      left: 243px; /* content width + border-width */
+      position: relative;
+    }
+  </style>
+
+  <div id="block">まだよく<br>ています<br>しかし特</div>
+
+  <div id="full-stop">。</div>

--- a/css/css-text/hanging-punctuation/reference/hanging-punctuation-inline-bound-001-ref.html
+++ b/css/css-text/hanging-punctuation/reference/hanging-punctuation-inline-bound-001-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Reference Test</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+
+  <style>
+  div
+    {
+      font-family: monospace;
+      font-size: 60px;
+      line-height: 1.5em; /* computes to 90px */
+    }
+
+  span
+    {
+      background-color: lime;
+      border-bottom: black solid 3px;
+      border-top: black solid 3px;
+    }
+
+  span#first
+    {
+      border-left: black solid 3px;
+    }
+
+  span#third
+    {
+      border-right: black solid 3px;
+    }
+  </style>
+
+  <div><span id="first">まだよく</span><br>
+
+  <span id="second">ています。</span><br>
+
+  <span id="third">しかし特</span></div>


### PR DESCRIPTION
/css/css-text/hanging-punctuation/hanging-punctuation-block-bound-001.html 
/css/css-text/hanging-punctuation/reference/hanging-punctuation-block-bound-001-ref.html 
/css/css-text/hanging-punctuation/hanging-punctuation-inline-bound-001.html 
/css/css-text/hanging-punctuation/reference/hanging-punctuation-inline-bound-001-ref.html

These 2 tests spun from
[Issue 4222: [css-text-3] hanging-punctuation effect on inline/block bounds](https://github.com/w3c/csswg-drafts/issues/4222)

Credits must go to @stantonma for creating those tests.

At my website, the files are:

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/hanging-punctuation/hanging-punctuation-block-bound-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/hanging-punctuation/reference/hanging-punctuation-block-bound-001-ref.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/hanging-punctuation/hanging-punctuation-inline-bound-001.html

http://www.gtalbot.org/BrowserBugsSection/CSS3Text/hanging-punctuation/reference/hanging-punctuation-inline-bound-001-ref.html

Epiphany 3.32.1.2 (WebKitGTK+ 2.30.3) pass these 2 tests perfectly on my system.