### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=216961

### DIFF
--- a/xhr/event-timeout.any.js
+++ b/xhr/event-timeout.any.js
@@ -14,5 +14,5 @@ test.step(function () {
   client.send(null);
   test.step_timeout(() => {
     assert_unreached("ontimeout not called.");
-  }, 10);
+  }, 1000);
 });


### PR DESCRIPTION
WebKit export from bug: [REGRESSION (r267227): imported/w3c/web-platform-tests/xhr/event-timeout.any.html is a flaky failure](https://bugs.webkit.org/show_bug.cgi?id=216961)