### PR TITLE
[selectors] Add new :focus-visible tests

### DIFF
--- a/css/selectors/focus-visible-014.html
+++ b/css/selectors/focus-visible-014.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>CSS Selectors Test: :focus-visible matches after script focus move</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo" />
+<meta name="assert" content="This test checks that if the active element matches ':focus-visible' and a script causes focus to move elsewhere, the newly focused element should match ':focus-visible'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  @supports not (selector(:focus-visible)) {
+    :focus {
+      background-color: red;
+    }
+  }
+
+  :focus-visible {
+    background: lime;
+  }
+
+  :focus:not(:focus-visible) {
+    background-color: red;
+  }
+</style>
+
+<input id="input"></input>
+<div id="target" tabindex="0">Target</div>
+
+<script>
+  async_test(function(t) {
+    input.addEventListener("focus", t.step_func(function() {
+      assert_equals(getComputedStyle(input).backgroundColor, "rgb(0, 255, 0)", `backgroundColor for ${input.tagName}#${input.id} should be lime`);
+      target.focus();
+    }));
+
+    target.addEventListener("focus", t.step_func(function() {
+      assert_equals(getComputedStyle(target).backgroundColor, "rgb(0, 255, 0)", `backgroundColor for ${target.tagName}#${target.id} should be lime`);
+      t.done();
+    }));
+
+    input.focus();
+  }, ":focus-visible matches after script focus move");
+</script>

--- a/css/selectors/focus-visible-015.html
+++ b/css/selectors/focus-visible-015.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>CSS Selectors Test: :focus-visible does not match after script focus move</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo" />
+<meta name="assert" content="This test checks that if the active element does not match ':focus-visible' and a script causes focus to move elsewhere, the newly focused element should not match ':focus-visible'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  @supports not (selector(:focus-visible)) {
+    :focus {
+      background-color: red;
+    }
+  }
+
+  :focus-visible {
+    background: red;
+  }
+
+  :focus:not(:focus-visible) {
+    background-color: lime;
+  }
+</style>
+
+<div id="initial" tabindex="0">Initial</div>
+<div id="target" tabindex="0">Target</div>
+
+<script>
+  async_test(function(t) {
+    initial.addEventListener("focus", t.step_func(function() {
+      assert_equals(getComputedStyle(initial).backgroundColor, "rgb(0, 255, 0)", `backgroundColor for ${initial.tagName}#${initial.id} should be lime`);
+      target.focus();
+    }));
+
+    target.addEventListener("focus", t.step_func(function() {
+      assert_equals(getComputedStyle(target).backgroundColor, "rgb(0, 255, 0)", `backgroundColor for ${target.tagName}#${target.id} should be lime`);
+      t.done();
+    }));
+
+    test_driver.click(initial);
+  }, ":focus-visible does not match after script focus move");
+</script>

--- a/css/selectors/focus-visible-016.html
+++ b/css/selectors/focus-visible-016.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>CSS Selectors Test: :focus-visible always match on text inputs</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo" />
+<meta name="assert" content="This test checks that even if the active element does not match ':focus-visible' and a script causes focus to move into a text input, the text input should  match ':focus-visible'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  @supports not (selector(:focus-visible)) {
+    :focus {
+      background-color: red;
+    }
+  }
+
+  div:focus-visible {
+    background: red;
+  }
+
+  div:focus:not(:focus-visible) {
+    background-color: lime;
+  }
+
+  input:focus-visible {
+    background: lime;
+  }
+
+  input:focus:not(:focus-visible) {
+    background-color: red;
+  }
+</style>
+
+<div id="initial" tabindex="0">Initial</div>
+<input id="target" />
+
+<script>
+  async_test(function(t) {
+    initial.addEventListener("focus", t.step_func(function() {
+      assert_equals(getComputedStyle(initial).backgroundColor, "rgb(0, 255, 0)", `backgroundColor for ${initial.tagName}#${initial.id} should be lime`);
+      target.focus();
+    }));
+
+    target.addEventListener("focus", t.step_func(function() {
+      assert_equals(getComputedStyle(target).backgroundColor, "rgb(0, 255, 0)", `backgroundColor for ${target.tagName}#${target.id} should be lime`);
+      t.done();
+    }));
+
+    test_driver.click(initial);
+  }, ":focus-visible always match on text inputs");
+</script>
+


### PR DESCRIPTION
These tests check what happens when an active element
matches (or not) :focus-visible, and a script causes focus
to move elsewhere.

Basically these are tests for the next two points of the spec
(https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo):
>  * If the active element matches :focus-visible, and a script
>    causes focus to move elsewhere, the newly focused element
>    should match :focus-visible.
>  * Conversely, if the active element does not match :focus-visible,
>    and a script causes focus to move elsewhere,
>    the newly focused element should not match :focus-visible.
