### PR TITLE
fix: default to ShellTestEnvironment

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -500,11 +500,7 @@ policies and contribution forms [3].
             return new DedicatedWorkerTestEnvironment();
         }
 
-        if (!('location' in global_scope)) {
-            return new ShellTestEnvironment();
-        }
-
-        throw new Error("Unsupported test environment");
+        return new ShellTestEnvironment();
     }
 
     var test_environment = create_test_environment();


### PR DESCRIPTION
The [Deno](https://deno.land) project uses WPT for test our Web API implementations. Deno will be getting the `window.location` global soon (and already needs to shim it for some WPT test suites, like `encoding`). Because the testharness uses this global to determine if the `ShellTestEnvironment` environment should be used, the harness crashes because no suitable `TestEnvironment` can be found.

This PR removes this check, so the harness will always use the `ShellTestEnvironment` if no other environments match.