### PR TITLE
Add further META.yml files to ease specs to WPT mapping

### DIFF
--- a/badging/META.yml
+++ b/badging/META.yml
@@ -1,0 +1,1 @@
+spec: https://w3c.github.io/badging/

--- a/content-index/META.yml
+++ b/content-index/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/content-index/spec/

--- a/css/css-color-adjust/META.yml
+++ b/css/css-color-adjust/META.yml
@@ -1,0 +1,1 @@
+spec: https://drafts.csswg.org/css-color-adjust/

--- a/css/css-size-adjust/META.yml
+++ b/css/css-size-adjust/META.yml
@@ -1,0 +1,1 @@
+spec: https://drafts.csswg.org/css-size-adjust/

--- a/custom-state-pseudo-class/META.yml
+++ b/custom-state-pseudo-class/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/custom-state-pseudo-class/

--- a/deprecation-reporting/META.yml
+++ b/deprecation-reporting/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/deprecation-reporting/

--- a/intervention-reporting/META.yml
+++ b/intervention-reporting/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/intervention-reporting/

--- a/is-input-pending/META.yml
+++ b/is-input-pending/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/is-input-pending/

--- a/js-self-profiling/META.yml
+++ b/js-self-profiling/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/js-self-profiling/

--- a/network-error-logging/META.yml
+++ b/network-error-logging/META.yml
@@ -1,2 +1,3 @@
+spec: https://w3c.github.io/network-error-logging/
 suggested_reviewers:
   - dcreager

--- a/origin-policy/META.yml
+++ b/origin-policy/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/origin-policy/

--- a/page-lifecycle/META.yml
+++ b/page-lifecycle/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/page-lifecycle/

--- a/permissions-request/META.yml
+++ b/permissions-request/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/permissions-request/

--- a/permissions-revoke/META.yml
+++ b/permissions-revoke/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/permissions-revoke/

--- a/savedata/META.yml
+++ b/savedata/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/savedata/

--- a/serial/META.yml
+++ b/serial/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/serial/

--- a/trusted-types/META.yml
+++ b/trusted-types/META.yml
@@ -1,2 +1,3 @@
+spec: https://w3c.github.io/webappsec-trusted-types/dist/spec/
 suggested_reviewers:
   - mikewest

--- a/ua-client-hints/META.yml
+++ b/ua-client-hints/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/ua-client-hints/

--- a/web-otp/META.yml
+++ b/web-otp/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/web-otp/

--- a/webhid/META.yml
+++ b/webhid/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/webhid/

--- a/webrtc-insertable-streams/META.yml
+++ b/webrtc-insertable-streams/META.yml
@@ -1,0 +1,1 @@
+spec: https://w3c.github.io/webrtc-insertable-streams/

--- a/webrtc-priority/META.yml
+++ b/webrtc-priority/META.yml
@@ -1,0 +1,1 @@
+spec: https://w3c.github.io/webrtc-priority/

--- a/webrtc-svc/META.yml
+++ b/webrtc-svc/META.yml
@@ -1,0 +1,1 @@
+spec: https://w3c.github.io/webrtc-svc/

--- a/webtransport/META.yml
+++ b/webtransport/META.yml
@@ -1,0 +1,1 @@
+spec: https://w3c.github.io/webtransport/

--- a/webxr/anchors/META.yml
+++ b/webxr/anchors/META.yml
@@ -1,0 +1,1 @@
+spec: https://immersive-web.github.io/anchors/

--- a/webxr/ar-module/META.yml
+++ b/webxr/ar-module/META.yml
@@ -1,0 +1,1 @@
+spec: https://immersive-web.github.io/webxr-ar-module/

--- a/webxr/gamepads-module/META.yml
+++ b/webxr/gamepads-module/META.yml
@@ -1,0 +1,1 @@
+spec: https://immersive-web.github.io/webxr-gamepads-module/

--- a/webxr/hand-input/META.yml
+++ b/webxr/hand-input/META.yml
@@ -1,0 +1,1 @@
+spec: https://immersive-web.github.io/webxr-hand-input/

--- a/webxr/hit-test/META.yml
+++ b/webxr/hit-test/META.yml
@@ -1,0 +1,1 @@
+spec: https://immersive-web.github.io/hit-test/


### PR DESCRIPTION
Follow-up to #26970 to address folders that do not expose a URL and that can only be mapped to a spec based on their name.

FYI, there are only 29 entries after all, and not 30 as initially stated: [`css/css-scroll-anchoring/META.yml`](https://github.com/web-platform-tests/wpt/blob/master/css/css-scroll-anchoring/META.yml) is actually correct, the URL of the ED rather needs to be adjusted in browser-specs (tracked in https://github.com/w3c/browser-specs/issues/226).