### PR TITLE
'wpt manifest': Add more logging and cap multiprocessing CPUs on Windows

### DIFF
--- a/tools/manifest/log.py
+++ b/tools/manifest/log.py
@@ -1,15 +1,10 @@
 import logging
-import sys
 
 logger = logging.getLogger("manifest")
 
-def setup():
+def enable_debug_logging():
     # type: () -> None
     logger.setLevel(logging.DEBUG)
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter(logging.BASIC_FORMAT, None)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
 
 def get_logger():
     # type: () -> logging.Logger

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -1,6 +1,7 @@
 import io
 import itertools
 import os
+import sys
 from atomicwrites import atomic_write
 from copy import deepcopy
 from multiprocessing import Pool, cpu_count
@@ -226,18 +227,27 @@ class Manifest(object):
             logger.debug("Computing manifest update for %s items" % len(to_update))
             changed = True
 
+
+        # 25 items was derived experimentally (2020-01) to be approximately the
+        # point at which it is quicker to create a Pool and parallelize update.
         if parallel and len(to_update) > 25 and cpu_count() > 1:
-            # 25 derived experimentally (2020-01) to be approximately
-            # the point at which it is quicker to create Pool and
-            # parallelize this
-            pool = Pool()
+            # On Python 3 on Windows, using >= MAXIMUM_WAIT_OBJECTS processes
+            # causes a crash in the multiprocessing module. Whilst this enum
+            # can technically have any value, it is usually 64. For safety,
+            # restrict manifest regeneration to 48 processes on Windows.
+            #
+            # See https://bugs.python.org/issue26903 and https://bugs.python.org/issue40263
+            processes = cpu_count()
+            if sys.platform == "win32" and processes > 48:
+                processes = 48
+            pool = Pool(processes)
 
             # chunksize set > 1 when more than 10000 tests, because
             # chunking is a net-gain once we get to very large numbers
             # of items (again, experimentally, 2020-01)
             chunksize = max(1, len(to_update) // 10000)
-            logger.debug("Doing a multiprocessed update. "
-                "CPU count: %s, chunksize: %s" % (cpu_count(), chunksize))
+            logger.debug("Doing a multiprocessed update. CPU count: %s, "
+                "processes: %s, chunksize: %s" % (cpu_count(), processes, chunksize))
             results = pool.imap_unordered(compute_manifest_items,
                                           to_update,
                                           chunksize=chunksize

--- a/tools/manifest/update.py
+++ b/tools/manifest/update.py
@@ -4,7 +4,7 @@ import os
 
 from . import manifest
 from . import vcs
-from .log import get_logger
+from .log import get_logger, enable_debug_logging
 from .download import download_from_github
 
 here = os.path.dirname(__file__)
@@ -65,6 +65,9 @@ def create_parser():
     # type: () -> argparse.ArgumentParser
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "-v", "--verbose", dest="verbose", action="store_true", default=False,
+        help="Turn on verbose logging")
+    parser.add_argument(
         "-p", "--path", type=abs_path, help="Path to manifest file.")
     parser.add_argument(
         "--tests-root", type=abs_path, default=wpt_root, help="Path to root of tests.")
@@ -90,6 +93,8 @@ def run(*args, **kwargs):
     # type: (*Any, **Any) -> None
     if kwargs["path"] is None:
         kwargs["path"] = os.path.join(kwargs["tests_root"], "MANIFEST.json")
+    if kwargs["verbose"]:
+        enable_debug_logging()
     update_from_cli(**kwargs)
 
 


### PR DESCRIPTION
In https://crbug.com/1160108, we are seeing a bug in Python 3 on Windows where high CPU counts + multiprocessing cause crashes and hangs (this is likely https://bugs.python.org/issue40263). Add a cap to avoid this.

I also noticed that one cannot actually get at the debug logs from 'wpt manifest', so add a flag for that too.