### PR TITLE
Corrected lh-rlh-on-root-001.html test based on issue 22055

### DIFF
--- a/css/css-values/lh-rlh-on-root-001.html
+++ b/css/css-values/lh-rlh-on-root-001.html
@@ -77,7 +77,7 @@
   test(function() {
     window.document.documentElement.style="font-size: 2rlh; line-height: 142px;";
     f_s = get_root_font_size();
-    assert_approx_equals( f_s, initial_f_s * 2, 1, "the rlh unit on the root element's font-size property actually works as a unit and doesn't merely cause a fallback that doesn't take the number of units into account");
+    assert_approx_equals( f_s, initial_l_h * 2, 1, "the rlh unit on the root element's font-size property actually works as a unit and doesn't merely cause a fallback that doesn't take the number of units into account");
 
   }, "2rlh in font-size on root");
 


### PR DESCRIPTION
This PR spun from [issue 22055: Possible issue with a `lh-rlh-on-root-001.html` testcase -- expect initial_l_h instead of initial_f_s?](https://github.com/web-platform-tests/wpt/issues/22055)

Credits must go to @twilco for spotting and reporting this issue.