### PR TITLE
Re-disable stash tests when using spawn-based multiprocessing

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -6,6 +6,7 @@ import abc
 import argparse
 import json
 import logging
+import multiprocessing
 import os
 import platform
 import signal
@@ -971,7 +972,10 @@ def run(config_cls=ConfigBuilder, route_builder=None, mp_context=None, **kwargs)
     received_signal = threading.Event()
 
     if mp_context is None:
-        import multiprocessing as mp_context
+        if hasattr(multiprocessing, "get_context"):
+            mp_context = multiprocessing.get_context()
+        else:
+            mp_context = multiprocessing
 
     with build_config(os.path.join(repo_root, "config.json"),
                       config_cls=config_cls,

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -968,6 +968,11 @@ def get_parser():
     return parser
 
 
+class MpContext(object):
+    def __getattr__(self, name):
+        return getattr(multiprocessing, name)
+
+
 def run(config_cls=ConfigBuilder, route_builder=None, mp_context=None, **kwargs):
     received_signal = threading.Event()
 
@@ -975,7 +980,7 @@ def run(config_cls=ConfigBuilder, route_builder=None, mp_context=None, **kwargs)
         if hasattr(multiprocessing, "get_context"):
             mp_context = multiprocessing.get_context()
         else:
-            mp_context = multiprocessing
+            mp_context = MpContext()
 
     with build_config(os.path.join(repo_root, "config.json"),
                       config_cls=config_cls,

--- a/tools/wptrunner/wptrunner/mpcontext.py
+++ b/tools/wptrunner/wptrunner/mpcontext.py
@@ -5,12 +5,17 @@ import six
 _context = None
 
 
+class MpContext(object):
+    def __getattr__(self, name):
+        return getattr(multiprocessing, name)
+
+
 def get_context():
     global _context
 
-    if six.PY2:
-        return multiprocessing
-
     if _context is None:
-        _context = multiprocessing.get_context("spawn")
+        if six.PY2:
+            _context = MpContext()
+        else:
+            _context = multiprocessing.get_context("spawn")
     return _context

--- a/tools/wptserve/tests/test_stash.py
+++ b/tools/wptserve/tests/test_stash.py
@@ -1,8 +1,11 @@
 import multiprocessing
 import threading
+import sys
+
 from multiprocessing.managers import BaseManager
 
 import pytest
+from six import PY3
 
 Stash = pytest.importorskip("wptserve.stash").Stash
 
@@ -63,6 +66,9 @@ class SlowLock(BaseManager):
     pass
 
 
+@pytest.mark.xfail(sys.platform == "win32" or
+                   PY3 and multiprocessing.get_start_method() == "spawn",
+                   reason="https://github.com/web-platform-tests/wpt/issues/16938")
 def test_delayed_lock(add_cleanup):
     """Ensure that delays in proxied Lock retrieval do not interfere with
     initialization in parallel threads."""
@@ -103,6 +109,9 @@ class SlowDict(BaseManager):
     pass
 
 
+@pytest.mark.xfail(sys.platform == "win32" or
+                   PY3 and multiprocessing.get_start_method() == "spawn",
+                   reason="https://github.com/web-platform-tests/wpt/issues/16938")
 def test_delayed_dict(add_cleanup):
     """Ensure that delays in proxied `dict` retrieval do not interfere with
     initialization in parallel threads."""


### PR DESCRIPTION
The supposed fix didn't actually fix them in that case. We didn't
notice because it didn't actually change the behaviour of the code on
Linux where they pass either way.