### PR TITLE
Add tests for ReadableStream.from()

### DIFF
--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -205,6 +205,27 @@ promise_test(async () => {
 
 }, `ReadableStream.from accepts an empty iterable`);
 
+promise_test(async t => {
+
+  const theError = new Error('a unique string');
+
+  const iterable = {
+    async next() {
+      throw theError;
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+
+  await Promise.all([
+    promise_rejects_exactly(t, theError, reader.read()),
+    promise_rejects_exactly(t, theError, reader.closed)
+  ]);
+
+}, `ReadableStream.from: stream errors when next() rejects`);
+
 promise_test(async () => {
 
   let nextCalls = 0;

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -122,3 +122,37 @@ for (const [label, iterable] of badIterables) {
     assert_throws_js(TypeError, () => ReadableStream.from(iterable), 'from() should throw a TypeError')
   }, `ReadableStream.from throws on invalid iterables; specifically ${label}`);
 }
+
+test(() => {
+  const theError = new Error('a unique string');
+  const iterable = {
+    [Symbol.iterator]() {
+      throw theError;
+    }
+  };
+
+  assert_throws_exactly(theError, () => ReadableStream.from(iterable), 'from() should re-throw the error');
+}, `ReadableStream.from re-throws errors from calling the @@iterator method`);
+
+test(() => {
+  const theError = new Error('a unique string');
+  const iterable = {
+    [Symbol.asyncIterator]() {
+      throw theError;
+    }
+  };
+
+  assert_throws_exactly(theError, () => ReadableStream.from(iterable), 'from() should re-throw the error');
+}, `ReadableStream.from re-throws errors from calling the @@asyncIterator method`);
+
+test(t => {
+  const theError = new Error('a unique string');
+  const iterable = {
+    [Symbol.iterator]: t.unreached_func('@@iterator should not be called'),
+    [Symbol.asyncIterator]() {
+      throw theError;
+    }
+  };
+
+  assert_throws_exactly(theError, () => ReadableStream.from(iterable), 'from() should re-throw the error');
+}, `ReadableStream.from ignores @@iterator if @@asyncIterator exists`);

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -342,7 +342,7 @@ promise_test(async t => {
 
 }, `ReadableStream.from: return() is not called when iterator completes normally`);
 
-promise_test(async t => {
+promise_test(async () => {
 
   let nextCalls = 0;
   let returnCalls = 0;

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -281,6 +281,7 @@ promise_test(async t => {
   let resolveReturn;
   const iterable = {
     next: t.unreached_func('next() should not be called'),
+    throw: t.unreached_func('throw() should not be called'),
     async return(...args) {
       returnCalls += 1;
       returnArgs = args;
@@ -312,7 +313,7 @@ promise_test(async t => {
 
 }, `ReadableStream.from: cancelling the returned stream calls and awaits return()`);
 
-promise_test(async () => {
+promise_test(async t => {
 
   let nextCalls = 0;
   let returnCalls = 0;
@@ -322,6 +323,7 @@ promise_test(async () => {
       nextCalls += 1;
       return { value: undefined, done: true };
     },
+    throw: t.unreached_func('throw() should not be called'),
     async return() {
       returnCalls += 1;
     },

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -80,6 +80,16 @@ const iterableFactories = [
       [Symbol.asyncIterator]: () => it
     };
     return it;
+  }],
+
+  ['a ReadableStream', () => {
+    return new ReadableStream({
+      start(c) {
+        c.enqueue('a');
+        c.enqueue('b');
+        c.close();
+      }
+    });
   }]
 ];
 

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -228,6 +228,26 @@ promise_test(async t => {
 
 promise_test(async () => {
 
+  const iterable = {
+    next() {
+      return new Promise(() => {});
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+
+  await Promise.race([
+    reader.read().then(() => assert_unreached(), () => assert_unreached()),
+    reader.closed.then(() => assert_unreached(), () => assert_unreached()),
+    flushAsyncEvents()
+  ]);
+
+}, 'ReadableStream.from: stream stalls when next() never settles');
+
+promise_test(async () => {
+
   let nextCalls = 0;
   let nextArgs;
   const iterable = {

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -426,3 +426,26 @@ promise_test(async t => {
   await reader.closed;
 
 }, `ReadableStream.from: reader.cancel() inside return()`);
+
+promise_test(async t => {
+
+  let array = ['a', 'b'];
+
+  const rs = ReadableStream.from(array);
+  const reader = rs.getReader();
+
+  const read1 = await reader.read();
+  assert_object_equals(read1, { value: 'a', done: false }, 'first read should be correct');
+  const read2 = await reader.read();
+  assert_object_equals(read2, { value: 'b', done: false }, 'second read should be correct');
+
+  array.push('c');
+
+  const read3 = await reader.read();
+  assert_object_equals(read3, { value: 'c', done: false }, 'third read after push() should be correct');
+  const read4 = await reader.read();
+  assert_object_equals(read4, { value: undefined, done: true }, 'fourth read should be done');
+
+  await reader.closed;
+
+}, `ReadableStream.from(array), push() to array while reading`);

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -226,7 +226,7 @@ promise_test(async t => {
 
 }, `ReadableStream.from: stream errors when next() rejects`);
 
-promise_test(async () => {
+promise_test(async t => {
 
   const iterable = {
     next() {
@@ -239,8 +239,8 @@ promise_test(async () => {
   const reader = rs.getReader();
 
   await Promise.race([
-    reader.read().then(() => assert_unreached(), () => assert_unreached()),
-    reader.closed.then(() => assert_unreached(), () => assert_unreached()),
+    reader.read().then(t.unreached_func('read() should not resolve'), t.unreached_func('read() should not reject')),
+    reader.closed.then(t.unreached_func('closed should not resolve'), t.unreached_func('closed should not reject')),
     flushAsyncEvents()
   ]);
 

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -98,3 +98,27 @@ for (const [label, factory] of iterableFactories) {
 
   }, `ReadableStream.from accepts ${label}`);
 }
+
+const badIterables = [
+  ['null', null],
+  ['undefined', undefined],
+  ['0', 0],
+  ['NaN', NaN],
+  ['true', true],
+  ['{}', {}],
+  ['Object.create(null)', Object.create(null)],
+  ['a function', () => 42],
+  ['a symbol', Symbol()],
+  ['an object with a non-callable @@iterator method', {
+    [Symbol.iterator]: 42
+  }],
+  ['an object with a non-callable @@asyncIterator method', {
+    [Symbol.asyncIterator]: 42
+  }],
+];
+
+for (const [label, iterable] of badIterables) {
+  test(() => {
+    assert_throws_js(TypeError, () => ReadableStream.from(iterable), 'from() should throw a TypeError')
+  }, `ReadableStream.from throws on invalid iterables; specifically ${label}`);
+}

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -1,0 +1,95 @@
+// META: global=window,worker,jsshell
+'use strict';
+
+const iterableFactories = [
+  ['an array of values', () => {
+    return ['a', 'b'];
+  }],
+
+  ['an array of promises', () => {
+    return [
+      Promise.resolve('a'),
+      Promise.resolve('b')
+    ];
+  }],
+
+  ['a Set', () => {
+    return new Set(['a', 'b']);
+  }],
+
+  ['a sync generator', () => {
+    function* syncGenerator() {
+      yield 'a';
+      yield 'b';
+    }
+
+    return syncGenerator();
+  }],
+
+  ['an async generator', () => {
+    async function* asyncGenerator() {
+      yield 'a';
+      yield 'b';
+    }
+
+    return asyncGenerator();
+  }],
+
+  ['a sync iterable of values', () => {
+    const chunks = ['a', 'b'];
+    const it = {
+      next() {
+        return {
+          done: chunks.length === 0,
+          value: chunks.shift()
+        };
+      },
+      [Symbol.iterator]: () => it
+    };
+    return it;
+  }],
+
+  ['a sync iterable of promises', () => {
+    const chunks = ['a', 'b'];
+    const it = {
+      next() {
+        return chunks.length === 0 ? { done: true } : {
+          done: false,
+          value: Promise.resolve(chunks.shift())
+        };
+      },
+      [Symbol.iterator]: () => it
+    };
+    return it;
+  }],
+
+  ['an async iterable', () => {
+    const chunks = ['a', 'b'];
+    const it = {
+      next() {
+        return Promise.resolve({
+          done: chunks.length === 0,
+          value: chunks.shift()
+        })
+      },
+      [Symbol.asyncIterator]: () => it
+    };
+    return it;
+  }]
+];
+
+for (const [label, factory] of iterableFactories) {
+  promise_test(async () => {
+
+    const iterable = factory();
+    const rs = ReadableStream.from(iterable);
+    assert_equals(rs.constructor, ReadableStream, 'from() should return a ReadableStream');
+
+    const reader = rs.getReader();
+    assert_object_equals(await reader.read(), { value: 'a', done: false }, 'first read should be correct');
+    assert_object_equals(await reader.read(), { value: 'b', done: false }, 'second read should be correct');
+    assert_object_equals(await reader.read(), { value: undefined, done: true }, 'third read should be done');
+    await reader.closed;
+
+  }, `ReadableStream.from accepts ${label}`);
+}

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -13,6 +13,11 @@ const iterableFactories = [
     ];
   }],
 
+  ['a string', () => {
+    // This iterates over the code points of the string.
+    return 'ab';
+  }],
+
   ['a Set', () => {
     return new Set(['a', 'b']);
   }],

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -188,6 +188,25 @@ test(t => {
 
 promise_test(async () => {
 
+  const iterable = {
+    async next() {
+      return { value: undefined, done: true };
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+
+  const read = await reader.read();
+  assert_object_equals(read, { value: undefined, done: true }, 'first read should be done');
+
+  await reader.closed;
+
+}, `ReadableStream.from accepts an empty iterable`);
+
+promise_test(async () => {
+
   let nextCalls = 0;
   let nextArgs;
   const iterable = {

--- a/streams/readable-streams/from.any.js
+++ b/streams/readable-streams/from.any.js
@@ -14,6 +14,10 @@ const iterableFactories = [
     ];
   }],
 
+  ['an array iterator', () => {
+    return ['a', 'b'][Symbol.iterator]();
+  }],
+
   ['a string', () => {
     // This iterates over the code points of the string.
     return 'ab';
@@ -21,6 +25,10 @@ const iterableFactories = [
 
   ['a Set', () => {
     return new Set(['a', 'b']);
+  }],
+
+  ['a Set iterator', () => {
+    return new Set(['a', 'b'])[Symbol.iterator]();
   }],
 
   ['a sync generator', () => {
@@ -91,6 +99,16 @@ const iterableFactories = [
         c.close();
       }
     });
+  }],
+
+  ['a ReadableStream async iterator', () => {
+    return new ReadableStream({
+      start(c) {
+        c.enqueue('a');
+        c.enqueue('b');
+        c.close();
+      }
+    })[Symbol.asyncIterator]();
   }]
 ];
 


### PR DESCRIPTION
Add tests for the new static method `ReadableStream.from()`.

See whatwg/streams#1083 for the accompanying spec change.