### PR TITLE
Add/Fix META.yml files to ease specs to WPT mapping

### DIFF
--- a/BackgroundSync/META.yml
+++ b/BackgroundSync/META.yml
@@ -1,3 +1,3 @@
-spec: https://wicg.github.io/BackgroundSync/spec/
+spec: https://wicg.github.io/background-sync/spec/
 suggested_reviewers:
   - beverloo

--- a/client-hints/META.yml
+++ b/client-hints/META.yml
@@ -1,3 +1,4 @@
+spec: https://wicg.github.io/client-hints-infrastructure/
 suggested_reviewers:
   - igrigorik
   - yoavweiss

--- a/compression/META.yml
+++ b/compression/META.yml
@@ -1,3 +1,3 @@
-spec: https://ricea.github.io/compression/
+spec: https://wicg.github.io/compression/
 suggested_reviewers:
   - ricea

--- a/contacts/META.yml
+++ b/contacts/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/contact-api/spec/

--- a/content-security-policy/embedded-enforcement/META.yml
+++ b/content-security-policy/embedded-enforcement/META.yml
@@ -1,0 +1,1 @@
+spec: https://w3c.github.io/webappsec-cspee/

--- a/css/css-inline/META.yml
+++ b/css/css-inline/META.yml
@@ -1,4 +1,4 @@
-spec: https://drafts.csswg.org/css-fonts/
+spec: https://drafts.csswg.org/css-inline/
 suggested_reviewers:
   - dauwhe
   - fantasai

--- a/css/css-overscroll-behavior/META.yml
+++ b/css/css-overscroll-behavior/META.yml
@@ -1,4 +1,4 @@
-spec: https://drafts.csswg.org/css-overscroll-behavior/
+spec: https://drafts.csswg.org/css-overscroll/
 suggested_reviewers:
   - majido
   - theres-waldo

--- a/css/css-parser-api/META.yml
+++ b/css/css-parser-api/META.yml
@@ -1,3 +1,3 @@
-spec: https://wicg.github.io/CSS-Parser-API/
+spec: https://wicg.github.io/css-parser-api/
 suggested_reviewers:
   - tabatkins

--- a/event-timing/META.yml
+++ b/event-timing/META.yml
@@ -1,3 +1,3 @@
-spec: https://github.com/WICG/event-timing
+spec: https://wicg.github.io/event-timing/
 suggested_reviewers:
   - npm1

--- a/fetch/metadata/META.yml
+++ b/fetch/metadata/META.yml
@@ -1,3 +1,4 @@
+spec: https://w3c.github.io/webappsec-fetch-metadata/
 suggested_reviewers:
   - mikewest
   - iVanlIsh

--- a/geolocation-sensor/META.yml
+++ b/geolocation-sensor/META.yml
@@ -1,4 +1,4 @@
-spec: https://wicg.github.io/geolocation-sensor/
+spec: https://w3c.github.io/geolocation-sensor/
 suggested_reviewers:
   - anssiko
   - Honry

--- a/idle-detection/META.yml
+++ b/idle-detection/META.yml
@@ -1,4 +1,4 @@
-spec: https://github.com/inexorabletash/idle-detection
+spec: https://wicg.github.io/idle-detection/
 suggested_reviewers:
   - goto
   - jsbell

--- a/import-maps/META.yml
+++ b/import-maps/META.yml
@@ -1,4 +1,4 @@
-spec: https://github.com/WICG/import-maps
+spec: https://wicg.github.io/import-maps/
 suggested_reviewers:
   - domenic
   - hiroshige-g

--- a/input-device-capabilities/META.yml
+++ b/input-device-capabilities/META.yml
@@ -1,4 +1,4 @@
-spec: https://wicg.github.io/InputDeviceCapabilities/
+spec: https://wicg.github.io/input-device-capabilities/
 suggested_reviewers:
   - SummerLW
   - NavidZ

--- a/keyboard-lock/META.yml
+++ b/keyboard-lock/META.yml
@@ -1,4 +1,4 @@
-spec: https://w3c.github.io/keyboard-lock/
+spec: https://wicg.github.io/keyboard-lock/
 suggested_reviewers:
   - garykac
   - joedow-42

--- a/lifecycle/META.yml
+++ b/lifecycle/META.yml
@@ -1,3 +1,3 @@
-spec: https://wicg.github.io/page-lifecycle/spec.html
+spec: https://wicg.github.io/page-lifecycle/
 suggested_reviewers:
   - fmeawad

--- a/media-capabilities/META.yml
+++ b/media-capabilities/META.yml
@@ -1,3 +1,3 @@
-spec: https://wicg.github.io/media-capabilities/
+spec: https://w3c.github.io/media-capabilities/
 suggested_reviewers:
   - mounirlamouri

--- a/mediasession/META.yml
+++ b/mediasession/META.yml
@@ -1,3 +1,3 @@
-spec: https://wicg.github.io/mediasession/
+spec: https://w3c.github.io/mediasession/
 suggested_reviewers:
   - mounirlamouri

--- a/picture-in-picture/META.yml
+++ b/picture-in-picture/META.yml
@@ -1,4 +1,4 @@
-spec: https://wicg.github.io/picture-in-picture/
+spec: https://w3c.github.io/picture-in-picture/
 suggested_reviewers:
   - beaufortfrancois
   - mounirlamouri

--- a/scroll-animations/META.yml
+++ b/scroll-animations/META.yml
@@ -1,4 +1,4 @@
-spec: https://wicg.github.io/scroll-animations/
+spec: https://drafts.csswg.org/scroll-animations/
 suggested_reviewers:
   - birtles
   - graouts

--- a/scroll-to-text-fragment/META.yml
+++ b/scroll-to-text-fragment/META.yml
@@ -1,4 +1,4 @@
-spec: https://wicg.github.io/ScrollToTextFragment/
+spec: https://wicg.github.io/scroll-to-text-fragment/
 suggested_reviewers:
   - nburris
   - bokan

--- a/speech-api/META.yml
+++ b/speech-api/META.yml
@@ -1,4 +1,4 @@
-spec: https://w3c.github.io/speech-api/
+spec: https://wicg.github.io/speech-api/
 suggested_reviewers:
   - andrenatal
   - foolip

--- a/storage-access-api/META.yml
+++ b/storage-access-api/META.yml
@@ -1,4 +1,4 @@
-spec: https://github.com/whatwg/html/issues/3338
+spec: https://privacycg.github.io/storage-access/
 suggested_reviewers:
   - Brandr0id
   - ehsan

--- a/timing-entrytypes-registry/META.yml
+++ b/timing-entrytypes-registry/META.yml
@@ -1,4 +1,4 @@
-spec: https://w3c.github.io/navigation-timing/
+spec: https://w3c.github.io/timing-entrytypes-registry/
 suggested_reviewers:
   - plehegar
   - igrigorik

--- a/video-rvfc/META.yml
+++ b/video-rvfc/META.yml
@@ -1,3 +1,3 @@
-spec: https://wicg.github.io/video-rvfc
+spec: https://wicg.github.io/video-rvfc/
 suggested_reviewers:
   - tguilbert

--- a/wasm/jsapi/META.yml
+++ b/wasm/jsapi/META.yml
@@ -1,0 +1,1 @@
+spec: https://webassembly.github.io/spec/js-api/

--- a/wasm/webapi/META.yml
+++ b/wasm/webapi/META.yml
@@ -1,0 +1,1 @@
+spec: https://webassembly.github.io/spec/web-api/

--- a/webcodecs/META.yml
+++ b/webcodecs/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/web-codecs/

--- a/webrtc-identity/META.yml
+++ b/webrtc-identity/META.yml
@@ -1,4 +1,4 @@
-spec: https://github.com/w3c/webrtc-identity
+spec: https://w3c.github.io/webrtc-identity/identity.html
 suggested_reviewers:
   - martinthomson
   - jan-ivar

--- a/webxr/META.yml
+++ b/webxr/META.yml
@@ -1,3 +1,3 @@
-spec: https://immersive-web.github.io/webxr/spec/latest/
+spec: https://immersive-web.github.io/webxr/
 suggested_reviewers:
   - klausw

--- a/webxr/dom-overlay/META.yml
+++ b/webxr/dom-overlay/META.yml
@@ -1,0 +1,1 @@
+spec: https://immersive-web.github.io/dom-overlays/

--- a/webxr/layers/META.yml
+++ b/webxr/layers/META.yml
@@ -1,0 +1,1 @@
+spec: https://immersive-web.github.io/layers/


### PR DESCRIPTION
I am trying to map specs listed in [w3c/browser-specs](https://github.com/w3c/browser-specs/) to their test suites in WPT. Thanks to `META.yml` files, I can map about 200 specs in that list directly to a WPT folder based on the spec's URL. I can also associate 30 other specs with WPT folders that do not link to a spec explicitly based on the spec's shortname.

There remain 32 cases for which the spec and folder cannot be directly associated because:

1. The URL in the `META.yml` file is not the right one, either because it targets an outdated version of the spec (e.g. because the spec has migrated from WICG to a working group), because it targets the GitHub repository instead of the spec itself, or simply because it is invalid.
2. There is no spec URL in the `META.yml` file or there is no `META.yml` file, and the folder's name does not match the spec's shortname.

This pull request fixes these cases.

I would also be happy to add `META.yml` files for the 30 folders that do not expose a URL and that I can only map based on their name, so that the mapping uses a consistent mechanism throughout. Should I complete the PR? Here is the list:

<details><summary>List of folders that can only be mapped to a spec based on their name</summary>

- `badging` => [Badging API](https://w3c.github.io/badging/)
- `content-index` => [Content Index](https://wicg.github.io/content-index/spec/)
- `css/css-color-adjust` => [CSS Color Adjustment Module Level 1](https://drafts.csswg.org/css-color-adjust-1/)
- `css/css-scroll-anchoring` => [CSS Scroll Anchoring Module Level 1](https://drafts.csswg.org/css-scroll-anchoring)
- `css/css-size-adjust` => [CSS Mobile Text Size Adjustment Module Level 1](https://drafts.csswg.org/css-size-adjust-1/)
- `custom-state-pseudo-class` => [Custom State Pseudo Class](https://wicg.github.io/custom-state-pseudo-class/)
- `deprecation-reporting` => [Deprecation Reporting](https://wicg.github.io/deprecation-reporting/)
- `intervention-reporting` => [Intervention Reporting](https://wicg.github.io/intervention-reporting/)
- `is-input-pending` => [isInputPending](https://wicg.github.io/is-input-pending/)
- `js-self-profiling` => [JS Self-Profiling API](https://wicg.github.io/js-self-profiling/)
- `network-error-logging` => [Network Error Logging](https://w3c.github.io/network-error-logging/)
- `origin-policy` => [Origin Policy](https://wicg.github.io/origin-policy/)
- `page-lifecycle` => [Page Lifecycle](https://wicg.github.io/page-lifecycle/)
- `permissions-request` => [Requesting Permissions](https://wicg.github.io/permissions-request/)
- `permissions-revoke` => [Relinquishing Permissions](https://wicg.github.io/permissions-revoke/)
- `savedata` => [Save Data API](https://wicg.github.io/savedata/)
- `serial` => [Web Serial API](https://wicg.github.io/serial/)
- `trusted-types` => [Trusted Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/)
- `ua-client-hints` => [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/)
- `web-otp` => [Web OTP API](https://wicg.github.io/web-otp/)
- `webhid` => [WebHID API](https://wicg.github.io/webhid/)
- `webrtc-insertable-streams` => [WebRTC Insertable Media using Streams](https://w3c.github.io/webrtc-insertable-streams/)
- `webrtc-priority` => [WebRTC Priority Control API](https://w3c.github.io/webrtc-priority/)
- `webrtc-svc` => [Scalable Video Coding (SVC) Extension for WebRTC](https://w3c.github.io/webrtc-svc/)
- `webtransport` => [WebTransport](https://w3c.github.io/webtransport/)
- `webxr/anchors` => [WebXR Anchors Module](https://immersive-web.github.io/anchors/)
- `webxr/ar-module` => [WebXR Augmented Reality Module - Level 1](https://immersive-web.github.io/webxr-ar-module/)
- `webxr/gamepads-module` => [WebXR Gamepads Module - Level 1](https://immersive-web.github.io/webxr-gamepads-module/)
- `webxr/hand-input` => [WebXR Hand Input Module - Level 1](https://immersive-web.github.io/webxr-hand-input/)
- `webxr/hit-test` => [WebXR Hit Test Module](https://immersive-web.github.io/hit-test/)
</details>

I note that there exist both a [`lifecycle`](https://github.com/web-platform-tests/wpt/tree/master/lifecycle) and a [`page-lifecycle`](https://github.com/web-platform-tests/wpt/tree/master/page-lifecycle) folder for the [Page Lifecycle](https://wicg.github.io/page-lifecycle/) specification. Is that intended?

Linked to https://github.com/w3c/browser-specs/issues/201

