### PR TITLE
Fix documentation build for python 3

### DIFF
--- a/tools/ci/website_build.sh
+++ b/tools/ci/website_build.sh
@@ -14,7 +14,7 @@ remote_url=https://${DEPLOY_TOKEN}@github.com/web-platform-tests/wpt.git
 
 function json_property {
   cat ${1} | \
-    python -c "import json, sys; print json.load(sys.stdin).get(\"${2}\", \"\")"
+    python -c "import json, sys; print(json.load(sys.stdin).get(\"${2}\", \"\"))"
 }
 
 function is_pull_request {


### PR DESCRIPTION
The shell script runs a python line that uses an old-style print, so it
broke (silently!) when we switched to python3.