### PR TITLE
Target additional specs in META.yml files

### DIFF
--- a/document-policy/META.yml
+++ b/document-policy/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/document-policy/

--- a/html/cross-origin-embedder-policy/META.yml
+++ b/html/cross-origin-embedder-policy/META.yml
@@ -1,4 +1,4 @@
-spec: https://mikewest.github.io/corpp/
+spec: https://html.spec.whatwg.org/multipage/origin.html#coep
 suggested_reviewers:
   - mikewest
   - jugglinmike

--- a/html/cross-origin-opener-policy/META.yml
+++ b/html/cross-origin-opener-policy/META.yml
@@ -1,4 +1,4 @@
-spec: https://gist.github.com/annevk/6f2dd8c79c77123f39797f6bdac43f3e
+spec: https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies
 suggested_reviewers:
   - mikewest
   - jugglinmike

--- a/installedapp/META.yml
+++ b/installedapp/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/get-installed-related-apps/spec/

--- a/js/META.yml
+++ b/js/META.yml
@@ -1,3 +1,3 @@
-spec: https://tc39.github.io/ecma262/
+spec: https://tc39.es/ecma262/
 suggested_reviewers:
   - Ms2ger

--- a/measure-memory/META.yml
+++ b/measure-memory/META.yml
@@ -1,2 +1,3 @@
+spec: https://wicg.github.io/performance-measure-memory/
 suggested_reviewers:
   - ulan

--- a/native-file-system/META.yml
+++ b/native-file-system/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/file-system-access/

--- a/screen_enumeration/META.yml
+++ b/screen_enumeration/META.yml
@@ -1,0 +1,1 @@
+spec: https://webscreens.github.io/window-placement/

--- a/webrtc-extensions/META.yml
+++ b/webrtc-extensions/META.yml
@@ -1,3 +1,3 @@
-spec: https://henbos.github.io/webrtc-extensions/
+spec: https://w3c.github.io/webrtc-extensions/
 suggested_reviewers:
   - hbos

--- a/x-frame-options/META.yml
+++ b/x-frame-options/META.yml
@@ -1,4 +1,4 @@
-spec: https://html.spec.whatwg.org/#the-x-frame-options-header
+spec: https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-x-frame-options-header
 suggested_reviewers:
   - annevk
   - mikewest


### PR DESCRIPTION
Completes #26970 and #26983 (to ease association between WPT folders and specs) with folders I had not paid attention to before:

- `document-policy` => link to Document Policy spec
- `html/cross-origin-embedder-policy` => proposal was integrated into HTML spec
- `html/cross-origin-opener-policy` => proposal was integrated into HTML spec
- `installedapps` => link to Get Installed Related Apps API
- `js` => update URL to use tc39.es domain name
- `measure-memory` => link to Measure Memory API
- `native-file-system` => link to File System Access
- `screen_enumeration` => link to Multi-Screen Window Placement
- `webrtc-extensions` => fix broken link
- `x-frame-options` => target multipage version (consistent with other folders)

With that, the association should work _well enough_. There will remain a few folders that don't have `META.yml` files or that don't have a `spec` entry in that file. From time to time, that is because the spec does not exist yet. From time to time, I do not really know what spec/feature to target precisely. That list includes `content-dpr`, `cookies`, `delegated-ink`, `density-size-correction`, `encoding-detection`, `focus`, `font-access`, `fonts`, `forced-colors-mode`, `inert` (there may be a few others, I checked the list manually). I suggest to handle these folders over time.