### PR TITLE
[selectors] Make :focus-visible tests platform independent

### DIFF
--- a/css/selectors/focus-visible-001.html
+++ b/css/selectors/focus-visible-001.html
@@ -13,6 +13,7 @@
   <style>
     @supports not (selector(:focus-visible)) {
       :focus {
+        outline: red solid 5px;
         background-color: red;
       }
     }

--- a/css/selectors/focus-visible-002.html
+++ b/css/selectors/focus-visible-002.html
@@ -14,6 +14,7 @@
   <style>
     @supports not (selector(:focus-visible)) {
       :focus {
+        outline: red solid 5px;
         background-color: red;
       }
     }

--- a/css/selectors/focus-visible-003.html
+++ b/css/selectors/focus-visible-003.html
@@ -14,6 +14,7 @@
     @supports not (selector(:focus-visible)) {
       :focus {
         outline: red solid 5px;
+        background-color: red;
       }
     }
 

--- a/css/selectors/focus-visible-004.html
+++ b/css/selectors/focus-visible-004.html
@@ -14,6 +14,7 @@
     @supports not (selector(:focus-visible)) {
       :focus {
         outline: red solid 5px;
+        background-color: red;
       }
     }
 

--- a/css/selectors/focus-visible-005.html
+++ b/css/selectors/focus-visible-005.html
@@ -13,6 +13,7 @@
     @supports not (selector(:focus-visible)) {
       :focus {
         outline: red solid 5px;
+        background-color: red;
       }
     }
 

--- a/css/selectors/focus-visible-006.html
+++ b/css/selectors/focus-visible-006.html
@@ -10,6 +10,13 @@
   <script src="/resources/testdriver.js"></script>
   <script src="/resources/testdriver-vendor.js"></script>
   <style>
+    @supports not (selector(:focus-visible)) {
+      :focus {
+        outline: red solid 5px;
+        background-color: red;
+      }
+    }
+
     span[contenteditable] {
         border: 1px solid black;
         background-color: white;

--- a/css/selectors/focus-visible-008.html
+++ b/css/selectors/focus-visible-008.html
@@ -12,6 +12,7 @@
   <style>
     @supports not (selector(:focus-visible)) {
       #el:focus {
+        outline: red solid 5px;
         background-color: red;
       }
     }

--- a/css/selectors/focus-visible-009.html
+++ b/css/selectors/focus-visible-009.html
@@ -10,6 +10,7 @@
   <style>
     @supports not (selector(:focus-visible)) {
       #buton:focus {
+        outline: red solid 5px;
         background-color: red;
       }
     }

--- a/css/selectors/focus-visible-009.html
+++ b/css/selectors/focus-visible-009.html
@@ -9,7 +9,7 @@
   <script src="/resources/testharnessreport.js"></script>
   <style>
     @supports not (selector(:focus-visible)) {
-      #buton:focus {
+      #button:focus {
         outline: red solid 5px;
         background-color: red;
       }

--- a/css/selectors/focus-visible-010.html
+++ b/css/selectors/focus-visible-010.html
@@ -10,6 +10,7 @@
   <style>
     @supports not (selector(:focus-visible)) {
       :focus {
+        outline: red solid 5px;
         background-color: red;
       }
     }

--- a/css/selectors/focus-visible-011.html
+++ b/css/selectors/focus-visible-011.html
@@ -12,6 +12,7 @@
   <style>
     @supports not (selector(:focus-visible)) {
       #next:focus {
+        outline: red solid 5px;
         background-color: red;
       }
     }

--- a/css/selectors/focus-visible-012.html
+++ b/css/selectors/focus-visible-012.html
@@ -13,6 +13,7 @@
   <style>
     @supports not (selector(:focus-visible)) {
       :focus {
+        outline: red solid 5px;
         background-color: red;
       }
     }

--- a/css/selectors/focus-visible-014.html
+++ b/css/selectors/focus-visible-014.html
@@ -9,6 +9,7 @@
 <style>
   @supports not (selector(:focus-visible)) {
     :focus {
+      outline: red solid 5px;
       background-color: red;
     }
   }

--- a/css/selectors/focus-visible-015.html
+++ b/css/selectors/focus-visible-015.html
@@ -11,6 +11,7 @@
 <style>
   @supports not (selector(:focus-visible)) {
     :focus {
+      outline: red solid 5px;
       background-color: red;
     }
   }

--- a/css/selectors/focus-visible-016.html
+++ b/css/selectors/focus-visible-016.html
@@ -11,6 +11,7 @@
 <style>
   @supports not (selector(:focus-visible)) {
     :focus {
+      outline: red solid 5px;
       background-color: red;
     }
   }


### PR DESCRIPTION
For browsers that don't support :focus-visible yet
this change will make them to have consistent failure results
independently of the focus ring color on the different platforms.

Apart from that focus-visible-006.html is modified
like we did for the other tests in #26994.