### PR TITLE
NDEFReader.scan rejects if promise is resolved

### DIFF
--- a/web-nfc/NDEFReader_scan.https.html
+++ b/web-nfc/NDEFReader_scan.https.html
@@ -298,6 +298,7 @@ nfc_test(async (t, mockNFC) => {
   const promise2 = promise_rejects_dom(t, 'InvalidStateError', ndef.scan());
   await promise1;
   await promise2;
+  await promise_rejects_dom(t, 'InvalidStateError', ndef.scan());
 }, "Test that NDEFReader.scan rejects if there is already an ongoing scan.");
 
 nfc_test(async (t, mockNFC) => {


### PR DESCRIPTION
As noted in https://github.com/w3c/web-nfc/pull/611#issuecomment-751644800, NDEFReader.scan test should be updated.